### PR TITLE
[codex] Fix media access authorization

### DIFF
--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -5,6 +5,7 @@ import {
     deleteVideo,
     getVideoById,
     getVideos,
+    serveMountVideo,
     updateVideoDetails,
 } from "../../controllers/videoController";
 import {
@@ -347,6 +348,23 @@ describe("VideoController", () => {
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith(mockVideos);
     });
+
+    it("should only return public videos to visitors", () => {
+      req.user = { role: "visitor" } as any;
+      const mockVideos = [
+        { id: "1", visibility: 1 },
+        { id: "2", visibility: 0 },
+        { id: "3" },
+      ];
+      (storageService.getVideos as any).mockReturnValue(mockVideos);
+
+      getVideos(req as Request, res as Response);
+
+      expect(json).toHaveBeenCalledWith([
+        { id: "1", visibility: 1 },
+        { id: "3" },
+      ]);
+    });
   });
 
   describe("getVideoById", () => {
@@ -368,6 +386,41 @@ describe("VideoController", () => {
 
       try {
         await getVideoById(req as Request, res as Response);
+        expect.fail("Should have thrown");
+      } catch (error: any) {
+        expect(error.name).toBe("NotFoundError");
+      }
+    });
+
+    it("should return 404 semantics for hidden videos requested by visitors", async () => {
+      req.params = { id: "1" };
+      req.user = { role: "visitor" } as any;
+      (storageService.getVideoById as any).mockReturnValue({
+        id: "1",
+        visibility: 0,
+      });
+
+      try {
+        await getVideoById(req as Request, res as Response);
+        expect.fail("Should have thrown");
+      } catch (error: any) {
+        expect(error.name).toBe("NotFoundError");
+      }
+    });
+  });
+
+  describe("serveMountVideo", () => {
+    it("should return 404 semantics for hidden mount videos requested by visitors", async () => {
+      req.params = { id: "1" };
+      req.user = { role: "visitor" } as any;
+      (storageService.getVideoById as any).mockReturnValue({
+        id: "1",
+        visibility: 0,
+        videoPath: "mount:/private/video.mp4",
+      });
+
+      try {
+        await serveMountVideo(req as Request, res as Response);
         expect.fail("Should have thrown");
       } catch (error: any) {
         expect(error.name).toBe("NotFoundError");

--- a/backend/src/__tests__/middleware/mediaAccessMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAccessMiddleware.test.ts
@@ -1,0 +1,168 @@
+import crypto from "crypto";
+import { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  canVisitorAccessMedia,
+  getRequestedMediaCandidates,
+  mediaAccessMiddleware,
+} from "../../middleware/mediaAccessMiddleware";
+import { isLoginRequired } from "../../services/passwordService";
+import * as storageService from "../../services/storageService";
+
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: vi.fn(),
+}));
+
+vi.mock("../../services/storageService", () => ({
+  getVideos: vi.fn(),
+}));
+
+const createRes = () => {
+  const res: Partial<Response> = {};
+  Object.assign(res, {
+    status: vi.fn().mockReturnValue(res),
+    send: vi.fn().mockReturnValue(res),
+  });
+  return res as Response & {
+    status: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe("mediaAccessMiddleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(storageService.getVideos).mockReturnValue([
+      {
+        id: "public",
+        title: "Public",
+        sourceUrl: "https://example.com/public",
+        createdAt: "2026-01-01",
+        visibility: 1,
+        videoPath: "/videos/public.mp4",
+        thumbnailPath: "/images/public.jpg",
+        authorAvatarPath: "/avatars/public.jpg",
+        subtitles: [
+          {
+            language: "en",
+            filename: "public.vtt",
+            path: "/subtitles/public.vtt",
+          },
+        ],
+      },
+      {
+        id: "hidden",
+        title: "Hidden",
+        sourceUrl: "https://example.com/hidden",
+        createdAt: "2026-01-01",
+        visibility: 0,
+        videoPath: "/videos/hidden.mp4",
+        thumbnailPath: "cloud:hidden.jpg",
+      },
+    ] as any);
+  });
+
+  it("allows media when login is disabled", () => {
+    vi.mocked(isLoginRequired).mockReturnValue(false);
+    const req = { baseUrl: "/videos", path: "/hidden.mp4" } as Request;
+    const res = createRes();
+    const next = vi.fn();
+
+    mediaAccessMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("blocks unauthenticated media when login is required", () => {
+    const req = { baseUrl: "/videos", path: "/public.mp4" } as Request;
+    const res = createRes();
+    const next = vi.fn();
+
+    mediaAccessMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.send).toHaveBeenCalledWith("Authentication required");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows admins to access protected media", () => {
+    const req = {
+      baseUrl: "/videos",
+      path: "/hidden.mp4",
+      user: { role: "admin" },
+    } as Request;
+    const res = createRes();
+    const next = vi.fn();
+
+    mediaAccessMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows visitors to access media attached to public videos", () => {
+    const req = {
+      baseUrl: "/images",
+      path: "/public.jpg",
+      user: { role: "visitor" },
+    } as Request;
+    const res = createRes();
+    const next = vi.fn();
+
+    mediaAccessMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides media that is only attached to hidden videos from visitors", () => {
+    const req = {
+      baseUrl: "/videos",
+      path: "/hidden.mp4",
+      user: { role: "visitor" },
+    } as Request;
+    const res = createRes();
+    const next = vi.fn();
+
+    mediaAccessMiddleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith("Not Found");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("maps small thumbnail requests back to public original thumbnails", () => {
+    const req = {
+      baseUrl: "/images-small",
+      path: "/public.jpg",
+    } as Request;
+
+    expect(getRequestedMediaCandidates(req)).toEqual([
+      "/images/public.jpg",
+      "/videos/public.jpg",
+    ]);
+  });
+
+  it("authorizes cached cloud thumbnails only for public matching videos", () => {
+    const publicCacheName = `${crypto
+      .createHash("sha256")
+      .update("cloud:public-cloud.jpg")
+      .digest("hex")}.jpg`;
+
+    expect(
+      canVisitorAccessMedia(
+        [`/api/cloud/thumbnail-cache/${publicCacheName}`],
+        [
+          {
+            id: "public-cloud",
+            title: "Public Cloud",
+            sourceUrl: "https://example.com/public-cloud",
+            createdAt: "2026-01-01",
+            visibility: 1,
+            thumbnailPath: "cloud:public-cloud.jpg",
+          } as any,
+        ]
+      )
+    ).toBe(true);
+  });
+});

--- a/backend/src/__tests__/server/cloudRoutes.test.ts
+++ b/backend/src/__tests__/server/cloudRoutes.test.ts
@@ -87,8 +87,8 @@ describe("server/cloudRoutes", () => {
   const registerAndGetHandlers = () => {
     const handlers: Record<string, any> = {};
     const app = {
-      get: vi.fn((route: string, handler: any) => {
-        handlers[route] = handler;
+      get: vi.fn((route: string, ...routeHandlers: any[]) => {
+        handlers[route] = routeHandlers[routeHandlers.length - 1];
       }),
     } as any;
     registerCloudRoutes(app);

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -30,10 +30,20 @@ vi.mock("../../services/thumbnailMirrorService", () => ({
   getThumbnailRelativePath: getThumbnailRelativePathMock,
 }));
 
+vi.mock("../../middleware/authMiddleware", () => ({
+  authMiddleware: vi.fn((_req, _res, next) => next()),
+}));
+
+vi.mock("../../middleware/mediaAccessMiddleware", () => ({
+  mediaAccessMiddleware: vi.fn((_req, _res, next) => next()),
+}));
+
 vi.mock("fs-extra", () => ({
   default: {
+    ensureDirSync: vi.fn(),
     pathExists: pathExistsMock,
   },
+  ensureDirSync: vi.fn(),
   pathExists: pathExistsMock,
 }));
 
@@ -56,23 +66,32 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    expect(use).toHaveBeenCalledTimes(8);
+    expect(use).toHaveBeenCalledTimes(9);
     expect(get).toHaveBeenCalledWith("/images-small/*", expect.any(Function));
 
-    const [videosPath, videosStatic] = use.mock.calls[0];
+    expect(use.mock.calls[0][0]).toEqual([
+      "/videos",
+      "/images",
+      "/images-small",
+      "/avatars",
+      "/api/cloud/thumbnail-cache",
+      "/subtitles",
+    ]);
+
+    const [videosPath, videosStatic] = use.mock.calls[1];
     expect(videosPath).toBe("/videos");
     expect(videosStatic.dir).toContain("/uploads/videos");
     expect(videosStatic.options.fallthrough).toBe(false);
 
-    const [imagesPath, imagesStatic] = use.mock.calls[1];
+    const [imagesPath, imagesStatic] = use.mock.calls[2];
     expect(imagesPath).toBe("/images");
     expect(imagesStatic.options.fallthrough).toBe(false);
 
-    const [smallImagesPath, smallImagesStatic] = use.mock.calls[2];
+    const [smallImagesPath, smallImagesStatic] = use.mock.calls[3];
     expect(smallImagesPath).toBe("/images-small");
     expect(smallImagesStatic.options.fallthrough).toBe(false);
 
-    const [assetsPath, assetsStatic] = use.mock.calls[6];
+    const [assetsPath, assetsStatic] = use.mock.calls[7];
     expect(assetsPath).toBe("/assets");
     expect(assetsStatic.dir).toBe("/frontend-dist/assets");
     expect(assetsStatic.options.fallthrough).toBe(false);
@@ -105,7 +124,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const subtitlesStatic = use.mock.calls[5][1];
+    const subtitlesStatic = use.mock.calls[6][1];
     const setHeaders = subtitlesStatic.options.setHeaders as (
       res: any,
       filePath: string

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -46,6 +46,10 @@ import {
   writeFileSafeSync,
 } from "../utils/security";
 
+const isVisitorRequest = (req: Request): boolean => req.user?.role === "visitor";
+const isVisibleToVisitor = (video: storageService.Video): boolean =>
+  (video.visibility ?? 1) === 1;
+
 const MAX_VIDEO_UPLOAD_FILE_SIZE = 100 * 1024 * 1024 * 1024;
 const MAX_BATCH_UPLOAD_FILES = 100;
 const MAX_BATCH_UPLOAD_TOTAL_SIZE = MAX_VIDEO_UPLOAD_FILE_SIZE;
@@ -526,10 +530,16 @@ const resolveVideoWebPath = (absoluteVideoPath: string): string | null => {
  * Note: Returns array directly for backward compatibility with frontend
  */
 export const getVideos = async (
-  _req: Request,
+  req: Request,
   res: Response
 ): Promise<void> => {
-  const videos = storageService.getVideos();
+  const videos = storageService.getVideos().filter((video) => {
+    if (!isVisitorRequest(req)) {
+      return true;
+    }
+
+    return isVisibleToVisitor(video);
+  });
   // Return array directly for backward compatibility (frontend expects response.data to be Video[])
   sendData(res, videos);
 };
@@ -547,6 +557,10 @@ export const getVideoById = async (
   const video = storageService.getVideoById(id);
 
   if (!video) {
+    throw new NotFoundError("Video", id);
+  }
+
+  if (isVisitorRequest(req) && !isVisibleToVisitor(video)) {
     throw new NotFoundError("Video", id);
   }
 
@@ -1216,6 +1230,10 @@ export const serveMountVideo = async (
   const video = storageService.getVideoById(id);
 
   if (!video) {
+    throw new NotFoundError("Video", id);
+  }
+
+  if (isVisitorRequest(req) && !isVisibleToVisitor(video)) {
     throw new NotFoundError("Video", id);
   }
 

--- a/backend/src/middleware/mediaAccessMiddleware.ts
+++ b/backend/src/middleware/mediaAccessMiddleware.ts
@@ -1,0 +1,146 @@
+import crypto from "crypto";
+import { NextFunction, Request, Response } from "express";
+import { isLoginRequired } from "../services/passwordService";
+import * as storageService from "../services/storageService";
+import { Video } from "../services/storageService/types";
+
+const stripQuery = (value: unknown): string | null => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  return value.split("?")[0];
+};
+
+const isPublicVideo = (video: Video): boolean => (video.visibility ?? 1) === 1;
+
+const normalizeRequestPath = (req: Request): string => {
+  const basePath = `${req.baseUrl ?? ""}${req.path ?? ""}`;
+  return basePath.replace(/\/{2,}/g, "/");
+};
+
+const cloudThumbnailCacheFilename = (cloudPath: string): string => {
+  const hash = crypto.createHash("sha256").update(cloudPath).digest("hex");
+  return `${hash}.jpg`;
+};
+
+const addWebPath = (paths: Set<string>, value: unknown): void => {
+  const pathValue = stripQuery(value);
+  if (!pathValue) {
+    return;
+  }
+
+  if (
+    pathValue.startsWith("/videos/") ||
+    pathValue.startsWith("/images/") ||
+    pathValue.startsWith("/subtitles/") ||
+    pathValue.startsWith("/avatars/") ||
+    pathValue.startsWith("cloud:")
+  ) {
+    paths.add(pathValue);
+  }
+
+  if (pathValue.startsWith("cloud:")) {
+    paths.add(
+      `/api/cloud/thumbnail-cache/${cloudThumbnailCacheFilename(pathValue)}`
+    );
+  }
+};
+
+const getVideoMediaPaths = (video: Video): Set<string> => {
+  const paths = new Set<string>();
+  addWebPath(paths, video.videoPath);
+  addWebPath(paths, video.thumbnailPath);
+  addWebPath(paths, video.thumbnailUrl);
+  addWebPath(paths, video.authorAvatarPath);
+
+  if (Array.isArray(video.subtitles)) {
+    for (const subtitle of video.subtitles) {
+      addWebPath(paths, subtitle?.path);
+    }
+  }
+
+  return paths;
+};
+
+const getCloudFilename = (req: Request): string | null => {
+  const filename = req.params?.filename;
+  if (typeof filename === "string" && filename.length > 0) {
+    return filename;
+  }
+  return null;
+};
+
+export const getRequestedMediaCandidates = (req: Request): string[] => {
+  const requestPath = stripQuery(normalizeRequestPath(req));
+  if (!requestPath) {
+    return [];
+  }
+
+  const cloudFilename = getCloudFilename(req);
+  if (requestPath.startsWith("/cloud/videos/") && cloudFilename) {
+    return [`cloud:${cloudFilename}`];
+  }
+
+  if (requestPath.startsWith("/cloud/images/") && cloudFilename) {
+    return [`cloud:${cloudFilename}`];
+  }
+
+  if (requestPath.startsWith("/images-small/")) {
+    const relativePath = requestPath.slice("/images-small/".length);
+    return [`/images/${relativePath}`, `/videos/${relativePath}`];
+  }
+
+  return [requestPath];
+};
+
+export const canVisitorAccessMedia = (
+  candidates: string[],
+  videos: Video[] = storageService.getVideos()
+): boolean => {
+  if (candidates.length === 0) {
+    return false;
+  }
+
+  return videos.some((video) => {
+    if (!isPublicVideo(video)) {
+      return false;
+    }
+
+    const mediaPaths = getVideoMediaPaths(video);
+    return candidates.some((candidate) => mediaPaths.has(candidate));
+  });
+};
+
+export const mediaAccessMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void => {
+  if (!isLoginRequired()) {
+    next();
+    return;
+  }
+
+  if (req.user?.role === "admin") {
+    next();
+    return;
+  }
+
+  if (!req.user) {
+    res.status(401).send("Authentication required");
+    return;
+  }
+
+  if (req.user.role !== "visitor") {
+    res.status(403).send("Forbidden");
+    return;
+  }
+
+  if (canVisitorAccessMedia(getRequestedMediaCandidates(req))) {
+    next();
+    return;
+  }
+
+  res.status(404).send("Not Found");
+};

--- a/backend/src/server/cloudRoutes.ts
+++ b/backend/src/server/cloudRoutes.ts
@@ -3,6 +3,8 @@ import path from "path";
 import {
   CLOUD_THUMBNAIL_CACHE_DIR,
 } from "../config/paths";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { mediaAccessMiddleware } from "../middleware/mediaAccessMiddleware";
 import { cloudflaredService } from "../services/cloudflaredService";
 import { getCachedThumbnail } from "../services/cloudStorage/cloudThumbnailCache";
 import { CloudStorageService } from "../services/CloudStorageService";
@@ -127,12 +129,22 @@ const redirectCloudFile = async (
 };
 
 export const registerCloudRoutes = (app: Express): void => {
-  app.get("/cloud/videos/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "video");
-  });
-  app.get("/cloud/images/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "image");
-  });
+  app.get(
+    "/cloud/videos/:filename",
+    authMiddleware,
+    mediaAccessMiddleware,
+    (req, res) => {
+      void redirectCloudFile(req, res, "video");
+    }
+  );
+  app.get(
+    "/cloud/images/:filename",
+    authMiddleware,
+    mediaAccessMiddleware,
+    (req, res) => {
+      void redirectCloudFile(req, res, "image");
+    }
+  );
 };
 
 export const startCloudflaredIfEnabled = (port: number): void => {

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -9,6 +9,8 @@ import {
   SUBTITLES_DIR,
   VIDEOS_DIR,
 } from "../config/paths";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { mediaAccessMiddleware } from "../middleware/mediaAccessMiddleware";
 import {
   ensureSmallThumbnailForRelativePath,
   getThumbnailRelativePath,
@@ -33,6 +35,15 @@ const IMAGE_MIME_TYPES = new Map([
 
 const getImageMimeType = (filePath: string): string | null =>
   IMAGE_MIME_TYPES.get(path.extname(filePath).toLowerCase()) ?? null;
+
+const PROTECTED_MEDIA_PATHS = [
+  "/videos",
+  "/images",
+  "/images-small",
+  "/avatars",
+  "/api/cloud/thumbnail-cache",
+  "/subtitles",
+];
 
 const isReservedBackendPath = (requestPath: string): boolean =>
   requestPath.startsWith("/api") ||
@@ -110,6 +121,8 @@ export const registerStaticRoutes = (
 ): void => {
   const safeFrontendDist = normalizeSafeAbsolutePath(frontendDist);
   const safeFrontendAssetsDir = resolveSafeChildPath(safeFrontendDist, "assets");
+
+  app.use(PROTECTED_MEDIA_PATHS, authMiddleware, mediaAccessMiddleware);
 
   app.use(
     "/videos",


### PR DESCRIPTION
## Summary

- Adds backend media authorization for static and cloud media routes when login is enabled.
- Restricts visitor media access to files attached to public videos only.
- Filters visitor video list/detail and mount-video access so hidden records return 404 semantics.
- Adds focused tests for media route authorization and visitor visibility behavior.

## Advisories

- GHSA-hcm6-w6x8-6jhr: Visitor can access hidden video metadata and content.
- GHSA-rwwf-29mq-5j43: Unauthenticated media access via static routes bypassing login.

## Validation

- npm run build
- npx vitest run src/__tests__/middleware/mediaAccessMiddleware.test.ts src/__tests__/server/staticRoutes.test.ts src/__tests__/server/cloudRoutes.test.ts
- npx vitest run src/__tests__/controllers/videoController.test.ts -t 'public videos|404 semantics|hidden mount'
- git diff --check

Note: full backend npm test still has one pre-existing failure in VideoController > uploadVideo > should upload video where saveVideoIfAbsent is not called.
