### PR TITLE
Fix Dependabot undici vulnerabilities

### DIFF
--- a/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
+++ b/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
@@ -268,9 +268,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -342,9 +342,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1651,9 +1651,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2299,9 +2299,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
+++ b/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
@@ -4355,9 +4355,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.24.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-            "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+            "version": "6.27.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.17"

--- a/backend/bgutil-ytdlp-pot-provider/server/package.json
+++ b/backend/bgutil-ytdlp-pot-provider/server/package.json
@@ -51,6 +51,6 @@
         "basic-ftp": "^5.3.1",
         "flatted": "^3.4.0",
         "ip-address": "^10.1.1",
-        "undici": "^6.24.0"
+        "undici": "^6.27.0"
     }
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6500,9 +6500,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/backend/package.json
+++ b/backend/package.json
@@ -70,7 +70,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
-    "undici": "^7.24.0",
+    "undici": "^7.28.0",
     "yauzl": "^3.2.1"
   }
 }


### PR DESCRIPTION
## Summary

Resolves all **11 open Dependabot alerts** (all `undici`) plus one related transitive ReDoS finding, across the two backend manifests. undici is a transitive dependency pinned via `overrides` in both projects; this raises the override floors to the patched releases and refreshes the lockfiles.

| Project | Package | Was → Now | Notes |
|---|---|---|---|
| `backend` | undici | 7.27.0 → **7.28.0** (override `^7.24.0`→`^7.28.0`) | required by `cheerio` (`^7.19.0`) |
| `backend/bgutil-ytdlp-pot-provider/server` | undici | 6.24.0 → **6.27.0** (override `^6.24.0`→`^6.27.0`) | required by `proxy-agent` (`^6.21.3`) |
| `backend/bgutil-ytdlp-pot-provider/server` | brace-expansion | → **1.1.15 / 2.1.1** | dev-only (eslint), `npm audit fix` |

## Advisories fixed (undici)

- GHSA-vxpw-j846-p89q — DoS via WebSocket fragment count bypass (high)
- GHSA-hm92-r4w5-c3mj — cross-origin request routing via SOCKS5 proxy pool reuse (high)
- GHSA-vmh5-mc38-953g — TLS cert validation bypass via dropped requestTls in SOCKS5 ProxyAgent (high)
- GHSA-p88m-4jfj-68fv — HTTP header injection via Set-Cookie percent-decoding (medium)
- GHSA-pr7r-676h-xcf6 — cross-user info disclosure via shared cache whitespace bypass (medium)
- GHSA-35p6-xmwp-9g52 — HTTP response queue poisoning via keep-alive socket reuse (low)
- GHSA-g8m3-5g58-fq7m — Set-Cookie SameSite downgrade via permissive substring matching (low)

Plus GHSA-f886-m6hf-6m8v — brace-expansion ReDoS (moderate, dev dep).

## Verification

- All changes are manifest/lockfile-only — no `node_modules` writes or install scripts in the commits.
- `undici` is not imported directly anywhere in source; both patched versions satisfy the ranges their dependents declare (no resolution conflicts).
- Backend: installed undici 7.28.0 and ran the full suite — **162 test files / 2072 tests passing**, 0 failures. `npm audit` → 0 vulnerabilities.
- bgutil server: no test/build suite (lint/format only); lockfile ↔ manifest validated consistent via `npm ci --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
