### PR TITLE
Add retention policies for subscription downloads

### DIFF
--- a/backend/drizzle/0017_subscription_retention.sql
+++ b/backend/drizzle/0017_subscription_retention.sql
@@ -1,0 +1,1 @@
+ALTER TABLE subscriptions ADD COLUMN retention_days integer;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1774828800000,
       "tag": "0016_twitch_channel_subscriptions",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1776038400000,
+      "tag": "0017_subscription_retention",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -193,7 +193,28 @@ export const updateSubscription = async (
     );
   }
 
+  // retentionDays is optional; null means "disable retention"
+  let retentionDays: number | null | undefined = undefined;
+  if (Object.prototype.hasOwnProperty.call(req.body, "retentionDays")) {
+    const raw = req.body.retentionDays;
+    if (raw === null || raw === "") {
+      retentionDays = null;
+    } else {
+      const parsed = parsePositiveInteger(raw);
+      if (parsed === null) {
+        throw new ValidationError(
+          "retentionDays must be a positive integer or null",
+          "retentionDays"
+        );
+      }
+      retentionDays = parsed;
+    }
+  }
+
   await subscriptionService.updateSubscriptionInterval(id, parsedInterval);
+  if (retentionDays !== undefined) {
+    await subscriptionService.updateSubscriptionRetention(id, retentionDays);
+  }
   res.status(200).json(successMessage("Subscription updated"));
 };
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -151,6 +151,7 @@ export const subscriptions = sqliteTable("subscriptions", {
   twitchBroadcasterId: text("twitch_broadcaster_id"),
   twitchBroadcasterLogin: text("twitch_broadcaster_login"),
   lastTwitchVideoId: text("last_twitch_video_id"),
+  retentionDays: integer("retention_days"), // Auto-delete videos older than this many days (null = disabled)
 });
 
 // Track downloaded video IDs to prevent re-downloading

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import path from "path";
 import {
     AVATARS_DIR,
@@ -8,7 +8,7 @@ import {
     VIDEOS_DIR,
 } from "../../config/paths";
 import { db } from "../../db";
-import { videos } from "../../db/schema";
+import { downloadHistory, videos } from "../../db/schema";
 import { DatabaseError } from "../../errors/DownloadErrors";
 import { formatVideoFilename } from "../../utils/helpers";
 import { logger } from "../../utils/logger";
@@ -583,6 +583,12 @@ export function deleteVideo(id: string): boolean {
 
     // Mark video as deleted in download history
     markVideoDownloadDeleted(id);
+
+    // Mark any download history entries for this video as deleted
+    db.update(downloadHistory)
+      .set({ status: "deleted", deletedAt: Date.now() })
+      .where(and(eq(downloadHistory.videoId, id), eq(downloadHistory.status, "success")))
+      .run();
 
     // Delete from DB
     db.delete(videos).where(eq(videos.id, id)).run();

--- a/backend/src/services/subscriptionRetentionService.ts
+++ b/backend/src/services/subscriptionRetentionService.ts
@@ -1,0 +1,87 @@
+import { eq, and, isNotNull } from "drizzle-orm";
+import { db } from "../db";
+import { subscriptions, downloadHistory } from "../db/schema";
+import { logger } from "../utils/logger";
+import * as storageService from "./storageService";
+
+/**
+ * Runs once per hour. For each subscription that has retentionDays set,
+ * deletes any locally-stored video that was downloaded via that subscription
+ * and whose addedAt/createdAt date is older than retentionDays days.
+ */
+export async function runSubscriptionRetentionCleanup(): Promise<void> {
+  try {
+    // Get all subscriptions that have retention configured
+    const subsWithRetention = await db
+      .select()
+      .from(subscriptions)
+      .where(isNotNull(subscriptions.retentionDays));
+
+    if (subsWithRetention.length === 0) {
+      return;
+    }
+
+    logger.info(
+      `[RetentionCleanup] Checking ${subsWithRetention.length} subscription(s) with retention policy`
+    );
+
+    for (const sub of subsWithRetention) {
+      const retentionDays = sub.retentionDays;
+      if (!retentionDays || retentionDays <= 0) {
+        continue;
+      }
+
+      const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+      // Find all successful download history entries for this subscription
+      // where the video was downloaded before the cutoff
+      const historyEntries = await db
+        .select()
+        .from(downloadHistory)
+        .where(
+          and(
+            eq(downloadHistory.subscriptionId, sub.id),
+            eq(downloadHistory.status, "success")
+          )
+        );
+
+      for (const entry of historyEntries) {
+        // Use finishedAt as the "downloaded at" timestamp
+        const downloadedAt = entry.finishedAt;
+        if (!downloadedAt || downloadedAt > cutoffMs) {
+          continue;
+        }
+
+        if (!entry.videoId) {
+          continue;
+        }
+
+        // Check the video still exists in the DB
+        const videoRecord = storageService.getVideoById(entry.videoId);
+        if (!videoRecord) {
+          continue;
+        }
+
+        try {
+          const deleted = storageService.deleteVideo(entry.videoId);
+          if (deleted) {
+            logger.info(
+              `[RetentionCleanup] Deleted video "${videoRecord.title}" (id=${entry.videoId}) ` +
+              `from subscription "${sub.author}" (retentionDays=${retentionDays})`
+            );
+          }
+        } catch (err) {
+          logger.error(
+            `[RetentionCleanup] Failed to delete video ${entry.videoId}:`,
+            err instanceof Error ? err : new Error(String(err))
+          );
+        }
+      }
+    }
+  } catch (error) {
+    logger.error(
+      "[RetentionCleanup] Unexpected error during retention cleanup:",
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+}

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -114,6 +114,9 @@ export interface Subscription {
   twitchBroadcasterId?: string;
   twitchBroadcasterLogin?: string;
   lastTwitchVideoId?: string;
+
+  // Retention
+  retentionDays?: number | null; // Auto-delete videos older than this many days (null = disabled)
 }
 
 export class SubscriptionService {
@@ -679,6 +682,25 @@ export class SubscriptionService {
 
     logger.info(
       `Updated subscription ${updated[0].id} (${updated[0].author}) interval to ${interval} minutes`
+    );
+  }
+
+  async updateSubscriptionRetention(id: string, retentionDays: number | null): Promise<void> {
+    const updated = await db
+      .update(subscriptions)
+      .set({ retentionDays })
+      .where(eq(subscriptions.id, id))
+      .returning({
+        id: subscriptions.id,
+        author: subscriptions.author,
+      });
+
+    if (updated.length === 0) {
+      throw NotFoundError.subscription(id);
+    }
+
+    logger.info(
+      `Updated subscription ${updated[0].id} (${updated[0].author}) retention to ${retentionDays ?? "disabled"} days`
     );
   }
 
@@ -1317,6 +1339,16 @@ export class SubscriptionService {
       });
     });
     logger.info("Subscription scheduler started (node-cron).");
+
+    // Run retention cleanup once per hour
+    cron.schedule("0 * * * *", () => {
+      import("./subscriptionRetentionService").then(({ runSubscriptionRetentionCleanup }) =>
+        runSubscriptionRetentionCleanup()
+      ).catch((error) => {
+        logger.error("Subscription retention cleanup failed:", error);
+      });
+    });
+    logger.info("Subscription retention scheduler started (node-cron).");
   }
 
   // Helper to get latest video URL based on platform

--- a/frontend/src/pages/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage.tsx
@@ -44,6 +44,8 @@ interface Subscription {
     playlistTitle?: string;
     subscriptionType?: string; // 'author' or 'playlist'
     collectionId?: string;
+    // Retention
+    retentionDays?: number | null;
 }
 
 interface ContinuousDownloadTask {
@@ -101,6 +103,9 @@ const SubscriptionsPage: React.FC = () => {
     const [editingSubscriptionId, setEditingSubscriptionId] = useState<string | null>(null);
     const [editedInterval, setEditedInterval] = useState<string>('');
     const [isSavingInterval, setIsSavingInterval] = useState(false);
+    const [editingRetentionId, setEditingRetentionId] = useState<string | null>(null);
+    const [editedRetention, setEditedRetention] = useState<string>('');
+    const [isSavingRetention, setIsSavingRetention] = useState(false);
 
     // Use React Query for better caching and memory management
     const { data: subscriptions = [], refetch: refetchSubscriptions } = useQuery({
@@ -268,6 +273,77 @@ const SubscriptionsPage: React.FC = () => {
         }
     };
 
+    const handleStartEditingRetention = (subscription: Subscription) => {
+        setEditingRetentionId(subscription.id);
+        setEditedRetention(subscription.retentionDays != null ? String(subscription.retentionDays) : '');
+    };
+
+    const handleCancelEditingRetention = () => {
+        setEditingRetentionId(null);
+        setEditedRetention('');
+        setIsSavingRetention(false);
+    };
+
+    const handleSaveRetention = async (id: string, currentInterval: number) => {
+        setIsSavingRetention(true);
+        const retentionValue = editedRetention.trim() === '' ? null : parsePositiveInteger(editedRetention);
+        if (editedRetention.trim() !== '' && retentionValue === null) {
+            showSnackbar(t('retentionDaysUpdateFailed'));
+            setIsSavingRetention(false);
+            return;
+        }
+        try {
+            await api.put(`/subscriptions/${id}`, { interval: currentInterval, retentionDays: retentionValue });
+            showSnackbar(t('retentionDaysUpdated'));
+            await refetchSubscriptions();
+            handleCancelEditingRetention();
+        } catch (error) {
+            console.error('Error updating retention:', error);
+            showSnackbar(t('retentionDaysUpdateFailed'));
+            setIsSavingRetention(false);
+        }
+    };
+
+    const renderRetentionEditor = (subscriptionId: string, currentInterval: number) => (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
+            <TextField
+                value={editedRetention}
+                onChange={(e) => setEditedRetention(e.target.value)}
+                size="small"
+                type="number"
+                placeholder={t('retentionDaysNone')}
+                autoFocus
+                slotProps={{ htmlInput: { min: 1, step: 1, 'aria-label': t('retentionDays') } }}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter') void handleSaveRetention(subscriptionId, currentInterval);
+                    if (e.key === 'Escape') handleCancelEditingRetention();
+                }}
+                sx={{ width: 88 }}
+            />
+            <Typography variant="body2" color="text.secondary">
+                {t('retentionDaysLabel')}
+            </Typography>
+            <IconButton
+                size="small"
+                color="primary"
+                title={t('save')}
+                onClick={() => void handleSaveRetention(subscriptionId, currentInterval)}
+                disabled={isSavingRetention}
+            >
+                {isSavingRetention ? <CircularProgress size={18} /> : <Check fontSize="small" />}
+            </IconButton>
+            <IconButton
+                size="small"
+                color="inherit"
+                title={t('cancel')}
+                onClick={handleCancelEditingRetention}
+                disabled={isSavingRetention}
+            >
+                <Close fontSize="small" />
+            </IconButton>
+        </Box>
+    );
+
     const handlePauseTask = async (task: ContinuousDownloadTask) => {
         try {
             await api.put(`/subscriptions/tasks/${task.id}/pause`);
@@ -372,13 +448,14 @@ const SubscriptionsPage: React.FC = () => {
                                 </Box>
                             </TableCell>
                             <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>{t('downloads')}</TableCell>
+                            <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>{t('retentionDays')}</TableCell>
                             {!isVisitor && <TableCell align="right">{t('actions')}</TableCell>}
                         </TableRow>
                     </TableHead>
                     <TableBody>
                         {subscriptions.length === 0 ? (
                             <TableRow>
-                                <TableCell colSpan={isVisitor ? 5 : 6} align="center">
+                                <TableCell colSpan={isVisitor ? 6 : 7} align="center">
                                     <Typography color="text.secondary" sx={{ py: 4 }}>
                                         {t('noVideos')} {/* Reusing "No videos found" or similar if "No subscriptions" key missing */}
                                     </Typography>
@@ -387,6 +464,7 @@ const SubscriptionsPage: React.FC = () => {
                         ) : (
                             subscriptions.map((sub) => {
                                 const isEditingInterval = editingSubscriptionId === sub.id;
+                                const isEditingRetention = editingRetentionId === sub.id;
 
                                 return (
                                 <TableRow key={sub.id}>
@@ -411,6 +489,15 @@ const SubscriptionsPage: React.FC = () => {
                                                     </Typography>
                                                 )
                                             )}
+                                            {isMobileLayout && !isVisitor && (
+                                                isEditingRetention ? (
+                                                    renderRetentionEditor(sub.id, sub.interval)
+                                                ) : (
+                                                    <Typography variant="body2" color="text.secondary">
+                                                        {t('retentionDays')}: {sub.retentionDays != null ? `${sub.retentionDays}d` : t('retentionDaysNone')}
+                                                    </Typography>
+                                                )
+                                            )}
                                         </Box>
                                     </TableCell>
                                     <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>{sub.platform}</TableCell>
@@ -432,21 +519,38 @@ const SubscriptionsPage: React.FC = () => {
                                         </Box>
                                     </TableCell>
                                     <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>{sub.downloadCount}</TableCell>
+                                    <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>
+                                        {isEditingRetention && !isMobileLayout ? (
+                                            renderRetentionEditor(sub.id, sub.interval)
+                                        ) : (
+                                            sub.retentionDays != null
+                                                ? `${sub.retentionDays}d`
+                                                : <Typography variant="body2" color="text.secondary">{t('retentionDaysNone')}</Typography>
+                                        )}
+                                    </TableCell>
                                     {!isVisitor && (
                                         <TableCell align="right">
                                             <IconButton
                                                 color="primary"
                                                 onClick={() => handleStartEditingInterval(sub)}
                                                 title={t('editInterval')}
-                                                disabled={isEditingInterval || isSavingInterval}
+                                                disabled={isEditingInterval || isSavingInterval || isEditingRetention}
                                             >
                                                 <Edit />
+                                            </IconButton>
+                                            <IconButton
+                                                color="primary"
+                                                onClick={() => handleStartEditingRetention(sub)}
+                                                title={t('editRetention')}
+                                                disabled={isEditingRetention || isSavingRetention || isEditingInterval}
+                                            >
+                                                <DeleteOutline />
                                             </IconButton>
                                             <IconButton
                                                 color="error"
                                                 onClick={() => handleUnsubscribeClick(sub.id, sub.author, sub.subscriptionType)}
                                                 title={t('unsubscribe')}
-                                                disabled={isEditingInterval && isSavingInterval}
+                                                disabled={(isEditingInterval && isSavingInterval) || (isEditingRetention && isSavingRetention)}
                                             >
                                                 <Delete />
                                             </IconButton>

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -812,6 +812,15 @@ export const en = {
     "Are you sure you want to clear all finished tasks (completed, cancelled)? This will remove them from the list but will not delete any downloaded files.",
   clear: "Clear",
 
+  // Subscription Retention
+  retentionDays: "Auto-Delete After",
+  retentionDaysHelper: "Automatically delete downloaded videos older than this many days. Leave empty to disable.",
+  retentionDaysLabel: "days (empty = off)",
+  retentionDaysNone: "Off",
+  retentionDaysUpdated: "Retention policy updated",
+  retentionDaysUpdateFailed: "Failed to update retention policy",
+  editRetention: "Edit Auto-Delete",
+
   // Subscription Pause/Resume
   pause: "Pause",
   resume: "Resume",


### PR DESCRIPTION
## Summary
- add per-subscription retention settings for downloaded videos
- add scheduled cleanup for expired subscription downloads
- expose retention editing in the subscriptions UI and API

## Testing
- frontend production build via Docker image build
- no dedicated automated backend test suite run