### PR TITLE
[codex] Add Telegram notification for subscription downloads

### DIFF
--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -8,6 +8,7 @@ import { YtDlpDownloader } from '../../services/downloaders/YtDlpDownloader';
 import * as downloadService from '../../services/downloadService';
 import * as storageService from '../../services/storageService';
 import { subscriptionService } from '../../services/subscriptionService';
+import { TelegramService } from '../../services/telegramService';
 import { executeYtDlpJson } from '../../utils/ytDlpUtils';
 
 // Test setup
@@ -33,6 +34,11 @@ vi.mock('../../db/schema', () => ({
 
 vi.mock('../../services/downloadService');
 vi.mock('../../services/storageService');
+vi.mock('../../services/telegramService', () => ({
+  TelegramService: {
+    notifyTaskComplete: vi.fn().mockResolvedValue(undefined),
+  },
+}));
 vi.mock('../../services/subscriptionRetentionService', () => ({
   runSubscriptionRetentionCleanup: vi.fn().mockResolvedValue({}),
 }));
@@ -219,6 +225,11 @@ describe('SubscriptionService', () => {
       expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(expect.objectContaining({
         status: 'success'
       }));
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'New Video',
+        status: 'success',
+        sourceUrl: 'new-link',
+      });
       expect(db.update).toHaveBeenCalled();
     });
 
@@ -252,6 +263,11 @@ describe('SubscriptionService', () => {
 
       expect(YtDlpDownloader.getLatestShortsUrl).toHaveBeenCalled();
       expect(downloadService.downloadYouTubeVideo).toHaveBeenCalledWith('new-short');
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'New Short',
+        status: 'success',
+        sourceUrl: 'new-short',
+      });
       expect(db.update).toHaveBeenCalled();
     });
 
