### PR TITLE
fix(test): remove broken localStorage cleanup in AuthContext tests

### DIFF
--- a/frontend/src/contexts/__tests__/AuthContext.test.tsx
+++ b/frontend/src/contexts/__tests__/AuthContext.test.tsx
@@ -43,15 +43,6 @@ const renderWithProviders = (ui: React.ReactNode) => {
 describe('AuthContext', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Clear localStorage
-        if (typeof localStorage !== 'undefined' && localStorage.clear) {
-            localStorage.clear();
-        } else {
-            // Fallback for test environments
-            Object.keys(localStorage).forEach(key => {
-                delete (localStorage as any)[key];
-            });
-        }
         document.cookie = '';
         queryClient.clear();
         // Mock axios.post for logout


### PR DESCRIPTION
AuthContext does not use localStorage, and the fallback threw when Node's experimental localStorage was unavailable.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
