### PR TITLE
fix(bilibili): clean up empty author folders & recover from cookie risk-control on collections

### DIFF
--- a/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
@@ -423,4 +423,103 @@ describe("bilibiliCollection.downloadCollection", () => {
 
     expect(mocks.cleanupCollectionDirectories).not.toHaveBeenCalled();
   });
+
+  it("retries an episode once after a Bilibili risk-control rejection (issue #295)", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.axiosGet.mockResolvedValue({
+        data: {
+          data: {
+            archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
+            page: { total: 1 },
+          },
+        },
+      });
+      mocks.getCollectionById.mockReturnValue(undefined);
+      mocks.getVideoBySourceUrl.mockReturnValue(undefined);
+      mocks.downloadSinglePart
+        .mockResolvedValueOnce({
+          success: false,
+          error: "ERROR: HTTP Error 412: Precondition Failed (-352)",
+        })
+        .mockResolvedValueOnce({ success: true, videoData: { id: "video-1" } });
+
+      const promise = downloadCollection(
+        { success: true, type: "collection", id: 42, mid: 9, title: "Series" },
+        "Series",
+        "download-riskretry",
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      // Initial attempt + exactly one backoff retry.
+      expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(true);
+      expect(result.downloadedCount).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces a cookie-refresh hint when an episode keeps failing risk control", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.axiosGet.mockResolvedValue({
+        data: {
+          data: {
+            archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
+            page: { total: 1 },
+          },
+        },
+      });
+      mocks.getCollectionById.mockReturnValue(undefined);
+      mocks.getVideoBySourceUrl.mockReturnValue(undefined);
+      mocks.downloadSinglePart.mockResolvedValue({
+        success: false,
+        error: "请先登录 (-101)",
+      });
+
+      const promise = downloadCollection(
+        { success: true, type: "collection", id: 42, mid: 9, title: "Series" },
+        "Series",
+        "download-riskhint",
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
+      // Initial attempt + one retry, then it gives up and surfaces the hint.
+      expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("refresh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry a generic (non-risk-control) failure", async () => {
+    mocks.axiosGet.mockResolvedValue({
+      data: {
+        data: {
+          archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
+          page: { total: 1 },
+        },
+      },
+    });
+    mocks.getCollectionById.mockReturnValue(undefined);
+    mocks.getVideoBySourceUrl.mockReturnValue(undefined);
+    mocks.downloadSinglePart.mockResolvedValue({
+      success: false,
+      error: "network error",
+    });
+
+    const result = await downloadCollection(
+      { success: true, type: "collection", id: 42, mid: 9, title: "Series" },
+      "Series",
+      "download-generic-fail",
+    );
+
+    expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.error ?? "").not.toContain("refresh");
+  });
 });

--- a/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
@@ -83,6 +83,7 @@ describe("bilibiliCollection.downloadCollection", () => {
       activeDownloads: [
         { id: "download-riskretry" },
         { id: "download-riskhint" },
+        { id: "download-riskthengeneric" },
       ],
     });
     mocks.saveCollection.mockImplementation((collection: any) => collection);
