### PR TITLE
Fix live translation in real deployments (WebSocket proxy, secure-context + error UX)

### DIFF
--- a/documents/en/docker-guide.md
+++ b/documents/en/docker-guide.md
@@ -241,6 +241,43 @@ However, if you experience connection issues where the frontend cannot reach the
     ```
     
 
+## 🔌 Deploying Behind a Reverse Proxy (WebSocket Support)
+
+The **Live Translation** feature uses a **WebSocket** connection (`/api/live-translation/ws`). MyTube's built-in `frontend` container already proxies WebSocket upgrades to the backend, so **direct deployments work out of the box** — there is nothing to configure.
+
+However, if you put **your own** reverse proxy in front of MyTube (Nginx Proxy Manager, Traefik, Caddy, a hand-written Nginx vhost, a Synology/QNAP reverse proxy, a Cloudflare Tunnel, etc.) to add TLS or a custom domain, that proxy **must forward the WebSocket upgrade**. This is a standard requirement for any app that uses WebSockets. If it is not enabled, the browser reports:
+
+> WebSocket connection to 'wss://your-domain/api/live-translation/ws' failed: There was a bad response from the server.
+
+Enable WebSocket passthrough on your proxy:
+
+- **Nginx (hand-written vhost):** add the upgrade headers to the location that proxies MyTube.
+
+    ```nginx
+    location / {
+        proxy_pass http://MYTUBE_FRONTEND_HOST:5556;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+    ```
+
+- **Nginx Proxy Manager:** edit the Proxy Host → **Details** tab → toggle **Websockets Support** ON → Save.
+- **Synology / QNAP reverse proxy:** in the rule's **Custom Header** section, add the **WebSocket** header preset (sets `Upgrade` / `Connection`).
+- **Traefik / Caddy:** no extra config — both forward WebSocket upgrades automatically.
+- **Cloudflare (proxied DNS / Tunnel):** WebSockets are supported by default; no change needed.
+
+> [!TIP]
+> Verify the path end-to-end with `curl`. A correctly proxied endpoint reaches the backend's upgrade handler and returns a **bare `401`** with an `X-Live-Translation-Error: ticket_missing` header (the missing-ticket case is expected for a raw curl). A **JSON `401` body**, an HTML page, or a `404` means a proxy in front stripped the upgrade.
+>
+> ```bash
+> curl -i -H "Connection: Upgrade" -H "Upgrade: websocket" \
+>   -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+>   -H "Origin: https://your-domain" \
+>   https://your-domain/api/live-translation/ws
+> ```
+
 ## 🏗️ Building from Source (Optional)
 
 If you prefer to build the images yourself (e.g., to modify code), follow these steps:
@@ -334,3 +371,8 @@ For unified frontend+backend deployment, the repo also includes:
 ```
 docker-compose -f stacks/docker-compose.single-container.yml up -d
 ```
+
+### 5. Live Translation fails with "bad response from the server" (WebSocket)
+
+- **Cause:** A reverse proxy in front of MyTube is not forwarding the WebSocket upgrade for `/api/live-translation/ws`. This only affects deployments that add their own proxy (TLS termination, custom domain); the built-in `frontend` container already handles it.
+- **Fix:** Enable WebSocket support on your proxy — see [Deploying Behind a Reverse Proxy (WebSocket Support)](#-deploying-behind-a-reverse-proxy-websocket-support).

--- a/documents/zh/docker-guide.md
+++ b/documents/zh/docker-guide.md
@@ -238,6 +238,43 @@ MYTUBE_ADMIN_TRUST_LEVEL=container
    docker-compose up -d
    ```
 
+## 🔌 部署在反向代理之后 (WebSocket 支持)
+
+**实时翻译 (Live Translation)** 功能使用 **WebSocket** 连接 (`/api/live-translation/ws`)。MyTube 自带的 `frontend` 容器已经配置好将 WebSocket 升级转发到后端,因此**直接部署开箱即用**,无需任何额外配置。
+
+但如果你在 MyTube 前面再套了**自己的**反向代理(Nginx Proxy Manager、Traefik、Caddy、手写的 Nginx vhost、群晖/QNAP 反向代理、Cloudflare Tunnel 等)来做 TLS 或自定义域名,那么这层代理**必须转发 WebSocket 升级**。这是所有使用 WebSocket 的应用的通用要求。如果没有开启,浏览器会报:
+
+> WebSocket connection to 'wss://your-domain/api/live-translation/ws' failed: There was a bad response from the server.
+
+在你的代理上开启 WebSocket 透传:
+
+- **Nginx(手写 vhost):** 在代理 MyTube 的 location 中加上升级头。
+
+    ```nginx
+    location / {
+        proxy_pass http://MYTUBE_FRONTEND_HOST:5556;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+    ```
+
+- **Nginx Proxy Manager:** 编辑该 Proxy Host → **Details** 标签 → 打开 **Websockets Support** 开关 → 保存。
+- **群晖 / QNAP 反向代理:** 在规则的 **自定义标头 (Custom Header)** 中添加 **WebSocket** 预设(会写入 `Upgrade` / `Connection`)。
+- **Traefik / Caddy:** 无需额外配置,二者会自动转发 WebSocket 升级。
+- **Cloudflare(代理 DNS / Tunnel):** 默认即支持 WebSocket,无需更改。
+
+> [!TIP]
+> 可以用 `curl` 端到端验证。配置正确的端点会抵达后端的升级处理器,返回一个**裸 `401`** 并带有 `X-Live-Translation-Error: ticket_missing` 头(裸 curl 没带票据,所以 ticket_missing 是预期的)。如果返回的是 **JSON 格式的 `401`**、HTML 页面或 `404`,说明前面某层代理把升级请求剥掉了。
+>
+> ```bash
+> curl -i -H "Connection: Upgrade" -H "Upgrade: websocket" \
+>   -H "Sec-WebSocket-Version: 13" -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+>   -H "Origin: https://your-domain" \
+>   https://your-domain/api/live-translation/ws
+> ```
+
 ## 🏗️ 从源码构建 (可选)
 
 如果您更喜欢自己构建镜像（例如，为了修改代码），请按照以下步骤操作：
@@ -322,3 +359,8 @@ docker-compose -f stacks/docker-compose.host-network.yml up -d
 ```
 docker-compose -f stacks/docker-compose.single-container.yml up -d
 ```
+
+### 5. 实时翻译报 "bad response from the server" (WebSocket)
+
+- **原因:** MyTube 前面的某层反向代理没有转发 `/api/live-translation/ws` 的 WebSocket 升级。这只影响自己额外加了代理(TLS、自定义域名)的部署;自带的 `frontend` 容器已经处理好了。
+- **修复:** 在你的代理上开启 WebSocket 支持 —— 参见 [部署在反向代理之后 (WebSocket 支持)](#-部署在反向代理之后-websocket-支持)。

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,15 @@
+# Map the Upgrade request header to the value sent to the backend on the
+# Connection header. WebSocket upgrades get "upgrade"; everything else gets
+# "close" so regular HTTP requests are unaffected. Must live in the http
+# context, which is where conf.d/*.conf files are included.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 5556;
-    
+
     # Enable gzip compression for better performance
     gzip on;
     gzip_vary on;
@@ -21,6 +30,24 @@ server {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         # Enable compression for HTML
         gzip_types text/html;
+    }
+
+    # Live translation WebSocket. Needs HTTP/1.1 plus the Upgrade/Connection
+    # headers, which the generic /api block does not set. Exact match so it
+    # takes priority over the /api prefix for this single path.
+    location = /api/live-translation/ws {
+        proxy_pass __BACKEND_URL__/api/live-translation/ws;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Disable buffering and keep the long-lived stream open.
+        proxy_buffering off;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
     }
 
     # Backend URL placeholder - will be replaced by entrypoint.sh at runtime

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -6,7 +6,10 @@ import {
     useLiveTranslationSession,
 } from '../hooks/useLiveTranslationSession';
 import { useLiveTranslationAvailability } from '../hooks/useLiveTranslationAvailability';
-import { isAudioCaptureSupported } from '../hooks/useLiveTranslationAudioCapture';
+import {
+    isAudioCaptureSupported,
+    isSecureContextForCapture,
+} from '../hooks/useLiveTranslationAudioCapture';
 import { isCaptureSupportedForSrc } from '../utils/mediaOrigin';
 import {
     getLiveTranslationLanguageAbbreviation,
@@ -136,7 +139,12 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
                 disabledReason = t('liveTranslationUnavailable');
             }
         } else if (!isAudioCaptureSupported()) {
-            disabledReason = t('liveTranslationUnsupportedBrowser');
+            // AudioWorklet is missing. The usual real-world cause is an insecure
+            // origin (http:// on a LAN IP), where browsers don't expose it — point
+            // users at HTTPS/localhost rather than implying the browser is too old.
+            disabledReason = isSecureContextForCapture()
+                ? t('liveTranslationUnsupportedBrowser')
+                : t('liveTranslationInsecureContext');
         } else if (!isCaptureSupportedForSrc(src)) {
             disabledReason = t('liveTranslationAudioCaptureBlocked');
         } else if (!videoElement) {

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -28,6 +28,7 @@ const ERROR_MESSAGE_KEY_BY_CODE: Partial<Record<LiveTranslationErrorCode, Transl
     ticket_missing: 'liveTranslationErrorTicket',
     ticket_expired: 'liveTranslationErrorTicket',
     ticket_used: 'liveTranslationErrorTicket',
+    websocket_connect_failed: 'liveTranslationErrorWebSocket',
     gemini_connect_failed: 'liveTranslationErrorConnection',
     gemini_setup_failed: 'liveTranslationErrorConnection',
     gemini_stream_closed: 'liveTranslationErrorConnection',

--- a/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
+++ b/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
@@ -7,6 +7,10 @@ import {
 } from '../LiveTranslationContext';
 import { useLiveTranslationAvailability } from '../../hooks/useLiveTranslationAvailability';
 import { useLiveTranslationSession } from '../../hooks/useLiveTranslationSession';
+import {
+    isAudioCaptureSupported,
+    isSecureContextForCapture,
+} from '../../hooks/useLiveTranslationAudioCapture';
 
 vi.mock('../LanguageContext', () => ({
     useLanguage: () => ({ t: (key: string) => key }),
@@ -18,7 +22,8 @@ vi.mock('../../hooks/useLiveTranslationSession', () => ({
     useLiveTranslationSession: vi.fn(),
 }));
 vi.mock('../../hooks/useLiveTranslationAudioCapture', () => ({
-    isAudioCaptureSupported: () => true,
+    isAudioCaptureSupported: vi.fn(() => true),
+    isSecureContextForCapture: vi.fn(() => true),
     useLiveTranslationAudioCapture: () => ({}),
 }));
 vi.mock('../../utils/mediaOrigin', () => ({
@@ -27,6 +32,8 @@ vi.mock('../../utils/mediaOrigin', () => ({
 
 const mockAvailability = useLiveTranslationAvailability as unknown as Mock;
 const mockSession = useLiveTranslationSession as unknown as Mock;
+const mockAudioSupported = isAudioCaptureSupported as unknown as Mock;
+const mockSecureContext = isSecureContextForCapture as unknown as Mock;
 
 function setAvailability(overrides: Record<string, unknown> = {}) {
     mockAvailability.mockReturnValue({
@@ -92,6 +99,9 @@ function renderProvider() {
 describe('LiveTranslationContext', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        // Re-establish defaults after clearAllMocks so per-test overrides don't leak.
+        mockAudioSupported.mockReturnValue(true);
+        mockSecureContext.mockReturnValue(true);
     });
 
     it('does not render the control when the feature is disabled globally', () => {
@@ -114,6 +124,24 @@ describe('LiveTranslationContext', () => {
         setSession();
         renderProvider();
         expect(screen.getByTestId('disabled').textContent).toBe('liveTranslationAdminRequiredPlayer');
+    });
+
+    it('hints at HTTPS when capture is unsupported because of an insecure context', () => {
+        setAvailability();
+        setSession();
+        mockAudioSupported.mockReturnValue(false);
+        mockSecureContext.mockReturnValue(false);
+        renderProvider();
+        expect(screen.getByTestId('disabled').textContent).toBe('liveTranslationInsecureContext');
+    });
+
+    it('blames the browser when capture is unsupported in a secure context', () => {
+        setAvailability();
+        setSession();
+        mockAudioSupported.mockReturnValue(false);
+        mockSecureContext.mockReturnValue(true);
+        renderProvider();
+        expect(screen.getByTestId('disabled').textContent).toBe('liveTranslationUnsupportedBrowser');
     });
 
     it('starts the session via onToggle when idle', async () => {

--- a/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
+++ b/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
@@ -429,6 +429,39 @@ describe('useLiveTranslationSession', () => {
     expect(s.hook.result.current.retryable).toBe(true);
   });
 
+  it('reports websocket_connect_failed when the socket errors before opening', async () => {
+    const s = setup();
+    act(() => s.hook.result.current.start());
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const ws = MockWebSocket.instances[0];
+    await act(async () => {
+      ws.onerror?.({});
+    });
+    expect(s.hook.result.current.status).toBe('error');
+    expect(s.hook.result.current.errorCode).toBe('websocket_connect_failed');
+    expect(s.hook.result.current.retryable).toBe(true);
+  });
+
+  it('reports websocket_connect_failed when the socket closes before opening', async () => {
+    const s = setup();
+    act(() => s.hook.result.current.start());
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const ws = MockWebSocket.instances[0];
+    await act(async () => {
+      ws.onclose?.({});
+    });
+    expect(s.hook.result.current.errorCode).toBe('websocket_connect_failed');
+  });
+
+  it('reports gemini_connect_failed when the socket errors after opening', async () => {
+    const s = setup();
+    const ws = await startAndOpen(s);
+    await act(async () => {
+      ws.onerror?.({});
+    });
+    expect(s.hook.result.current.errorCode).toBe('gemini_connect_failed');
+  });
+
   it('disposes the capture graph on unmount', async () => {
     const s = setup();
     await startAndOpen(s);

--- a/frontend/src/hooks/useLiveTranslationAudioCapture.ts
+++ b/frontend/src/hooks/useLiveTranslationAudioCapture.ts
@@ -41,6 +41,21 @@ export function isAudioCaptureSupported(): boolean {
   );
 }
 
+/**
+ * Whether the page is a secure context. The capture tap relies on AudioWorklet,
+ * which browsers expose only over https:// or http://localhost. On a plain
+ * http:// LAN-IP origin `AudioWorkletNode` is undefined, so capture is reported
+ * as unsupported; this lets the UI show a "needs HTTPS" hint instead of blaming
+ * the browser. Treats an unknown value as secure so we never surface a false
+ * insecure-context warning.
+ */
+export function isSecureContextForCapture(): boolean {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+  return window.isSecureContext !== false;
+}
+
 class MediaCaptureGraph {
   private readonly ctx: AudioContext;
   private readonly source: MediaElementAudioSourceNode;

--- a/frontend/src/hooks/useLiveTranslationSession.ts
+++ b/frontend/src/hooks/useLiveTranslationSession.ts
@@ -319,11 +319,16 @@ export function useLiveTranslationSession(
         wsRef.current = ws;
         seqRef.current = 0;
         audioSeqRef.current = 0;
+        // Whether the upgrade handshake completed. If the socket errors/closes
+        // before this flips true, the connection never opened — the usual cause
+        // is a reverse proxy that does not forward the WebSocket upgrade.
+        let opened = false;
 
         ws.onopen = () => {
           if (!isCurrentStart() || wsRef.current !== ws) {
             return;
           }
+          opened = true;
           sendControl({
             type: 'start',
             videoId,
@@ -400,10 +405,30 @@ export function useLiveTranslationSession(
           }
         };
         ws.onerror = () => {
-          fail('gemini_connect_failed', 'Live translation connection failed.', true);
+          if (!opened) {
+            // Handshake never completed: the WebSocket upgrade was rejected or
+            // dropped before the session opened (commonly a reverse proxy that
+            // does not forward Upgrade requests).
+            fail(
+              'websocket_connect_failed',
+              'Could not open the live translation connection.',
+              true,
+            );
+          } else {
+            fail('gemini_connect_failed', 'Live translation connection failed.', true);
+          }
         };
         ws.onclose = () => {
-          if (wsRef.current === ws) {
+          if (wsRef.current !== ws) {
+            return;
+          }
+          if (!opened) {
+            fail(
+              'websocket_connect_failed',
+              'Could not open the live translation connection.',
+              true,
+            );
+          } else {
             cleanup('idle');
           }
         };

--- a/frontend/src/utils/liveTranslationProtocol.ts
+++ b/frontend/src/utils/liveTranslationProtocol.ts
@@ -51,7 +51,8 @@ export type LiveTranslationErrorCode =
   | 'protocol_error'
   // Client-only conditions (the backend never emits these).
   | 'unsupported_playback_rate'
-  | 'audio_capture_failed';
+  | 'audio_capture_failed'
+  | 'websocket_connect_failed';
 
 export type ServerMessage =
   | { type: 'ready'; sessionId: string }

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -225,6 +225,7 @@ Total keys: 996
 | `liveTranslationAudioCaptureBlocked` |
 | `liveTranslationAdminRequiredPlayer` |
 | `liveTranslationApiKeyMissingPlayer` |
+| `liveTranslationErrorWebSocket` |
 | `liveTranslationErrorGeneric` |
 | `liveTranslationErrorRequiresNormalSpeed` |
 | `liveTranslationErrorTicket` |

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -221,6 +221,7 @@ Total keys: 996
 | `liveTranslationRetry` |
 | `liveTranslationUnavailable` |
 | `liveTranslationUnsupportedBrowser` |
+| `liveTranslationInsecureContext` |
 | `liveTranslationAudioCaptureBlocked` |
 | `liveTranslationAdminRequiredPlayer` |
 | `liveTranslationApiKeyMissingPlayer` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -202,6 +202,7 @@ export const ar = {
   liveTranslationErrorTicket: "تعذّر بدء جلسة الترجمة المباشرة. حاول مرة أخرى.",
   liveTranslationErrorCaptureFailed: "تعذّر التقاط صوت هذا الفيديو.",
   liveTranslationErrorConnection: "تعذّر الاتصال بخدمة الترجمة. حاول مرة أخرى.",
+  liveTranslationErrorWebSocket: "تعذّر فتح اتصال الترجمة المباشرة. إذا كان هذا الموقع خلف وكيل عكسي، فتأكد من أنه يمرّر طلبات WebSocket (Upgrade) للمسار /api/live-translation/ws.",
   liveTranslationErrorRateLimited: "خدمة الترجمة مشغولة. حاول مرة أخرى بعد قليل.",
   liveTranslationErrorSessionTimeout: "بلغت جلسة الترجمة المباشرة حدّها الزمني. يمكنك إعادة تشغيلها.",
   liveTranslationErrorTooManySessions: "عدد جلسات الترجمة المباشرة النشطة كبير جدًا. حاول مرة أخرى بعد قليل.",

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -193,6 +193,7 @@ export const ar = {
   liveTranslationRetry: "إعادة المحاولة",
   liveTranslationUnavailable: "الترجمة المباشرة غير متاحة حاليًا.",
   liveTranslationUnsupportedBrowser: "هذا المتصفح لا يدعم الترجمة المباشرة.",
+  liveTranslationInsecureContext: "تتطلب الترجمة المباشرة اتصالاً آمناً (HTTPS أو localhost).",
   liveTranslationAudioCaptureBlocked: "الترجمة المباشرة غير متاحة لمصدر صوت هذا الفيديو.",
   liveTranslationAdminRequiredPlayer: "تتطلب الترجمة المباشرة حساب مسؤول.",
   liveTranslationApiKeyMissingPlayer: "الترجمة المباشرة غير مهيأة. أضف مفتاح Gemini API في الإعدادات.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -212,6 +212,7 @@ export const de = {
   liveTranslationErrorTicket: "Die Live-Übersetzungssitzung konnte nicht gestartet werden. Bitte versuchen Sie es erneut.",
   liveTranslationErrorCaptureFailed: "Der Ton dieses Videos konnte nicht erfasst werden.",
   liveTranslationErrorConnection: "Verbindung zum Übersetzungsdienst fehlgeschlagen. Bitte versuchen Sie es erneut.",
+  liveTranslationErrorWebSocket: "Die Verbindung für die Live-Übersetzung konnte nicht hergestellt werden. Wenn diese Seite hinter einem Reverse-Proxy läuft, stellen Sie sicher, dass er WebSocket-(Upgrade-)Anfragen für /api/live-translation/ws weiterleitet.",
   liveTranslationErrorRateLimited: "Der Übersetzungsdienst ist ausgelastet. Bitte versuchen Sie es in Kürze erneut.",
   liveTranslationErrorSessionTimeout: "Die Live-Übersetzungssitzung hat ihr Zeitlimit erreicht. Sie können sie neu starten.",
   liveTranslationErrorTooManySessions: "Zu viele aktive Live-Übersetzungssitzungen. Bitte versuchen Sie es in Kürze erneut.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -203,6 +203,7 @@ export const de = {
   liveTranslationRetry: "Erneut versuchen",
   liveTranslationUnavailable: "Live-Übersetzung ist derzeit nicht verfügbar.",
   liveTranslationUnsupportedBrowser: "Dieser Browser unterstützt keine Live-Übersetzung.",
+  liveTranslationInsecureContext: "Live-Übersetzung erfordert eine sichere Verbindung (HTTPS oder localhost).",
   liveTranslationAudioCaptureBlocked: "Für die Audioquelle dieses Videos ist keine Live-Übersetzung verfügbar.",
   liveTranslationAdminRequiredPlayer: "Live-Übersetzung erfordert ein Administratorkonto.",
   liveTranslationApiKeyMissingPlayer: "Live-Übersetzung ist nicht konfiguriert. Fügen Sie in den Einstellungen einen Gemini-API-Schlüssel hinzu.",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -206,6 +206,8 @@ export const en = {
   liveTranslationErrorCaptureFailed: "Could not capture this video's audio.",
   liveTranslationErrorConnection:
     "Could not connect to the translation service. Please try again.",
+  liveTranslationErrorWebSocket:
+    "Couldn't open the live translation connection. If this site is behind a reverse proxy, make sure it forwards WebSocket (Upgrade) requests for /api/live-translation/ws.",
   liveTranslationErrorRateLimited:
     "The translation service is busy. Please try again shortly.",
   liveTranslationErrorSessionTimeout:

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -190,6 +190,8 @@ export const en = {
   liveTranslationUnavailable: "Live translation is currently unavailable.",
   liveTranslationUnsupportedBrowser:
     "Live translation is not supported in this browser.",
+  liveTranslationInsecureContext:
+    "Live translation requires a secure connection (HTTPS or localhost).",
   liveTranslationAudioCaptureBlocked:
     "Live translation is unavailable for this video's audio source.",
   liveTranslationAdminRequiredPlayer:

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -209,6 +209,7 @@ export const es = {
   liveTranslationErrorTicket: "No se pudo iniciar la sesión de traducción en vivo. Inténtalo de nuevo.",
   liveTranslationErrorCaptureFailed: "No se pudo capturar el audio de este video.",
   liveTranslationErrorConnection: "No se pudo conectar con el servicio de traducción. Inténtalo de nuevo.",
+  liveTranslationErrorWebSocket: "No se pudo abrir la conexión de traducción en vivo. Si este sitio está detrás de un proxy inverso, asegúrate de que reenvíe las solicitudes WebSocket (Upgrade) para /api/live-translation/ws.",
   liveTranslationErrorRateLimited: "El servicio de traducción está ocupado. Inténtalo de nuevo en un momento.",
   liveTranslationErrorSessionTimeout: "La sesión de traducción en vivo alcanzó su límite de tiempo. Puedes reiniciarla.",
   liveTranslationErrorTooManySessions: "Demasiadas sesiones de traducción en vivo activas. Inténtalo de nuevo en un momento.",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -200,6 +200,7 @@ export const es = {
   liveTranslationRetry: "Reintentar",
   liveTranslationUnavailable: "La traducción en vivo no está disponible por ahora.",
   liveTranslationUnsupportedBrowser: "Este navegador no admite la traducción en vivo.",
+  liveTranslationInsecureContext: "La traducción en vivo requiere una conexión segura (HTTPS o localhost).",
   liveTranslationAudioCaptureBlocked: "La traducción en vivo no está disponible para la fuente de audio de este video.",
   liveTranslationAdminRequiredPlayer: "La traducción en vivo requiere una cuenta de administrador.",
   liveTranslationApiKeyMissingPlayer: "La traducción en vivo no está configurada. Añade una clave de API de Gemini en Ajustes.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -201,6 +201,7 @@ export const fr = {
   liveTranslationRetry: "Réessayer",
   liveTranslationUnavailable: "La traduction en direct est actuellement indisponible.",
   liveTranslationUnsupportedBrowser: "Ce navigateur ne prend pas en charge la traduction en direct.",
+  liveTranslationInsecureContext: "La traduction en direct nécessite une connexion sécurisée (HTTPS ou localhost).",
   liveTranslationAudioCaptureBlocked: "La traduction en direct n'est pas disponible pour la source audio de cette vidéo.",
   liveTranslationAdminRequiredPlayer: "La traduction en direct nécessite un compte administrateur.",
   liveTranslationApiKeyMissingPlayer: "La traduction en direct n'est pas configurée. Ajoutez une clé API Gemini dans les Paramètres.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -210,6 +210,7 @@ export const fr = {
   liveTranslationErrorTicket: "La session de traduction en direct n'a pas pu démarrer. Veuillez réessayer.",
   liveTranslationErrorCaptureFailed: "Impossible de capturer l'audio de cette vidéo.",
   liveTranslationErrorConnection: "Impossible de se connecter au service de traduction. Veuillez réessayer.",
+  liveTranslationErrorWebSocket: "Impossible d'ouvrir la connexion de traduction en direct. Si ce site est derrière un proxy inverse, assurez-vous qu'il transmet les requêtes WebSocket (Upgrade) pour /api/live-translation/ws.",
   liveTranslationErrorRateLimited: "Le service de traduction est occupé. Veuillez réessayer dans un instant.",
   liveTranslationErrorSessionTimeout: "La session de traduction en direct a atteint sa limite de temps. Vous pouvez la redémarrer.",
   liveTranslationErrorTooManySessions: "Trop de sessions de traduction en direct actives. Veuillez réessayer dans un instant.",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -200,6 +200,7 @@ export const ja = {
   liveTranslationRetry: "再試行",
   liveTranslationUnavailable: "ライブ翻訳は現在利用できません。",
   liveTranslationUnsupportedBrowser: "このブラウザはライブ翻訳に対応していません。",
+  liveTranslationInsecureContext: "ライブ翻訳には安全な接続（HTTPS または localhost）が必要です。",
   liveTranslationAudioCaptureBlocked: "この動画の音声ソースではライブ翻訳を利用できません。",
   liveTranslationAdminRequiredPlayer: "ライブ翻訳には管理者アカウントが必要です。",
   liveTranslationApiKeyMissingPlayer: "ライブ翻訳が設定されていません。設定で Gemini API キーを追加してください。",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -209,6 +209,7 @@ export const ja = {
   liveTranslationErrorTicket: "ライブ翻訳セッションを開始できませんでした。もう一度お試しください。",
   liveTranslationErrorCaptureFailed: "この動画の音声を取得できませんでした。",
   liveTranslationErrorConnection: "翻訳サービスに接続できませんでした。もう一度お試しください。",
+  liveTranslationErrorWebSocket: "ライブ翻訳の接続を確立できませんでした。このサイトがリバースプロキシの背後にある場合は、/api/live-translation/ws の WebSocket（Upgrade）リクエストを転送するように設定してください。",
   liveTranslationErrorRateLimited: "翻訳サービスが混雑しています。しばらくしてからお試しください。",
   liveTranslationErrorSessionTimeout: "ライブ翻訳セッションが時間制限に達しました。再開できます。",
   liveTranslationErrorTooManySessions: "アクティブなライブ翻訳セッションが多すぎます。しばらくしてからお試しください。",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -197,6 +197,7 @@ export const ko = {
   liveTranslationRetry: "다시 시도",
   liveTranslationUnavailable: "실시간 번역을 현재 사용할 수 없습니다.",
   liveTranslationUnsupportedBrowser: "이 브라우저는 실시간 번역을 지원하지 않습니다.",
+  liveTranslationInsecureContext: "실시간 번역에는 보안 연결(HTTPS 또는 localhost)이 필요합니다.",
   liveTranslationAudioCaptureBlocked: "이 동영상의 오디오 소스에서는 실시간 번역을 사용할 수 없습니다.",
   liveTranslationAdminRequiredPlayer: "실시간 번역에는 관리자 계정이 필요합니다.",
   liveTranslationApiKeyMissingPlayer: "실시간 번역이 구성되지 않았습니다. 설정에서 Gemini API 키를 추가하세요.",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -206,6 +206,7 @@ export const ko = {
   liveTranslationErrorTicket: "실시간 번역 세션을 시작할 수 없습니다. 다시 시도하세요.",
   liveTranslationErrorCaptureFailed: "이 동영상의 오디오를 캡처할 수 없습니다.",
   liveTranslationErrorConnection: "번역 서비스에 연결할 수 없습니다. 다시 시도하세요.",
+  liveTranslationErrorWebSocket: "실시간 번역 연결을 열 수 없습니다. 이 사이트가 리버스 프록시 뒤에 있는 경우 /api/live-translation/ws에 대한 WebSocket(Upgrade) 요청을 전달하도록 설정하세요.",
   liveTranslationErrorRateLimited: "번역 서비스가 혼잡합니다. 잠시 후 다시 시도하세요.",
   liveTranslationErrorSessionTimeout: "실시간 번역 세션이 시간 제한에 도달했습니다. 다시 시작할 수 있습니다.",
   liveTranslationErrorTooManySessions: "활성 실시간 번역 세션이 너무 많습니다. 잠시 후 다시 시도하세요.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -200,6 +200,7 @@ export const pt = {
   liveTranslationRetry: "Tentar novamente",
   liveTranslationUnavailable: "A tradução ao vivo está indisponível no momento.",
   liveTranslationUnsupportedBrowser: "Este navegador não oferece suporte à tradução ao vivo.",
+  liveTranslationInsecureContext: "A tradução ao vivo requer uma conexão segura (HTTPS ou localhost).",
   liveTranslationAudioCaptureBlocked: "A tradução ao vivo não está disponível para a fonte de áudio deste vídeo.",
   liveTranslationAdminRequiredPlayer: "A tradução ao vivo requer uma conta de administrador.",
   liveTranslationApiKeyMissingPlayer: "A tradução ao vivo não está configurada. Adicione uma chave de API do Gemini nas Configurações.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -209,6 +209,7 @@ export const pt = {
   liveTranslationErrorTicket: "Não foi possível iniciar a sessão de tradução ao vivo. Tente novamente.",
   liveTranslationErrorCaptureFailed: "Não foi possível capturar o áudio deste vídeo.",
   liveTranslationErrorConnection: "Não foi possível conectar ao serviço de tradução. Tente novamente.",
+  liveTranslationErrorWebSocket: "Não foi possível abrir a conexão de tradução ao vivo. Se este site estiver atrás de um proxy reverso, verifique se ele encaminha as solicitações WebSocket (Upgrade) para /api/live-translation/ws.",
   liveTranslationErrorRateLimited: "O serviço de tradução está ocupado. Tente novamente em instantes.",
   liveTranslationErrorSessionTimeout: "A sessão de tradução ao vivo atingiu o limite de tempo. Você pode reiniciá-la.",
   liveTranslationErrorTooManySessions: "Muitas sessões de tradução ao vivo ativas. Tente novamente em instantes.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -200,6 +200,7 @@ export const ru = {
   liveTranslationRetry: "Повторить",
   liveTranslationUnavailable: "Живой перевод сейчас недоступен.",
   liveTranslationUnsupportedBrowser: "Этот браузер не поддерживает живой перевод.",
+  liveTranslationInsecureContext: "Для живого перевода требуется защищённое соединение (HTTPS или localhost).",
   liveTranslationAudioCaptureBlocked: "Живой перевод недоступен для источника звука этого видео.",
   liveTranslationAdminRequiredPlayer: "Для живого перевода требуется учётная запись администратора.",
   liveTranslationApiKeyMissingPlayer: "Живой перевод не настроен. Добавьте ключ API Gemini в настройках.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -209,6 +209,7 @@ export const ru = {
   liveTranslationErrorTicket: "Не удалось запустить сеанс живого перевода. Попробуйте ещё раз.",
   liveTranslationErrorCaptureFailed: "Не удалось захватить звук этого видео.",
   liveTranslationErrorConnection: "Не удалось подключиться к службе перевода. Попробуйте ещё раз.",
+  liveTranslationErrorWebSocket: "Не удалось установить соединение для живого перевода. Если сайт работает за обратным прокси, убедитесь, что он передаёт WebSocket-запросы (Upgrade) для /api/live-translation/ws.",
   liveTranslationErrorRateLimited: "Служба перевода занята. Повторите попытку чуть позже.",
   liveTranslationErrorSessionTimeout: "Сеанс живого перевода достиг ограничения по времени. Его можно перезапустить.",
   liveTranslationErrorTooManySessions: "Слишком много активных сеансов живого перевода. Повторите попытку чуть позже.",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -195,6 +195,7 @@ export const zh = {
   liveTranslationErrorTicket: "无法启动实时翻译会话，请重试。",
   liveTranslationErrorCaptureFailed: "无法捕获此视频的音频。",
   liveTranslationErrorConnection: "无法连接到翻译服务，请重试。",
+  liveTranslationErrorWebSocket: "无法建立实时翻译连接。如果本站点位于反向代理之后，请确保它为 /api/live-translation/ws 转发 WebSocket（Upgrade）请求。",
   liveTranslationErrorRateLimited: "翻译服务繁忙，请稍后重试。",
   liveTranslationErrorSessionTimeout: "实时翻译会话已达到时长上限，可重新开始。",
   liveTranslationErrorTooManySessions: "当前活动的实时翻译会话过多，请稍后重试。",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -186,6 +186,7 @@ export const zh = {
   liveTranslationRetry: "重试",
   liveTranslationUnavailable: "实时翻译当前不可用。",
   liveTranslationUnsupportedBrowser: "此浏览器不支持实时翻译。",
+  liveTranslationInsecureContext: "实时翻译需要安全连接（HTTPS 或 localhost）。",
   liveTranslationAudioCaptureBlocked: "此视频的音频来源无法用于实时翻译。",
   liveTranslationAdminRequiredPlayer: "实时翻译需要管理员账户。",
   liveTranslationApiKeyMissingPlayer: "实时翻译尚未配置。请在设置中添加 Gemini API 密钥。",


### PR DESCRIPTION
Three fixes for getting Live Translation working — and failing *legibly* — in real (non-localhost, proxied) deployments, found while debugging a NAS instance.

## 1. WebSocket proxying in the frontend nginx

Live Translation opens a WebSocket to `/api/live-translation/ws`. It worked in local dev but failed in Docker/NAS with *"There was a bad response from the server."*

**Cause:** the frontend container's `nginx.conf` proxied `/api` without the WebSocket upgrade headers, so nginx forwarded the handshake as a plain HTTP/1.0 GET and the backend's `server.on("upgrade")` handler never fired.

**Fix:** add a `$connection_upgrade` map + a dedicated `location = /api/live-translation/ws` block (`proxy_http_version 1.1`, `Upgrade`/`Connection`, no buffering, long timeouts). Documented the same requirement for **user-supplied** reverse proxies (NPM, Traefik, Caddy, Synology/QNAP, Cloudflare) in the EN/ZH Docker guides.

## 2. "Needs HTTPS" hint instead of "unsupported browser"

Audio capture uses **AudioWorklet**, exposed only in a **secure context** (`https://` or `http://localhost`). On a plain `http://` LAN-IP origin the button was disabled with *"not supported in this browser"* — misleading.

**Fix:** `isSecureContextForCapture()` (`window.isSecureContext`) branches the disabled tooltip — insecure context → new `liveTranslationInsecureContext` (*"requires a secure connection (HTTPS or localhost)"*); secure-but-unsupported → the existing browser message.

## 3. Explain the reverse-proxy cause on a failed handshake

When the handshake fails behind a misconfigured proxy, the browser only gives a generic error and the in-player alert showed a vague *"could not connect… try again"* + Retry — no actionable cause.

**Fix:** track whether the socket ever opened. Error/close **before open** → new client-only code `websocket_connect_failed` whose message points at the likely cause (a reverse proxy that must forward WebSocket `Upgrade` for `/api/live-translation/ws`). A post-open drop keeps the existing `gemini_connect_failed` message.

## i18n / tests

- New keys (`liveTranslationInsecureContext`, `liveTranslationErrorWebSocket`) added to **all 10 locales** + `KEY_LIST.md` (`t()` returns the raw key for missing entries — no en fallback).
- `nginx -t` passes; verified end-to-end on a live NAS deployment.
- Frontend: typecheck clean on changed files, lint clean, **53/53** live-translation tests pass (5 new cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)