### PR TITLE
fix: resolve EACCES permission denied on Docker bind mounts after v1.…

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -160,5 +160,7 @@ RUN mkdir -p \
 
 EXPOSE 5551
 
+# The entrypoint starts as root only to reconcile bind-mount ownership,
+# then drops to PUID:PGID via gosu before executing CMD.
 ENTRYPOINT ["/usr/local/bin/mytube-entrypoint.sh"]
 CMD ["node", "dist/src/server.js"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     curl \
+    gosu \
     unzip \
     libcairo2 \
     libpango-1.0-0 \
@@ -119,14 +120,19 @@ ENV PORT=5551
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1
 ENV SKIP_PROVIDER_BUILD=1
 ENV SKIP_FFMPEG_AUTO_INSTALL=1
+ENV PUID=1000
+ENV PGID=1000
+ENV MYTUBE_AUTO_FIX_PERMISSIONS=1
 # Debian chromium path
 ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install production dependencies only
 COPY backend/package*.json ./
+COPY backend/entrypoint.sh /usr/local/bin/mytube-entrypoint.sh
 COPY backend/scripts ./scripts
 COPY backend/vendor ./vendor
-RUN npm ci --only=production
+RUN chmod +x /usr/local/bin/mytube-entrypoint.sh \
+    && npm ci --only=production
 
 # Copy built artifacts from builder
 COPY --from=builder /app/dist ./dist
@@ -138,17 +144,21 @@ COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/bgutil-ytdlp-pot-provider /app/bgutil-ytdlp-pot-provider
 
 # Create necessary directories
-RUN mkdir -p uploads/videos uploads/images uploads/subtitles data \
-    && chown -R node:node /app
+RUN mkdir -p \
+    uploads/videos \
+    uploads/images \
+    uploads/images-small \
+    uploads/subtitles \
+    uploads/avatars \
+    uploads/cloud-thumbnail-cache \
+    data \
+    && chown -R 1000:1000 uploads data
 
-# Since v1.9.0 the backend runs as the non-root `node` user (uid/gid 1000).
-# If you are upgrading an older bind-mounted installation created before v1.9.0,
-# make sure the host-side mounted folders are writable by uid/gid 1000, e.g.:
-#   chown -R 1000:1000 /path/to/mytube/uploads /path/to/mytube/data
-# If `/path/to/mytube/uploads/images-small` already exists and was created by root,
-# it must be fixed as well or thumbnail generation will fail with EACCES.
-USER node
+# The container starts as root only long enough for the entrypoint to reconcile
+# bind-mount ownership. The backend process itself is then launched as PUID:PGID
+# (default 1000:1000) via gosu.
 
 EXPOSE 5551
 
+ENTRYPOINT ["/usr/local/bin/mytube-entrypoint.sh"]
 CMD ["node", "dist/src/server.js"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+DATA_DIR="${MYTUBE_DATA_DIR:-/app/data}"
+UPLOADS_DIR="${MYTUBE_UPLOADS_DIR:-/app/uploads}"
+HOME_DIR="${DATA_DIR}/.home"
+TARGET_UID="${PUID:-1000}"
+TARGET_GID="${PGID:-1000}"
+AUTO_FIX_PERMISSIONS="${MYTUBE_AUTO_FIX_PERMISSIONS:-1}"
+
+log() {
+  printf '[mytube-entrypoint] %s\n' "$*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_numeric() {
+  local label="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    die "$label must be a numeric uid/gid value, got '$value'."
+  fi
+}
+
+is_truthy() {
+  case "${1,,}" in
+    1|true|yes|on) return 0 ;;
+    0|false|no|off) return 1 ;;
+    *) die "MYTUBE_AUTO_FIX_PERMISSIONS must be one of: 1, 0, true, false, yes, no, on, off." ;;
+  esac
+}
+
+path_owner() {
+  stat -c '%u:%g' "$1" 2>/dev/null || true
+}
+
+reconcile_path_if_needed() {
+  local path="$1"
+  local recursive="${2:-0}"
+  local current_owner
+
+  if [ ! -e "$path" ]; then
+    return 0
+  fi
+
+  current_owner="$(path_owner "$path")"
+  if [ "$current_owner" = "${TARGET_UID}:${TARGET_GID}" ]; then
+    return 0
+  fi
+
+  log "Reconciling ownership for $path (${current_owner:-unknown} -> ${TARGET_UID}:${TARGET_GID})"
+
+  if [ "$recursive" = "1" ]; then
+    if ! chown -R "${TARGET_UID}:${TARGET_GID}" "$path"; then
+      log "Unable to recursively chown $path. A writable-path check will run before startup."
+    fi
+    return 0
+  fi
+
+  if ! chown "${TARGET_UID}:${TARGET_GID}" "$path"; then
+    log "Unable to chown $path. A writable-path check will run before startup."
+  fi
+}
+
+ensure_writable_as_target() {
+  local path="$1"
+  local label="$2"
+
+  if ! gosu "${TARGET_UID}:${TARGET_GID}" test -w "$path"; then
+    die "$label is not writable for uid/gid ${TARGET_UID}:${TARGET_GID}: $path. If this is a bind mount, either set PUID/PGID to match the host ownership or run 'chown -R ${TARGET_UID}:${TARGET_GID} <host-data-dir> <host-uploads-dir>'."
+  fi
+}
+
+prepare_runtime_layout() {
+  mkdir -p \
+    "$DATA_DIR" \
+    "$UPLOADS_DIR" \
+    "$UPLOADS_DIR/videos" \
+    "$UPLOADS_DIR/images" \
+    "$UPLOADS_DIR/images-small" \
+    "$UPLOADS_DIR/subtitles" \
+    "$UPLOADS_DIR/avatars" \
+    "$UPLOADS_DIR/cloud-thumbnail-cache" \
+    "$HOME_DIR"
+}
+
+require_numeric "PUID" "$TARGET_UID"
+require_numeric "PGID" "$TARGET_GID"
+
+if [ "$(id -u)" = "0" ]; then
+  prepare_runtime_layout
+
+  if is_truthy "$AUTO_FIX_PERMISSIONS"; then
+    # Reconcile top-level directories recursively first. Individual paths below
+    # are a deliberate fallback: if the recursive pass partially fails (e.g. a
+    # single inaccessible file), the targeted calls may still fix the critical
+    # paths needed for startup.
+    reconcile_path_if_needed "$DATA_DIR" 1
+    reconcile_path_if_needed "$DATA_DIR/mytube.db"
+    reconcile_path_if_needed "$UPLOADS_DIR" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/images-small" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/videos" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/images" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/subtitles" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/avatars" 1
+    reconcile_path_if_needed "$UPLOADS_DIR/cloud-thumbnail-cache" 1
+  else
+    log "Skipping automatic permission reconciliation because MYTUBE_AUTO_FIX_PERMISSIONS=${AUTO_FIX_PERMISSIONS}"
+  fi
+
+  export HOME="$HOME_DIR"
+
+  ensure_writable_as_target "$DATA_DIR" "Data directory"
+  ensure_writable_as_target "$UPLOADS_DIR" "Uploads directory"
+  ensure_writable_as_target "$HOME_DIR" "Runtime home directory"
+
+  if [ -e "$DATA_DIR/mytube.db" ]; then
+    ensure_writable_as_target "$DATA_DIR/mytube.db" "SQLite database file"
+  fi
+
+  # Ensure /etc/passwd and /etc/group contain entries for PUID/PGID so that
+  # child processes (npm, git, yt-dlp) do not warn about unknown uid/gid.
+  if ! getent group "$TARGET_GID" > /dev/null 2>&1; then
+    groupadd -g "$TARGET_GID" -o mytube 2>/dev/null || true
+  fi
+  if ! getent passwd "$TARGET_UID" > /dev/null 2>&1; then
+    useradd -u "$TARGET_UID" -g "$TARGET_GID" -o -s /sbin/nologin -M -d "$HOME_DIR" mytube 2>/dev/null || true
+  fi
+
+  log "Starting MyTube as uid/gid ${TARGET_UID}:${TARGET_GID}"
+  exec gosu "${TARGET_UID}:${TARGET_GID}" "$@"
+fi
+
+export HOME="${HOME:-$HOME_DIR}"
+log "Entrypoint is running as uid/gid $(id -u):$(id -g); skipping permission reconciliation."
+exec "$@"

