### PR TITLE
fix code scanning csrf: mount globally instead of on /api

### DIFF
--- a/backend/src/__tests__/middleware/csrfMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/csrfMiddleware.test.ts
@@ -30,7 +30,7 @@ describe("csrfMiddleware", () => {
     const app = express();
     app.use(cookieParser());
     app.use(express.json());
-    app.use("/api", doubleCsrfProtection);
+    app.use(doubleCsrfProtection);
     app.use(csrfTokenProvider);
 
     app.get("/api/token", (_req, res) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -58,7 +58,7 @@ app.use(rssManagementNoStoreHeaders);
 app.use("/api/statistics/events", statisticsEventsJsonParser);
 app.use(express.json({ limit: "100gb" }));
 app.use(express.urlencoded({ extended: true, limit: "100gb" }));
-app.use("/api", doubleCsrfProtection);
+app.use(doubleCsrfProtection);
 app.use(csrfTokenProvider);
 
 const configureProcessCrashReports = (): void => {


### PR DESCRIPTION
CodeQL's js/missing-token-validation rule treats the cookie-parser -> CSRF middleware -> handler flow as broken when the CSRF middleware is mounted on a sub-path while cookie-parser is global. Restoring the unprefixed mount lets CodeQL see global coverage. Behavior is unchanged since GET/HEAD/OPTIONS are exempt via ignoredMethods and no mutating endpoints live outside /api.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