@@ -516,6 +517,45 @@ describe("bilibiliCollection.downloadCollection", () => {
       const result = await promise;
 
       // Initial attempt + one retry, then it gives up and surfaces the hint.
+      expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(2);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("refresh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the cookie-refresh hint when risk control is followed by a generic retry failure (issue #295)", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.axiosGet.mockResolvedValue({
+        data: {
+          data: {
+            archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
+            page: { total: 1 },
+          },
+        },
+      });
+      mocks.getCollectionById.mockReturnValue(undefined);
+      mocks.getVideoBySourceUrl.mockReturnValue(undefined);
+      // First attempt hits risk control; the retry fails with an unrelated
+      // generic error. The hint must still come from the first attempt rather
+      // than being dropped because the retry's error is not risk-control.
+      mocks.downloadSinglePart
+        .mockResolvedValueOnce({
+          success: false,
+          error: "ERROR: HTTP Error 412: Precondition Failed (-352)",
+        })
+        .mockResolvedValueOnce({ success: false, error: "network error" });
+
+      const promise = downloadCollection(
+        { success: true, type: "collection", id: 42, mid: 9, title: "Series" },
+        "Series",
+        "download-riskthengeneric",
+      );
+      await vi.runAllTimersAsync();
+      const result = await promise;
+
       expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(2);
       expect(result.success).toBe(false);
       expect(result.error).toContain("refresh");

--- a/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 
 const mocks = vi.hoisted(() => ({
   axiosGet: vi.fn(),
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   saveCollection: vi.fn(),
   updateActiveDownloadTitle: vi.fn(),
   getVideoBySourceUrl: vi.fn(),
+  getDownloadStatus: vi.fn(),
   linkVideoToCollection: vi.fn(),
   getSettings: vi.fn(),
   cleanupCollectionDirectories: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock("../../../services/storageService", () => ({
   updateActiveDownloadTitle: (...args: any[]) =>
     mocks.updateActiveDownloadTitle(...args),
   getVideoBySourceUrl: (...args: any[]) => mocks.getVideoBySourceUrl(...args),
+  getDownloadStatus: (...args: any[]) => mocks.getDownloadStatus(...args),
   linkVideoToCollection: (...args: any[]) => mocks.linkVideoToCollection(...args),
   getSettings: (...args: any[]) => mocks.getSettings(...args),
   cleanupCollectionDirectories: (...args: any[]) =>
@@ -76,6 +79,12 @@ describe("bilibiliCollection.downloadCollection", () => {
     mocks.getCollectionByName.mockReturnValue(undefined);
     mocks.getCollectionBySourceKey.mockReturnValue(undefined);
     mocks.getCollectionsByVideoId.mockReturnValue([]);
+    mocks.getDownloadStatus.mockReturnValue({
+      activeDownloads: [
+        { id: "download-riskretry" },
+        { id: "download-riskhint" },
+      ],
+    });
     mocks.saveCollection.mockImplementation((collection: any) => collection);
     mocks.linkVideoToCollection.mockReturnValue(undefined);
     mocks.getSettings.mockReturnValue({});
@@ -491,6 +500,44 @@ describe("bilibiliCollection.downloadCollection", () => {
       expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(2);
       expect(result.success).toBe(false);
       expect(result.error).toContain("refresh");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retry risk-control failures after cancellation during backoff", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.axiosGet.mockResolvedValue({
+        data: {
+          data: {
+            archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
+            page: { total: 1 },
+          },
+        },
+      });
+      mocks.getCollectionById.mockReturnValue(undefined);
+      mocks.getVideoBySourceUrl.mockReturnValue(undefined);
+      mocks.getDownloadStatus
+        .mockReturnValueOnce({ activeDownloads: [{ id: "download-cancel" }] })
+        .mockReturnValueOnce({ activeDownloads: [] });
+      mocks.downloadSinglePart.mockResolvedValue({
+        success: false,
+        error: "ERROR: HTTP Error 412: Precondition Failed (-352)",
+      });
+
+      const promise = downloadCollection(
+        { success: true, type: "collection", id: 42, mid: 9, title: "Series" },
+        "Series",
+        "download-cancel",
+      );
+      const cancellationExpectation = expect(promise).rejects.toBeInstanceOf(
+        DownloadCancelledError,
+      );
+      await vi.runAllTimersAsync();
+
+      await cancellationExpectation;
+      expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
@@ -246,6 +246,9 @@ describe("bilibiliCollection.downloadCollection", () => {
       }
       return undefined;
     });
+    mocks.getSettings.mockReturnValue({
+      authorOrganizationMode: "author_folder_only",
+    });
     mocks.getCollectionBySourceKey.mockImplementation(
       (platform: string, type: string, mid: string, id: string) => {
         if (
@@ -256,8 +259,8 @@ describe("bilibiliCollection.downloadCollection", () => {
         ) {
           return {
             id: "col-existing",
-            name: "Series",
-            title: "Series",
+            name: "Renamed Series",
+            title: "Renamed Series",
             origin: "manual",
             videos: ["video-1"],
             sourcePlatform: "bilibili",
@@ -294,12 +297,28 @@ describe("bilibiliCollection.downloadCollection", () => {
     expect(mocks.saveCollection).not.toHaveBeenCalled();
     // Only the missing episode is downloaded; the existing one is linked.
     expect(mocks.downloadSinglePart).toHaveBeenCalledTimes(1);
+    expect(mocks.downloadSinglePart).toHaveBeenCalledWith(
+      "https://www.bilibili.com/video/BV2",
+      2,
+      2,
+      "Series",
+      "download-3",
+      undefined,
+      "Renamed Series",
+      expect.objectContaining({
+        sourceCollectionName: "Renamed Series",
+      }),
+    );
     expect(mocks.linkVideoToCollection).toHaveBeenNthCalledWith(
       1,
       "col-existing",
       "video-1",
       { moveFiles: false, order: 1 },
     );
+    expect(mocks.cleanupCollectionDirectories).toHaveBeenCalledWith(
+      "Renamed Series",
+    );
+    expect(mocks.cleanupCollectionDirectories).toHaveBeenCalledWith("Series");
   });
 
   it("does not reuse a same-named Bilibili collection with a different source key", async () => {

--- a/backend/src/__tests__/services/downloaders/bilibiliConfig.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliConfig.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../../utils/logger', () => ({
 }));
 
 import {
+  isLikelyBilibiliAuthFailure,
   prepareBilibiliDownloadFlags,
   resolveResolutionRetryTarget,
 } from '../../../services/downloaders/bilibili/bilibiliConfig';
@@ -486,5 +487,28 @@ describe('resolveResolutionRetryTarget', () => {
         1080, 2160,
       ])
     ).toBeNull();
+  });
+});
+
+describe('isLikelyBilibiliAuthFailure', () => {
+  it.each([
+    'ERROR: HTTP Error 412: Precondition Failed',
+    'bilibili API error code -352',
+    'code -101 (not logged in)',
+    '请先登录后再试',
+    'request blocked by risk control',
+  ])('treats %s as an auth/risk-control failure', (message) => {
+    expect(isLikelyBilibiliAuthFailure(message)).toBe(true);
+  });
+
+  it.each([
+    'network error',
+    'Requested format is not available',
+    'Connection timed out',
+    '',
+    undefined,
+    null,
+  ])('treats %s as a generic failure', (message) => {
+    expect(isLikelyBilibiliAuthFailure(message as any)).toBe(false);
   });
 });

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -629,9 +629,10 @@ describe("bilibiliVideo.downloadSinglePart", () => {
   });
 
   it("surfaces a cookie-refresh hint when the download fails with a risk-control error", async () => {
-    const failing: any = Promise.reject(
-      new Error("ERROR: HTTP Error 412: Precondition Failed"),
-    );
+    const ytDlpError = new Error("yt-dlp process exited with code 1");
+    (ytDlpError as any).stderr =
+      "ERROR: HTTP Error 412: Precondition Failed (-352)";
+    const failing: any = Promise.reject(ytDlpError);
     // Mark the rejection handled so it is not reported as an unhandled rejection;
     // downloadVideo attaches its own handler via `await`.
     failing.catch(() => {});
@@ -650,6 +651,7 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     );
 
     expect(result.success).toBe(false);
+    expect(result.error).toContain("yt-dlp process exited with code 1");
     expect(result.error).toContain("412");
     expect(result.error).toContain("refresh");
     expect(mocks.saveVideo).not.toHaveBeenCalled();

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -74,9 +74,13 @@ vi.mock("../../../utils/avatarUtils", () => ({
     mocks.downloadAndProcessAvatar(...args),
 }));
 
-vi.mock("../../../utils/logger", () => ({
-  logger: mocks.logger,
-}));
+vi.mock("../../../utils/logger", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return {
+    ...actual,
+    logger: mocks.logger,
+  };
+});
 
 vi.mock("../../../utils/ytDlpUtils", () => {
   class InvalidProxyError extends Error {}
@@ -636,8 +640,13 @@ describe("bilibiliVideo.downloadSinglePart", () => {
 
   it("surfaces a cookie-refresh hint when the download fails with a risk-control error", async () => {
     const ytDlpError = new Error("yt-dlp process exited with code 1");
-    (ytDlpError as any).stderr =
-      "ERROR: HTTP Error 412: Precondition Failed (-352)";
+    (ytDlpError as any).stderr = [
+      "ERROR: HTTP Error 412: Precondition Failed (-352)",
+      "Cookie: SESSDATA=very-secret; bili_jct=csrf-secret",
+      "authorization=Bearer abc123",
+      "https://user:pass@example.com/video?token=rawtoken",
+      "/Users/franklioxygen/private/cookies.txt",
+    ].join("\n");
     const failing: any = Promise.reject(ytDlpError);
     // Mark the rejection handled so it is not reported as an unhandled rejection;
     // downloadVideo attaches its own handler via `await`.
@@ -660,6 +669,12 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(result.error).toContain("yt-dlp process exited with code 1");
     expect(result.error).toContain("412");
     expect(result.error).toContain("refresh");
+    expect(result.error).not.toContain("very-secret");
+    expect(result.error).not.toContain("csrf-secret");
+    expect(result.error).not.toContain("abc123");
+    expect(result.error).not.toContain("user:pass");
+    expect(result.error).not.toContain("rawtoken");
+    expect(result.error).not.toContain("/Users/franklioxygen");
     expect(mocks.saveVideo).not.toHaveBeenCalled();
   });
 

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -682,6 +682,43 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(mocks.saveVideo).not.toHaveBeenCalled();
   });
 
+  it("surfaces a cookie-refresh hint when yt-dlp exits 0 with no file but risk-control stderr (issue #295)", async () => {
+    // With `ignoreErrors: true`, yt-dlp can resolve (exit 0) after skipping a
+    // rejected download: no rejection, no file, and the 412/-352 text only in
+    // stderr. The no-file path must still fold that stderr into the failure so
+    // the risk-control classification (and the cookie hint) fire.
+    const riskStderr =
+      "ERROR: [BiliBili] HTTP Error 412: Precondition Failed (-352)\n" +
+      "Cookie: SESSDATA=very-secret; bili_jct=csrf-secret\n";
+    const resolving: any = Promise.resolve(undefined);
+    resolving.stdout = { on: vi.fn() };
+    resolving.stderr = {
+      on: vi.fn((event: string, cb: (chunk: Buffer) => void) => {
+        if (event === "data") {
+          cb(Buffer.from(riskStderr));
+        }
+      }),
+    };
+    resolving.kill = vi.fn();
+    mocks.executeYtDlpSpawn.mockReturnValue(resolving);
+    mocks.findVideoFileInTemp.mockReturnValue(null);
+
+    const result = await downloadSinglePart(
+      "https://www.bilibili.com/video/BV1ignoreerr",
+      1,
+      1,
+      "",
+      "download-ignoreerr",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("412");
+    expect(result.error).toContain("refresh");
+    expect(result.error).not.toContain("very-secret");
+    expect(result.error).not.toContain("csrf-secret");
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
+  });
+
   it("propagates cancellation instead of recording a failed episode when the part is cancelled (issue #295)", async () => {
     // A cancelled part comes back from downloadVideo through its fallback return
     // (error set, no file), not as a thrown error. downloadSinglePart must

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { formatVideoFilename } from "../../../utils/helpers";
+import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 
 const mocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
@@ -39,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   downloadSubtitles: vi.fn(),
   downloadAndProcessAvatar: vi.fn(),
   downloadThumbnail: vi.fn(),
+  throwIfCancelled: vi.fn(),
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
@@ -122,7 +124,9 @@ vi.mock("../../../services/downloaders/BaseDownloader", () => ({
       }
     }
 
-    protected throwIfCancelled(_downloadId?: string): void {}
+    protected throwIfCancelled(downloadId?: string): void {
+      mocks.throwIfCancelled(downloadId);
+    }
 
     protected async downloadThumbnail(
       ...args: any[]
@@ -189,6 +193,8 @@ const buildExistingVideo = (overrides: Record<string, any> = {}) => ({
 describe("bilibiliVideo.downloadSinglePart", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: not cancelled. Individual tests opt into cancellation.
+    mocks.throwIfCancelled.mockReset();
 
     const subprocess: any = Promise.resolve(undefined);
     subprocess.stdout = { on: vi.fn() };
@@ -655,6 +661,33 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(result.error).toContain("412");
     expect(result.error).toContain("refresh");
     expect(mocks.saveVideo).not.toHaveBeenCalled();
+  });
+
+  it("propagates cancellation instead of recording a failed episode when the part is cancelled (issue #295)", async () => {
+    // A cancelled part comes back from downloadVideo through its fallback return
+    // (error set, no file), not as a thrown error. downloadSinglePart must
+    // re-check and surface DownloadCancelledError so downloadCollection aborts the
+    // whole collection rather than logging a normal failed episode and continuing
+    // to the next video.
+    // existsSync=false keeps downloadVideo off the temp-dir cleanup branch so the
+    // cancellation surfaces as a clean "Download cancelled by user" fallback.
+    mocks.existsSync.mockReturnValue(false);
+    mocks.throwIfCancelled.mockImplementation(() => {
+      throw DownloadCancelledError.create();
+    });
+
+    await expect(
+      downloadSinglePart(
+        "https://www.bilibili.com/video/BV1cancelled",
+        1,
+        1,
+        "",
+        "download-cancelled",
+      ),
+    ).rejects.toBeInstanceOf(DownloadCancelledError);
+
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
+    expect(mocks.organizeVideoByAuthor).not.toHaveBeenCalled();
   });
 
   it("uses zero-padded multipart prefixes for legacy filenames and subtitles", async () => {

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -646,6 +646,7 @@ describe("bilibiliVideo.downloadSinglePart", () => {
       "authorization=Bearer abc123",
       "https://user:pass@example.com/video?token=rawtoken",
       "/Users/franklioxygen/private/cookies.txt",
+      "ERROR: unable to open file /Users/leaky-user/data/output.mp4",
     ].join("\n");
     const failing: any = Promise.reject(ytDlpError);
     // Mark the rejection handled so it is not reported as an unhandled rejection;
@@ -675,6 +676,9 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(result.error).not.toContain("user:pass");
     expect(result.error).not.toContain("rawtoken");
     expect(result.error).not.toContain("/Users/franklioxygen");
+    // A space-preceded absolute path must also be redacted, not just one that
+    // happens to follow a word char.
+    expect(result.error).not.toContain("/Users/leaky-user");
     expect(mocks.saveVideo).not.toHaveBeenCalled();
   });
 

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -132,14 +132,23 @@ vi.mock("../../../services/downloaders/BaseDownloader", () => ({
   },
 }));
 
-vi.mock("../../../services/downloaders/bilibili/bilibiliConfig", () => ({
-  prepareBilibiliDownloadFlags: (...args: any[]) =>
-    mocks.prepareBilibiliDownloadFlags(...args),
-  resolveResolutionPreference: (...args: any[]) =>
-    mocks.resolveResolutionPreference(...args),
-  resolveResolutionRetryTarget: (...args: any[]) =>
-    mocks.resolveResolutionRetryTarget(...args),
-}));
+vi.mock(
+  "../../../services/downloaders/bilibili/bilibiliConfig",
+  async (importOriginal) => {
+    // Keep the real, pure helpers (isLikelyBilibiliAuthFailure, the cookie hint)
+    // and override only the settings-driven functions the tests control.
+    const actual = await importOriginal<any>();
+    return {
+      ...actual,
+      prepareBilibiliDownloadFlags: (...args: any[]) =>
+        mocks.prepareBilibiliDownloadFlags(...args),
+      resolveResolutionPreference: (...args: any[]) =>
+        mocks.resolveResolutionPreference(...args),
+      resolveResolutionRetryTarget: (...args: any[]) =>
+        mocks.resolveResolutionRetryTarget(...args),
+    };
+  },
+);
 
 vi.mock("../../../services/downloaders/bilibili/bilibiliFileManager", () => ({
   cleanupFilesOnCancellation: (...args: any[]) =>
@@ -600,6 +609,50 @@ describe("bilibiliVideo.downloadSinglePart", () => {
       expect.any(String),
       expect.objectContaining({ retryFloorHeight: expect.anything() }),
     );
+  });
+
+  it("returns a failure instead of saving a record when the download fails (issue #295)", async () => {
+    // No file is produced — downloadVideo returns its fallback object with an error.
+    mocks.findVideoFileInTemp.mockReturnValue(null);
+
+    const result = await downloadSinglePart(
+      "https://www.bilibili.com/video/BV1nofile",
+      1,
+      1,
+      "",
+      "download-nofile",
+    );
+
+    expect(result.success).toBe(false);
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
+    expect(mocks.organizeVideoByAuthor).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a cookie-refresh hint when the download fails with a risk-control error", async () => {
+    const failing: any = Promise.reject(
+      new Error("ERROR: HTTP Error 412: Precondition Failed"),
+    );
+    // Mark the rejection handled so it is not reported as an unhandled rejection;
+    // downloadVideo attaches its own handler via `await`.
+    failing.catch(() => {});
+    failing.stdout = { on: vi.fn() };
+    failing.stderr = { on: vi.fn() };
+    failing.kill = vi.fn();
+    mocks.executeYtDlpSpawn.mockReturnValue(failing);
+    mocks.findVideoFileInTemp.mockReturnValue(null);
+
+    const result = await downloadSinglePart(
+      "https://www.bilibili.com/video/BV1risk",
+      1,
+      1,
+      "",
+      "download-risk",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("412");
+    expect(result.error).toContain("refresh");
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
   });
 
   it("uses zero-padded multipart prefixes for legacy filenames and subtitles", async () => {

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -147,6 +147,18 @@ const canReuseCollectionForSource = (
   !hasBilibiliSourceKey(collection) ||
   (sourceKey != null && matchesBilibiliSourceKey(collection, sourceKey));
 
+const getCollectionCleanupNames = (
+  collection: Collection,
+  fallbackName: string,
+): string[] =>
+  Array.from(
+    new Set(
+      [collection.name, collection.title, fallbackName].filter(
+        (name): name is string => typeof name === "string" && name.trim() !== "",
+      ),
+    ),
+  );
+
 function resolveExistingBilibiliCollection(
   videos: BilibiliVideoItem[],
   preferredCollectionName: string,
@@ -686,8 +698,13 @@ export async function downloadCollection(
       const organizationMode = resolveAuthorOrganizationMode(
         storageService.getSettings(),
       );
-      if (organizationMode === "author_folder_only" && resolvedCollectionName) {
-        storageService.cleanupCollectionDirectories(resolvedCollectionName);
+      if (organizationMode === "author_folder_only") {
+        for (const cleanupName of getCollectionCleanupNames(
+          mytubeCollection,
+          resolvedCollectionName,
+        )) {
+          storageService.cleanupCollectionDirectories(cleanupName);
+        }
       }
     } catch (cleanupError) {
       logger.warn(

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -1,5 +1,9 @@
 import axios from "axios";
 import { logger } from "../../../utils/logger";
+import {
+  isCancellationError,
+  throwIfCancelled,
+} from "../../../utils/downloadUtils";
 import type { DownloadRetryMetadata } from "../../downloadRetryMetadata";
 import * as storageService from "../../storageService";
 import { Collection } from "../../storageService";
@@ -22,6 +26,14 @@ import {
 // control, wait this long before the single retry — longer than the normal
 // 2s inter-part delay to let a transient throttle clear (issue #295).
 const RISK_CONTROL_RETRY_DELAY_MS = 15000;
+
+async function waitForRiskControlRetry(downloadId: string): Promise<void> {
+  throwIfCancelled(downloadId);
+  await new Promise((resolve) =>
+    setTimeout(resolve, RISK_CONTROL_RETRY_DELAY_MS),
+  );
+  throwIfCancelled(downloadId);
+}
 
 const buildAggregateErrorMessage = (
   label: string,
@@ -593,9 +605,7 @@ export async function downloadCollection(
               `backing off ${RISK_CONTROL_RETRY_DELAY_MS / 1000}s and retrying once. ` +
               `If episodes keep failing, refresh your Bilibili cookie and re-download.`,
           );
-          await new Promise((resolve) =>
-            setTimeout(resolve, RISK_CONTROL_RETRY_DELAY_MS),
-          );
+          await waitForRiskControlRetry(downloadId);
           result = await downloadPart();
         }
 
@@ -643,6 +653,9 @@ export async function downloadCollection(
           );
         }
       } catch (videoError) {
+        if (isCancellationError(videoError)) {
+          throw videoError;
+        }
         failedPartNumbers.push(videoNumber);
         if (retryCollectionMetadata) {
           retryCollectionMetadata.failedVideoBvids = Array.from(
@@ -712,6 +725,9 @@ export async function downloadCollection(
       error: error || undefined,
     };
   } catch (error: any) {
+    if (isCancellationError(error)) {
+      throw error;
+    }
     logger.error(`Error downloading ${collectionInfo.type}:`, error);
     return {
       success: false,

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -611,7 +611,9 @@ export async function downloadCollection(
         // control even with a valid cookie. Back off once and retry the part
         // before marking it failed (issue #295). Cancellations throw rather than
         // returning a failure result, so they are never retried here.
-        if (!result.success && isLikelyBilibiliAuthFailure(result.error)) {
+        const hitRiskControl =
+          !result.success && isLikelyBilibiliAuthFailure(result.error);
+        if (hitRiskControl) {
           logger.warn(
             `Video ${videoNumber}/${videos.length} hit a possible Bilibili risk-control/cookie rejection; ` +
               `backing off ${RISK_CONTROL_RETRY_DELAY_MS / 1000}s and retrying once. ` +
@@ -649,7 +651,10 @@ export async function downloadCollection(
           );
         } else {
           failedPartNumbers.push(videoNumber);
-          if (isLikelyBilibiliAuthFailure(result.error)) {
+          // The retry overwrites `result`, so key off the first attempt: a part
+          // that hit risk control and then failed (even with a generic retry
+          // error) must still surface the cookie-refresh hint (issue #295).
+          if (hitRiskControl) {
             sawRiskControlFailure = true;
           }
           if (retryCollectionMetadata) {

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -5,6 +5,10 @@ import * as storageService from "../../storageService";
 import { Collection } from "../../storageService";
 import { resolveAuthorOrganizationMode } from "../../../types/settings";
 import { downloadSinglePart } from "./bilibiliVideo";
+import {
+  BILIBILI_COOKIE_REFRESH_HINT,
+  isLikelyBilibiliAuthFailure,
+} from "./bilibiliConfig";
 import type { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import {
   BilibiliAggregateDownloadResult,
@@ -13,6 +17,11 @@ import {
   BilibiliVideosResult,
   CollectionDownloadResult,
 } from "./types";
+
+// When a collection episode is rejected for what looks like Bilibili risk
+// control, wait this long before the single retry — longer than the normal
+// 2s inter-part delay to let a transient throttle clear (issue #295).
+const RISK_CONTROL_RETRY_DELAY_MS = 15000;
 
 const buildAggregateErrorMessage = (
   label: string,
@@ -504,6 +513,7 @@ export async function downloadCollection(
     logger.info(`Using MyTube collection: ${mytubeCollection.name}`);
     let downloadedCount = 0;
     const failedPartNumbers: number[] = [];
+    let sawRiskControlFailure = false;
     let firstVideo: CollectionDownloadResult["firstVideo"];
 
     // Download each video sequentially
@@ -554,20 +564,40 @@ export async function downloadCollection(
       try {
         // Download this video
         const collectionName = mytubeCollection.name || mytubeCollection.title;
-        const result = await downloadSinglePart(
-          videoUrl,
-          videoNumber,
-          videos.length,
-          title || "Collection",
-          downloadId,
-          onStart,
-          collectionName, // collectionName
-          {
-            sourceCollectionName: collectionName || title || "Collection",
-            sourceCollectionType: "playlist",
-            mediaPlaylistIndex: videoNumber,
-          } // filenameTemplateSourceOptions
-        );
+        const sourceOptions: FilenameTemplateSourceOptions = {
+          sourceCollectionName: collectionName || title || "Collection",
+          sourceCollectionType: "playlist",
+          mediaPlaylistIndex: videoNumber,
+        };
+        const downloadPart = () =>
+          downloadSinglePart(
+            videoUrl,
+            videoNumber,
+            videos.length,
+            title || "Collection",
+            downloadId,
+            onStart,
+            collectionName, // collectionName
+            sourceOptions, // filenameTemplateSourceOptions
+          );
+
+        let result = await downloadPart();
+
+        // Bilibili sometimes rejects individual episodes mid-collection for risk
+        // control even with a valid cookie. Back off once and retry the part
+        // before marking it failed (issue #295). Cancellations throw rather than
+        // returning a failure result, so they are never retried here.
+        if (!result.success && isLikelyBilibiliAuthFailure(result.error)) {
+          logger.warn(
+            `Video ${videoNumber}/${videos.length} hit a possible Bilibili risk-control/cookie rejection; ` +
+              `backing off ${RISK_CONTROL_RETRY_DELAY_MS / 1000}s and retrying once. ` +
+              `If episodes keep failing, refresh your Bilibili cookie and re-download.`,
+          );
+          await new Promise((resolve) =>
+            setTimeout(resolve, RISK_CONTROL_RETRY_DELAY_MS),
+          );
+          result = await downloadPart();
+        }
 
         // If download was successful, add to collection
         if (result.success && result.videoData) {
@@ -597,6 +627,9 @@ export async function downloadCollection(
           );
         } else {
           failedPartNumbers.push(videoNumber);
+          if (isLikelyBilibiliAuthFailure(result.error)) {
+            sawRiskControlFailure = true;
+          }
           if (retryCollectionMetadata) {
             retryCollectionMetadata.failedVideoBvids = Array.from(
               new Set([
@@ -654,13 +687,16 @@ export async function downloadCollection(
     const partial =
       failedPartNumbers.length > 0 && downloadedCount + skippedCount > 0;
     const success = failedPartNumbers.length === 0;
-    const error = buildAggregateErrorMessage(
+    let error = buildAggregateErrorMessage(
       "collection",
       videos.length,
       downloadedCount,
       skippedCount,
       failedPartNumbers,
     );
+    if (error && sawRiskControlFailure) {
+      error = `${error}. ${BILIBILI_COOKIE_REFRESH_HINT}`;
+    }
 
     return {
       success,

--- a/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
@@ -370,3 +370,44 @@ export function prepareBilibiliDownloadFlags(
     formatSort: formatSortValue,
   };
 }
+
+/**
+ * Hint surfaced to the user when a Bilibili download fails in a way that looks
+ * like an auth / risk-control (风控) rejection rather than a generic error.
+ */
+export const BILIBILI_COOKIE_REFRESH_HINT =
+  "Bilibili rejected the request (possible risk control / expired cookie). " +
+  "Try refreshing your Bilibili cookie in Settings, then download again.";
+
+// High-signal substrings that indicate Bilibili refused the request for auth /
+// risk-control reasons (HTTP 412 + API code -352 are the classic risk-control
+// pair; -101 is "not logged in"). Kept conservative so a generic network or
+// format error does not trigger a needless backoff retry (issue #295).
+const BILIBILI_AUTH_FAILURE_SIGNATURES = [
+  "-352",
+  "-101",
+  "412",
+  "precondition failed",
+  "风控",
+  "risk control",
+  "请先登录",
+  "需要登录",
+  "account_freeze",
+  "not logged in",
+  "please log in",
+];
+
+/**
+ * Whether an error/stderr string looks like a Bilibili auth or risk-control
+ * rejection (as opposed to a generic download failure). Used to drive a single
+ * backoff retry and to surface the cookie-refresh hint (issue #295).
+ */
+export function isLikelyBilibiliAuthFailure(text?: string | null): boolean {
+  if (!text) {
+    return false;
+  }
+  const lower = text.toLowerCase();
+  return BILIBILI_AUTH_FAILURE_SIGNATURES.some((signature) =>
+    lower.includes(signature)
+  );
+}

--- a/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
@@ -386,7 +386,9 @@ export const BILIBILI_COOKIE_REFRESH_HINT =
 const BILIBILI_AUTH_FAILURE_SIGNATURES = [
   "-352",
   "-101",
-  "412",
+  // Keep "412" in HTTP-status context so a bare 3-digit number elsewhere in the
+  // error (a byte count, an id) does not trigger a needless backoff retry.
+  "error 412",
   "precondition failed",
   "风控",
   "risk control",

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -182,6 +182,23 @@ function extractAvailableHeights(
   return heights;
 }
 
+function formatYtDlpFailureMessage(error: unknown): string {
+  const message =
+    typeof (error as { message?: unknown })?.message === "string"
+      ? (error as { message: string }).message.trim()
+      : "";
+  const stderr =
+    typeof (error as { stderr?: unknown })?.stderr === "string"
+      ? (error as { stderr: string }).stderr.trim()
+      : "";
+
+  if (message && stderr && message !== stderr && !message.includes(stderr)) {
+    return `${message}\nstderr: ${stderr}`;
+  }
+
+  return message || stderr || "Unknown error";
+}
+
 /**
  * Core video download function using yt-dlp
  */
@@ -418,9 +435,7 @@ export async function downloadVideo(
         throw DownloadCancelledError.create();
       }
       throw new Error(
-        `yt-dlp download failed: ${
-          downloadError.message || downloadError.stderr || "Unknown error"
-        }`
+        `yt-dlp download failed: ${formatYtDlpFailureMessage(downloadError)}`
       );
     }
 
@@ -429,8 +444,8 @@ export async function downloadVideo(
       await cleanupTempDir(tempDir);
       const errorMsg = downloadError
         ? `Downloaded video file not found. yt-dlp error: ${
-            downloadError.message
-          }. stderr: ${(downloadError.stderr || "").substring(0, 500)}`
+            formatYtDlpFailureMessage(downloadError)
+          }`
         : `Downloaded video file not found.`;
       throw new Error(errorMsg);
     }
@@ -630,7 +645,7 @@ export async function downloadVideo(
       date: new Date().toISOString().slice(0, 10).replace(/-/g, ""),
       thumbnailUrl: null,
       thumbnailSaved: false,
-      error: error.message,
+      error: formatYtDlpFailureMessage(error),
     };
   }
 }

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -203,7 +203,10 @@ function redactYtDlpFailureDetail(value: string): string {
       "$1[REDACTED]",
     )
     .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1[REDACTED]@")
-    .replace(/\b(?:\/Users|\/home|\/var|\/tmp|\/private)\/[^\s)]+/g, "[local path redacted]")
+    // No leading \b: an absolute path's leading "/" is usually preceded by a
+    // space, newline, or start-of-string (all non-word), where \b would not
+    // match and the home prefix (e.g. /Users/<name>) would leak.
+    .replace(/(?:\/Users|\/home|\/var|\/tmp|\/private)\/[^\s)]+/g, "[local path redacted]")
     .replace(/\b[A-Za-z]:\\[^\s)]+/g, "[local path redacted]");
 
   return redactSensitive(redacted);
@@ -233,16 +236,19 @@ function formatYtDlpFailureMessage(error: unknown): string {
     rawFailure && isLikelyBilibiliAuthFailure(rawFailure)
       ? "Bilibili risk control/auth failure detected."
       : "";
-  const formatDetail = (value: string) =>
-    toUserVisibleYtDlpFailureDetail(
-      authSignal ? `${value}\n${authSignal}` : value,
-    );
+  const combined =
+    message && stderr && message !== stderr && !message.includes(stderr)
+      ? `${toUserVisibleYtDlpFailureDetail(message)} stderr: ${toUserVisibleYtDlpFailureDetail(stderr)}`
+      : message || stderr
+        ? toUserVisibleYtDlpFailureDetail(message || stderr)
+        : "Unknown error";
 
-  if (message && stderr && message !== stderr && !message.includes(stderr)) {
-    return `${formatDetail(message)} stderr: ${formatDetail(stderr)}`;
-  }
-
-  return message || stderr ? formatDetail(message || stderr) : "Unknown error";
+  // Append the auth-failure note once. The `includes` guard keeps it from being
+  // duplicated when this output is wrapped in an Error and re-formatted (the
+  // note text itself trips isLikelyBilibiliAuthFailure on the second pass).
+  return authSignal && !combined.includes(authSignal)
+    ? `${combined} ${authSignal}`
+    : combined;
 }
 
 /**

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -190,6 +190,9 @@ const USER_VISIBLE_YTDLP_FAILURE_LIMIT = 500;
 
 function redactYtDlpFailureDetail(value: string): string {
   const redacted = value
+    // Redact the cookie/authorization header value through to end-of-line.
+    // Headers sit one-per-line, so consuming the rest of the line scrubs the
+    // whole secret; any over-capture here is safe over-redaction, never a leak.
     .replace(
       /\b(cookie|set-cookie|authorization)\s*[:=]\s*[^\r\n]+/gi,
       "$1=[REDACTED]",
@@ -209,6 +212,13 @@ function redactYtDlpFailureDetail(value: string): string {
     .replace(/(?:\/Users|\/home|\/var|\/tmp|\/private)\/[^\s)]+/g, "[local path redacted]")
     .replace(/\b[A-Za-z]:\\[^\s)]+/g, "[local path redacted]");
 
+  // Final pass through the shared logger redactor. Complementary, not redundant:
+  // the patterns above only catch token/key/secret material in URL-query form
+  // (?key=...), while redactSensitive also strips plain key=value forms
+  // (password=, secret=, api_key=, token=) that show up in free-text yt-dlp
+  // output. Some already-redacted values can match both passes (for example
+  // authorization or query-style token/api_key values), which is harmless — do
+  // not drop this call.
   return redactSensitive(redacted);
 }
 

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -501,12 +501,21 @@ export async function downloadVideo(
       );
     }
 
-    // If no file found and no error was caught, something went wrong
+    // If no file found and no error was caught, something went wrong. With
+    // `ignoreErrors: true` yt-dlp can exit 0 after silently skipping a rejected
+    // download, so a Bilibili 412/-352 rejection lands here with no
+    // downloadError and the risk-control text only in the captured stderr. Fold
+    // that stderr into the failure so isLikelyBilibiliAuthFailure can still
+    // classify it and drive the collection backoff / cookie-refresh hint
+    // (issue #295).
     if (!videoFile) {
       await cleanupTempDir(tempDir);
-      const errorMsg = downloadError
+      const failureSource =
+        downloadError ??
+        (stderrOutput.trim() ? { stderr: stderrOutput } : null);
+      const errorMsg = failureSource
         ? `Downloaded video file not found. yt-dlp error: ${
-            formatYtDlpFailureMessage(downloadError)
+            formatYtDlpFailureMessage(failureSource)
           }`
         : `Downloaded video file not found.`;
       throw new Error(errorMsg);

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -2,7 +2,7 @@ import path from "path";
 import { IMAGES_DIR, SUBTITLES_DIR, VIDEOS_DIR } from "../../../config/paths";
 import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 import { downloadAndProcessAvatar } from "../../../utils/avatarUtils";
-import { formatBytes } from "../../../utils/downloadUtils";
+import { formatBytes, isCancellationError } from "../../../utils/downloadUtils";
 import { formatVideoFilename } from "../../../utils/helpers";
 import { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import { resolveAuthorOrganizationMode } from "../../../types/settings";
@@ -724,6 +724,15 @@ export async function downloadSinglePart(
     // with generic "Bilibili User" metadata, and surface a cookie-refresh hint
     // when the failure looks like Bilibili risk control (issue #295).
     if (bilibiliInfo.error) {
+      // downloadVideo funnels cancellations through its fallback return path
+      // (its catch swallows DownloadCancelledError instead of rethrowing), so a
+      // cancelled collection part arrives here with a cancellation message.
+      // Re-check the download id first and propagate DownloadCancelledError;
+      // otherwise downloadCollection would record this as a normal failed
+      // episode and keep downloading the rest of the collection (issue #295).
+      const downloader = new BilibiliDownloaderHelper();
+      downloader.throwIfCancelledPublic(downloadId);
+
       const failureError = isLikelyBilibiliAuthFailure(bilibiliInfo.error)
         ? `${bilibiliInfo.error} — ${BILIBILI_COOKIE_REFRESH_HINT}`
         : bilibiliInfo.error;
@@ -1049,6 +1058,13 @@ export async function downloadSinglePart(
     });
     return { success: true, videoData };
   } catch (error: any) {
+    // A cancelled part must abort the whole download, not be recorded as a
+    // failed episode. downloadCollection relies on a thrown DownloadCancelledError
+    // to stop its loop, so let cancellations propagate instead of swallowing
+    // them into a { success: false } result (issue #295).
+    if (isCancellationError(error)) {
+      throw error;
+    }
     logger.error(
       `Error downloading Bilibili part ${partNumber}/${totalParts}:`,
       error

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -6,7 +6,11 @@ import { formatBytes, isCancellationError } from "../../../utils/downloadUtils";
 import { formatVideoFilename } from "../../../utils/helpers";
 import { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import { resolveAuthorOrganizationMode } from "../../../types/settings";
-import { logger } from "../../../utils/logger";
+import {
+  logger,
+  redactSensitive,
+  sanitizeLogMessage,
+} from "../../../utils/logger";
 import { ProgressTracker } from "../../../utils/progressTracker";
 import {
   pathExistsSafeSync,
@@ -182,6 +186,38 @@ function extractAvailableHeights(
   return heights;
 }
 
+const USER_VISIBLE_YTDLP_FAILURE_LIMIT = 500;
+
+function redactYtDlpFailureDetail(value: string): string {
+  const redacted = value
+    .replace(
+      /\b(cookie|set-cookie|authorization)\s*[:=]\s*[^\r\n]+/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(
+      /\b(SESSDATA|bili_jct|DedeUserID|DedeUserID__ckMd5|buvid3|buvid4|sid)=([^;\s]+)/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(
+      /([?&](?:access_token|token|api[_-]?key|apikey|key|signature|sig|auth|authorization|X-Amz-Signature|X-Amz-Credential|Policy)=)[^&\s]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi, "$1[REDACTED]@")
+    .replace(/\b(?:\/Users|\/home|\/var|\/tmp|\/private)\/[^\s)]+/g, "[local path redacted]")
+    .replace(/\b[A-Za-z]:\\[^\s)]+/g, "[local path redacted]");
+
+  return redactSensitive(redacted);
+}
+
+function toUserVisibleYtDlpFailureDetail(value: string): string {
+  const redacted = sanitizeLogMessage(redactYtDlpFailureDetail(value.trim()));
+  if (redacted.length <= USER_VISIBLE_YTDLP_FAILURE_LIMIT) {
+    return redacted;
+  }
+
+  return `${redacted.slice(0, USER_VISIBLE_YTDLP_FAILURE_LIMIT)}... [truncated]`;
+}
+
 function formatYtDlpFailureMessage(error: unknown): string {
   const message =
     typeof (error as { message?: unknown })?.message === "string"
@@ -192,11 +228,21 @@ function formatYtDlpFailureMessage(error: unknown): string {
       ? (error as { stderr: string }).stderr.trim()
       : "";
 
+  const rawFailure = [message, stderr].filter(Boolean).join("\n");
+  const authSignal =
+    rawFailure && isLikelyBilibiliAuthFailure(rawFailure)
+      ? "Bilibili risk control/auth failure detected."
+      : "";
+  const formatDetail = (value: string) =>
+    toUserVisibleYtDlpFailureDetail(
+      authSignal ? `${value}\n${authSignal}` : value,
+    );
+
   if (message && stderr && message !== stderr && !message.includes(stderr)) {
-    return `${message}\nstderr: ${stderr}`;
+    return `${formatDetail(message)} stderr: ${formatDetail(stderr)}`;
   }
 
-  return message || stderr || "Unknown error";
+  return message || stderr ? formatDetail(message || stderr) : "Unknown error";
 }
 
 /**

--- a/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliVideo.ts
@@ -38,6 +38,8 @@ import {
 import { BaseDownloader } from "../BaseDownloader";
 import { buildManagedThumbnailWebPath } from "../thumbnailPathUtils";
 import {
+  BILIBILI_COOKIE_REFRESH_HINT,
+  isLikelyBilibiliAuthFailure,
   prepareBilibiliDownloadFlags,
   resolveResolutionPreference,
   resolveResolutionRetryTarget,
@@ -700,6 +702,20 @@ export async function downloadSinglePart(
 
     if (!bilibiliInfo) {
       throw new Error("Failed to get Bilibili video info");
+    }
+
+    // downloadVideo only returns its fallback object (error set, no usable file)
+    // when the download genuinely failed. Stop here rather than saving a record
+    // with generic "Bilibili User" metadata, and surface a cookie-refresh hint
+    // when the failure looks like Bilibili risk control (issue #295).
+    if (bilibiliInfo.error) {
+      const failureError = isLikelyBilibiliAuthFailure(bilibiliInfo.error)
+        ? `${bilibiliInfo.error} — ${BILIBILI_COOKIE_REFRESH_HINT}`
+        : bilibiliInfo.error;
+      logger.error(
+        `Bilibili download failed for ${url}: ${failureError}`
+      );
+      return { success: false, error: failureError };
     }
 
     logger.info("Bilibili download info:", bilibiliInfo);

--- a/backend/src/services/storageService/__tests__/authorCollectionUtils.test.ts
+++ b/backend/src/services/storageService/__tests__/authorCollectionUtils.test.ts
@@ -27,6 +27,7 @@ vi.mock("../collections", () => ({
 
 vi.mock("../collectionFileManager", () => ({
   moveAllFilesToCollection: vi.fn(),
+  cleanupCollectionDirectories: vi.fn(),
 }));
 
 vi.mock("../videos", () => ({
@@ -282,6 +283,64 @@ describe("authorCollectionUtils", () => {
         videoPath: "/videos/TestAuthor/video.mp4",
       });
       expect(collections.linkVideoToCollection).not.toHaveBeenCalled();
+    });
+
+    it.each(["Bilibili User", "Bilibili User 12345"])(
+      "should not create an author folder for the unresolved author %s (issue #295 follow-up)",
+      (placeholder) => {
+        const result = organizeVideoByAuthor(
+          "vid1",
+          placeholder,
+          "author_folder_only",
+          "legacy"
+        );
+
+        expect(result).toBeNull();
+        expect(
+          collectionFileManager.moveAllFilesToCollection
+        ).not.toHaveBeenCalled();
+        expect(videos.updateVideo).not.toHaveBeenCalled();
+      }
+    );
+
+    it("should clean up the folder a video is moved out of so no empty 'Bilibili User' dir is left (issue #295 follow-up)", () => {
+      (videos.getVideoById as any).mockReturnValue({
+        id: "vid1",
+        videoFilename: "video.mp4",
+        videoPath: "/videos/Bilibili User/video.mp4",
+      });
+      (collectionFileManager.moveAllFilesToCollection as any).mockReturnValue({
+        videoPath: "/videos/RealAuthor/video.mp4",
+      });
+
+      const result = organizeVideoByAuthor(
+        "vid1",
+        "RealAuthor",
+        "author_folder_only",
+        "legacy"
+      );
+
+      expect(result).toEqual({ collection: null, filesMoved: true });
+      expect(
+        collectionFileManager.cleanupCollectionDirectories
+      ).toHaveBeenCalledWith("Bilibili User");
+    });
+
+    it("should not clean up the destination folder when the video was already at the videos root", () => {
+      (videos.getVideoById as any).mockReturnValue({
+        id: "vid1",
+        videoFilename: "video.mp4",
+        videoPath: "/videos/video.mp4",
+      });
+      (collectionFileManager.moveAllFilesToCollection as any).mockReturnValue({
+        videoPath: "/videos/RealAuthor/video.mp4",
+      });
+
+      organizeVideoByAuthor("vid1", "RealAuthor", "author_folder_only", "legacy");
+
+      expect(
+        collectionFileManager.cleanupCollectionDirectories
+      ).not.toHaveBeenCalled();
     });
 
     it("should skip folder-only organization for template-based naming when file moves are disabled", () => {

--- a/backend/src/services/storageService/authorCollectionUtils.ts
+++ b/backend/src/services/storageService/authorCollectionUtils.ts
@@ -6,7 +6,10 @@ import {
   usesAuthorCollectionLinking,
 } from "../../types/settings";
 import { logger } from "../../utils/logger";
-import { moveAllFilesToCollection } from "./collectionFileManager";
+import {
+  cleanupCollectionDirectories,
+  moveAllFilesToCollection,
+} from "./collectionFileManager";
 import {
   deleteCollection,
   generateUniqueCollectionName,
@@ -47,6 +50,34 @@ function isLegacyFilenameNamingValue(value?: string): boolean {
 
 function getCollectionName(collection: Collection): string {
   return collection.name || collection.title;
+}
+
+/**
+ * Placeholder author names produced when the real uploader could not be
+ * resolved (e.g. a Bilibili cookie failure during a collection download).
+ * Such videos must not get their own author folder — otherwise an empty
+ * "Bilibili User" directory is left at the storage root once the real author is
+ * resolved on a later re-download (issue #295 follow-up).
+ */
+function isUnresolvedAuthorName(authorName: string): boolean {
+  return (
+    authorName === "Unknown" ||
+    authorName === "Bilibili User" ||
+    /^Bilibili User \d+$/.test(authorName)
+  );
+}
+
+/**
+ * The managed subfolder a video currently lives in (e.g. an old author folder or
+ * a collection folder), derived from its stored web path. Returns null when the
+ * file sits directly at the videos root.
+ */
+function getCurrentVideoSubfolder(videoPath?: string): string | null {
+  if (!videoPath) {
+    return null;
+  }
+  const match = videoPath.match(/^\/videos\/([^/]+)\/[^/]+$/);
+  return match ? match[1] : null;
 }
 
 function isUuidLikeCollectionId(collectionId: string): boolean {
@@ -396,6 +427,11 @@ function moveVideoFilesToAuthorFolder(
     return false;
   }
 
+  // Remember where the files lived so we can clean up the folder they leave
+  // behind (e.g. a stale "Bilibili User" folder from a cookie-failed download
+  // that is now being re-homed under the real author — issue #295 follow-up).
+  const previousSubfolder = getCurrentVideoSubfolder(video.videoPath);
+
   const updates = moveAllFilesToCollection(
     video,
     validatedAuthorName,
@@ -410,6 +446,13 @@ function moveVideoFilesToAuthorFolder(
   logger.info("Moved video files into author folder", {
     author: validatedAuthorName,
   });
+
+  if (previousSubfolder && previousSubfolder !== validatedAuthorName) {
+    // Only removes the directory if it is now empty, so collections that still
+    // hold other videos are never touched.
+    cleanupCollectionDirectories(previousSubfolder);
+  }
+
   return true;
 }
 
@@ -545,7 +588,7 @@ export function organizeVideoByAuthor(
     return null;
   }
 
-  if (!authorName || authorName === "Unknown") {
+  if (!authorName || isUnresolvedAuthorName(authorName)) {
     return null;
   }
 

--- a/backend/src/services/storageService/authorCollectionUtils.ts
+++ b/backend/src/services/storageService/authorCollectionUtils.ts
@@ -71,6 +71,12 @@ function isUnresolvedAuthorName(authorName: string): boolean {
  * The managed subfolder a video currently lives in (e.g. an old author folder or
  * a collection folder), derived from its stored web path. Returns null when the
  * file sits directly at the videos root.
+ *
+ * The pattern matches exactly one subfolder level (`/videos/<folder>/<file>`),
+ * which is the only layout the managed store produces today. A deeper or
+ * shallower path yields null, so the caller skips the leftover-folder cleanup
+ * instead of acting on an unexpected layout — null is the safe (no-op)
+ * direction, never a wrong delete.
  */
 function getCurrentVideoSubfolder(videoPath?: string): string | null {
   if (!videoPath) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,25 +14,6 @@
     />
     <meta name="theme-color" content="#ff3e3e" />
     <title>MyTube - My Videos, My Rules.</title>
-    <script>
-      (() => {
-        if (typeof window.matchMedia !== "function") {
-          return;
-        }
-
-        try {
-          Object.defineProperty(window, "styleMedia", {
-            configurable: true,
-            value: {
-              matchMedium: (query) => window.matchMedia(query).matches,
-              type: "screen",
-            },
-          });
-        } catch {
-          // Ignore browsers that do not allow overriding this legacy API.
-        }
-      })();
-    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,25 @@
     />
     <meta name="theme-color" content="#ff3e3e" />
     <title>MyTube - My Videos, My Rules.</title>
+    <script>
+      (() => {
+        if (typeof window.matchMedia !== "function") {
+          return;
+        }
+
+        try {
+          Object.defineProperty(window, "styleMedia", {
+            configurable: true,
+            value: {
+              matchMedium: (query) => window.matchMedia(query).matches,
+              type: "screen",
+            },
+          });
+        } catch {
+          // Ignore browsers that do not allow overriding this legacy API.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Follow-up to issue #295, addressing two items from tester feedback on the v1.10.x images (the merged `codex/issue295-complete` work is already in `master`).

## 1. Leftover empty `Bilibili User` folder at the storage root
**Cause:** when a part's uploader can't be resolved (e.g. a cookie/metadata miss), the downloader falls back to the literal author `"Bilibili User"`. `organizeVideoByAuthor` only skipped `"Unknown"`, so the placeholder got its own `video/Bilibili User/` folder; a later re-download with a working cookie re-homed the file under the real author and left the folder empty.

**Fix** (`authorCollectionUtils.ts`):
- `organizeVideoByAuthor` now skips unresolved placeholder authors (`Unknown`, `Bilibili User`, `Bilibili User <mid>`) — no folder is created for an unidentified uploader.
- `moveVideoFilesToAuthorFolder` cleans up the folder a video is relocated out of, once empty (only removes empty dirs, so shared collections are untouched).

## 2. Bilibili risk control (风控) failing some collection episodes
Tester reported some episodes failing mid-collection with a still-valid cookie; re-importing a freshly fetched cookie (without re-login) fixed it. The cookie cache is keyed on file mtime+size, so this is **not** a caching bug on our side — it's Bilibili throttling the session fingerprint. Mitigations:
- `isLikelyBilibiliAuthFailure` detects auth/risk-control rejections (HTTP 412 / code `-352`, `-101`, login-required, …).
- A failed episode that looks like risk control is retried **once** after a 15s backoff before being marked failed (cancellations are never retried).
- `downloadSinglePart` returns a clean failure instead of saving a broken `Bilibili User` record when a download genuinely fails — this also reinforces fix #1.
- A "refresh your Bilibili cookie" hint is surfaced on the failing download (per-part log + the collection's aggregate error).

## Tests
+16 new tests across `bilibiliConfig`, `bilibiliVideo`, `bilibiliCollection`, and `authorCollectionUtils` suites (placeholder-author skip + folder cleanup; auth-failure detection; retry-once / hint / no-retry-on-generic; clean failure without saving a record). Full backend suite passes except 4 pre-existing, unrelated `ytdlpHelpers` failures (environment-dependent bundled-script paths; fail identically on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)