### PR TITLE
Fix MissAV download 403 with global yt-dlp browser impersonation

### DIFF
--- a/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
+++ b/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
@@ -5,6 +5,7 @@ import puppeteer from 'puppeteer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MissAVDownloader } from '../../../services/downloaders/MissAVDownloader';
 import { cleanupTemporaryFiles, isCancellationError } from '../../../utils/downloadUtils';
+import { flagsToArgs } from '../../../utils/ytDlpUtils';
 import * as security from '../../../utils/security';
 
 vi.mock('puppeteer');
@@ -402,6 +403,28 @@ describe('MissAVDownloader', () => {
         expect.any(String),
         expect.arrayContaining(['https://surrit.com/playlist.m3u8']),
       );
+    });
+
+    it('uses the global --impersonate flag (not the generic extractor-arg) to bypass the Cloudflare CDN block', async () => {
+      const mockPage = buildPageMock('success');
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      // spawn exits with code 1 (top-level mock); swallow the resulting error
+      await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
+
+      const calls = (flagsToArgs as ReturnType<typeof vi.fn>).mock.calls;
+      const flags = calls[calls.length - 1]?.[0] ?? {};
+
+      // The global `--impersonate` flag impersonates the whole session, including
+      // the m3u8 manifest/segment fetches. The `generic:impersonate` extractor-arg
+      // only covers the initial webpage fetch and leaves the m3u8 download to 403,
+      // so it must NOT be used here.
+      expect(flags.impersonate).toBe('chrome');
+      expect(flags.extractorArgs).toBeUndefined();
+      // Referer is the only extra header the CDN needs once impersonation is on;
+      // the earlier Origin/Sec-Fetch headers were a red herring and are dropped.
+      expect(flags.addHeader).toEqual(['Referer:https://missav.com/']);
     });
 
     it('treats SIGTERM from user cancellation as DownloadCancelledError', async () => {

--- a/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
+++ b/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
@@ -5,7 +5,7 @@ import puppeteer from 'puppeteer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MissAVDownloader } from '../../../services/downloaders/MissAVDownloader';
 import { cleanupTemporaryFiles, isCancellationError } from '../../../utils/downloadUtils';
-import { flagsToArgs } from '../../../utils/ytDlpUtils';
+import { flagsToArgs, isYtDlpImpersonateAvailable } from '../../../utils/ytDlpUtils';
 import * as security from '../../../utils/security';
 
 vi.mock('puppeteer');
@@ -22,6 +22,7 @@ vi.mock('../../../utils/ytDlpUtils', () => ({
   flagsToArgs: vi.fn().mockReturnValue([]),
   getAxiosProxyConfig: vi.fn().mockReturnValue({}),
   InvalidProxyError: class InvalidProxyError extends Error {},
+  isYtDlpImpersonateAvailable: vi.fn().mockResolvedValue(true),
 }));
 vi.mock('../../../utils/downloadUtils', () => ({
   cleanupTemporaryFiles: vi.fn().mockResolvedValue(undefined),
@@ -424,6 +425,24 @@ describe('MissAVDownloader', () => {
       expect(flags.extractorArgs).toBeUndefined();
       // Referer is the only extra header the CDN needs once impersonation is on;
       // the earlier Origin/Sec-Fetch headers were a red herring and are dropped.
+      expect(flags.addHeader).toEqual(['Referer:https://missav.com/']);
+    });
+
+    it('omits --impersonate when curl_cffi is unavailable instead of hard-failing', async () => {
+      (isYtDlpImpersonateAvailable as ReturnType<typeof vi.fn>).mockResolvedValueOnce(false);
+      const mockPage = buildPageMock('success');
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      // spawn exits with code 1 (top-level mock); swallow the resulting error
+      await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
+
+      const calls = (flagsToArgs as ReturnType<typeof vi.fn>).mock.calls;
+      const flags = calls[calls.length - 1]?.[0] ?? {};
+
+      // Without curl_cffi, `--impersonate` would error ("target not available"),
+      // so the flag must be omitted and the download attempted unimpersonated.
+      expect(flags.impersonate).toBeUndefined();
       expect(flags.addHeader).toEqual(['Referer:https://missav.com/']);
     });
 

--- a/backend/src/__tests__/utils/ytDlpUtils.test.ts
+++ b/backend/src/__tests__/utils/ytDlpUtils.test.ts
@@ -543,6 +543,7 @@ describe("ytDlpUtils", () => {
         "--user",
         "yt-dlp",
         "bgutil-ytdlp-pot-provider",
+        "curl-cffi",
       ]);
     });
 

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -510,6 +510,23 @@ export class MissAVDownloader extends BaseDownloader {
           }
         });
 
+        // Telemetry: record the status the browser gets for each m3u8 response
+        // (plus Cloudflare markers). When a download later 403s, this line shows
+        // whether the CDN still serves the browser — distinguishing a yt-dlp/
+        // impersonation regression from the CDN blocking this host outright.
+        page.on("response", (response) => {
+          const resUrl = response.url();
+          if (!isM3u8(resUrl)) return;
+          const headers = response.headers();
+          logger.info(
+            `[MissAV m3u8 probe] status=${response.status()} ` +
+              `cf-mitigated=${headers["cf-mitigated"] ?? "none"} ` +
+              `cf-ray=${headers["cf-ray"] ?? "none"} ` +
+              `server=${headers["server"] ?? "?"} ` +
+              `set-cookie=${headers["set-cookie"] ? "yes" : "no"} ${resUrl}`,
+          );
+        });
+
         await navigateMissAvPage(page, safeNavigationUrl);
 
         // Extra wait is created AFTER networkidle2, so the full 20 s budget
@@ -807,10 +824,22 @@ export class MissAVDownloader extends BaseDownloader {
         output: newVideoPath,
         format: downloadFormat,
         mergeOutputFormat: mergeOutputFormat,
-        addHeader: [
-          `Referer:${referer}`,
-          `User-Agent:${MISSAV_BROWSER_USER_AGENT}`,
-        ],
+        // The m3u8 host (e.g. surrit.com) sits behind Cloudflare bot management
+        // that fingerprints the TLS/JA3 handshake; a default yt-dlp request gets
+        // a 403. Route every request through curl_cffi browser impersonation so
+        // the handshake matches a real browser (curl-cffi is bundled in the
+        // backend image, so no extra runtime dependency is needed).
+        //
+        // IMPORTANT: this must be the GLOBAL `--impersonate` flag, not the
+        // `--extractor-args generic:impersonate` arg that yt-dlp's own error
+        // message suggests. The extractor-arg only impersonates the initial
+        // webpage fetch; the m3u8 manifest (and segment) downloads still go out
+        // with the default fingerprint and 403. The global flag impersonates the
+        // whole session. Verified directly against surrit.com from the deployment
+        // environment: `--impersonate chrome` succeeds where the extractor-arg
+        // returns 403. Referer is the only extra header the CDN needs.
+        impersonate: "chrome",
+        addHeader: [`Referer:${referer}`],
       };
 
       // Apply format sort if user specified it

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -33,6 +33,7 @@ import {
   getNetworkConfigFromUserConfig,
   getUserYtDlpConfig,
   InvalidProxyError,
+  isYtDlpImpersonateAvailable,
 } from "../../utils/ytDlpUtils";
 import { syncMediaServerArtifactsForRecord } from "../mediaServerExport";
 import * as storageService from "../storageService";
@@ -818,27 +819,40 @@ export class MissAVDownloader extends BaseDownloader {
       const referer = `${urlObjForReferer.protocol}//${urlObjForReferer.host}/`;
       logger.info("Using Referer:", referer);
 
+      // The m3u8 host (e.g. surrit.com) sits behind Cloudflare bot management
+      // that fingerprints the TLS/JA3 handshake; a default yt-dlp request gets a
+      // 403. Route every request through curl_cffi browser impersonation so the
+      // handshake matches a real browser.
+      //
+      // IMPORTANT: this must be the GLOBAL `--impersonate` flag, not the
+      // `--extractor-args generic:impersonate` arg that yt-dlp's own error
+      // message suggests. The extractor-arg only impersonates the initial
+      // webpage fetch; the m3u8 manifest (and segment) downloads still go out
+      // with the default fingerprint and 403. The global flag impersonates the
+      // whole session. Verified directly against surrit.com from the deployment
+      // environment: `--impersonate chrome` succeeds where the extractor-arg
+      // returns 403. Referer is the only extra header the CDN needs.
+      //
+      // Gate on availability: `--impersonate` hard-fails ("target not available")
+      // when curl_cffi is missing, which can happen on non-Docker installs. When
+      // unavailable, omit it and warn — the download proceeds unimpersonated
+      // (works for non-blocked hosts) instead of erroring outright.
+      const canImpersonate = await isYtDlpImpersonateAvailable();
+      if (!canImpersonate) {
+        logger.warn(
+          "[MissAV] yt-dlp browser impersonation is unavailable (curl_cffi not installed); " +
+            "proceeding without --impersonate. Cloudflare-protected hosts may return 403. " +
+            "Install it with: pip install curl-cffi",
+        );
+      }
+
       // Prepare flags object - merge user config with required settings
       const flags: any = {
         ...networkConfig, // Apply network settings (proxy, etc.)
         output: newVideoPath,
         format: downloadFormat,
         mergeOutputFormat: mergeOutputFormat,
-        // The m3u8 host (e.g. surrit.com) sits behind Cloudflare bot management
-        // that fingerprints the TLS/JA3 handshake; a default yt-dlp request gets
-        // a 403. Route every request through curl_cffi browser impersonation so
-        // the handshake matches a real browser (curl-cffi is bundled in the
-        // backend image, so no extra runtime dependency is needed).
-        //
-        // IMPORTANT: this must be the GLOBAL `--impersonate` flag, not the
-        // `--extractor-args generic:impersonate` arg that yt-dlp's own error
-        // message suggests. The extractor-arg only impersonates the initial
-        // webpage fetch; the m3u8 manifest (and segment) downloads still go out
-        // with the default fingerprint and 403. The global flag impersonates the
-        // whole session. Verified directly against surrit.com from the deployment
-        // environment: `--impersonate chrome` succeeds where the extractor-arg
-        // returns 403. Referer is the only extra header the CDN needs.
-        impersonate: "chrome",
+        ...(canImpersonate ? { impersonate: "chrome" } : {}),
         addHeader: [`Referer:${referer}`],
       };
 

--- a/backend/src/utils/ytDlpUtils.ts
+++ b/backend/src/utils/ytDlpUtils.ts
@@ -53,6 +53,7 @@ type CookiesFileCache = CookiesFileSignature & {
 
 let jsRuntimeFlagPromise: Promise<YouTubeJsRuntimeFlag | null> | null = null;
 let remoteComponentsSupportPromise: Promise<boolean> | null = null;
+let impersonateSupportPromise: Promise<boolean> | null = null;
 const runtimeWarningCache = new Set<string>();
 let cookiesFileCache: CookiesFileCache | null = null;
 
@@ -564,6 +565,7 @@ export function resetYtDlpAvailabilityCacheForTests(): void {
   resolvedYtDlpPathCache = null;
   jsRuntimeFlagPromise = null;
   remoteComponentsSupportPromise = null;
+  impersonateSupportPromise = null;
   runtimeWarningCache.clear();
   cookiesFileCache = null;
 }
@@ -573,7 +575,11 @@ export function resetYtDlpAvailabilityCacheForTests(): void {
  */
 async function installYtDlp(options: { upgrade?: boolean } = {}): Promise<void> {
   const { upgrade = false } = options;
-  const packages = ["yt-dlp", "bgutil-ytdlp-pot-provider"];
+  // curl-cffi powers yt-dlp's browser impersonation (--impersonate), which the
+  // MissAV downloader needs to get past Cloudflare on the m3u8 CDN. The Docker
+  // image installs it explicitly; install it here too so non-Docker setups
+  // gain the capability instead of hard-failing on --impersonate.
+  const packages = ["yt-dlp", "bgutil-ytdlp-pot-provider", "curl-cffi"];
   const installArgs = ["install"];
   if (upgrade) {
     installArgs.push("-U");
@@ -863,6 +869,74 @@ async function isDenoAvailable(): Promise<boolean> {
   });
 
   return denoAvailablePromise;
+}
+
+/**
+ * Whether the resolved yt-dlp binary can impersonate a Chrome browser via
+ * curl_cffi. Probes `--list-impersonate-targets`: when curl_cffi is missing,
+ * yt-dlp still lists targets but tags every one "(unavailable)", and passing
+ * `--impersonate` would then hard-fail the download. Callers use this to gate
+ * the flag and degrade gracefully instead of erroring. Cached per process.
+ */
+export async function isYtDlpImpersonateAvailable(): Promise<boolean> {
+  if (impersonateSupportPromise) {
+    return impersonateSupportPromise;
+  }
+
+  impersonateSupportPromise = (async () => {
+    try {
+      const ytDlpPath = await resolveYtDlpPath();
+      return await new Promise<boolean>((resolve) => {
+        let output = "";
+        let settled = false;
+        const finish = (value: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          // A usable target row names a client and ends with the curl_cffi
+          // source without the "(unavailable)" marker.
+          const available = output
+            .split("\n")
+            .some(
+              (line) =>
+                /chrome/i.test(line) &&
+                /curl_cffi/.test(line) &&
+                !/unavailable/i.test(line),
+            );
+          if (!available) {
+            impersonateSupportPromise = null;
+          }
+          resolve(available && value);
+        };
+        const timeout = setTimeout(() => {
+          proc.kill("SIGTERM");
+          finish(true);
+        }, YT_DLP_HELP_PROBE_TIMEOUT_MS);
+        timeout.unref?.();
+
+        // ytDlpPath is either explicitly configured by the operator or selected
+        // from enumerated PATH entries and fixed executable names above.
+        // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+        const proc = spawn(ytDlpPath, ["--list-impersonate-targets"], {
+          env: getYtDlpSpawnEnv(),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        proc.stdout?.on("data", (data: Buffer) => {
+          output += data.toString();
+        });
+        proc.on("close", () => finish(true));
+        proc.on("error", () => {
+          impersonateSupportPromise = null;
+          finish(false);
+        });
+      });
+    } catch {
+      impersonateSupportPromise = null;
+      return false;
+    }
+  })();
+
+  return impersonateSupportPromise;
 }
 
 function warnRuntimeOnce(key: string, message: string): void {

--- a/documents/en/getting-started.md
+++ b/documents/en/getting-started.md
@@ -38,12 +38,13 @@ cd ../backend && npm install
 **Note**: The backend installation will automatically build the `bgutil-ytdlp-pot-provider` server. It also performs a best-effort auto-install for `ffmpeg`/`ffprobe` if missing (does not fail install when auto-install is unavailable). You can disable this behavior with `SKIP_FFMPEG_AUTO_INSTALL=1`. You must still ensure `yt-dlp` and the `bgutil-ytdlp-pot-provider` python plugin are installed in your environment:
 
 ```bash
-# Install yt-dlp and the plugin
-pip install yt-dlp bgutil-ytdlp-pot-provider
+# Install yt-dlp and the plugin. curl-cffi enables yt-dlp browser
+# impersonation, which MissAV downloads need to get past Cloudflare.
+pip install yt-dlp bgutil-ytdlp-pot-provider curl-cffi
 
 # OR using pipx (recommended for isolation)
 pipx install yt-dlp
-pipx inject yt-dlp bgutil-ytdlp-pot-provider
+pipx inject yt-dlp bgutil-ytdlp-pot-provider curl-cffi
 ```
 
 ### 3. Configure Environment Variables

--- a/documents/zh/getting-started.md
+++ b/documents/zh/getting-started.md
@@ -38,12 +38,13 @@ cd ../backend && npm install
 **注意**: 后端安装会自动构建 `bgutil-ytdlp-pot-provider` 服务器。但是，您必须确保在环境中安装了 `yt-dlp` 和 `bgutil-ytdlp-pot-provider` Python 插件：
 
 ```bash
-# 安装 yt-dlp 和插件
-pip install yt-dlp bgutil-ytdlp-pot-provider
+# 安装 yt-dlp 和插件。curl-cffi 用于启用 yt-dlp 的浏览器模拟，
+# MissAV 下载需要它来绕过 Cloudflare。
+pip install yt-dlp bgutil-ytdlp-pot-provider curl-cffi
 
 # 或使用 pipx (推荐，用于隔离)
 pipx install yt-dlp
-pipx inject yt-dlp bgutil-ytdlp-pot-provider
+pipx inject yt-dlp bgutil-ytdlp-pot-provider curl-cffi
 ```
 
 ### 3. 配置环境变量


### PR DESCRIPTION
## Problem

MissAV downloads were failing with a `403 Forbidden` from the m3u8 host (`surrit.com`), which is behind Cloudflare bot management that fingerprints the TLS/JA3 handshake. yt-dlp's default request gets blocked before any video bytes transfer. Puppeteer m3u8 extraction was unaffected — only the yt-dlp download stage failed.

## Root cause

`--extractor-args generic:impersonate` (what the code used, and what yt-dlp's own error message recommends) **only impersonates the initial webpage fetch**. The actual m3u8 manifest and segment downloads still went out with yt-dlp's default fingerprint and got a 403.

The fix is the **global `--impersonate` flag**, which routes the whole yt-dlp session through `curl_cffi` (already bundled in the image) with a real browser fingerprint.

## Fix

- `MissAVDownloader` now passes `impersonate: "chrome"` (→ `--impersonate chrome`) instead of the `generic:impersonate` extractor-arg.
- Drops the forced `User-Agent` (curl_cffi sets a coherent one) and keeps only `Referer` — no `Origin`/`Sec-Fetch` headers needed.
- Adds a lightweight m3u8 response-status probe (status + Cloudflare markers) so a future CDN-side change is diagnosable straight from the logs.

## Verification

Reproduced and verified **directly against `surrit.com` from the deployment container**. With `--impersonate chrome` + `Referer`:

| Request | Status |
|---|---|
| master `playlist.m3u8` | 200 |
| variant `video.m3u8` | 200 |
| first segment | 206 |

The `generic:impersonate` extractor-arg returns 403 on the same URL. `curl_cffi` produces a passing fingerprint with any chrome/safari target.

- `tsc --noEmit`: clean
- Downloader unit tests: 22/22 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)