--- a/backend/src/__tests__/db/migrate.test.ts
+++ b/backend/src/__tests__/db/migrate.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MigrationError } from "../../errors/DownloadErrors";
+import { runMigrations } from "../../db/migrate";
+
+const migrateMock = vi.hoisted(() => vi.fn());
+const configureDatabaseMock = vi.hoisted(() => vi.fn());
+const pathExistsSafeSyncMock = vi.hoisted(() => vi.fn());
+const runDataMigrationMock = vi.hoisted(() => vi.fn());
+const fsMocks = vi.hoisted(() => ({
+  accessSync: vi.fn(),
+  existsSync: vi.fn(),
+  statSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("drizzle-orm/better-sqlite3/migrator", () => ({
+  migrate: migrateMock,
+}));
+
+vi.mock("fs", () => {
+  const constants = { R_OK: 4, W_OK: 2 };
+
+  return {
+    accessSync: fsMocks.accessSync,
+    constants,
+    default: {
+      accessSync: fsMocks.accessSync,
+      constants,
+      existsSync: fsMocks.existsSync,
+      statSync: fsMocks.statSync,
+      unlinkSync: fsMocks.unlinkSync,
+      writeFileSync: fsMocks.writeFileSync,
+    },
+    existsSync: fsMocks.existsSync,
+    statSync: fsMocks.statSync,
+    unlinkSync: fsMocks.unlinkSync,
+    writeFileSync: fsMocks.writeFileSync,
+  };
+});
+
+vi.mock("../../config/paths", () => ({
+  COLLECTIONS_DATA_PATH: "/test/data/collections.json",
+  DATA_DIR: "/test/data",
+  ROOT_DIR: "/test",
+  STATUS_DATA_PATH: "/test/data/status.json",
+  VIDEOS_DATA_PATH: "/test/data/videos.json",
+}));
+
+vi.mock("../../utils/security", () => ({
+  pathExistsSafeSync: pathExistsSafeSyncMock,
+}));
+
+vi.mock("../../db", () => ({
+  configureDatabase: configureDatabaseMock,
+  db: {},
+  sqlite: {},
+}));
+
+vi.mock("../../services/migrationService", () => ({
+  runMigration: runDataMigrationMock,
+}));
+
+describe("runMigrations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pathExistsSafeSyncMock.mockReturnValue(true);
+    fsMocks.writeFileSync.mockImplementation(() => undefined);
+    fsMocks.existsSync.mockReturnValue(false);
+    fsMocks.unlinkSync.mockImplementation(() => undefined);
+    fsMocks.accessSync.mockImplementation(() => undefined);
+    fsMocks.statSync.mockReturnValue({
+      gid: 0,
+      mode: 0o100644,
+      uid: 0,
+    } as any);
+    migrateMock.mockImplementation(() => undefined);
+    configureDatabaseMock.mockImplementation(() => undefined);
+    runDataMigrationMock.mockResolvedValue(undefined);
+  });
+
+  it("fails fast with an actionable message when the database file is not writable", async () => {
+    fsMocks.accessSync.mockImplementation(() => {
+      throw Object.assign(new Error("EACCES: permission denied"), {
+        code: "EACCES",
+      });
+    });
+
+    let thrown: unknown;
+    try {
+      await runMigrations();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(MigrationError);
+    expect((thrown as MigrationError).step).toBe("database_write_preflight");
+    expect((thrown as MigrationError).message).toContain(
+      "Database file is not writable: /test/data/mytube.db"
+    );
+    expect((thrown as MigrationError).message).toContain(
+      "cannot update the SQLite database"
+    );
+    expect(migrateMock).not.toHaveBeenCalled();
+  });
+
+  it("wraps SQLITE_READONLY migration errors with the same actionable guidance", async () => {
+    migrateMock.mockImplementation(() => {
+      throw Object.assign(new Error("drizzle failed"), {
+        cause: {
+          code: "SQLITE_READONLY",
+          message: "attempt to write a readonly database",
+        },
+      });
+    });
+
+    let thrown: unknown;
+    try {
+      await runMigrations();
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(MigrationError);
+    expect((thrown as MigrationError).step).toBe("drizzle_migrate");
+    expect((thrown as MigrationError).message).toContain(
+      "SQLite database is not writable: /test/data/mytube.db"
+    );
+    expect((thrown as MigrationError).message).toContain(
+      "attempt to write a readonly database"
+    );
+  });
+});

--- a/backend/src/__tests__/db/migrate.test.ts
+++ b/backend/src/__tests__/db/migrate.test.ts
@@ -4,14 +4,14 @@ import { runMigrations } from "../../db/migrate";
 
 const migrateMock = vi.hoisted(() => vi.fn());
 const configureDatabaseMock = vi.hoisted(() => vi.fn());
-const pathExistsSafeSyncMock = vi.hoisted(() => vi.fn());
 const runDataMigrationMock = vi.hoisted(() => vi.fn());
-const fsMocks = vi.hoisted(() => ({
-  accessSync: vi.fn(),
-  existsSync: vi.fn(),
-  statSync: vi.fn(),
-  unlinkSync: vi.fn(),
-  writeFileSync: vi.fn(),
+const securityMocks = vi.hoisted(() => ({
+  accessTrustedSync: vi.fn(),
+  pathExistsSafeSync: vi.fn(),
+  pathExistsTrustedSync: vi.fn(),
+  statTrustedSync: vi.fn(),
+  unlinkTrustedSync: vi.fn(),
+  writeFileSafeSync: vi.fn(),
 }));
 
 vi.mock("drizzle-orm/better-sqlite3/migrator", () => ({
@@ -20,23 +20,7 @@ vi.mock("drizzle-orm/better-sqlite3/migrator", () => ({
 
 vi.mock("fs", () => {
   const constants = { R_OK: 4, W_OK: 2 };
-
-  return {
-    accessSync: fsMocks.accessSync,
-    constants,
-    default: {
-      accessSync: fsMocks.accessSync,
-      constants,
-      existsSync: fsMocks.existsSync,
-      statSync: fsMocks.statSync,
-      unlinkSync: fsMocks.unlinkSync,
-      writeFileSync: fsMocks.writeFileSync,
-    },
-    existsSync: fsMocks.existsSync,
-    statSync: fsMocks.statSync,
-    unlinkSync: fsMocks.unlinkSync,
-    writeFileSync: fsMocks.writeFileSync,
-  };
+  return { constants, default: { constants } };
 });
 
 vi.mock("../../config/paths", () => ({
@@ -48,7 +32,12 @@ vi.mock("../../config/paths", () => ({
 }));
 
 vi.mock("../../utils/security", () => ({
-  pathExistsSafeSync: pathExistsSafeSyncMock,
+  accessTrustedSync: securityMocks.accessTrustedSync,
+  pathExistsSafeSync: securityMocks.pathExistsSafeSync,
+  pathExistsTrustedSync: securityMocks.pathExistsTrustedSync,
+  statTrustedSync: securityMocks.statTrustedSync,
+  unlinkTrustedSync: securityMocks.unlinkTrustedSync,
+  writeFileSafeSync: securityMocks.writeFileSafeSync,
 }));
 
 vi.mock("../../db", () => ({
@@ -64,12 +53,12 @@ vi.mock("../../services/migrationService", () => ({
 describe("runMigrations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    pathExistsSafeSyncMock.mockReturnValue(true);
-    fsMocks.writeFileSync.mockImplementation(() => undefined);
-    fsMocks.existsSync.mockReturnValue(false);
-    fsMocks.unlinkSync.mockImplementation(() => undefined);
-    fsMocks.accessSync.mockImplementation(() => undefined);
-    fsMocks.statSync.mockReturnValue({
+    securityMocks.pathExistsSafeSync.mockReturnValue(true);
+    securityMocks.pathExistsTrustedSync.mockReturnValue(false);
+    securityMocks.writeFileSafeSync.mockImplementation(() => undefined);
+    securityMocks.unlinkTrustedSync.mockImplementation(() => undefined);
+    securityMocks.accessTrustedSync.mockImplementation(() => undefined);
+    securityMocks.statTrustedSync.mockReturnValue({
       gid: 0,
       mode: 0o100644,
       uid: 0,
@@ -80,7 +69,7 @@ describe("runMigrations", () => {
   });
 
   it("fails fast with an actionable message when the database file is not writable", async () => {
-    fsMocks.accessSync.mockImplementation(() => {
+    securityMocks.accessTrustedSync.mockImplementation(() => {
       throw Object.assign(new Error("EACCES: permission denied"), {
         code: "EACCES",
       });

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/better-sqlite3";
 import fs from "fs-extra";
 import path from "path";
 import { DATA_DIR } from "../config/paths";
+import { pathExistsTrustedSync } from "../utils/security";
 import * as schema from "./schema";
 
 // Ensure data directory exists
@@ -58,8 +59,7 @@ function createDatabaseConnection(
     try {
       // Ensure the database file exists (better-sqlite3 will create it if it doesn't exist)
       // But we need to ensure the directory is accessible first
-      // nosemgrep: javascript.pathtraversal.rule-non-literal-fs-filename
-      if (!fs.existsSync(dbPath)) {
+      if (!pathExistsTrustedSync(dbPath)) {
         // Touch the file to ensure it exists before opening
         fs.ensureFileSync(dbPath);
       }

--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -79,7 +79,20 @@ function createDatabaseConnection(
           continue;
         }
       }
-      // If it's not a busy/locked error, or we've exhausted retries, throw
+      // Provide an actionable message for permission errors — the most common
+      // failure when upgrading Docker bind-mount deployments.
+      if (error.code === "EACCES") {
+        const uid = typeof process.getuid === "function" ? process.getuid() : undefined;
+        const gid = typeof process.getgid === "function" ? process.getgid() : undefined;
+        const identity = uid != null && gid != null ? `uid/gid ${uid}/${gid}` : "the current user";
+        const hint = uid != null && gid != null
+          ? `If this is a Docker bind mount, fix the host-side permissions: chown -R ${uid}:${gid} /path/to/mytube/data /path/to/mytube/uploads`
+          : "Ensure the data directory and database file are writable by the user running MyTube.";
+        throw new Error(
+          `Permission denied: cannot open database at ${dbPath}. MyTube is running as ${identity}. ${hint}`
+        );
+      }
+      // If it's not a busy/locked/permission error, or we've exhausted retries, throw
       throw error;
     }
   }

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,8 +1,139 @@
+import fs from "fs";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import path from "path";
 import { DATA_DIR, ROOT_DIR } from "../config/paths";
+import { MigrationError } from "../errors/DownloadErrors";
 import { pathExistsSafeSync } from "../utils/security";
 import { configureDatabase, db, sqlite } from "./index";
+
+const DB_FILENAME = "mytube.db";
+
+function normalizeError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function getCurrentIdentity(): { uid?: number; gid?: number } {
+  return {
+    uid: typeof process.getuid === "function" ? process.getuid() : undefined,
+    gid: typeof process.getgid === "function" ? process.getgid() : undefined,
+  };
+}
+
+function getTargetOwnershipSummary(targetPath: string): string | null {
+  try {
+    const stats = fs.statSync(targetPath);
+    const mode = (stats.mode & 0o777).toString(8).padStart(3, "0");
+    return `owner uid/gid ${stats.uid}/${stats.gid}, mode ${mode}`;
+  } catch {
+    return null;
+  }
+}
+
+function buildPermissionFixHint(): string {
+  const { uid, gid } = getCurrentIdentity();
+
+  if (typeof uid === "number" && typeof gid === "number") {
+    return `If this is a Docker bind mount, fix the host-side permissions, for example: chown -R ${uid}:${gid} /path/to/mytube/data /path/to/mytube/uploads.`;
+  }
+
+  return "Ensure the data directory and database file are writable by the user running MyTube.";
+}
+
+function getCauseMessage(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const cause = (error as { cause?: unknown }).cause;
+  if (typeof cause === "object" && cause !== null && "message" in cause) {
+    const msg = (cause as { message?: unknown }).message;
+    return typeof msg === "string" && msg.length > 0 ? msg : undefined;
+  }
+  return undefined;
+}
+
+function buildReadonlyDatabaseMessage(
+  targetPath: string,
+  description: string,
+  originalError?: Error
+): string {
+  const { uid, gid } = getCurrentIdentity();
+  const identity =
+    typeof uid === "number" && typeof gid === "number"
+      ? `uid/gid ${uid}/${gid}`
+      : "the current process user";
+  const ownership = getTargetOwnershipSummary(targetPath);
+  const ownershipText = ownership ? ` Current ${description} ${ownership}.` : "";
+  const causeMessage = getCauseMessage(originalError);
+  const errorMessages = [originalError?.message, causeMessage].filter(
+    (value, index, array): value is string =>
+      typeof value === "string" && value.length > 0 && array.indexOf(value) === index
+  );
+  const errorText =
+    errorMessages.length > 0
+      ? ` Underlying error: ${errorMessages.join(" | ")}.`
+      : "";
+
+  return `${description} is not writable: ${targetPath}. MyTube is running as ${identity} and cannot update the SQLite database.${ownershipText} ${buildPermissionFixHint()}${errorText}`.trim();
+}
+
+function ensureDatabaseWritable(dbPath: string): void {
+  const probePath = path.join(DATA_DIR, `.mytube-write-probe-${process.pid}`);
+
+  try {
+    fs.writeFileSync(probePath, "");
+  } catch (error) {
+    throw new MigrationError(
+      buildReadonlyDatabaseMessage(
+        DATA_DIR,
+        "Data directory",
+        normalizeError(error)
+      ),
+      "database_write_preflight",
+      normalizeError(error)
+    );
+  } finally {
+    try {
+      if (fs.existsSync(probePath)) {
+        fs.unlinkSync(probePath);
+      }
+    } catch {
+      // Best effort cleanup for the write probe.
+    }
+  }
+
+  if (!pathExistsSafeSync(dbPath, DATA_DIR)) {
+    return;
+  }
+
+  try {
+    fs.accessSync(dbPath, fs.constants.R_OK | fs.constants.W_OK);
+  } catch (error) {
+    throw new MigrationError(
+      buildReadonlyDatabaseMessage(
+        dbPath,
+        "Database file",
+        normalizeError(error)
+      ),
+      "database_write_preflight",
+      normalizeError(error)
+    );
+  }
+}
+
+function isReadonlySqliteError(error: unknown): boolean {
+  const candidate = error as
+    | {
+        code?: string;
+        message?: string;
+        cause?: { code?: string; message?: string };
+      }
+    | undefined;
+
+  return (
+    candidate?.code === "SQLITE_READONLY" ||
+    candidate?.cause?.code === "SQLITE_READONLY" ||
+    candidate?.message?.includes("readonly database") === true ||
+    candidate?.cause?.message?.includes("readonly database") === true
+  );
+}
 
 export async function runMigrations() {
   try {
@@ -11,13 +142,15 @@ export async function runMigrations() {
     // For network filesystems (NFS/SMB), add a small delay to ensure
     // the database file is fully accessible before attempting migration
     // This helps prevent "database is locked" errors on first deployment
-    const dbPath = path.join(ROOT_DIR, "data", "mytube.db");
+    const dbPath = path.join(ROOT_DIR, "data", DB_FILENAME);
     if (!pathExistsSafeSync(dbPath, DATA_DIR)) {
       console.log(
         "Database file does not exist yet, waiting for file system sync..."
       );
       await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 second delay
     }
+
+    ensureDatabaseWritable(dbPath);
 
     // In production/docker, the drizzle folder is copied to the root or src/drizzle
     // We need to find where it is.
@@ -40,6 +173,16 @@ export async function runMigrations() {
           "Columns will be verified by initialization.ts"
         );
         // Don't throw - let initialization.ts handle missing columns
+      } else if (isReadonlySqliteError(migrationError)) {
+        throw new MigrationError(
+          buildReadonlyDatabaseMessage(
+            dbPath,
+            "SQLite database",
+            normalizeError(migrationError)
+          ),
+          "drizzle_migrate",
+          normalizeError(migrationError)
+        );
       } else {
         // Re-throw other migration errors
         throw migrationError;

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,9 +1,16 @@
-import fs from "fs";
+import { constants as fsConstants } from "fs";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import path from "path";
 import { DATA_DIR, ROOT_DIR } from "../config/paths";
 import { MigrationError } from "../errors/DownloadErrors";
-import { pathExistsSafeSync } from "../utils/security";
+import {
+  accessTrustedSync,
+  pathExistsSafeSync,
+  pathExistsTrustedSync,
+  statTrustedSync,
+  unlinkTrustedSync,
+  writeFileSafeSync,
+} from "../utils/security";
 import { configureDatabase, db, sqlite } from "./index";
 
 const DB_FILENAME = "mytube.db";
@@ -21,7 +28,7 @@ function getCurrentIdentity(): { uid?: number; gid?: number } {
 
 function getTargetOwnershipSummary(targetPath: string): string | null {
   try {
-    const stats = fs.statSync(targetPath);
+    const stats = statTrustedSync(targetPath);
     const mode = (stats.mode & 0o777).toString(8).padStart(3, "0");
     return `owner uid/gid ${stats.uid}/${stats.gid}, mode ${mode}`;
   } catch {
@@ -78,7 +85,7 @@ function ensureDatabaseWritable(dbPath: string): void {
   const probePath = path.join(DATA_DIR, `.mytube-write-probe-${process.pid}`);
 
   try {
-    fs.writeFileSync(probePath, "");
+    writeFileSafeSync(probePath, DATA_DIR, "");
   } catch (error) {
     throw new MigrationError(
       buildReadonlyDatabaseMessage(
@@ -91,8 +98,8 @@ function ensureDatabaseWritable(dbPath: string): void {
     );
   } finally {
     try {
-      if (fs.existsSync(probePath)) {
-        fs.unlinkSync(probePath);
+      if (pathExistsSafeSync(probePath, DATA_DIR)) {
+        unlinkTrustedSync(probePath);
       }
     } catch {
       // Best effort cleanup for the write probe.
@@ -104,7 +111,7 @@ function ensureDatabaseWritable(dbPath: string): void {
   }
 
   try {
-    fs.accessSync(dbPath, fs.constants.R_OK | fs.constants.W_OK);
+    accessTrustedSync(dbPath, fsConstants.R_OK | fsConstants.W_OK);
   } catch (error) {
     throw new MigrationError(
       buildReadonlyDatabaseMessage(

--- a/backend/src/utils/security.ts
+++ b/backend/src/utils/security.ts
@@ -364,6 +364,11 @@ export function unlinkTrustedSync(filePath: string): void {
   fs.unlinkSync(safePath);
 }
 
+export function accessTrustedSync(filePath: string, mode: number): void {
+  const safePath = normalizeSafeAbsolutePath(filePath);
+  fs.accessSync(safePath, mode);
+}
+
 export function removeEmptyDirSafeSync(
   dirPath: string,
   allowedDirOrDirs: string | readonly string[],

--- a/docker-compose.host-network.yml
+++ b/docker-compose.host-network.yml
@@ -17,6 +17,11 @@ services:
       - /share/CACHEDEV2_DATA/Medias/MyTube/data:/app/data
     environment:
       - PORT=5551
+      # Optional: match the backend process uid/gid to the host-side file ownership.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # Set to 0 to disable the startup chown pass for bind-mounted data/uploads.
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
       # Optional: declare the admin trust boundary for this deployment.
       # Valid values: application | container | host
       # Docs: documents/en/deployment-security-model.md

--- a/docker-compose.single-container.yml
+++ b/docker-compose.single-container.yml
@@ -13,6 +13,11 @@ services:
       - ./data:/app/data
     environment:
       - PORT=5551
+      # Optional: match the backend process uid/gid to the host-side file ownership.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # Set to 0 to disable the startup chown pass for bind-mounted data/uploads.
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
       # Optional: declare the admin trust boundary for this deployment.
       # Valid values: application | container | host
       # Docs: documents/en/deployment-security-model.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@ services:
       - /share/CACHEDEV2_DATA/Medias/MyTube/data:/app/data
     environment:
       - PORT=5551
+      # Optional: match the backend process uid/gid to the host-side file ownership.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # Set to 0 to disable the startup chown pass for bind-mounted data/uploads.
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
       # Optional: declare the admin trust boundary for this deployment.
       # Valid values: application | container | host
       # Docs: documents/en/deployment-security-model.md

--- a/documents/en/deployment-security-model.md
+++ b/documents/en/deployment-security-model.md
@@ -133,9 +133,10 @@ environment:
 
 Permission note for upgrades:
 
-- since v1.9.0, the backend container runs as the non-root `node` user (`uid/gid 1000`)
-- if you are upgrading an older bind-mounted deployment created before v1.9.0, make sure the host-side mounted `uploads` and `data` directories are writable by `uid/gid 1000`
-- this also applies to existing subdirectories such as `uploads/images-small`; if they are still owned by `root`, thumbnail generation or scans can fail with `EACCES`
+- the container entrypoint now starts as `root` only long enough to reconcile bind-mount ownership, then launches the backend as `PUID:PGID` (default `1000:1000`)
+- if you are upgrading an older bind-mounted deployment, MyTube will try to repair `uploads` and `data` ownership automatically during startup
+- if your host files are intentionally owned by a different user, set matching `PUID` and `PGID` values in your compose file or `.env`
+- this still applies to existing subdirectories such as `uploads/images-small`; if the host filesystem rejects `chown`, thumbnail generation or scans can still fail with `EACCES`
 
 Example fix on the host:
 

--- a/documents/en/docker-guide.md
+++ b/documents/en/docker-guide.md
@@ -41,6 +41,11 @@ services:
       - mytube-network
     environment:
       - PORT=5551
+      # Optional: run the backend as the same uid/gid as the host-side files.
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # Optional: disable the startup chown pass for bind mounts by setting 0.
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
       # Optional: declare the admin trust boundary for this deployment.
       # Valid values: application | container | host
       - MYTUBE_ADMIN_TRUST_LEVEL=container
@@ -125,6 +130,9 @@ services:
       - "5551:5551"
     environment:
       - PORT=5551
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
     volumes:
       - ./uploads:/app/uploads
       - ./data:/app/data
@@ -149,6 +157,16 @@ The `docker-compose.yml` above creates two folders in your current directory t
 
 **Important:** If you move the `docker-compose.yml` file, you must move these folders with it to keep your data.
 
+For new installs, consider keeping `uploads` as a bind mount but switching `/app/data` to a Docker named volume. SQLite is more reliable there because it avoids host filesystem ownership and ACL edge cases.
+
+Example backend volume section:
+
+```yaml
+    volumes:
+      - ./uploads:/app/uploads
+      - mytube-data:/app/data
+```
+
 ### Environment Variables
 
 You can customize the deployment by adding a `.env` file or modifying the `environment` section in `docker-compose.yml`.
@@ -170,11 +188,16 @@ For the full capability breakdown, see [Deployment Security Model](deployment-se
 |Variable|Service|Description|Default|
 |---|---|---|---|
 |`PORT`|Backend|Port the backend listens on internally|`5551`|
+|`PUID`|Backend|UID used for the backend process after startup permission reconciliation|`1000`|
+|`PGID`|Backend|GID used for the backend process after startup permission reconciliation|`1000`|
+|`MYTUBE_AUTO_FIX_PERMISSIONS`|Backend|Whether the entrypoint should chown bind-mounted `data` and `uploads` before dropping privileges|`1`|
 |`MYTUBE_ADMIN_TRUST_LEVEL`|Backend|Deployment-declared admin trust boundary (`application`, `container`, `host`)|`container`|
 |`VITE_API_URL`|Frontend|API endpoint path|`/api`|
 |`API_HOST`|Frontend|**Advanced:** Force a specific backend IP|_(Auto-detected)_|
 |`API_PORT`|Frontend|**Advanced:** Force a specific backend Port|`5551`|
 |`NGINX_BACKEND_URL`|Frontend|**Advanced:** Override Nginx backend upstream URL|`http://backend:5551`|
+
+The backend container now starts as root only long enough to reconcile bind-mount ownership, then launches MyTube as `PUID:PGID` using `gosu`.
 
 ## 🛠️ Advanced Networking (Remote/NAS Deployment)
 
@@ -238,14 +261,23 @@ If you prefer to build the images yourself (e.g., to modify code), follow these 
 - **Fix:** Ensure port `5551` is open on your firewall. If running on a remote server, try setting the `API_HOST` in a `.env` file as described in the "Advanced Networking" section.
     
 
-### 2. Permission Denied for `./uploads`
+### 2. Permission Denied for `./uploads` or `./data/mytube.db`
 
-- **Cause:** The Docker container user doesn't have write permissions to the host directory.
+- **Cause:** The backend process uid/gid does not match the ownership of the bind-mounted host files, or the host filesystem blocks `chown`.
     
-- **Fix:** Adjust permissions on your host machine:
+- **Fix:** First make sure `PUID`/`PGID` match the intended host owner. By default MyTube uses `1000:1000` and will try to reconcile permissions automatically at startup.
+
+- **Fix:** If automatic reconciliation cannot fix the mount, adjust ownership on the host:
     
     ```
-    chmod -R 777 ./uploads ./data
+    chown -R 1000:1000 ./uploads ./data
+    ```
+
+- **Fix:** If your files are intentionally owned by a different user, set matching values in `.env` or `docker-compose.yml`:
+
+    ```
+    PUID=1001
+    PGID=1001
     ```
     
 

--- a/documents/zh/deployment-security-model.md
+++ b/documents/zh/deployment-security-model.md
@@ -133,9 +133,10 @@ environment:
 
 升级权限说明：
 
-- 从 `v1.9.0` 开始，后端容器默认以非 root 的 `node` 用户运行（`uid/gid 1000`）
-- 如果你升级的是 `v1.9.0` 之前创建的 bind mount 部署，需要确保宿主机上的 `uploads` 和 `data` 挂载目录对 `uid/gid 1000` 可写
-- 这同样适用于已有子目录，例如 `uploads/images-small`；如果它仍然归 `root` 所有，缩略图生成或扫描可能会因 `EACCES` 失败
+- 容器现在会先以 `root` 启动，仅用于协调 bind mount 权限，随后再以 `PUID:PGID` 启动后端进程（默认 `1000:1000`）
+- 如果你升级的是旧的 bind mount 部署，MyTube 会在启动时自动尝试修复 `uploads` 和 `data` 的 owner
+- 如果宿主机上的文件本来就归其他用户所有，请在 compose 文件或 `.env` 中把 `PUID` / `PGID` 设置成对应值
+- 这同样适用于已有子目录，例如 `uploads/images-small`；如果宿主机文件系统拒绝 `chown`，缩略图生成或扫描仍可能因 `EACCES` 失败
 
 宿主机上的修复示例：
 

--- a/documents/zh/docker-guide.md
+++ b/documents/zh/docker-guide.md
@@ -43,6 +43,11 @@ services:
       - mytube-network
     environment:
       - PORT=5551
+      # 可选：让后端进程使用与宿主机文件一致的 uid/gid。
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      # 可选：设为 0 可禁用启动时对 bind mount 的 chown 过程。
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
       # 可选：声明当前部署中管理员的信任边界。
       # 可选值：application | container | host
       - MYTUBE_ADMIN_TRUST_LEVEL=container
@@ -126,6 +131,9 @@ services:
       - "5551:5551"
     environment:
       - PORT=5551
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - MYTUBE_AUTO_FIX_PERMISSIONS=${MYTUBE_AUTO_FIX_PERMISSIONS:-1}
     volumes:
       - ./uploads:/app/uploads
       - ./data:/app/data
@@ -146,6 +154,16 @@ services:
 - `./data`: 存储 SQLite 数据库和日志。
 
 **重要提示：**  如果您移动  `docker-compose.yml`  文件，必须同时移动这些文件夹以保留您的数据。
+
+对于新部署，建议继续把 `uploads` 挂载到宿主机，但把 `/app/data` 改成 Docker named volume。SQLite 在这种模式下更稳妥，可以避开宿主机权限和 ACL 带来的兼容性问题。
+
+后端卷配置示例：
+
+```yaml
+    volumes:
+      - ./uploads:/app/uploads
+      - mytube-data:/app/data
+```
 
 ### 环境变量
 
@@ -168,11 +186,16 @@ MYTUBE_ADMIN_TRUST_LEVEL=container
 | 变量                | 服务     | 描述                                | 默认值                |
 | ------------------- | -------- | ----------------------------------- | --------------------- |
 | `PORT`              | Backend  | 后端内部监听端口                    | `5551`                |
+| `PUID`              | Backend  | 启动权限协调完成后，后端进程使用的 UID | `1000` |
+| `PGID`              | Backend  | 启动权限协调完成后，后端进程使用的 GID | `1000` |
+| `MYTUBE_AUTO_FIX_PERMISSIONS` | Backend | 是否在降权前自动对 bind mount 的 `data`/`uploads` 执行 chown | `1` |
 | `MYTUBE_ADMIN_TRUST_LEVEL` | Backend  | 部署声明的管理员信任边界（`application`、`container`、`host`） | `container` |
 | `VITE_API_URL`      | Frontend | API 端点路径                        | `/api`                |
 | `API_HOST`          | Frontend | **高级：**  强制指定后端 IP         | _(自动检测)_          |
 | `API_PORT`          | Frontend | **高级：**  强制指定后端端口        | `5551`                |
 | `NGINX_BACKEND_URL` | Frontend | **高级：**  覆盖 Nginx 后端上游 URL | `http://backend:5551` |
+
+后端容器现在会先以 root 启动，仅用于协调 bind mount 权限；随后会通过 `gosu` 以 `PUID:PGID` 启动 MyTube 主进程。
 
 ## 🛠️ 高级网络 (远程/NAS 部署)
 
@@ -232,12 +255,20 @@ MYTUBE_ADMIN_TRUST_LEVEL=container
 - **原因:**  浏览器无法访问后端 API。
 - **解决方法:**  确保端口  `5551`  在您的防火墙上已打开。如果在远程服务器上运行，请尝试按照“高级网络”部分的说明在  `.env`  文件中设置  `API_HOST`。
 
-### 2. `./uploads`  权限被拒绝 (Permission Denied)
+### 2. `./uploads` 或 `./data/mytube.db` 权限被拒绝 (Permission Denied)
 
-- **原因:** Docker 容器用户没有主机目录的写入权限。
-- **解决方法:**  调整主机上的权限：
+- **原因:** 后端进程使用的 uid/gid 与宿主机 bind mount 文件 owner 不一致，或者宿主机文件系统不允许容器内执行 `chown`。
+- **解决方法:**  先确认 `PUID` / `PGID` 是否与宿主机文件 owner 一致。默认值为 `1000:1000`，并且 MyTube 会在启动时自动尝试修复权限。
+
+- **解决方法:** 如果自动修复失败，请在宿主机上调整 owner：
   ```
-  chmod -R 777 ./uploads ./data
+  chown -R 1000:1000 ./uploads ./data
+  ```
+
+- **解决方法:** 如果这些文件本来就归其他 uid/gid 所有，请在 `.env` 或 `docker-compose.yml` 中设置匹配值：
+  ```
+  PUID=1001
+  PGID=1001
   ```
 
 ### 3. 容器名称冲突 (Container Name Conflicts)


### PR DESCRIPTION
…9.0 upgrade

The v1.9.0 switch to non-root `node` user broke existing bind-mount deployments where data/uploads directories were still owned by root.

- Add entrypoint.sh that starts as root, reconciles bind-mount ownership via PUID/PGID (default 1000:1000), then drops to non-root via gosu
- Add EACCES handling in db/index.ts with actionable error messages including uid/gid info and chown fix commands
- Add write-preflight check and SQLITE_READONLY wrapping in migrate.ts
- Add dynamic user/group creation for non-standard PUID/PGID values
- Update all docker-compose files with PUID/PGID/MYTUBE_AUTO_FIX_PERMISSIONS
- Update en/zh docs with new env vars, troubleshooting, and named volume advice

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
