### PR TITLE
[codex] Fix CodeQL cleartext warn alert

### DIFF
--- a/backend/src/__tests__/utils/logger.test.ts
+++ b/backend/src/__tests__/utils/logger.test.ts
@@ -67,6 +67,7 @@ describe('Logger', () => {
     });
 
     it('should redact sensitive structured fields in warn logs', () => {
+        const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
         const testLogger = new Logger(LogLevel.WARN);
 
         testLogger.warn('warning message', {
@@ -74,12 +75,13 @@ describe('Logger', () => {
             authorUrl: 'https://example.com/secret-author',
         });
 
-        expect(consoleSpy.warn).toHaveBeenCalled();
-        const [, message, context] = consoleSpy.warn.mock.calls[0];
-        expect(message).toBe('warning message');
-        expect(context).toEqual({
-            author: '[REDACTED]',
-            authorUrl: 'https://example.com/secret-author',
-        });
+        expect(stderrSpy).toHaveBeenCalled();
+        const output = stderrSpy.mock.calls[0][0] as string;
+        expect(output).toContain('[WARN]');
+        expect(output).toContain('warning message');
+        expect(output).toContain('"author":"[REDACTED]"');
+        expect(output).toContain('"authorUrl":"https://example.com/secret-author"');
+        expect(output).not.toContain('Secret Author');
+        stderrSpy.mockRestore();
     });
 });

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -163,9 +163,14 @@ export class Logger {
    */
   warn(message: string, ...args: any[]): void {
     if (this.level <= LogLevel.WARN) {
+      const timestamp = this.formatTimestamp();
       const sanitizedMessage = redactSensitive(sanitizeLogMessage(message));
       const sanitizedArgs = this.sanitizeArgs(args);
-      console.warn(`[${this.formatTimestamp()}] [WARN]`, sanitizedMessage, ...sanitizedArgs);
+      const serializedArgs = sanitizedArgs.map((arg) => this.formatArg(arg));
+      const line = [`[${timestamp}] [WARN]`, sanitizedMessage, ...serializedArgs]
+        .join(" ")
+        .trim();
+      process.stderr.write(`${line}\n`);
     }
   }
 


### PR DESCRIPTION
## Summary
- route warn logs through sanitized serialization before writing to stderr
- extend logger tests to cover warn redaction at the sink

## Context
GitHub Code scanning opened a follow-up `js/clear-text-logging` alert on `backend/src/utils/logger.ts` for `console.warn`. This mirrors the prior fix for `console.error` so dynamic warning metadata is sanitized and serialized before it reaches the output sink.

## Validation
- `npm --prefix backend run build`
- `npm --prefix backend run test -- src/__tests__/utils/logger.test.ts src/services/storageService/__tests__/authorCollectionUtils.test.ts src/__tests__/services/CloudStorageService.test.ts`
- `npm --prefix backend run test`
