### PR TITLE
fix(security): enforce video visibility on API and static media routes

### DIFF
--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -17,6 +17,7 @@ import {
 import { rateVideo } from "../../controllers/videoMetadataController";
 import downloadManager from "../../services/downloadManager";
 import * as downloadService from "../../services/downloadService";
+import { isLoginRequired } from "../../services/passwordService";
 import * as storageService from "../../services/storageService";
 
 vi.mock("../../db", () => ({
@@ -34,6 +35,12 @@ vi.mock("../../db", () => ({
 
 vi.mock("../../services/downloadService");
 vi.mock("../../services/storageService");
+// isLoginRequired defaults to false (single-user mode) so existing tests are
+// unaffected; visibility tests override it per-case.
+vi.mock("../../services/passwordService", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, isLoginRequired: vi.fn(() => false) };
+});
 vi.mock("../../services/downloadManager");
 vi.mock("../../services/metadataService");
 vi.mock("../../services/statistics", () => ({
@@ -112,6 +119,11 @@ describe("VideoController", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks does not reset implementations; restore safe defaults so a
+    // return value set by one test does not leak into later tests.
+    vi.mocked(isLoginRequired).mockReturnValue(false);
+    vi.mocked(storageService.getVideoById).mockReturnValue(undefined);
+    vi.mocked(storageService.getVideos).mockReturnValue([]);
     json = vi.fn();
     status = vi.fn().mockReturnValue({ json });
     req = { headers: {} };
@@ -347,6 +359,39 @@ describe("VideoController", () => {
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith(mockVideos);
     });
+
+    it("filters out hidden videos for a visitor when login is enabled", () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
+      (storageService.isVideoPublic as any).mockImplementation(
+        (v: any) => (v.visibility ?? 1) === 1
+      );
+      (storageService.getVideos as any).mockReturnValue([
+        { id: "public", visibility: 1 },
+        { id: "hidden", visibility: 0 },
+      ]);
+      req.user = { role: "visitor", id: "v1" } as any;
+
+      getVideos(req as Request, res as Response);
+
+      expect(json).toHaveBeenCalledWith([{ id: "public", visibility: 1 }]);
+    });
+
+    it("returns hidden videos to an admin when login is enabled", () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
+      (storageService.isVideoPublic as any).mockImplementation(
+        (v: any) => (v.visibility ?? 1) === 1
+      );
+      const all = [
+        { id: "public", visibility: 1 },
+        { id: "hidden", visibility: 0 },
+      ];
+      (storageService.getVideos as any).mockReturnValue(all);
+      req.user = { role: "admin", id: "a1" } as any;
+
+      getVideos(req as Request, res as Response);
+
+      expect(json).toHaveBeenCalledWith(all);
+    });
   });
 
   describe("getVideoById", () => {
@@ -365,6 +410,26 @@ describe("VideoController", () => {
     it("should throw NotFoundError if not found", async () => {
       req.params = { id: "1" };
       (storageService.getVideoById as any).mockReturnValue(undefined);
+
+      try {
+        await getVideoById(req as Request, res as Response);
+        expect.fail("Should have thrown");
+      } catch (error: any) {
+        expect(error.name).toBe("NotFoundError");
+      }
+    });
+
+    it("returns 404 (NotFoundError) for a visitor requesting a hidden video", async () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
+      (storageService.isVideoPublic as any).mockImplementation(
+        (v: any) => (v.visibility ?? 1) === 1
+      );
+      req.params = { id: "hidden" };
+      req.user = { role: "visitor", id: "v1" } as any;
+      (storageService.getVideoById as any).mockReturnValue({
+        id: "hidden",
+        visibility: 0,
+      });
 
       try {
         await getVideoById(req as Request, res as Response);

--- a/backend/src/__tests__/middleware/mediaAccessMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAccessMiddleware.test.ts
@@ -1,0 +1,161 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: vi.fn(),
+}));
+
+vi.mock("../../services/authService", () => ({
+  getUserPayloadFromSession: vi.fn(),
+  verifyToken: vi.fn(),
+}));
+
+vi.mock("../../services/storageService", () => ({
+  classifyMediaVisibility: vi.fn(),
+}));
+
+import { mediaVisibilityGuard } from "../../middleware/mediaAccessMiddleware";
+import {
+  getUserPayloadFromSession,
+  verifyToken,
+} from "../../services/authService";
+import { isLoginRequired } from "../../services/passwordService";
+import * as storageService from "../../services/storageService";
+
+const createRes = () => {
+  const res: Partial<Response> = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.send = vi.fn().mockReturnValue(res);
+  return res as Response & {
+    status: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+  };
+};
+
+const createReq = (overrides: Partial<Request> = {}): Request =>
+  ({
+    path: "/secret.mp4",
+    params: {},
+    headers: {},
+    cookies: {},
+    ...overrides,
+  } as unknown as Request);
+
+describe("mediaVisibilityGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("allows everything when login is not required (single-user mode)", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(false);
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("videos")(createReq(), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(storageService.classifyMediaVisibility).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to access hidden media via session cookie", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue({
+      role: "admin",
+      id: "a1",
+    });
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("videos")(
+      createReq({ cookies: { mytube_auth_session: "sid" } as any }),
+      res,
+      next
+    );
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(storageService.classifyMediaVisibility).not.toHaveBeenCalled();
+  });
+
+  it("blocks anonymous access to hidden media with 404", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
+    vi.mocked(verifyToken).mockReturnValue(null);
+    vi.mocked(storageService.classifyMediaVisibility).mockReturnValue("hidden");
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("videos")(createReq(), res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith("Not Found");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("blocks a logged-in visitor from hidden media", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue({
+      role: "visitor",
+      id: "v1",
+    });
+    vi.mocked(storageService.classifyMediaVisibility).mockReturnValue("hidden");
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("videos")(
+      createReq({ cookies: { mytube_auth_session: "sid" } as any }),
+      res,
+      next
+    );
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows public media to be served without a session (RSS clients)", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
+    vi.mocked(verifyToken).mockReturnValue(null);
+    vi.mocked(storageService.classifyMediaVisibility).mockReturnValue("public");
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("videos")(createReq(), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("allows unknown media (orphan files, frontend assets, avatars)", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
+    vi.mocked(verifyToken).mockReturnValue(null);
+    vi.mocked(storageService.classifyMediaVisibility).mockReturnValue("unknown");
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("subtitles")(createReq({ path: "/x.vtt" }), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies cloud routes by the filename route param", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
+    vi.mocked(verifyToken).mockReturnValue(null);
+    vi.mocked(storageService.classifyMediaVisibility).mockReturnValue("public");
+    const next = vi.fn() as NextFunction;
+    const res = createRes();
+
+    mediaVisibilityGuard("cloud-video")(
+      createReq({ params: { filename: "abc.mp4" } as any }),
+      res,
+      next
+    );
+
+    expect(storageService.classifyMediaVisibility).toHaveBeenCalledWith({
+      exactPaths: ["cloud:abc.mp4"],
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/__tests__/server/cloudRoutes.test.ts
+++ b/backend/src/__tests__/server/cloudRoutes.test.ts
@@ -16,6 +16,12 @@ vi.mock("../../services/storageService", () => ({
   getSettings: vi.fn(),
 }));
 
+// The media visibility guard is exercised in its own test suite; here we focus
+// on the cloud redirect handlers, so the guard is a transparent passthrough.
+vi.mock("../../middleware/mediaAccessMiddleware", () => ({
+  mediaVisibilityGuard: () => (_req: any, _res: any, next: any) => next(),
+}));
+
 vi.mock("../../services/cloudStorage/cloudThumbnailCache", () => ({
   getCachedThumbnail: vi.fn(),
 }));
@@ -87,8 +93,9 @@ describe("server/cloudRoutes", () => {
   const registerAndGetHandlers = () => {
     const handlers: Record<string, any> = {};
     const app = {
-      get: vi.fn((route: string, handler: any) => {
-        handlers[route] = handler;
+      get: vi.fn((route: string, ...routeHandlers: any[]) => {
+        // Routes now register [guard, handler]; keep the final handler.
+        handlers[route] = routeHandlers[routeHandlers.length - 1];
       }),
     } as any;
     registerCloudRoutes(app);

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -37,10 +37,21 @@ vi.mock("fs-extra", () => ({
   pathExists: pathExistsMock,
 }));
 
+// The media visibility guard is covered by its own suite; treat it as a
+// transparent passthrough so these tests stay focused on static mount config.
+vi.mock("../../middleware/mediaAccessMiddleware", () => ({
+  mediaVisibilityGuard: () => (_req: any, _res: any, next: any) => next(),
+}));
+
 import {
   registerSpaFallback,
   registerStaticRoutes,
 } from "../../server/staticRoutes";
+
+// Guarded mounts register [path, guard, static]; pick the final argument (the
+// express.static config or route handler). Avoids Array.prototype.at for the
+// project's TS lib target.
+const lastArg = (call: any[]): any => call[call.length - 1];
 
 describe("server/staticRoutes", () => {
   beforeEach(() => {
@@ -57,22 +68,32 @@ describe("server/staticRoutes", () => {
     registerStaticRoutes(app, "/frontend-dist");
 
     expect(use).toHaveBeenCalledTimes(8);
-    expect(get).toHaveBeenCalledWith("/images-small/*", expect.any(Function));
+    expect(get).toHaveBeenCalledWith(
+      "/images-small/*",
+      expect.any(Function),
+      expect.any(Function)
+    );
 
-    const [videosPath, videosStatic] = use.mock.calls[0];
+    // Guarded mounts register [path, guard, static]; the static config is the
+    // last argument. Unguarded mounts (e.g. /assets) register [path, static].
+    const videosPath = use.mock.calls[0][0];
+    const videosStatic = lastArg(use.mock.calls[0]);
     expect(videosPath).toBe("/videos");
     expect(videosStatic.dir).toContain("/uploads/videos");
     expect(videosStatic.options.fallthrough).toBe(false);
 
-    const [imagesPath, imagesStatic] = use.mock.calls[1];
+    const imagesPath = use.mock.calls[1][0];
+    const imagesStatic = lastArg(use.mock.calls[1]);
     expect(imagesPath).toBe("/images");
     expect(imagesStatic.options.fallthrough).toBe(false);
 
-    const [smallImagesPath, smallImagesStatic] = use.mock.calls[2];
+    const smallImagesPath = use.mock.calls[2][0];
+    const smallImagesStatic = lastArg(use.mock.calls[2]);
     expect(smallImagesPath).toBe("/images-small");
     expect(smallImagesStatic.options.fallthrough).toBe(false);
 
-    const [assetsPath, assetsStatic] = use.mock.calls[6];
+    const assetsPath = use.mock.calls[6][0];
+    const assetsStatic = lastArg(use.mock.calls[6]);
     expect(assetsPath).toBe("/assets");
     expect(assetsStatic.dir).toBe("/frontend-dist/assets");
     expect(assetsStatic.options.fallthrough).toBe(false);
@@ -105,7 +126,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const subtitlesStatic = use.mock.calls[5][1];
+    const subtitlesStatic = lastArg(use.mock.calls[5]);
     const setHeaders = subtitlesStatic.options.setHeaders as (
       res: any,
       filePath: string
@@ -132,7 +153,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    const smallImageHandler = lastArg(get.mock.calls[0]);
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -167,7 +188,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    const smallImageHandler = lastArg(get.mock.calls[0]);
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -206,7 +227,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    const smallImageHandler = lastArg(get.mock.calls[0]);
     const sendFile = vi.fn((_path: string, cb?: (err?: Error | null) => void) => {
       cb?.(null);
     });

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -32,6 +32,7 @@ import {
   getUploadVideoId,
   UploadedVideoFile,
 } from "../utils/videoUpload";
+import { isLoginRequired } from "../services/passwordService";
 import { resolvePlayableVideoFilePath } from "../utils/videoFileResolver";
 import {
   createReadStreamSafe,
@@ -45,6 +46,17 @@ import {
   unlinkSafeSync,
   writeFileSafeSync,
 } from "../utils/security";
+
+/**
+ * When login is enabled, non-admin callers (visitors and any request that
+ * reaches here without an admin session) must only see public videos. In
+ * single-user mode (login disabled) every caller is owner-equivalent. API-key
+ * automation is admin-configured owner access, so it is never restricted.
+ */
+const restrictToPublicVideos = (req: Request): boolean =>
+  isLoginRequired() &&
+  req.apiKeyAuthenticated !== true &&
+  req.user?.role !== "admin";
 
 const MAX_VIDEO_UPLOAD_FILE_SIZE = 100 * 1024 * 1024 * 1024;
 const MAX_BATCH_UPLOAD_FILES = 100;
@@ -526,12 +538,17 @@ const resolveVideoWebPath = (absoluteVideoPath: string): string | null => {
  * Note: Returns array directly for backward compatibility with frontend
  */
 export const getVideos = async (
-  _req: Request,
+  req: Request,
   res: Response
 ): Promise<void> => {
   const videos = storageService.getVideos();
+  // Visitors must never receive hidden videos: the visibility filter is enforced
+  // here on the backend, not just in the frontend.
+  const visibleVideos = restrictToPublicVideos(req)
+    ? videos.filter((video) => storageService.isVideoPublic(video))
+    : videos;
   // Return array directly for backward compatibility (frontend expects response.data to be Video[])
-  sendData(res, videos);
+  sendData(res, visibleVideos);
 };
 
 /**
@@ -547,6 +564,12 @@ export const getVideoById = async (
   const video = storageService.getVideoById(id);
 
   if (!video) {
+    throw new NotFoundError("Video", id);
+  }
+
+  // Hidden videos do not exist for visitors — return 404 (not 403) so the
+  // response is indistinguishable from a genuinely missing video.
+  if (restrictToPublicVideos(req) && !storageService.isVideoPublic(video)) {
     throw new NotFoundError("Video", id);
   }
 
@@ -660,6 +683,13 @@ export const getVideoComments = async (
   res: Response
 ): Promise<void> => {
   const id = getStringParam(req.params.id) ?? "";
+  // Don't reveal a hidden video's existence/comments to visitors.
+  if (restrictToPublicVideos(req)) {
+    const video = storageService.getVideoById(id);
+    if (!video || !storageService.isVideoPublic(video)) {
+      throw new NotFoundError("Video", id);
+    }
+  }
   const comments = await import("../services/commentService").then((m) =>
     m.getComments(id)
   );
@@ -1216,6 +1246,11 @@ export const serveMountVideo = async (
   const video = storageService.getVideoById(id);
 
   if (!video) {
+    throw new NotFoundError("Video", id);
+  }
+
+  // Visitors must not be able to stream hidden mount videos.
+  if (restrictToPublicVideos(req) && !storageService.isVideoPublic(video)) {
     throw new NotFoundError("Video", id);
   }
 

--- a/backend/src/middleware/mediaAccessMiddleware.ts
+++ b/backend/src/middleware/mediaAccessMiddleware.ts
@@ -1,0 +1,131 @@
+import { NextFunction, Request, Response } from "express";
+import {
+  getUserPayloadFromSession,
+  verifyToken,
+} from "../services/authService";
+import { isLoginRequired } from "../services/passwordService";
+import * as storageService from "../services/storageService";
+import { getStringParam } from "../utils/paramUtils";
+
+/**
+ * Static media routes (videos, thumbnails, subtitles, cloud redirects) are
+ * registered before the API auth stack, so without this guard they are reachable
+ * by anyone even when login is enabled. The guard enforces video `visibility`:
+ * media belonging only to hidden videos is served to admins only, while public
+ * media stays reachable without a session (so RSS/podcast clients keep working).
+ */
+
+type MediaKind =
+  | "videos"
+  | "images"
+  | "images-small"
+  | "subtitles"
+  | "cloud-video"
+  | "cloud-image";
+
+/**
+ * Resolve whether the request carries a valid admin session/token. Mirrors the
+ * resolution order in authMiddleware (session cookie first, then bearer JWT) but
+ * only cares about admin because admins may access hidden media.
+ */
+const isAdminRequest = (req: Request): boolean => {
+  const sessionId = req.cookies?.mytube_auth_session;
+  if (sessionId) {
+    const payload = getUserPayloadFromSession(sessionId);
+    if (payload) {
+      return payload.role === "admin";
+    }
+  }
+
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    const decoded = verifyToken(authHeader.split(" ")[1]);
+    if (decoded) {
+      return decoded.role === "admin";
+    }
+  }
+
+  return false;
+};
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/**
+ * Build the storage classification query inputs for the requested media. Static
+ * mounts strip their prefix from req.path, so it is re-added to reconstruct the
+ * stored web path. Cloud routes carry the cloud filename as a route param.
+ */
+const classifyRequest = (
+  kind: MediaKind,
+  req: Request
+): storageService.MediaVisibility => {
+  switch (kind) {
+    case "videos": {
+      const webPath = `/videos${safeDecode(req.path)}`;
+      return storageService.classifyMediaVisibility({ exactPaths: [webPath] });
+    }
+    case "images": {
+      const webPath = `/images${safeDecode(req.path)}`;
+      return storageService.classifyMediaVisibility({ exactPaths: [webPath] });
+    }
+    case "images-small": {
+      // Small thumbnails mirror the original thumbnail, which may live under
+      // either /images or /videos. Check both candidate originals.
+      const sub = safeDecode(req.path);
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`/images${sub}`, `/videos${sub}`],
+      });
+    }
+    case "subtitles": {
+      const webPath = `/subtitles${safeDecode(req.path)}`;
+      return storageService.classifyMediaVisibility({
+        subtitlePaths: [webPath],
+      });
+    }
+    case "cloud-video": {
+      const filename = getStringParam(req.params.filename) ?? "";
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`cloud:${filename}`],
+      });
+    }
+    case "cloud-image": {
+      const filename = getStringParam(req.params.filename) ?? "";
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`cloud:${filename}`],
+      });
+    }
+    default:
+      return "unknown";
+  }
+};
+
+export const mediaVisibilityGuard =
+  (kind: MediaKind) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    // Single-user mode: no roles, owner-equivalent access to everything.
+    if (!isLoginRequired()) {
+      next();
+      return;
+    }
+
+    // Admins may always access hidden media.
+    if (isAdminRequest(req)) {
+      next();
+      return;
+    }
+
+    // Visitors and unauthenticated callers: serve public/unknown media, but
+    // never media that belongs solely to a hidden video.
+    if (classifyRequest(kind, req) === "hidden") {
+      res.status(404).send("Not Found");
+      return;
+    }
+
+    next();
+  };

--- a/backend/src/server/cloudRoutes.ts
+++ b/backend/src/server/cloudRoutes.ts
@@ -8,6 +8,7 @@ import { getCachedThumbnail } from "../services/cloudStorage/cloudThumbnailCache
 import { CloudStorageService } from "../services/CloudStorageService";
 import * as storageService from "../services/storageService";
 import { logger } from "../utils/logger";
+import { mediaVisibilityGuard } from "../middleware/mediaAccessMiddleware";
 import { getStringParam } from "../utils/paramUtils";
 import {
   validateCloudThumbnailCachePath,
@@ -127,12 +128,20 @@ const redirectCloudFile = async (
 };
 
 export const registerCloudRoutes = (app: Express): void => {
-  app.get("/cloud/videos/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "video");
-  });
-  app.get("/cloud/images/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "image");
-  });
+  app.get(
+    "/cloud/videos/:filename",
+    mediaVisibilityGuard("cloud-video"),
+    (req, res) => {
+      void redirectCloudFile(req, res, "video");
+    }
+  );
+  app.get(
+    "/cloud/images/:filename",
+    mediaVisibilityGuard("cloud-image"),
+    (req, res) => {
+      void redirectCloudFile(req, res, "image");
+    }
+  );
 };
 
 export const startCloudflaredIfEnabled = (port: number): void => {

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -17,6 +17,7 @@ import {
   normalizeSafeAbsolutePath,
   resolveSafeChildPath,
 } from "../utils/security";
+import { mediaVisibilityGuard } from "../middleware/mediaAccessMiddleware";
 
 const setCommonImageHeaders = (res: Response): void => {
   res.setHeader("Access-Control-Allow-Origin", "*");
@@ -113,6 +114,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/videos",
+    mediaVisibilityGuard("videos"),
     express.static(VIDEOS_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {
@@ -157,18 +159,24 @@ export const registerStaticRoutes = (
 
   app.use(
     "/images",
+    mediaVisibilityGuard("images"),
     express.static(IMAGES_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
     })
   );
 
-  app.get("/images-small/*", (req, res, next) => {
-    void ensureSmallThumbnail(req, res, next);
-  });
+  app.get(
+    "/images-small/*",
+    mediaVisibilityGuard("images-small"),
+    (req, res, next) => {
+      void ensureSmallThumbnail(req, res, next);
+    }
+  );
 
   app.use(
     "/images-small",
+    mediaVisibilityGuard("images-small"),
     express.static(IMAGES_SMALL_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
@@ -192,6 +200,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/subtitles",
+    mediaVisibilityGuard("subtitles"),
     express.static(SUBTITLES_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -10,12 +10,14 @@ import * as fileHelpers from "../fileHelpers";
 import { markDownloadHistoryDeletedByVideoId } from "../downloadHistory";
 import { markVideoDownloadDeleted } from "../videoDownloadTracking";
 import {
+  classifyMediaVisibility,
   deleteVideo,
   formatLegacyFilenames,
   getVideoById,
   getVideoBySourceUrl,
   getVideoPartBySourceUrl,
   getVideos,
+  isVideoPublic,
   saveVideo,
   updateVideo,
 } from "../videos";
@@ -697,6 +699,63 @@ describe("storageService videos", () => {
         throw new Error("db fail");
       });
       expect(() => deleteVideo("1")).toThrow(DatabaseError);
+    });
+  });
+
+  describe("isVideoPublic", () => {
+    it("treats visibility 1, null and undefined as public; 0 as hidden", () => {
+      expect(isVideoPublic({ visibility: 1 })).toBe(true);
+      expect(isVideoPublic({ visibility: null })).toBe(true);
+      expect(isVideoPublic({})).toBe(true);
+      expect(isVideoPublic({ visibility: 0 })).toBe(false);
+    });
+  });
+
+  describe("classifyMediaVisibility", () => {
+    const mockClassifyRows = (rows: any[]) => {
+      const allMock = vi.fn().mockReturnValue(rows);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ all: allMock }),
+        }),
+      } as any);
+      return allMock;
+    };
+
+    it("returns 'unknown' without querying when there are no candidates", () => {
+      const allMock = mockClassifyRows([]);
+      expect(classifyMediaVisibility({})).toBe("unknown");
+      expect(allMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 'unknown' when no video references the media", () => {
+      mockClassifyRows([]);
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/orphan.mp4"] })
+      ).toBe("unknown");
+    });
+
+    it("returns 'hidden' when every referencing video is hidden", () => {
+      mockClassifyRows([{ visibility: 0 }]);
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/secret.mp4"] })
+      ).toBe("hidden");
+    });
+
+    it("returns 'public' when any referencing video is visible", () => {
+      mockClassifyRows([{ visibility: 0 }, { visibility: 1 }]);
+      expect(
+        classifyMediaVisibility({ subtitlePaths: ["/subtitles/shared.vtt"] })
+      ).toBe("public");
+    });
+
+    it("fails closed to 'hidden' on a database error", () => {
+      vi.mocked(db.select).mockImplementation(() => {
+        throw new Error("db down");
+      });
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/secret.mp4"] })
+      ).toBe("hidden");
     });
   });
 });

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -53,17 +53,20 @@ export {
 
 // Videos
 export {
+    classifyMediaVisibility,
     deleteVideo,
     formatLegacyFilenames,
     getVideoById,
     getVideoBySourceUrl,
     getVideos,
     isThumbnailReferencedByOtherVideo,
+    isVideoPublic,
     saveVideo,
     saveVideoIfAbsent,
     saveVideoWithInsertFlag,
     updateVideo
 } from "./videos";
+export type { MediaVisibility } from "./videos";
 
 // Collections
 export {

--- a/backend/src/services/storageService/types.ts
+++ b/backend/src/services/storageService/types.ts
@@ -11,6 +11,7 @@ export interface Video {
   progress?: number;
   fileSize?: string;
   description?: string;
+  visibility?: number; // 1 = visible, 0 = hidden
   [key: string]: any;
 }
 

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, or, sql, type SQL } from "drizzle-orm";
 import path from "path";
 import {
     AVATARS_DIR,
@@ -107,6 +107,80 @@ export function getVideoById(id: string): import("./types").Video | undefined {
       error instanceof Error ? error : new Error(String(error)),
       "getVideoById"
     );
+  }
+}
+
+/**
+ * A video is treated as publicly visible unless visibility is explicitly 0.
+ * Mirrors the frontend contract `(visibility ?? 1) === 1`.
+ */
+export function isVideoPublic(video: {
+  visibility?: number | null;
+}): boolean {
+  return (video.visibility ?? 1) === 1;
+}
+
+export type MediaVisibility = "public" | "hidden" | "unknown";
+
+const escapeLikePattern = (value: string): string =>
+  value.replace(/[\\%_]/g, "\\$&");
+
+/**
+ * Classify a piece of static media by the visibility of the video(s) that
+ * reference it. Used to gate unauthenticated static routes: media that belongs
+ * only to hidden videos must not be served to non-admin callers, while public
+ * media stays reachable (e.g. for RSS clients).
+ *
+ * - `exactPaths` are matched against `videoPath`/`thumbnailPath`.
+ * - `subtitlePaths` are matched against entries inside the `subtitles` JSON.
+ *
+ * Returns "public" if any referencing video is visible, "hidden" if every
+ * referencing video is hidden, and "unknown" if no video references the media
+ * (orphan files, frontend assets, avatars — left untouched).
+ */
+export function classifyMediaVisibility(opts: {
+  exactPaths?: string[];
+  subtitlePaths?: string[];
+}): MediaVisibility {
+  const conditions: SQL[] = [];
+
+  for (const candidate of opts.exactPaths ?? []) {
+    if (!candidate) continue;
+    conditions.push(eq(videos.videoPath, candidate));
+    conditions.push(eq(videos.thumbnailPath, candidate));
+  }
+
+  for (const candidate of opts.subtitlePaths ?? []) {
+    if (!candidate) continue;
+    const pattern = `%"${escapeLikePattern(candidate)}"%`;
+    conditions.push(sql`${videos.subtitles} LIKE ${pattern} ESCAPE '\\'`);
+  }
+
+  if (conditions.length === 0) {
+    return "unknown";
+  }
+
+  try {
+    const rows = db
+      .select({ visibility: videos.visibility })
+      .from(videos)
+      .where(or(...conditions))
+      .all();
+
+    if (rows.length === 0) {
+      return "unknown";
+    }
+
+    // Any visible reference makes the file public (a thumbnail could be shared);
+    // only block when every match is hidden.
+    return rows.some((row) => isVideoPublic(row)) ? "public" : "hidden";
+  } catch (error) {
+    logger.error(
+      "Error classifying media visibility",
+      error instanceof Error ? error : new Error(String(error))
+    );
+    // Fail closed: treat as hidden so a transient DB error can't leak media.
+    return "hidden";
   }
 }
 


### PR DESCRIPTION
Fixes two triaged GitHub Security Advisories, both exploitable when `loginEnabled=true`.

## Advisories addressed

### GHSA-hcm6-w6x8-6jhr — Visitor Can Access Hidden Video Metadata and Content (High)
The backend never filtered videos by `visibility`, so a visitor could enumerate every hidden video and read its `videoPath` / `sourceUrl` / subtitle / thumbnail paths — then download the files via the unauthenticated static routes. The RSS feed *did* filter `visibility=1` for visitors, confirming this is the intended contract the main API skipped.

### GHSA-rwwf-29mq-5j43 — Unauthenticated Media Access via Static Routes (High)
`server.ts` registers the static (`/videos`, `/images`, `/images-small`, `/subtitles`) and cloud (`/cloud/videos`, `/cloud/images`) routes **before** the API auth stack, so they ignored login entirely.

## Approach (visibility-based, RSS-safe)

- **API metadata** (`videoController.ts`): `getVideos` filters hidden videos for non-admins; `getVideoById` / `serveMountVideo` / `getVideoComments` return **404** (not 403, so a hidden video is indistinguishable from a missing one). API-key automation retains full owner access; single-user mode (login disabled) is unchanged.
- **Static + cloud media** (new `mediaVisibilityGuard` in `middleware/mediaAccessMiddleware.ts`): each request is mapped back to its video via the new `classifyMediaVisibility` storage helper. Media belonging **only to hidden videos** is blocked for non-admins; **public media stays reachable without a session** so RSS/podcast clients keep working. Admins (session cookie / JWT) keep full access. The guard **fails closed** on DB errors.
- Avatars, the cloud thumbnail cache, and frontend assets are intentionally left open (not visibility-bound).

## Tests
- `tsc --noEmit` clean
- Full backend suite: **2090 passed** (163 files)
- New tests: guard middleware (7 cases), storage classifier + `isVideoPublic` (6), visitor filtering in the controller (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)