@@ -988,6 +1004,63 @@ describe('SubscriptionService', () => {
           error: 'download exploded',
         })
       );
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'Video from FailAuthor',
+        status: 'fail',
+        sourceUrl: 'https://www.youtube.com/watch?v=failed',
+        error: 'download exploded',
+      });
+    });
+
+    it('should wait for video marker update before Telegram success notification', async () => {
+      const sub = {
+        id: 'marker-failed-sub',
+        author: 'MarkerFailAuthor',
+        platform: 'YouTube',
+        authorUrl: 'https://www.youtube.com/@marker-fail',
+        interval: 1,
+        lastCheck: 0,
+        lastVideoLink: 'old-link',
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any, reject: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb); // listSubscriptions
+        if (callCount === 2) return Promise.resolve([{ id: sub.id }]).then(cb); // lock update
+        if (callCount === 3) {
+          return Promise.reject(new Error('marker update failed')).then(cb, reject);
+        }
+        return Promise.resolve([]).then(cb);
+      };
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue(
+        'https://www.youtube.com/watch?v=marker-failed'
+      );
+      (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+        videoData: { id: 'video-marker-failed', title: 'Marker Failed Video' },
+      });
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskTitle: 'Marker Failed Video',
+          status: 'success',
+        })
+      );
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'Marker Failed Video',
+        status: 'fail',
+        sourceUrl: 'https://www.youtube.com/watch?v=marker-failed',
+        error:
+          'Subscription processing failed after download: marker update failed',
+      });
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          sourceUrl: 'https://www.youtube.com/watch?v=marker-failed',
+        })
+      );
     });
 
     it('should record failed shorts history when short download throws non-Error', async () => {
@@ -1025,6 +1098,102 @@ describe('SubscriptionService', () => {
           sourceUrl: 'new-short-link',
         })
       );
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'Short from ShortAuthor',
+        status: 'fail',
+        sourceUrl: 'new-short-link',
+        error: 'Download failed',
+      });
+    });
+
+    it('should wait for shorts marker update before Telegram success notification', async () => {
+      const sub = {
+        id: 'short-marker-failed-sub',
+        author: 'ShortMarkerAuthor',
+        platform: 'YouTube',
+        authorUrl: 'https://www.youtube.com/@short-marker',
+        interval: 1,
+        lastCheck: 0,
+        lastVideoLink: 'same-link',
+        lastShortVideoLink: 'old-short',
+        downloadShorts: 1,
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any, reject: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb); // listSubscriptions
+        if (callCount === 2) return Promise.resolve([{ id: sub.id }]).then(cb); // lastCheck update
+        if (callCount === 3) return Promise.resolve([{ id: sub.id }]).then(cb); // short check select
+        if (callCount === 4) {
+          return Promise.reject(new Error('short marker update failed')).then(cb, reject);
+        }
+        return Promise.resolve([]).then(cb);
+      };
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue('same-link');
+      (YtDlpDownloader.getLatestShortsUrl as any).mockResolvedValue(
+        'new-short-marker-link'
+      );
+      (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+        videoData: { id: 'short-marker-video', title: 'Short Marker Video' },
+      });
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskTitle: 'Short Marker Video',
+          status: 'success',
+        })
+      );
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'Short Marker Video',
+        status: 'fail',
+        sourceUrl: 'new-short-marker-link',
+        error:
+          'Subscription processing failed after short download: short marker update failed',
+      });
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          sourceUrl: 'new-short-marker-link',
+        })
+      );
+    });
+
+    it('should skip shorts Telegram success when marker update affects no rows', async () => {
+      const sub = {
+        id: 'short-deleted-sub',
+        author: 'ShortDeletedAuthor',
+        platform: 'YouTube',
+        authorUrl: 'https://www.youtube.com/@short-deleted',
+        interval: 1,
+        lastCheck: 0,
+        lastVideoLink: 'same-link',
+        lastShortVideoLink: 'old-short',
+        downloadShorts: 1,
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb); // listSubscriptions
+        if (callCount === 2) return Promise.resolve([{ id: sub.id }]).then(cb); // lastCheck update
+        if (callCount === 3) return Promise.resolve([{ id: sub.id }]).then(cb); // short check select
+        if (callCount === 4) return Promise.resolve([]).then(cb); // short marker update
+        return Promise.resolve([]).then(cb);
+      };
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue('same-link');
+      (YtDlpDownloader.getLatestShortsUrl as any).mockResolvedValue(
+        'new-short-deleted-link'
+      );
+      (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+        videoData: { id: 'short-deleted-video', title: 'Short Deleted Video' },
+      });
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
     });
 
     it('should ignore shorts lookup exceptions and continue processing', async () => {

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -921,6 +921,49 @@ describe('SubscriptionService', () => {
       expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'success', sourceUrl: 'https://www.bilibili.com/video/BV1x' })
       );
+      expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+        taskTitle: 'Bili Video',
+        status: 'success',
+        sourceUrl: 'https://www.bilibili.com/video/BV1x',
+      });
+    });
+
+    it('should skip YouTube Telegram success when marker update affects no rows', async () => {
+      const sub = {
+        id: 'video-deleted-sub',
+        author: 'VideoDeletedAuthor',
+        platform: 'YouTube',
+        authorUrl: 'https://www.youtube.com/@video-deleted',
+        interval: 1,
+        lastCheck: 0,
+        lastVideoLink: 'old-link',
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb); // listSubscriptions
+        if (callCount === 2) return Promise.resolve([{ id: sub.id }]).then(cb); // lock update
+        if (callCount === 3) return Promise.resolve([]).then(cb); // marker update
+        return Promise.resolve([]).then(cb);
+      };
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue(
+        'https://www.youtube.com/watch?v=video-deleted'
+      );
+      (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+        videoData: { id: 'video-deleted', title: 'Video Deleted' },
+      });
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Video Deleted',
+          status: 'success',
+          sourceUrl: 'https://www.youtube.com/watch?v=video-deleted',
+        })
+      );
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
     });
 
     it('should tolerate collection add failures and continue playlist subscription processing', async () => {

--- a/backend/src/__tests__/services/subscriptionService.twitch.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.twitch.test.ts
@@ -4,6 +4,7 @@ import { downloadYouTubeVideo } from "../../services/downloadService";
 import { getTwitchChannelVideos } from "../../services/downloaders/ytdlp/ytdlpTwitch";
 import * as storageService from "../../services/storageService";
 import { subscriptionService } from "../../services/subscriptionService";
+import { TelegramService } from "../../services/telegramService";
 import { twitchApiService } from "../../services/twitchService";
 
 vi.mock("../../db", () => ({
@@ -29,6 +30,12 @@ vi.mock("../../services/downloadService", () => ({
 vi.mock("../../services/storageService", () => ({
   addDownloadHistoryItem: vi.fn(),
   checkVideoDownloadBySourceId: vi.fn(),
+}));
+
+vi.mock("../../services/telegramService", () => ({
+  TelegramService: {
+    notifyTaskComplete: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock("../../services/twitchService", () => ({
@@ -234,8 +241,8 @@ describe("SubscriptionService Twitch support", () => {
     const lockBuilder = createMockBuilder([{ id: sub.id }]);
     const channelRefreshBuilder = createMockBuilder([]);
     const existingMarkerBuilder = createMockBuilder([]);
-    const firstDownloadMarkerBuilder = createMockBuilder([]);
-    const secondDownloadMarkerBuilder = createMockBuilder([]);
+    const firstDownloadMarkerBuilder = createMockBuilder([{ id: sub.id }]);
+    const secondDownloadMarkerBuilder = createMockBuilder([{ id: sub.id }]);
     const updateBuilders = [
       lockBuilder,
       channelRefreshBuilder,
@@ -350,6 +357,16 @@ describe("SubscriptionService Twitch support", () => {
       "https://www.twitch.tv/videos/1004"
     );
     expect(storageService.addDownloadHistoryItem).toHaveBeenCalledTimes(2);
+    expect(TelegramService.notifyTaskComplete).toHaveBeenNthCalledWith(1, {
+      taskTitle: "Middle",
+      status: "success",
+      sourceUrl: "https://www.twitch.tv/videos/1003",
+    });
+    expect(TelegramService.notifyTaskComplete).toHaveBeenNthCalledWith(2, {
+      taskTitle: "Newest",
+      status: "success",
+      sourceUrl: "https://www.twitch.tv/videos/1004",
+    });
     expect(lockBuilder.set).toHaveBeenCalledWith(
       expect.objectContaining({
         lastCheck: expect.any(Number),
@@ -377,6 +394,140 @@ describe("SubscriptionService Twitch support", () => {
     });
   });
 
+  it("notifies Telegram when Twitch subscription downloads fail", async () => {
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+    vi.mocked(downloadYouTubeVideo).mockRejectedValueOnce(
+      new Error("twitch download failed")
+    );
+
+    await (subscriptionService as any).processTwitchSubscriptionVideos(
+      {
+        id: "sub-twitch-failed",
+        author: "Some Channel",
+        lastVideoLink: "",
+        downloadCount: 0,
+      },
+      [
+        {
+          id: "archive-failed",
+          url: "https://www.twitch.tv/videos/failed",
+          title: "Failed Twitch",
+          authorName: "Some Channel",
+        },
+      ]
+    );
+
+    expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Failed Twitch",
+        status: "failed",
+        sourceUrl: "https://www.twitch.tv/videos/failed",
+        error: "twitch download failed",
+      })
+    );
+    expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+      taskTitle: "Failed Twitch",
+      status: "fail",
+      sourceUrl: "https://www.twitch.tv/videos/failed",
+      error: "twitch download failed",
+    });
+  });
+
+  it("waits for Twitch marker updates before Telegram success notification", async () => {
+    const failingUpdateBuilder = createMockBuilder([]);
+    failingUpdateBuilder.then = (resolve: any, reject: any) =>
+      Promise.reject(new Error("twitch marker update failed")).then(
+        resolve,
+        reject
+      );
+
+    (db.update as any).mockReturnValue(failingUpdateBuilder);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+    vi.mocked(downloadYouTubeVideo).mockResolvedValueOnce({
+      videoData: {
+        id: "video-twitch-marker-failed",
+        title: "Twitch Marker Video",
+        author: "Some Channel",
+      },
+    } as any);
+
+    await (subscriptionService as any).processTwitchSubscriptionVideos(
+      {
+        id: "sub-twitch-marker-failed",
+        author: "Some Channel",
+        lastVideoLink: "",
+        downloadCount: 0,
+      },
+      [
+        {
+          id: "archive-marker-failed",
+          url: "https://www.twitch.tv/videos/marker-failed",
+          title: "Twitch Marker",
+          authorName: "Some Channel",
+        },
+      ]
+    );
+
+    expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskTitle: "Twitch Marker Video",
+        status: "success",
+      })
+    );
+    expect(TelegramService.notifyTaskComplete).toHaveBeenCalledWith({
+      taskTitle: "Twitch Marker Video",
+      status: "fail",
+      sourceUrl: "https://www.twitch.tv/videos/marker-failed",
+      error:
+        "Subscription processing failed after download: twitch marker update failed",
+    });
+    expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        sourceUrl: "https://www.twitch.tv/videos/marker-failed",
+      })
+    );
+  });
+
+  it("skips Twitch Telegram success when marker update affects no rows", async () => {
+    const deletedUpdateBuilder = createMockBuilder([]);
+
+    (db.update as any).mockReturnValue(deletedUpdateBuilder);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+    vi.mocked(downloadYouTubeVideo).mockResolvedValueOnce({
+      videoData: {
+        id: "video-twitch-deleted",
+        title: "Twitch Deleted Video",
+        author: "Some Channel",
+      },
+    } as any);
+
+    await (subscriptionService as any).processTwitchSubscriptionVideos(
+      {
+        id: "sub-twitch-deleted",
+        author: "Some Channel",
+        lastVideoLink: "",
+        downloadCount: 0,
+      },
+      [
+        {
+          id: "archive-deleted",
+          url: "https://www.twitch.tv/videos/deleted",
+          title: "Twitch Deleted",
+          authorName: "Some Channel",
+        },
+      ]
+    );
+
+    expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
+  });
+
   it("falls back to yt-dlp polling when Helix requests fail for configured Twitch subscriptions", async () => {
     const sub = {
       id: "sub-twitch-api-fallback",
@@ -398,7 +549,7 @@ describe("SubscriptionService Twitch support", () => {
     const lockBuilder = createMockBuilder([{ id: sub.id }]);
     const channelRefreshBuilder = createMockBuilder([]);
     const existingMarkerBuilder = createMockBuilder([]);
-    const downloadMarkerBuilder = createMockBuilder([]);
+    const downloadMarkerBuilder = createMockBuilder([{ id: sub.id }]);
     const updateBuilders = [
       lockBuilder,
       channelRefreshBuilder,
@@ -512,8 +663,8 @@ describe("SubscriptionService Twitch support", () => {
     const lockBuilder = createMockBuilder([{ id: sub.id }]);
     const channelRefreshBuilder = createMockBuilder([]);
     const existingMarkerBuilder = createMockBuilder([]);
-    const firstDownloadMarkerBuilder = createMockBuilder([]);
-    const secondDownloadMarkerBuilder = createMockBuilder([]);
+    const firstDownloadMarkerBuilder = createMockBuilder([{ id: sub.id }]);
+    const secondDownloadMarkerBuilder = createMockBuilder([{ id: sub.id }]);
     const updateBuilders = [
       lockBuilder,
       channelRefreshBuilder,

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -30,6 +30,7 @@ import {
 import { YtDlpDownloader } from "./downloaders/YtDlpDownloader";
 import * as storageService from "./storageService";
 import { runSubscriptionRetentionCleanup } from "./subscriptionRetentionService";
+import { TelegramService } from "./telegramService";
 import { TwitchVideoInfo, twitchApiService } from "./twitchService";
 
 const MAX_TWITCH_SUBSCRIPTION_PAGES_PER_CHECK = 5;
@@ -86,6 +87,35 @@ function shouldFallbackToTwitchYtDlp(error: unknown): boolean {
     error instanceof Error &&
     error.message.includes("Twitch API is temporarily rate limited")
   );
+}
+
+function notifySubscriptionDownloadResult(context: {
+  taskTitle: string;
+  status: "success" | "fail";
+  sourceUrl?: string;
+  error?: string;
+}): void {
+  void TelegramService.notifyTaskComplete(context).catch((error) => {
+    logger.error(
+      "Subscription Telegram notification failed:",
+      error instanceof Error ? error : new Error(String(error))
+    );
+  });
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (error && typeof error === "object") {
+    const maybeError = error as { message?: unknown };
+    if (typeof maybeError.message === "string") {
+      return maybeError.message;
+    }
+  }
+
+  return fallback;
 }
 
 export interface Subscription {
@@ -793,6 +823,8 @@ export class SubscriptionService {
 
               // 3. Download the video
               let downloadResult: any;
+              let videoDownloaded = false;
+              let downloadedVideoTitle = `New video from ${sub.author}`;
               try {
                 if (sub.platform === "Bilibili") {
                   downloadResult = await downloadSingleBilibiliPart(
@@ -808,9 +840,12 @@ export class SubscriptionService {
                 // Add to download history on success
                 const videoData =
                   downloadResult?.videoData || downloadResult || {};
+                downloadedVideoTitle =
+                  videoData.title || `New video from ${sub.author}`;
+                videoDownloaded = true;
                 storageService.addDownloadHistoryItem({
                   id: uuidv4(),
-                  title: videoData.title || `New video from ${sub.author}`,
+                  title: downloadedVideoTitle,
                   author: videoData.author || sub.author,
                   sourceUrl: latestVideoUrl,
                   finishedAt: Date.now(),
@@ -856,15 +891,46 @@ export class SubscriptionService {
                   );
                   continue;
                 } else {
+                  notifySubscriptionDownloadResult({
+                    taskTitle: downloadedVideoTitle,
+                    status: "success",
+                    sourceUrl: latestVideoUrl,
+                  });
                   logger.debug(
                     `Successfully processed subscription ${sub.id} (${sub.author})`
                   );
                 }
               } catch (downloadError: any) {
+                const errorMessage = getErrorMessage(
+                  downloadError,
+                  "Download failed"
+                );
+
+                if (videoDownloaded) {
+                  logger.error(
+                    `Error updating subscription after video download for ${sub.author}:`,
+                    downloadError
+                  );
+
+                  notifySubscriptionDownloadResult({
+                    taskTitle: downloadedVideoTitle,
+                    status: "fail",
+                    sourceUrl: latestVideoUrl,
+                    error: `Subscription processing failed after download: ${errorMessage}`,
+                  });
+                  continue;
+                }
+
                 logger.error(
                   `Error downloading subscription video for ${sub.author}:`,
                   downloadError
                 );
+                notifySubscriptionDownloadResult({
+                  taskTitle: `Video from ${sub.author}`,
+                  status: "fail",
+                  sourceUrl: latestVideoUrl,
+                  error: errorMessage,
+                });
 
                 // Add to download history on failure
                 storageService.addDownloadHistoryItem({
@@ -874,7 +940,7 @@ export class SubscriptionService {
                   sourceUrl: latestVideoUrl,
                   finishedAt: Date.now(),
                   status: "failed",
-                  error: downloadError.message || "Download failed",
+                  error: errorMessage,
                   subscriptionId: sub.id,
                 });
 
@@ -923,6 +989,8 @@ export class SubscriptionService {
                 );
 
                 // Download the short
+                let shortDownloaded = false;
+                let downloadedShortTitle = `New short from ${sub.author}`;
                 try {
                   const downloadResult = await downloadYouTubeVideo(
                     latestShortUrl
@@ -931,9 +999,12 @@ export class SubscriptionService {
                   // Add to download history on success
                   const videoData =
                     downloadResult?.videoData || downloadResult || {};
+                  downloadedShortTitle =
+                    videoData.title || `New short from ${sub.author}`;
+                  shortDownloaded = true;
                   storageService.addDownloadHistoryItem({
                     id: uuidv4(),
-                    title: videoData.title || `New short from ${sub.author}`,
+                    title: downloadedShortTitle,
                     author: videoData.author || sub.author,
                     sourceUrl: latestShortUrl,
                     finishedAt: Date.now(),
@@ -945,22 +1016,61 @@ export class SubscriptionService {
                   });
 
                   // Update subscription record with new short link
-                  await db
+                  const shortUpdateResult = await db
                     .update(subscriptions)
                     .set({
                       lastShortVideoLink: latestShortUrl,
                       downloadCount: (sub.downloadCount || 0) + 1,
                     })
-                    .where(eq(subscriptions.id, sub.id));
+                    .where(eq(subscriptions.id, sub.id))
+                    .returning({ id: subscriptions.id });
+
+                  if (shortUpdateResult.length === 0) {
+                    logger.warn(
+                      `Subscription ${sub.id} (${sub.author}) was deleted after short download completed`
+                    );
+                    continue;
+                  }
+
+                  notifySubscriptionDownloadResult({
+                    taskTitle: downloadedShortTitle,
+                    status: "success",
+                    sourceUrl: latestShortUrl,
+                  });
 
                   logger.debug(
                     `Successfully processed short for ${sub.author}: ${latestShortUrl}`
                   );
                 } catch (downloadError: unknown) {
                   logger.error(
-                    `Error downloading subscription short for ${sub.author}:`,
-                    downloadError instanceof Error ? downloadError : new Error(String(downloadError))
+                    shortDownloaded
+                      ? `Error updating subscription after short download for ${sub.author}:`
+                      : `Error downloading subscription short for ${sub.author}:`,
+                    downloadError instanceof Error
+                      ? downloadError
+                      : new Error(String(downloadError))
                   );
+
+                  const errorMessage = getErrorMessage(
+                    downloadError,
+                    "Download failed"
+                  );
+                  if (shortDownloaded) {
+                    notifySubscriptionDownloadResult({
+                      taskTitle: downloadedShortTitle,
+                      status: "fail",
+                      sourceUrl: latestShortUrl,
+                      error: `Subscription processing failed after short download: ${errorMessage}`,
+                    });
+                    continue;
+                  }
+
+                  notifySubscriptionDownloadResult({
+                    taskTitle: `Short from ${sub.author}`,
+                    status: "fail",
+                    sourceUrl: latestShortUrl,
+                    error: errorMessage,
+                  });
 
                   storageService.addDownloadHistoryItem({
                     id: uuidv4(),
@@ -969,7 +1079,7 @@ export class SubscriptionService {
                     sourceUrl: latestShortUrl,
                     finishedAt: Date.now(),
                     status: "failed",
-                    error: downloadError instanceof Error ? downloadError.message : "Download failed",
+                    error: errorMessage,
                     subscriptionId: sub.id,
                   });
                 }
@@ -1271,13 +1381,17 @@ export class SubscriptionService {
         continue;
       }
 
+      let twitchVideoDownloaded = false;
+      let downloadedTwitchTitle = video.title || `Video from ${sub.author}`;
       try {
         const downloadResult = await downloadYouTubeVideo(video.url);
         const videoData = downloadResult?.videoData || downloadResult || {};
+        downloadedTwitchTitle = videoData.title || video.title;
+        twitchVideoDownloaded = true;
 
         storageService.addDownloadHistoryItem({
           id: uuidv4(),
-          title: videoData.title || video.title,
+          title: downloadedTwitchTitle,
           author: videoData.author || video.authorName || sub.author,
           sourceUrl: video.url,
           finishedAt: Date.now(),
@@ -1292,20 +1406,53 @@ export class SubscriptionService {
         currentLastVideoLink = video.url;
         currentDownloadCount += 1;
 
-        await db
+        const updateResult = await db
           .update(subscriptions)
           .set({
             lastTwitchVideoId: currentLastTwitchVideoId,
             lastVideoLink: currentLastVideoLink,
             downloadCount: currentDownloadCount,
           })
-          .where(eq(subscriptions.id, sub.id));
+          .where(eq(subscriptions.id, sub.id))
+          .returning({ id: subscriptions.id });
+
+        if (updateResult.length === 0) {
+          logger.warn(
+            `Twitch subscription ${sub.id} (${sub.author}) was deleted after download completed`
+          );
+          break;
+        }
+
+        notifySubscriptionDownloadResult({
+          taskTitle: downloadedTwitchTitle,
+          status: "success",
+          sourceUrl: video.url,
+        });
       } catch (downloadError: any) {
+        const errorMessage = getErrorMessage(
+          downloadError,
+          "Download failed"
+        );
+
+        if (twitchVideoDownloaded) {
+          logger.error(
+            `Error updating Twitch subscription after video download for ${sub.author}:`,
+            downloadError
+          );
+
+          notifySubscriptionDownloadResult({
+            taskTitle: downloadedTwitchTitle,
+            status: "fail",
+            sourceUrl: video.url,
+            error: `Subscription processing failed after download: ${errorMessage}`,
+          });
+          break;
+        }
+
         logger.error(
           `Error downloading Twitch subscription video for ${sub.author}:`,
           downloadError
         );
-
         storageService.addDownloadHistoryItem({
           id: uuidv4(),
           title: video.title || `Video from ${sub.author}`,
@@ -1313,8 +1460,14 @@ export class SubscriptionService {
           sourceUrl: video.url,
           finishedAt: Date.now(),
           status: "failed",
-          error: downloadError?.message || "Download failed",
+          error: errorMessage,
           subscriptionId: sub.id,
+        });
+        notifySubscriptionDownloadResult({
+          taskTitle: video.title || `Video from ${sub.author}`,
+          status: "fail",
+          sourceUrl: video.url,
+          error: errorMessage,
         });
         break;
       }


### PR DESCRIPTION
## Summary

Adds Telegram completion notifications for subscription-triggered downloads across YouTube/Bilibili, YouTube Shorts, and Twitch subscription flows.

## Details

- Sends Telegram success notifications after a subscription download is recorded and the subscription marker update succeeds.
- Sends Telegram failure notifications when subscription downloads fail.
- Avoids false success notifications when marker updates fail or the subscription row is deleted after a download.
- Adds test coverage for normal downloads, Shorts, Twitch downloads, failed downloads, and marker-update failure cases.

## Validation

- `npm test -- subscriptionService.test.ts subscriptionService.twitch.test.ts`
- `npm run build`