### PR TITLE
[codex] Fix Telegram text download queueing

### DIFF
--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -233,6 +233,33 @@ describe("videoDownloadController extra coverage", () => {
     ).rejects.toBeInstanceOf(ValidationError);
   });
 
+  it("checkVideoDownloadStatus validates the URL extracted from Telegram-style text", async () => {
+    req.query = {
+      url: "Shared from Telegram: https://youtube.com/watch?v=status123",
+    } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://youtube.com/watch?v=status123",
+      sourceVideoId: "status123",
+      platform: "youtube",
+    } as any);
+    vi.mocked(validateUrl).mockImplementation((candidate: string) => {
+      if (candidate.startsWith("Shared from Telegram")) {
+        throw new Error("raw text should not be validated");
+      }
+      return candidate;
+    });
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(validateUrl).toHaveBeenCalledWith(
+      "https://youtube.com/watch?v=status123"
+    );
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
   it("checkVideoDownloadStatus throws when url is missing", async () => {
     req.query = {} as any;
 
@@ -376,6 +403,51 @@ describe("videoDownloadController extra coverage", () => {
       success: false,
       error: "validation failed",
     });
+  });
+
+  it("downloadVideo queues the URL extracted from Telegram-style text", async () => {
+    req.body = {
+      youtubeUrl: "Shared from Telegram: https://youtube.com/watch?v=tele123",
+    };
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://youtube.com/watch?v=tele123",
+      sourceVideoId: "tele123",
+      platform: "youtube",
+    } as any);
+    vi.mocked(validateUrl).mockImplementation((candidate: string) => {
+      if (candidate.startsWith("Shared from Telegram")) {
+        throw new Error("raw text should not be validated");
+      }
+      return candidate;
+    });
+    vi.mocked(isYouTubeUrl).mockReturnValue(true);
+    vi.mocked(downloadService.downloadYouTubeVideo).mockResolvedValue({
+      id: "video-telegram",
+      title: "Telegram Video",
+      sourceUrl: "https://youtube.com/watch?v=tele123",
+    } as any);
+
+    await downloadVideo(req as Request, res as Response);
+    await flushBackgroundTasks();
+
+    expect(validateUrl).toHaveBeenCalledWith(
+      "https://youtube.com/watch?v=tele123"
+    );
+    expect(downloadManager.addDownload).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(String),
+      "YouTube Video",
+      "https://youtube.com/watch?v=tele123",
+      "youtube",
+      expect.objectContaining({
+        actorRole: "admin",
+        surface: "web",
+        sourceKind: "manual",
+      })
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, message: "Download queued" })
+    );
   });
 
   it("downloadVideo skips already-downloaded items when handler says skip", async () => {

--- a/backend/src/__tests__/controllers/videoDownloadController.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.test.ts
@@ -42,7 +42,11 @@ describe('videoDownloadController', () => {
             mockReq.query = { url: mockUrl };
             (helpers.trimBilibiliUrl as any).mockReturnValue(mockUrl);
             (helpers.isValidUrl as any).mockReturnValue(true);
-            (helpers.processVideoUrl as any).mockResolvedValue({ sourceVideoId: '123' });
+            (helpers.processVideoUrl as any).mockResolvedValue({
+                videoUrl: mockUrl,
+                sourceVideoId: '123',
+                platform: 'youtube',
+            });
             (storageService.checkVideoDownloadBySourceId as any).mockReturnValue({ found: true, status: 'exists', videoId: '123' });
             (storageService.verifyVideoExists as any).mockReturnValue({ exists: true, video: { id: '123', title: 'Existing Video' } });
 
@@ -60,7 +64,11 @@ describe('videoDownloadController', () => {
              mockReq.query = { url: mockUrl };
              (helpers.trimBilibiliUrl as any).mockReturnValue(mockUrl);
              (helpers.isValidUrl as any).mockReturnValue(true);
-             (helpers.processVideoUrl as any).mockResolvedValue({ sourceVideoId: '123' });
+             (helpers.processVideoUrl as any).mockResolvedValue({
+                 videoUrl: mockUrl,
+                 sourceVideoId: '123',
+                 platform: 'youtube',
+             });
              (storageService.checkVideoDownloadBySourceId as any).mockReturnValue({ found: false });
 
              await videoDownloadController.checkVideoDownloadStatus(mockReq as Request, mockRes as Response);

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -74,19 +74,19 @@ export const checkVideoDownloadStatus = async (
     throw new ValidationError("URL is required", "url");
   }
 
-  // Validate URL to prevent SSRF attacks
-  let validatedUrl: string;
+  // Process URL: extract from text, resolve shortened URLs, extract source video ID
+  const { videoUrl, sourceVideoId, platform } = await processVideoUrl(url);
+
+  // Validate the extracted URL to prevent SSRF attacks while allowing
+  // Telegram/share text that includes a title plus the actual URL.
   try {
-    validatedUrl = validateUrl(url);
+    validateUrl(videoUrl);
   } catch (error) {
     throw new ValidationError(
       error instanceof Error ? error.message : "Invalid URL format",
       "url",
     );
   }
-
-  // Process URL: extract from text, resolve shortened URLs, extract source video ID
-  const { sourceVideoId, platform } = await processVideoUrl(validatedUrl);
 
   if (!sourceVideoId) {
     // Return object directly for backward compatibility (frontend expects response.data.found)
@@ -194,10 +194,19 @@ export const downloadVideo = async (
         ? statisticsContext.relatedEventId
         : null;
 
-    // Validate URL to prevent SSRF attacks before processing
+    // Process URL: extract from text, resolve shortened URLs, extract source video ID
+    const {
+      videoUrl: processedUrl,
+      sourceVideoId,
+      platform,
+    } = await processVideoUrl(videoUrl);
+    logger.info("Processed URL:", processedUrl);
+
+    // Validate the extracted URL to prevent SSRF attacks while accepting
+    // Telegram/share text that includes surrounding title or commentary.
     let validatedVideoUrl: string;
     try {
-      validatedVideoUrl = validateUrl(videoUrl);
+      validatedVideoUrl = validateUrl(processedUrl);
     } catch (error) {
       return sendBadRequest(
         res,
@@ -205,22 +214,14 @@ export const downloadVideo = async (
       );
     }
 
-    // Process URL: extract from text, resolve shortened URLs, extract source video ID
-    const {
-      videoUrl: processedUrl,
-      sourceVideoId,
-      platform,
-    } = await processVideoUrl(validatedVideoUrl);
-    logger.info("Processed URL:", processedUrl);
-
     // Check if the input is a valid URL
-    if (!isValidUrl(processedUrl)) {
+    if (!isValidUrl(validatedVideoUrl)) {
       // If not a valid URL, treat it as a search term
       return sendBadRequest(res, "Not a valid URL");
     }
 
     // Use processed URL as resolved URL
-    const resolvedUrl = processedUrl;
+    const resolvedUrl = validatedVideoUrl;
     logger.info("Resolved URL to:", resolvedUrl);
     // Check if video was previously downloaded (skip for collections/multi-part)
     if (sourceVideoId && !downloadAllParts && !downloadCollection) {


### PR DESCRIPTION
## What changed

- Extract the actual URL from download and download-status inputs before validating it.
- Keep SSRF URL validation on the extracted/resolved URL before queueing downloads.
- Add regression coverage for Telegram-style text that contains a title/comment plus a link.

## Why

Telegram/share flows can submit message text around the URL. The backend previously validated the raw message before URL extraction, so the request could be rejected before `downloadManager.addDownload` persisted an active/queued download. With no download row, the Manage Downloads page had nothing to show.

## Validation

- `cd backend && npm test -- --run src/__tests__/controllers/videoDownloadController.test.ts src/__tests__/controllers/videoDownloadController.extra.test.ts`
- `cd backend && npm run build`
- `cd backend && npm test -- --run`
- `npm run build`