### PR TITLE
fix: enforce UTF-8 byte limits for filename template paths

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,10 +1,4 @@
-runtimes:
-    - java@17.0.10
-    - node@22.2.0
-    - python@3.11.11
 tools:
-    - eslint@9.39.4
-    - opengrep@1.21.0
-    - pmd@6.55.0
     - pylint@4.0.5
     - trivy@0.70.0
+    - eslint@9.39.4

--- a/backend/src/__tests__/services/filenameTemplate/renderer.test.ts
+++ b/backend/src/__tests__/services/filenameTemplate/renderer.test.ts
@@ -21,6 +21,10 @@ import {
 } from "../../../services/filenameTemplate/renderer";
 import { FilenameTemplateContext } from "../../../services/filenameTemplate/types";
 
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
 function makeCtx(overrides: Partial<FilenameTemplateContext> = {}): FilenameTemplateContext {
   return {
     title: "My Video",
@@ -503,7 +507,7 @@ describe("renderFilenameTemplate — sanitization & errors", () => {
     expect(result.directory).toBe("");
   });
 
-  it("keeps a long path within the per-segment limit (180 chars per segment)", () => {
+  it("keeps a long path within the per-segment limit (180 bytes per segment)", () => {
     const longTitle = "x".repeat(300);
     const result = renderFilenameTemplate({
       template: "dir/{{ title }}.{{ ext }}",
@@ -515,6 +519,56 @@ describe("renderFilenameTemplate — sanitization & errors", () => {
     for (const segment of result.relativePath.split("/")) {
       expect(segment.length).toBeLessThanOrEqual(180);
     }
+  });
+
+  it("preserves the real video extension for long multi-byte template filenames", () => {
+    const longTitle =
+      "示例標題 foo bar baz qux quux corge grault garply waldo fred plugh xyzzy thud lorem ipsum dolor sit amet";
+    const result = renderFilenameTemplate({
+      template: "{{ source_collection_name }}/Season 1/s01e20260101 - {{ title }}.{{ ext }}",
+      context: makeCtx({
+        title: longTitle,
+        sourceCollectionName: "Foo Channel",
+        sourceCollectionType: "series",
+      }),
+      extension: "webm",
+      mode: "video",
+    });
+
+    expect(result.basename.endsWith(".webm")).toBe(true);
+    expect(result.extension).toBe("webm");
+    expect(utf8ByteLength(result.basename)).toBeLessThanOrEqual(180);
+  });
+});
+
+describe("planVideoOutputPaths — long filename handling", () => {
+  it("keeps the video filename extension for long multi-byte template filenames", () => {
+    const longTitle =
+      "示例標題 foo bar baz qux quux corge grault garply waldo fred plugh xyzzy thud lorem ipsum dolor sit amet";
+    const result = planVideoOutputPaths({
+      settings: {
+        downloadFilenamePresetId: "custom",
+        downloadFilenameTemplate:
+          "{{ source_collection_name }}/Season 1/s01e20260101 - {{ title }}.{{ ext }}",
+      },
+      context: makeCtx({
+        title: longTitle,
+        sourceCollectionName: "Foo Channel",
+        sourceCollectionType: "series",
+      }),
+      videoExtension: "webm",
+      moveThumbnailsToVideoFolder: false,
+      moveSubtitlesToVideoFolder: false,
+    });
+
+    expect(result.video.filename.endsWith(".webm")).toBe(true);
+    expect(result.video.relativePath).toContain(".webm");
+    expect(result.subtitle.baseNameWithoutLanguageOrExt).toBe(
+      result.video.filename.slice(0, -".webm".length)
+    );
+    expect(
+      utf8ByteLength(`${result.video.filename.replace(/\.webm$/, "")}.en-US.vtt.part`)
+    ).toBeLessThan(255);
   });
 });
 

--- a/backend/src/__tests__/services/filenameTemplate/renderer.test.ts
+++ b/backend/src/__tests__/services/filenameTemplate/renderer.test.ts
@@ -529,7 +529,7 @@ describe("renderFilenameTemplate — sanitization & errors", () => {
       context: makeCtx({
         title: longTitle,
         sourceCollectionName: "Foo Channel",
-        sourceCollectionType: "series",
+        sourceCollectionType: "playlist",
       }),
       extension: "webm",
       mode: "video",
@@ -554,7 +554,7 @@ describe("planVideoOutputPaths — long filename handling", () => {
       context: makeCtx({
         title: longTitle,
         sourceCollectionName: "Foo Channel",
-        sourceCollectionType: "series",
+        sourceCollectionType: "playlist",
       }),
       videoExtension: "webm",
       moveThumbnailsToVideoFolder: false,

--- a/backend/src/__tests__/services/filenameTemplate/sanitize.test.ts
+++ b/backend/src/__tests__/services/filenameTemplate/sanitize.test.ts
@@ -149,6 +149,16 @@ describe("enforcePathLengthLimit", () => {
     expect(result[result.length - 1].endsWith(".mp4")).toBe(true);
   });
 
+  it("keeps a non-empty stem when the remaining byte budget cannot fit a multibyte char", () => {
+    const result = enforcePathLengthLimit([
+      "a".repeat(117),
+      "b".repeat(116),
+      "你.mp4",
+    ]);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+    expect(result[result.length - 1]).toBe("x.mp4");
+  });
+
   it("does not truncate a valid path that exceeds only the old headroom-reduced budget", () => {
     const segments = [
       "A".repeat(50),

--- a/backend/src/__tests__/services/filenameTemplate/sanitize.test.ts
+++ b/backend/src/__tests__/services/filenameTemplate/sanitize.test.ts
@@ -7,6 +7,10 @@ import {
   sanitizeSegment,
 } from "../../../services/filenameTemplate/sanitize";
 
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
 describe("replaceSegmentSeparators", () => {
   it("replaces forward and back slashes with spaces", () => {
     expect(replaceSegmentSeparators("a/b\\c")).toBe("a b c");
@@ -34,10 +38,16 @@ describe("sanitizeSegment", () => {
     expect(sanitizeSegment("filename...   ")).toBe("filename");
   });
 
-  it("truncates to 180 characters max", () => {
+  it("truncates ASCII segments to 180 bytes max", () => {
     const long = "a".repeat(300);
     const result = sanitizeSegment(long);
     expect(result.length).toBe(180);
+  });
+
+  it("truncates by UTF-8 bytes for multi-byte characters", () => {
+    const longCjk = "你".repeat(200); // 600 bytes
+    const result = sanitizeSegment(longCjk);
+    expect(utf8ByteLength(result)).toBeLessThanOrEqual(180);
   });
 });
 
@@ -75,6 +85,14 @@ describe("sanitizeRelativePath", () => {
     const result = sanitizeRelativePath("a//b.mp4");
     expect(result?.segments).toEqual(["a", "b.mp4"]);
   });
+
+  it("preserves the final extension when truncating a long filename segment", () => {
+    const result = sanitizeRelativePath(`dir/${"你".repeat(120)}.webm`);
+    expect(result).not.toBeNull();
+    expect(result?.segments).toHaveLength(2);
+    expect(result?.segments[1].endsWith(".webm")).toBe(true);
+    expect(utf8ByteLength(result?.segments[1] || "")).toBeLessThanOrEqual(180);
+  });
 });
 
 describe("enforcePathLengthLimit", () => {
@@ -90,14 +108,67 @@ describe("enforcePathLengthLimit", () => {
     expect(result.length).toBe(2);
     const last = result[result.length - 1];
     expect(last.endsWith(".mp4")).toBe(true);
-    expect(result.join("/").length).toBeLessThanOrEqual(240);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
   });
 
   it("truncates whole basename when there is no extension", () => {
     const longSegment = "a".repeat(300);
     const result = enforcePathLengthLimit(["dir", longSegment]);
     expect(result.length).toBe(2);
-    expect(result.join("/").length).toBeLessThanOrEqual(240);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+  });
+
+  it("keeps CJK-heavy filenames under the full path limit", () => {
+    const longCjkStem = "字幕測試".repeat(90);
+    const result = enforcePathLengthLimit(["dir", `${longCjkStem}.mp4`]);
+    const candidate = result.join("/");
+    expect(utf8ByteLength(candidate)).toBeLessThanOrEqual(240);
+    expect(
+      utf8ByteLength(`${result[result.length - 1]}.en-US.vtt.part`)
+    ).toBeLessThan(255);
+  });
+
+  it("trims leading directory segments when prefix alone exceeds budget", () => {
+    const result = enforcePathLengthLimit([
+      "你".repeat(60),
+      "你".repeat(60),
+      "a.mp4",
+    ]);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+    expect(result[result.length - 1]).toBe("a.mp4");
+  });
+
+  it("falls back to minimal filename when prefix leaves no stem budget", () => {
+    const result = enforcePathLengthLimit([
+      "你".repeat(60),
+      "你".repeat(60),
+      "你".repeat(60),
+      "verylongfilename.mp4",
+    ]);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+    expect(result[result.length - 1].endsWith(".mp4")).toBe(true);
+  });
+
+  it("does not truncate a valid path that exceeds only the old headroom-reduced budget", () => {
+    const segments = [
+      "A".repeat(50),
+      "B".repeat(50),
+      `${"C".repeat(90)}.mp4`,
+    ];
+    expect(utf8ByteLength(segments.join("/"))).toBe(196);
+    expect(enforcePathLengthLimit(segments)).toEqual(segments);
+  });
+
+  it("keeps a short extensionless path unchanged when already under 240 bytes", () => {
+    const result = enforcePathLengthLimit(["a".repeat(191), "z"]);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+    expect(result).toEqual(["a".repeat(191), "z"]);
+  });
+
+  it("keeps a longer extensionless path unchanged when already under 240 bytes", () => {
+    const result = enforcePathLengthLimit(["a".repeat(191), "longname"]);
+    expect(utf8ByteLength(result.join("/"))).toBeLessThanOrEqual(240);
+    expect(result).toEqual(["a".repeat(191), "longname"]);
   });
 
   it("returns empty array for empty input", () => {

--- a/backend/src/services/filenameTemplate/sanitize.ts
+++ b/backend/src/services/filenameTemplate/sanitize.ts
@@ -218,6 +218,6 @@ export function enforcePathLengthLimit(
   const truncatedStem = truncateToByteLength(stem, maxStemBytes)
     .replace(TRAILING_DOTS_SPACES_RE, "")
     .trim();
-  const truncatedLast = `${truncatedStem}${ext}`;
+  const truncatedLast = `${truncatedStem || "x"}${ext}`;
   return [...workingSegments.slice(0, -1), truncatedLast];
 }

--- a/backend/src/services/filenameTemplate/sanitize.ts
+++ b/backend/src/services/filenameTemplate/sanitize.ts
@@ -1,8 +1,75 @@
-const SEGMENT_MAX_LENGTH = 180;
-const PATH_MAX_LENGTH = 240;
+const SEGMENT_MAX_BYTES = 180;
+const PATH_MAX_BYTES = 240;
 const ILLEGAL_CHARS_RE = /[<>:"|?*\x00]/g;
 const TRAILING_DOTS_SPACES_RE = /[. ]+$/;
 const REPEATED_WHITESPACE_RE = /\s+/g;
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function truncateToByteLength(value: string, maxBytes: number): string {
+  if (byteLength(value) <= maxBytes) {
+    return value;
+  }
+  let out = "";
+  let bytes = 0;
+  for (const ch of value) {
+    const chBytes = byteLength(ch);
+    if (bytes + chBytes > maxBytes) break;
+    out += ch;
+    bytes += chBytes;
+  }
+  return out;
+}
+
+function truncateFilenameSegmentPreservingExtension(
+  value: string,
+  maxBytes: number
+): string {
+  if (byteLength(value) <= maxBytes) {
+    return value;
+  }
+
+  const dotIndex = value.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return truncateToByteLength(value, maxBytes);
+  }
+
+  const stem = value.slice(0, dotIndex);
+  const ext = value.slice(dotIndex);
+  const extBytes = byteLength(ext);
+
+  if (extBytes >= maxBytes) {
+    return truncateToByteLength(value, maxBytes);
+  }
+
+  const truncatedStem = truncateToByteLength(stem, maxBytes - extBytes)
+    .replace(TRAILING_DOTS_SPACES_RE, "")
+    .trim();
+
+  return `${truncatedStem || "x"}${ext}`;
+}
+
+function trimLeadingDirectorySegmentsToFit(
+  segments: string[],
+  maxPathBytes: number,
+  minFilenameBytes: number
+): string[] {
+  let workingSegments = [...segments];
+  while (workingSegments.length > 1) {
+    const prefix = workingSegments.slice(0, -1).join("/");
+    const separatorBytes = prefix.length > 0 ? 1 : 0;
+    if (
+      byteLength(prefix) + separatorBytes + minFilenameBytes <=
+      maxPathBytes
+    ) {
+      break;
+    }
+    workingSegments = workingSegments.slice(1);
+  }
+  return workingSegments;
+}
 
 /**
  * Replaces in-segment path separators with a space so that a variable value
@@ -17,7 +84,7 @@ export function replaceSegmentSeparators(value: string): string {
  * - Removes NUL and characters illegal on common filesystems.
  * - Collapses repeated whitespace.
  * - Trims trailing dots/spaces for Windows compatibility.
- * - Truncates to SEGMENT_MAX_LENGTH.
+ * - Truncates to SEGMENT_MAX_BYTES (UTF-8 byte count).
  */
 export function sanitizeSegment(segment: string): string {
   let s = segment;
@@ -25,8 +92,24 @@ export function sanitizeSegment(segment: string): string {
   s = s.replace(REPEATED_WHITESPACE_RE, " ");
   s = s.replace(TRAILING_DOTS_SPACES_RE, "");
   s = s.trim();
-  if (s.length > SEGMENT_MAX_LENGTH) {
-    s = s.slice(0, SEGMENT_MAX_LENGTH).replace(TRAILING_DOTS_SPACES_RE, "").trim();
+  if (byteLength(s) > SEGMENT_MAX_BYTES) {
+    s = truncateToByteLength(s, SEGMENT_MAX_BYTES)
+      .replace(TRAILING_DOTS_SPACES_RE, "")
+      .trim();
+  }
+  return s;
+}
+
+function sanitizeFilenameSegment(segment: string): string {
+  let s = segment;
+  s = s.replace(ILLEGAL_CHARS_RE, "");
+  s = s.replace(REPEATED_WHITESPACE_RE, " ");
+  s = s.replace(TRAILING_DOTS_SPACES_RE, "");
+  s = s.trim();
+  if (byteLength(s) > SEGMENT_MAX_BYTES) {
+    s = truncateFilenameSegmentPreservingExtension(s, SEGMENT_MAX_BYTES)
+      .replace(TRAILING_DOTS_SPACES_RE, "")
+      .trim();
   }
   return s;
 }
@@ -42,11 +125,14 @@ export function sanitizeRelativePath(
   const rawSegments = relativePath.split("/");
 
   const sanitized: string[] = [];
-  for (const seg of rawSegments) {
+  for (const [index, seg] of rawSegments.entries()) {
     if (seg === "." || seg === "..") {
       return null;
     }
-    const clean = sanitizeSegment(seg);
+    const clean =
+      index === rawSegments.length - 1
+        ? sanitizeFilenameSegment(seg)
+        : sanitizeSegment(seg);
     if (clean.length > 0) {
       sanitized.push(clean);
     }
@@ -67,7 +153,10 @@ export function sanitizeRelativePath(
 
 /**
  * Truncates the basename stem of the final segment to keep the full relative
- * path within PATH_MAX_LENGTH, while preserving the extension.
+ * path within PATH_MAX_BYTES, while preserving the extension.
+ * Per-segment truncation already keeps any individual filename component
+ * comfortably below common 255-byte filesystem limits, even after yt-dlp
+ * appends temporary suffixes like ".part".
  */
 export function enforcePathLengthLimit(
   segments: string[]
@@ -77,28 +166,58 @@ export function enforcePathLengthLimit(
   }
 
   const current = segments.join("/");
-  if (current.length <= PATH_MAX_LENGTH) {
+  const currentBytes = byteLength(current);
+  if (currentBytes <= PATH_MAX_BYTES) {
     return segments;
   }
 
   const last = segments[segments.length - 1];
   const dotIndex = last.lastIndexOf(".");
   if (dotIndex <= 0) {
+    const workingSegments = trimLeadingDirectorySegmentsToFit(
+      segments,
+      PATH_MAX_BYTES,
+      1
+    );
+    if (byteLength(workingSegments.join("/")) <= PATH_MAX_BYTES) {
+      return workingSegments;
+    }
+
     // No recognizable extension; truncate the whole basename
-    const excess = current.length - PATH_MAX_LENGTH;
-    const truncated = last.slice(0, Math.max(1, last.length - excess));
-    return [...segments.slice(0, -1), truncated.replace(TRAILING_DOTS_SPACES_RE, "").trim()];
+    const prefix = workingSegments.slice(0, -1).join("/");
+    const separatorLen = prefix.length > 0 ? 1 : 0;
+    const maxBaseBytes =
+      PATH_MAX_BYTES - byteLength(prefix) - separatorLen;
+    if (maxBaseBytes <= 0) {
+      return ["x"];
+    }
+    const truncated = truncateToByteLength(last, maxBaseBytes)
+      .replace(TRAILING_DOTS_SPACES_RE, "")
+      .trim();
+    return [...workingSegments.slice(0, -1), truncated || "x"];
   }
 
   const stem = last.slice(0, dotIndex);
   const ext = last.slice(dotIndex); // includes the dot
-  const prefix = segments.slice(0, -1).join("/");
-  const separatorLen = prefix.length > 0 ? 1 : 0;
-  const maxStemLen = PATH_MAX_LENGTH - prefix.length - separatorLen - ext.length;
-  if (maxStemLen <= 0) {
-    return segments;
+  const workingSegments = trimLeadingDirectorySegmentsToFit(
+    segments,
+    PATH_MAX_BYTES,
+    byteLength(ext) + 1
+  );
+  if (byteLength(workingSegments.join("/")) <= PATH_MAX_BYTES) {
+    return workingSegments;
   }
-  const truncatedStem = stem.slice(0, maxStemLen).replace(TRAILING_DOTS_SPACES_RE, "").trim();
+
+  const prefix = workingSegments.slice(0, -1).join("/");
+  const separatorLen = prefix.length > 0 ? 1 : 0;
+  const maxStemBytes =
+    PATH_MAX_BYTES - byteLength(prefix) - separatorLen - byteLength(ext);
+  if (maxStemBytes <= 0) {
+    return [`x${ext}`];
+  }
+  const truncatedStem = truncateToByteLength(stem, maxStemBytes)
+    .replace(TRAILING_DOTS_SPACES_RE, "")
+    .trim();
   const truncatedLast = `${truncatedStem}${ext}`;
-  return [...segments.slice(0, -1), truncatedLast];
+  return [...workingSegments.slice(0, -1), truncatedLast];
 }


### PR DESCRIPTION
Prevent Windows download failures on long CJK titles by truncating path segments and full paths by byte count, preserving file extensions and dropping leading directories when needed.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
