### PR TITLE
fix(security): gate media routes + enforce visitor visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fix
+
+- Gate static and cloud media routes behind authentication when login is enabled, and enforce visitor visibility per-file as defense-in-depth (GHSA-rwwf-29mq-5j43, GHSA-hcm6-w6x8-6jhr)
+
+### Note
+
+- When login is enabled, RSS feed media URLs carry an `?rss=<token>` query parameter so feed readers (which send no session cookie) can still load cover art. This token is the feed's existing secret and introduces no new exposure, but it will now appear in reverse-proxy/access logs that record query strings.
+
 ## v1.9.32 (2026-06-05)
 
 ### Feat

--- a/backend/src/__tests__/controllers/cloudStorageController.test.ts
+++ b/backend/src/__tests__/controllers/cloudStorageController.test.ts
@@ -18,11 +18,15 @@ import {
   getVideos,
   isCloudFileVisibleToVisitor,
 } from "../../services/storageService";
+import { isLoginRequired } from "../../services/passwordService";
 import { logger } from "../../utils/logger";
 
 vi.mock("../../services/storageService", () => ({
   getVideos: vi.fn(),
   isCloudFileVisibleToVisitor: vi.fn(() => true),
+}));
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: vi.fn(() => true),
 }));
 vi.mock("../../services/CloudStorageService", () => ({
   CloudStorageService: {
@@ -74,6 +78,8 @@ describe("cloudStorageController", () => {
       end: endMock,
     };
     vi.mocked(resolveAbsolutePath).mockReturnValue(null);
+    vi.mocked(isLoginRequired).mockReturnValue(true);
+    vi.mocked(isCloudFileVisibleToVisitor).mockReturnValue(true);
   });
 
   describe("getSignedUrl", () => {
@@ -104,6 +110,25 @@ describe("cloudStorageController", () => {
         expect.objectContaining({ success: false })
       );
       expect(CloudStorageService.getSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it("should ignore stale visitor roles when login is disabled", async () => {
+      req.query = { filename: "secret.mp4", type: "video" };
+      req.user = { role: "visitor" } as any;
+      vi.mocked(isLoginRequired).mockReturnValue(false);
+      vi.mocked(isCloudFileVisibleToVisitor).mockReturnValue(false);
+      (CloudStorageService.getSignedUrl as any).mockResolvedValue(
+        "https://signed.example/secret.mp4"
+      );
+
+      await getSignedUrl(req as Request, res as Response);
+
+      expect(isCloudFileVisibleToVisitor).not.toHaveBeenCalled();
+      expect(CloudStorageService.getSignedUrl).toHaveBeenCalledWith(
+        "secret.mp4",
+        "video"
+      );
+      expect(statusMock).toHaveBeenCalledWith(200);
     });
 
     it("should let a visitor fetch a public cloud file", async () => {

--- a/backend/src/__tests__/controllers/cloudStorageController.test.ts
+++ b/backend/src/__tests__/controllers/cloudStorageController.test.ts
@@ -14,11 +14,15 @@ import {
   getCachedThumbnail,
 } from "../../services/cloudStorage/cloudThumbnailCache";
 import { resolveAbsolutePath } from "../../services/cloudStorage/pathUtils";
-import { getVideos } from "../../services/storageService";
+import {
+  getVideos,
+  isCloudFileVisibleToVisitor,
+} from "../../services/storageService";
 import { logger } from "../../utils/logger";
 
 vi.mock("../../services/storageService", () => ({
   getVideos: vi.fn(),
+  isCloudFileVisibleToVisitor: vi.fn(() => true),
 }));
 vi.mock("../../services/CloudStorageService", () => ({
   CloudStorageService: {
@@ -85,6 +89,35 @@ describe("cloudStorageController", () => {
       await expect(getSignedUrl(req as Request, res as Response)).rejects.toThrow(
         ValidationError
       );
+    });
+
+    it("should 404 a visitor requesting a hidden cloud file", async () => {
+      req.query = { filename: "secret.mp4", type: "video" };
+      req.user = { role: "visitor" } as any;
+      vi.mocked(isCloudFileVisibleToVisitor).mockReturnValue(false);
+
+      await getSignedUrl(req as Request, res as Response);
+
+      expect(isCloudFileVisibleToVisitor).toHaveBeenCalledWith("secret.mp4");
+      expect(statusMock).toHaveBeenCalledWith(404);
+      expect(jsonMock).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false })
+      );
+      expect(CloudStorageService.getSignedUrl).not.toHaveBeenCalled();
+    });
+
+    it("should let a visitor fetch a public cloud file", async () => {
+      req.query = { filename: "pub.mp4", type: "video" };
+      req.user = { role: "visitor" } as any;
+      vi.mocked(isCloudFileVisibleToVisitor).mockReturnValue(true);
+      (CloudStorageService.getSignedUrl as any).mockResolvedValue(
+        "https://signed.example/pub.mp4"
+      );
+
+      await getSignedUrl(req as Request, res as Response);
+
+      expect(isCloudFileVisibleToVisitor).toHaveBeenCalledWith("pub.mp4");
+      expect(statusMock).toHaveBeenCalledWith(200);
     });
 
     it("should return cached thumbnail if present", async () => {

--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -347,6 +347,17 @@ describe("VideoController", () => {
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith(mockVideos);
     });
+
+    it("should scope videos to public-only when caller is a visitor", () => {
+      const mockVideos = [{ id: "1" }];
+      (storageService.getVideos as any).mockReturnValue(mockVideos);
+      req.user = { role: "visitor" } as any;
+
+      getVideos(req as Request, res as Response);
+
+      expect(storageService.getVideos).toHaveBeenCalledWith("visitor");
+      expect(json).toHaveBeenCalledWith(mockVideos);
+    });
   });
 
   describe("getVideoById", () => {
@@ -357,9 +368,28 @@ describe("VideoController", () => {
 
       getVideoById(req as Request, res as Response);
 
-      expect(storageService.getVideoById).toHaveBeenCalledWith("1");
+      // Unauthenticated caller -> role undefined (admin/server-side default).
+      expect(storageService.getVideoById).toHaveBeenCalledWith("1", undefined);
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith(mockVideo);
+    });
+
+    it("should treat hidden videos as not found for a visitor", async () => {
+      req.params = { id: "hidden-1" };
+      req.user = { role: "visitor" } as any;
+      // getVideoById returns undefined for a hidden video when role=visitor.
+      (storageService.getVideoById as any).mockReturnValue(undefined);
+
+      try {
+        await getVideoById(req as Request, res as Response);
+        expect.fail("Should have thrown");
+      } catch (error: any) {
+        expect(error.name).toBe("NotFoundError");
+      }
+      expect(storageService.getVideoById).toHaveBeenCalledWith(
+        "hidden-1",
+        "visitor"
+      );
     });
 
     it("should throw NotFoundError if not found", async () => {

--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -17,6 +17,7 @@ import {
 import { rateVideo } from "../../controllers/videoMetadataController";
 import downloadManager from "../../services/downloadManager";
 import * as downloadService from "../../services/downloadService";
+import { isLoginRequired } from "../../services/passwordService";
 import * as storageService from "../../services/storageService";
 
 vi.mock("../../db", () => ({
@@ -34,6 +35,12 @@ vi.mock("../../db", () => ({
 
 vi.mock("../../services/downloadService");
 vi.mock("../../services/storageService");
+// isLoginRequired defaults to false (single-user mode) so existing tests are
+// unaffected; visitor-visibility tests opt into login-enabled per-case.
+vi.mock("../../services/passwordService", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, isLoginRequired: vi.fn(() => false) };
+});
 vi.mock("../../services/downloadManager");
 vi.mock("../../services/metadataService");
 vi.mock("../../services/statistics", () => ({
@@ -112,6 +119,9 @@ describe("VideoController", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // clearAllMocks resets call history but not implementations; restore the
+    // single-user default so a login-enabled test doesn't leak into later ones.
+    vi.mocked(isLoginRequired).mockReturnValue(false);
     json = vi.fn();
     status = vi.fn().mockReturnValue({ json });
     req = { headers: {} };
@@ -349,6 +359,7 @@ describe("VideoController", () => {
     });
 
     it("should scope videos to public-only when caller is a visitor", () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
       const mockVideos = [{ id: "1" }];
       (storageService.getVideos as any).mockReturnValue(mockVideos);
       req.user = { role: "visitor" } as any;
@@ -356,6 +367,21 @@ describe("VideoController", () => {
       getVideos(req as Request, res as Response);
 
       expect(storageService.getVideos).toHaveBeenCalledWith("visitor");
+      expect(json).toHaveBeenCalledWith(mockVideos);
+    });
+
+    it("should ignore a stale visitor role when login is disabled", () => {
+      // Regression for the single-user-mode compatibility gap: when login is
+      // off, a leftover visitor session must not scope the query (which would
+      // wrongly hide hidden videos in single-user mode).
+      vi.mocked(isLoginRequired).mockReturnValue(false);
+      const mockVideos = [{ id: "1" }];
+      (storageService.getVideos as any).mockReturnValue(mockVideos);
+      req.user = { role: "visitor" } as any;
+
+      getVideos(req as Request, res as Response);
+
+      expect(storageService.getVideos).toHaveBeenCalledWith(undefined);
       expect(json).toHaveBeenCalledWith(mockVideos);
     });
   });
@@ -375,6 +401,7 @@ describe("VideoController", () => {
     });
 
     it("should treat hidden videos as not found for a visitor", async () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
       req.params = { id: "hidden-1" };
       req.user = { role: "visitor" } as any;
       // getVideoById returns undefined for a hidden video when role=visitor.
@@ -597,6 +624,25 @@ describe("VideoController", () => {
 
       expect(status).toHaveBeenCalledWith(200);
       expect(json).toHaveBeenCalledWith([]);
+    });
+
+    it("should treat a hidden video's comments as not found for a visitor", async () => {
+      vi.mocked(isLoginRequired).mockReturnValue(true);
+      req.params = { id: "hidden-1" };
+      req.user = { role: "visitor" } as any;
+      // Query-layer role filter yields undefined for a hidden id + visitor.
+      (storageService.getVideoById as any).mockReturnValue(undefined);
+
+      await expect(
+        import("../../controllers/videoController").then((m) =>
+          m.getVideoComments(req as Request, res as Response)
+        )
+      ).rejects.toMatchObject({ name: "NotFoundError" });
+
+      expect(storageService.getVideoById).toHaveBeenCalledWith(
+        "hidden-1",
+        "visitor"
+      );
     });
   });
 

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -14,6 +14,7 @@ import { ValidationError } from "../../errors/DownloadErrors";
 import downloadManager from "../../services/downloadManager";
 import * as downloadService from "../../services/downloadService";
 import * as storageService from "../../services/storageService";
+import { isLoginRequired } from "../../services/passwordService";
 import {
   extractBilibiliVideoId,
   getMissAVPlaceholderTitle,
@@ -70,6 +71,10 @@ vi.mock("../../services/storageService", () => ({
   linkVideoToCollection: vi.fn(),
   cleanupCollectionDirectories: vi.fn(),
   getDownloadStatus: vi.fn(),
+}));
+
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: vi.fn(() => true),
 }));
 
 vi.mock("../../services/statistics", () => ({
@@ -217,6 +222,7 @@ describe("videoDownloadController extra coverage", () => {
       activeDownloads: [],
       queuedDownloads: [],
     } as any);
+    vi.mocked(isLoginRequired).mockReturnValue(true);
     vi.mocked(downloadManager.addDownload).mockImplementation(
       async (task: any) => task(vi.fn())
     );
@@ -352,6 +358,74 @@ describe("videoDownloadController extra coverage", () => {
         status: "exists",
         videoId: "video-2",
         videoPath: "/videos/v2.mp4",
+      })
+    );
+  });
+
+  it("checkVideoDownloadStatus hides existing hidden downloads from visitors", async () => {
+    req.query = { url: "http://ok" } as any;
+    req.user = { role: "visitor" } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      sourceVideoId: "id-hidden",
+      platform: "youtube",
+    } as any);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "hidden-video",
+      title: "Hidden Title",
+      author: "Hidden Author",
+      downloadedAt: "2026-01-03",
+    } as any);
+    vi.mocked(storageService.getVideoById).mockReturnValue(undefined);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.getVideoById).toHaveBeenCalledWith(
+      "hidden-video",
+      "visitor"
+    );
+    expect(storageService.verifyVideoExists).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus ignores stale visitor roles when login is disabled", async () => {
+    req.query = { url: "http://ok" } as any;
+    req.user = { role: "visitor" } as any;
+    vi.mocked(isLoginRequired).mockReturnValue(false);
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      sourceVideoId: "id-owner",
+      platform: "youtube",
+    } as any);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "owner-video",
+    } as any);
+    vi.mocked(storageService.verifyVideoExists).mockReturnValue({
+      exists: true,
+      video: {
+        id: "owner-video",
+        title: "Owner Visible",
+        videoPath: "/videos/owner.mp4",
+        thumbnailPath: "/images/owner.jpg",
+      },
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    const getVideoById = vi.mocked(storageService.verifyVideoExists).mock
+      .calls[0][1];
+    getVideoById("owner-video");
+    expect(storageService.getVideoById).toHaveBeenCalledWith(
+      "owner-video",
+      undefined
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        found: true,
+        status: "exists",
+        videoId: "owner-video",
       })
     );
   });

--- a/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
@@ -90,33 +90,54 @@ describe("middleware/mediaAuthMiddleware", () => {
 
   it("allows access with a valid, active RSS token query param", async () => {
     isLoginRequiredMock.mockReturnValue(true);
-    getRssTokenMock.mockResolvedValue({ isActive: true });
+    getRssTokenMock.mockResolvedValue({ isActive: true, role: "visitor" });
     const next = vi.fn();
+    const req = createReq({
+      query: { rss: "550e8400-e29b-41d4-a716-446655440000" },
+    } as any);
     await requireAuthenticatedMediaAccess(
-      createReq({ query: { rss: "550e8400-e29b-41d4-a716-446655440000" } } as any),
+      req,
       createRes(),
       next as any
     );
     expect(getRssTokenMock).toHaveBeenCalledWith(
       "550e8400-e29b-41d4-a716-446655440000"
     );
+    expect(req.rssTokenRole).toBe("visitor");
     expect(next).toHaveBeenCalledTimes(1);
   });
 
   it("allows access with a valid RSS token cookie", async () => {
     isLoginRequiredMock.mockReturnValue(true);
-    getRssTokenMock.mockResolvedValue({ isActive: true });
+    getRssTokenMock.mockResolvedValue({ isActive: true, role: "admin" });
     const next = vi.fn();
+    const req = createReq({
+      cookies: { mytube_rss_token: "550e8400-e29b-41d4-a716-446655440000" },
+    } as any);
     await requireAuthenticatedMediaAccess(
-      createReq({
-        cookies: { mytube_rss_token: "550e8400-e29b-41d4-a716-446655440000" },
-      } as any),
+      req,
       createRes(),
       next as any
     );
     expect(getRssTokenMock).toHaveBeenCalledWith(
       "550e8400-e29b-41d4-a716-446655440000"
     );
+    expect(req.rssTokenRole).toBe("admin");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets a valid admin RSS token override a stale visitor session", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockResolvedValue({ isActive: true, role: "admin" });
+    const next = vi.fn();
+    const req = createReq({
+      user: { role: "visitor" },
+      query: { rss: "550e8400-e29b-41d4-a716-446655440000" },
+    } as any);
+
+    await requireAuthenticatedMediaAccess(req, createRes(), next as any);
+
+    expect(req.rssTokenRole).toBe("admin");
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -227,6 +248,18 @@ describe("middleware/requireVisibleMediaForVisitors", () => {
     expect(classifyMediaVisibilityMock).not.toHaveBeenCalled();
   });
 
+  it("lets admin RSS tokens reach hidden media without classifying", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("videos")(
+      createReq({ rssTokenRole: "admin" } as any),
+      createRes(),
+      next
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(classifyMediaVisibilityMock).not.toHaveBeenCalled();
+  });
+
   it("404s a visitor requesting media that belongs solely to a hidden video", () => {
     isLoginRequiredMock.mockReturnValue(true);
     classifyMediaVisibilityMock.mockReturnValue("hidden");
@@ -286,6 +319,41 @@ describe("middleware/requireVisibleMediaForVisitors", () => {
     expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
       exactPaths: ["/images/poster.jpg", "/videos/poster.jpg"],
     });
+  });
+
+  it("uses the wildcard-relative path for explicit images-small routes", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("public");
+    requireVisibleMediaForVisitors("images-small")(
+      createReq({
+        user: { role: "visitor" } as any,
+        path: "/images-small/poster.jpg",
+        params: { 0: "poster.jpg" },
+      } as any),
+      createRes(),
+      vi.fn()
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["/images/poster.jpg", "/videos/poster.jpg"],
+    });
+  });
+
+  it("classifies cloud thumbnail cache routes by cache filename", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("hidden");
+    const res = createRes();
+    requireVisibleMediaForVisitors("cloud-thumbnail-cache")(
+      createReq({
+        user: { role: "visitor" } as any,
+        path: "/abc123.jpg",
+      }),
+      res,
+      vi.fn()
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      cloudThumbnailCacheKeys: ["/abc123.jpg"],
+    });
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 
   it("classifies cloud routes by the cloud: filename param", () => {

--- a/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Request, Response } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isLoginRequiredMock, getRssTokenMock } = vi.hoisted(() => ({
+  isLoginRequiredMock: vi.fn(),
+  getRssTokenMock: vi.fn(),
+}));
+
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: isLoginRequiredMock,
+}));
+
+vi.mock("../../services/rssService", () => ({
+  getRssToken: getRssTokenMock,
+}));
+
+vi.mock("../../utils/logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+import { requireAuthenticatedMediaAccess } from "../../middleware/mediaAuthMiddleware";
+
+describe("middleware/mediaAuthMiddleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createReq = (overrides: Partial<Request> = {}): Request =>
+    ({
+      cookies: {},
+      query: {},
+      ...overrides,
+    } as unknown as Request);
+
+  const createRes = () => {
+    const res: Partial<Response> = {};
+    const status = vi.fn().mockReturnValue(res);
+    const json = vi.fn().mockReturnValue(res);
+    Object.assign(res, { status, json });
+    return res as Response & {
+      status: ReturnType<typeof vi.fn>;
+      json: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  it("allows access when login is not required (single-user mode)", async () => {
+    isLoginRequiredMock.mockReturnValue(false);
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(
+      createReq(),
+      createRes(),
+      next as any
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows access for an authenticated session user", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(
+      createReq({ user: { role: "visitor" } as any }),
+      createRes(),
+      next as any
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows access for an API-key-authenticated request", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(
+      createReq({ apiKeyAuthenticated: true } as any),
+      createRes(),
+      next as any
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows access with a valid, active RSS token query param", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockResolvedValue({ isActive: true });
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(
+      createReq({ query: { rss: "550e8400-e29b-41d4-a716-446655440000" } } as any),
+      createRes(),
+      next as any
+    );
+    expect(getRssTokenMock).toHaveBeenCalledWith(
+      "550e8400-e29b-41d4-a716-446655440000"
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows access with a valid RSS token cookie", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockResolvedValue({ isActive: true });
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(
+      createReq({
+        cookies: { mytube_rss_token: "550e8400-e29b-41d4-a716-446655440000" },
+      } as any),
+      createRes(),
+      next as any
+    );
+    expect(getRssTokenMock).toHaveBeenCalledWith(
+      "550e8400-e29b-41d4-a716-446655440000"
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an inactive RSS token", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockResolvedValue({ isActive: false });
+    const res = createRes();
+    await requireAuthenticatedMediaAccess(
+      createReq({ query: { rss: "550e8400-e29b-41d4-a716-446655440000" } } as any),
+      res,
+      vi.fn() as any
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false })
+    );
+  });
+
+  it("rejects an unauthenticated request with no credential", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockResolvedValue(null);
+    const res = createRes();
+    const next = vi.fn();
+    await requireAuthenticatedMediaAccess(createReq(), res, next as any);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("rejects when the RSS token is too short to be valid", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const res = createRes();
+    await requireAuthenticatedMediaAccess(
+      createReq({ query: { rss: "short" } } as any),
+      res,
+      vi.fn() as any
+    );
+    expect(getRssTokenMock).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("rejects when getRssToken throws (defensive)", async () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    getRssTokenMock.mockRejectedValue(new Error("db down"));
+    const res = createRes();
+    await requireAuthenticatedMediaAccess(
+      createReq({ query: { rss: "550e8400-e29b-41d4-a716-446655440000" } } as any),
+      res,
+      vi.fn() as any
+    );
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});

--- a/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
@@ -278,6 +278,29 @@ describe("middleware/requireVisibleMediaForVisitors", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("checks video-root subtitle files through subtitle metadata", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("hidden");
+    const res = createRes();
+    const next = vi.fn();
+
+    requireVisibleMediaForVisitors("videos")(
+      createReq({
+        user: { role: "visitor" } as any,
+        path: "/Collection/secret.en.vtt",
+      }),
+      res,
+      next
+    );
+
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["/videos/Collection/secret.en.vtt"],
+      subtitlePaths: ["/videos/Collection/secret.en.vtt"],
+    });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("allows a visitor to reach public media", () => {
     isLoginRequiredMock.mockReturnValue(true);
     classifyMediaVisibilityMock.mockReturnValue("public");

--- a/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
@@ -2,10 +2,12 @@
 import { Request, Response } from "express";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { isLoginRequiredMock, getRssTokenMock } = vi.hoisted(() => ({
-  isLoginRequiredMock: vi.fn(),
-  getRssTokenMock: vi.fn(),
-}));
+const { isLoginRequiredMock, getRssTokenMock, classifyMediaVisibilityMock } =
+  vi.hoisted(() => ({
+    isLoginRequiredMock: vi.fn(),
+    getRssTokenMock: vi.fn(),
+    classifyMediaVisibilityMock: vi.fn(),
+  }));
 
 vi.mock("../../services/passwordService", () => ({
   isLoginRequired: isLoginRequiredMock,
@@ -15,11 +17,18 @@ vi.mock("../../services/rssService", () => ({
   getRssToken: getRssTokenMock,
 }));
 
+vi.mock("../../services/storageService", () => ({
+  classifyMediaVisibility: classifyMediaVisibilityMock,
+}));
+
 vi.mock("../../utils/logger", () => ({
   logger: { warn: vi.fn() },
 }));
 
-import { requireAuthenticatedMediaAccess } from "../../middleware/mediaAuthMiddleware";
+import {
+  requireAuthenticatedMediaAccess,
+  requireVisibleMediaForVisitors,
+} from "../../middleware/mediaAuthMiddleware";
 
 describe("middleware/mediaAuthMiddleware", () => {
   beforeEach(() => {
@@ -37,10 +46,12 @@ describe("middleware/mediaAuthMiddleware", () => {
     const res: Partial<Response> = {};
     const status = vi.fn().mockReturnValue(res);
     const json = vi.fn().mockReturnValue(res);
-    Object.assign(res, { status, json });
+    const send = vi.fn().mockReturnValue(res);
+    Object.assign(res, { status, json, send });
     return res as Response & {
       status: ReturnType<typeof vi.fn>;
       json: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -156,5 +167,139 @@ describe("middleware/mediaAuthMiddleware", () => {
       vi.fn() as any
     );
     expect(res.status).toHaveBeenCalledWith(401);
+  });
+});
+
+describe("middleware/requireVisibleMediaForVisitors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const createReq = (overrides: Partial<Request> = {}): Request =>
+    ({
+      cookies: {},
+      query: {},
+      params: {},
+      path: "/secret.mp4",
+      ...overrides,
+    } as unknown as Request);
+
+  const createRes = () => {
+    const res: Partial<Response> = {};
+    const status = vi.fn().mockReturnValue(res);
+    const send = vi.fn().mockReturnValue(res);
+    Object.assign(res, { status, send });
+    return res as Response & {
+      status: ReturnType<typeof vi.fn>;
+      send: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  it("skips the check entirely in single-user mode", () => {
+    isLoginRequiredMock.mockReturnValue(false);
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("videos")(createReq(), createRes(), next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(classifyMediaVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("lets admins reach hidden media without classifying", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("videos")(
+      createReq({ user: { role: "admin" } as any }),
+      createRes(),
+      next
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(classifyMediaVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("lets API-key automation reach hidden media without classifying", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("videos")(
+      createReq({ apiKeyAuthenticated: true } as any),
+      createRes(),
+      next
+    );
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(classifyMediaVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("404s a visitor requesting media that belongs solely to a hidden video", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("hidden");
+    const res = createRes();
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("videos")(
+      createReq({ user: { role: "visitor" } as any, path: "/secret.mp4" }),
+      res,
+      next
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["/videos/secret.mp4"],
+    });
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith("Not Found");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("allows a visitor to reach public media", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("public");
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("images")(
+      createReq({ user: { role: "visitor" } as any, path: "/poster.jpg" }),
+      createRes(),
+      next
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["/images/poster.jpg"],
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows unknown (orphan) media so RSS/shared files keep resolving", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("unknown");
+    const next = vi.fn();
+    requireVisibleMediaForVisitors("subtitles")(
+      createReq({ user: { role: "visitor" } as any, path: "/x.vtt" }),
+      createRes(),
+      next
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      subtitlePaths: ["/subtitles/x.vtt"],
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks both /images and /videos originals for images-small", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("public");
+    requireVisibleMediaForVisitors("images-small")(
+      createReq({ user: { role: "visitor" } as any, path: "/poster.jpg" }),
+      createRes(),
+      vi.fn()
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["/images/poster.jpg", "/videos/poster.jpg"],
+    });
+  });
+
+  it("classifies cloud routes by the cloud: filename param", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("hidden");
+    const res = createRes();
+    requireVisibleMediaForVisitors("cloud-video")(
+      createReq({ user: { role: "visitor" } as any, params: { filename: "secret.mp4" } } as any),
+      res,
+      vi.fn()
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: ["cloud:secret.mp4"],
+    });
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 });

--- a/backend/src/__tests__/server/cloudRoutes.test.ts
+++ b/backend/src/__tests__/server/cloudRoutes.test.ts
@@ -6,6 +6,7 @@ import { CLOUD_THUMBNAIL_CACHE_DIR } from "../../config/paths";
 import { cloudflaredService } from "../../services/cloudflaredService";
 import { getCachedThumbnail } from "../../services/cloudStorage/cloudThumbnailCache";
 import { CloudStorageService } from "../../services/CloudStorageService";
+import { requireVisibleMediaForVisitors } from "../../middleware/mediaAuthMiddleware";
 import * as storageService from "../../services/storageService";
 import {
   validateCloudThumbnailCachePath,
@@ -51,6 +52,11 @@ vi.mock("../../middleware/authMiddleware", () => ({
 
 vi.mock("../../middleware/mediaAuthMiddleware", () => ({
   requireAuthenticatedMediaAccess: vi.fn((_req, _res, next) => next()),
+  // Per-file visitor visibility is enforced by this guard (covered in its own
+  // suite). Pass-through here so the redirect handler logic can be tested.
+  requireVisibleMediaForVisitors: vi.fn(
+    () => (_req: any, _res: any, next: any) => next()
+  ),
 }));
 
 const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -120,20 +126,13 @@ describe("server/cloudRoutes", () => {
     ]);
   });
 
-  it("should 404 for a visitor requesting a hidden cloud video", async () => {
-    vi.mocked(storageService.getVideos).mockReturnValue([
-      { videoPath: "cloud:secret.mp4", visibility: 0 } as any,
-    ]);
-    const handlers = registerAndGetHandlers();
-    const req = createReq("secret.mp4", "visitor");
-    const res = createRes();
-
-    handlers["/cloud/videos/:filename"](req, res);
-    await flushAsync();
-
-    expect(res.status).toHaveBeenCalledWith(404);
-    expect(res.send).toHaveBeenCalledWith("File not found");
-    expect(CloudStorageService.getSignedUrl).not.toHaveBeenCalled();
+  it("should register both routes with the visitor visibility guard", () => {
+    registerAndGetHandlers();
+    // The guard factory is invoked once per cloud route (video + image) so the
+    // per-file visibility check is wired in front of each redirect handler.
+    expect(
+      vi.mocked(requireVisibleMediaForVisitors).mock.calls.map((c) => c[0])
+    ).toEqual(["cloud-video", "cloud-image"]);
   });
 
   it("should allow a visitor to fetch a public cloud video", async () => {

--- a/backend/src/__tests__/server/cloudRoutes.test.ts
+++ b/backend/src/__tests__/server/cloudRoutes.test.ts
@@ -14,6 +14,7 @@ import {
 
 vi.mock("../../services/storageService", () => ({
   getSettings: vi.fn(),
+  getVideos: vi.fn(() => []),
 }));
 
 vi.mock("../../services/cloudStorage/cloudThumbnailCache", () => ({
@@ -42,6 +43,14 @@ vi.mock("../../utils/logger", () => ({
     warn: vi.fn(),
     error: vi.fn(),
   },
+}));
+
+vi.mock("../../middleware/authMiddleware", () => ({
+  authMiddleware: vi.fn((_req, _res, next) => next()),
+}));
+
+vi.mock("../../middleware/mediaAuthMiddleware", () => ({
+  requireAuthenticatedMediaAccess: vi.fn((_req, _res, next) => next()),
 }));
 
 const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
@@ -87,16 +96,21 @@ describe("server/cloudRoutes", () => {
   const registerAndGetHandlers = () => {
     const handlers: Record<string, any> = {};
     const app = {
-      get: vi.fn((route: string, handler: any) => {
-        handlers[route] = handler;
+      get: vi.fn((route: string, ...args: any[]) => {
+        // Route registration is now app.get(route, authMiddleware,
+        // requireAuthenticatedMediaAccess, handler); the handler is last.
+        handlers[route] = args[args.length - 1];
       }),
     } as any;
     registerCloudRoutes(app);
     return handlers;
   };
 
-  const createReq = (filename: string): Request =>
-    ({ params: { filename } } as unknown as Request);
+  const createReq = (filename: string, role?: "visitor" | "admin"): Request =>
+    ({
+      params: { filename },
+      user: role ? ({ role } as any) : undefined,
+    } as unknown as Request);
 
   it("should register cloud video/image routes", () => {
     const handlers = registerAndGetHandlers();
@@ -104,6 +118,44 @@ describe("server/cloudRoutes", () => {
       "/cloud/videos/:filename",
       "/cloud/images/:filename",
     ]);
+  });
+
+  it("should 404 for a visitor requesting a hidden cloud video", async () => {
+    vi.mocked(storageService.getVideos).mockReturnValue([
+      { videoPath: "cloud:secret.mp4", visibility: 0 } as any,
+    ]);
+    const handlers = registerAndGetHandlers();
+    const req = createReq("secret.mp4", "visitor");
+    const res = createRes();
+
+    handlers["/cloud/videos/:filename"](req, res);
+    await flushAsync();
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith("File not found");
+    expect(CloudStorageService.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("should allow a visitor to fetch a public cloud video", async () => {
+    (CloudStorageService.getSignedUrl as any).mockResolvedValue(
+      "https://cdn.example/pub.mp4?sign=ok"
+    );
+    vi.mocked(validateRedirectUrl).mockReturnValue(
+      "https://cdn.example/pub.mp4?sign=ok"
+    );
+    vi.mocked(storageService.getVideos).mockReturnValue([
+      { videoPath: "cloud:pub.mp4", visibility: 1 } as any,
+    ]);
+    const handlers = registerAndGetHandlers();
+    const req = createReq("pub.mp4", "visitor");
+    const res = createRes();
+
+    handlers["/cloud/videos/:filename"](req, res);
+    await flushAsync();
+
+    expect(res.writeHead).toHaveBeenCalledWith(302, {
+      Location: "https://cdn.example/pub.mp4?sign=ok",
+    });
   });
 
   it("should return 404 when cloud storage is not configured", async () => {

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -43,6 +43,9 @@ vi.mock("../../middleware/authMiddleware", () => ({
 
 vi.mock("../../middleware/mediaAuthMiddleware", () => ({
   requireAuthenticatedMediaAccess: vi.fn((_req, _res, next) => next()),
+  requireVisibleMediaForVisitors: vi.fn(
+    () => (_req: any, _res: any, next: any) => next()
+  ),
 }));
 
 import {
@@ -65,27 +68,35 @@ describe("server/staticRoutes", () => {
     registerStaticRoutes(app, "/frontend-dist");
 
     expect(use).toHaveBeenCalledTimes(8);
-    // /images-small/* now carries the media auth stack before its handler.
+    // /images-small/* now carries the media auth stack + visibility guard
+    // before its handler.
     expect(get).toHaveBeenCalledWith(
       "/images-small/*",
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
       expect.any(Function)
     );
 
-    // Media mounts carry the auth stack (authMiddleware, requireAuthenticatedMediaAccess)
-    // before the express.static() result. Index 3 holds that static result.
-    const [videosPath, , , videosStatic] = use.mock.calls[0];
-    expect(videosPath).toBe("/videos");
+    // Media mounts carry the auth stack (authMiddleware,
+    // requireAuthenticatedMediaAccess) and the per-video visibility guard
+    // before the express.static() result, which is always the last argument.
+    const lastArg = (call: any[]) => call[call.length - 1];
+
+    const videosCall = use.mock.calls[0];
+    const videosStatic = lastArg(videosCall);
+    expect(videosCall[0]).toBe("/videos");
     expect(videosStatic.dir).toContain("/uploads/videos");
     expect(videosStatic.options.fallthrough).toBe(false);
 
-    const [imagesPath, , , imagesStatic] = use.mock.calls[1];
-    expect(imagesPath).toBe("/images");
+    const imagesCall = use.mock.calls[1];
+    const imagesStatic = lastArg(imagesCall);
+    expect(imagesCall[0]).toBe("/images");
     expect(imagesStatic.options.fallthrough).toBe(false);
 
-    const [smallImagesPath, , , smallImagesStatic] = use.mock.calls[2];
-    expect(smallImagesPath).toBe("/images-small");
+    const smallImagesCall = use.mock.calls[2];
+    const smallImagesStatic = lastArg(smallImagesCall);
+    expect(smallImagesCall[0]).toBe("/images-small");
     expect(smallImagesStatic.options.fallthrough).toBe(false);
 
     // /assets is the frontend bundle (login page assets) and stays unguarded.
@@ -123,24 +134,29 @@ describe("server/staticRoutes", () => {
     registerStaticRoutes(app, "/frontend-dist");
 
     // The first six use() calls are media routes (videos, images, images-small,
-    // avatars, api/cloud/thumbnail-cache, subtitles) and must carry two auth
-    // middlewares before the static result. /assets and the SPA dist do not.
-    const mediaPaths = [
-      "/videos",
-      "/images",
-      "/images-small",
-      "/avatars",
-      "/api/cloud/thumbnail-cache",
-      "/subtitles",
+    // avatars, api/cloud/thumbnail-cache, subtitles) and must carry the two auth
+    // middlewares (authMiddleware + requireAuthenticatedMediaAccess) before the
+    // static result. Per-video media (videos/images/images-small/subtitles) also
+    // carries the requireVisibleMediaForVisitors guard; avatars and the cloud
+    // thumbnail cache are not per-video so they keep just the auth stack.
+    const mediaPaths: Array<{ path: string; hasVisibilityGuard: boolean }> = [
+      { path: "/videos", hasVisibilityGuard: true },
+      { path: "/images", hasVisibilityGuard: true },
+      { path: "/images-small", hasVisibilityGuard: true },
+      { path: "/avatars", hasVisibilityGuard: false },
+      { path: "/api/cloud/thumbnail-cache", hasVisibilityGuard: false },
+      { path: "/subtitles", hasVisibilityGuard: true },
     ];
-    mediaPaths.forEach((expectedPath, index) => {
+    mediaPaths.forEach(({ path: expectedPath, hasVisibilityGuard }, index) => {
       const call = use.mock.calls[index];
       expect(call[0]).toBe(expectedPath);
-      // path + authMiddleware + requireAuthenticatedMediaAccess + static result
-      expect(call).toHaveLength(4);
+      // path + authMiddleware + requireAuthenticatedMediaAccess (+ visibility
+      // guard) + static result.
+      expect(call).toHaveLength(hasVisibilityGuard ? 5 : 4);
       expect(typeof call[1]).toBe("function");
       expect(typeof call[2]).toBe("function");
-      expect(call[3]).toBeTruthy();
+      // The static result is always the last argument.
+      expect(call[call.length - 1]).toBeTruthy();
     });
 
     // /assets (index 6) and the SPA dist (index 7) are NOT auth-gated.
@@ -154,8 +170,9 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    // /subtitles is media call index 5; its static result sits at arg index 3.
-    const subtitlesStatic = use.mock.calls[5][3];
+    // /subtitles is media call index 5; its static result is the last argument.
+    const subtitlesCall = use.mock.calls[5];
+    const subtitlesStatic = subtitlesCall[subtitlesCall.length - 1];
     const setHeaders = subtitlesStatic.options.setHeaders as (
       res: any,
       filePath: string
@@ -184,7 +201,7 @@ describe("server/staticRoutes", () => {
 
     // The /images-small/* GET carries [authMiddleware, requireMedia, handler];
     // the handler is the 4th argument (index 3).
-    const smallImageHandler = get.mock.calls[0][3];
+    const smallImageHandler = get.mock.calls[0][get.mock.calls[0].length - 1];
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -219,7 +236,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][3];
+    const smallImageHandler = get.mock.calls[0][get.mock.calls[0].length - 1];
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -258,7 +275,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][3];
+    const smallImageHandler = get.mock.calls[0][get.mock.calls[0].length - 1];
     const sendFile = vi.fn((_path: string, cb?: (err?: Error | null) => void) => {
       cb?.(null);
     });

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -37,6 +37,14 @@ vi.mock("fs-extra", () => ({
   pathExists: pathExistsMock,
 }));
 
+vi.mock("../../middleware/authMiddleware", () => ({
+  authMiddleware: vi.fn((_req, _res, next) => next()),
+}));
+
+vi.mock("../../middleware/mediaAuthMiddleware", () => ({
+  requireAuthenticatedMediaAccess: vi.fn((_req, _res, next) => next()),
+}));
+
 import {
   registerSpaFallback,
   registerStaticRoutes,
@@ -57,21 +65,30 @@ describe("server/staticRoutes", () => {
     registerStaticRoutes(app, "/frontend-dist");
 
     expect(use).toHaveBeenCalledTimes(8);
-    expect(get).toHaveBeenCalledWith("/images-small/*", expect.any(Function));
+    // /images-small/* now carries the media auth stack before its handler.
+    expect(get).toHaveBeenCalledWith(
+      "/images-small/*",
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
 
-    const [videosPath, videosStatic] = use.mock.calls[0];
+    // Media mounts carry the auth stack (authMiddleware, requireAuthenticatedMediaAccess)
+    // before the express.static() result. Index 3 holds that static result.
+    const [videosPath, , , videosStatic] = use.mock.calls[0];
     expect(videosPath).toBe("/videos");
     expect(videosStatic.dir).toContain("/uploads/videos");
     expect(videosStatic.options.fallthrough).toBe(false);
 
-    const [imagesPath, imagesStatic] = use.mock.calls[1];
+    const [imagesPath, , , imagesStatic] = use.mock.calls[1];
     expect(imagesPath).toBe("/images");
     expect(imagesStatic.options.fallthrough).toBe(false);
 
-    const [smallImagesPath, smallImagesStatic] = use.mock.calls[2];
+    const [smallImagesPath, , , smallImagesStatic] = use.mock.calls[2];
     expect(smallImagesPath).toBe("/images-small");
     expect(smallImagesStatic.options.fallthrough).toBe(false);
 
+    // /assets is the frontend bundle (login page assets) and stays unguarded.
     const [assetsPath, assetsStatic] = use.mock.calls[6];
     expect(assetsPath).toBe("/assets");
     expect(assetsStatic.dir).toBe("/frontend-dist/assets");
@@ -99,13 +116,46 @@ describe("server/staticRoutes", () => {
     expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "video/mp4");
   });
 
+  it("should gate media mounts behind the media auth stack", () => {
+    const use = vi.fn();
+    const get = vi.fn();
+    const app = { use, get } as any;
+    registerStaticRoutes(app, "/frontend-dist");
+
+    // The first six use() calls are media routes (videos, images, images-small,
+    // avatars, api/cloud/thumbnail-cache, subtitles) and must carry two auth
+    // middlewares before the static result. /assets and the SPA dist do not.
+    const mediaPaths = [
+      "/videos",
+      "/images",
+      "/images-small",
+      "/avatars",
+      "/api/cloud/thumbnail-cache",
+      "/subtitles",
+    ];
+    mediaPaths.forEach((expectedPath, index) => {
+      const call = use.mock.calls[index];
+      expect(call[0]).toBe(expectedPath);
+      // path + authMiddleware + requireAuthenticatedMediaAccess + static result
+      expect(call).toHaveLength(4);
+      expect(typeof call[1]).toBe("function");
+      expect(typeof call[2]).toBe("function");
+      expect(call[3]).toBeTruthy();
+    });
+
+    // /assets (index 6) and the SPA dist (index 7) are NOT auth-gated.
+    expect(use.mock.calls[6][0]).toBe("/assets");
+    expect(use.mock.calls[6]).toHaveLength(2);
+  });
+
   it("should set subtitle content-type headers by extension", () => {
     const use = vi.fn();
     const get = vi.fn();
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const subtitlesStatic = use.mock.calls[5][1];
+    // /subtitles is media call index 5; its static result sits at arg index 3.
+    const subtitlesStatic = use.mock.calls[5][3];
     const setHeaders = subtitlesStatic.options.setHeaders as (
       res: any,
       filePath: string
@@ -132,7 +182,9 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    // The /images-small/* GET carries [authMiddleware, requireMedia, handler];
+    // the handler is the 4th argument (index 3).
+    const smallImageHandler = get.mock.calls[0][3];
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -167,7 +219,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    const smallImageHandler = get.mock.calls[0][3];
     const res = {
       status: vi.fn().mockReturnThis(),
       send: vi.fn(),
@@ -206,7 +258,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    const smallImageHandler = get.mock.calls[0][1];
+    const smallImageHandler = get.mock.calls[0][3];
     const sendFile = vi.fn((_path: string, cb?: (err?: Error | null) => void) => {
       cb?.(null);
     });

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -137,14 +137,15 @@ describe("server/staticRoutes", () => {
     // avatars, api/cloud/thumbnail-cache, subtitles) and must carry the two auth
     // middlewares (authMiddleware + requireAuthenticatedMediaAccess) before the
     // static result. Per-video media (videos/images/images-small/subtitles) also
-    // carries the requireVisibleMediaForVisitors guard; avatars and the cloud
-    // thumbnail cache are not per-video so they keep just the auth stack.
+    // carries the requireVisibleMediaForVisitors guard. The cloud thumbnail cache
+    // also carries the guard because cache filenames map back to cloud thumbnail
+    // paths. Avatars keep just the auth stack.
     const mediaPaths: Array<{ path: string; hasVisibilityGuard: boolean }> = [
       { path: "/videos", hasVisibilityGuard: true },
       { path: "/images", hasVisibilityGuard: true },
       { path: "/images-small", hasVisibilityGuard: true },
       { path: "/avatars", hasVisibilityGuard: false },
-      { path: "/api/cloud/thumbnail-cache", hasVisibilityGuard: false },
+      { path: "/api/cloud/thumbnail-cache", hasVisibilityGuard: true },
       { path: "/subtitles", hasVisibilityGuard: true },
     ];
     mediaPaths.forEach(({ path: expectedPath, hasVisibilityGuard }, index) => {

--- a/backend/src/__tests__/services/rssService.test.ts
+++ b/backend/src/__tests__/services/rssService.test.ts
@@ -142,7 +142,11 @@ describe("rssService", () => {
       expect(xml).toContain("<title>Title &lt;tag&gt; &amp; more</title>");
       expect(xml).toContain("<dc:creator>Author &lt;script&gt;</dc:creator>");
       expect(xml).toContain("<category>alpha &amp; beta</category>");
-      expect(xml).toContain('url="https://mytube.example/images/thumb.webp"');
+      // Media URLs carry the feed token so they authenticate against the
+      // auth-gated media routes (see mediaAuthMiddleware).
+      expect(xml).toContain(
+        `url="https://mytube.example/images/thumb.webp?rss=${baseToken.id}"`
+      );
       expect(xml).toContain('type="image/webp"');
       expect(xml).toContain("Author &lt;script&gt;");
       expect(xml).toContain("<p>来源：YouTube</p>");

--- a/backend/src/__tests__/services/storageService.test.ts
+++ b/backend/src/__tests__/services/storageService.test.ts
@@ -419,6 +419,43 @@ describe('StorageService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].tags).toEqual(['tag1']);
     });
+
+    it('should filter to public-only videos for a visitor', () => {
+      const mockVideos = [{ id: '1', title: 'Public', tags: '[]' }];
+      const whereMock = vi.fn().mockReturnValue({
+        all: vi.fn().mockReturnValue(mockVideos),
+      });
+      (db.select as any).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            where: whereMock,
+            all: vi.fn().mockReturnValue([]),
+          }),
+        }),
+      });
+
+      const result = storageService.getVideos('visitor');
+      expect(whereMock).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('1');
+    });
+
+    it('should not apply a visibility filter when no role is given', () => {
+      const allMock = vi.fn().mockReturnValue([{ id: '1', title: 'Any', tags: '[]' }]);
+      const whereMock = vi.fn();
+      (db.select as any).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          orderBy: vi.fn().mockReturnValue({
+            where: whereMock,
+            all: allMock,
+          }),
+        }),
+      });
+
+      storageService.getVideos();
+      expect(whereMock).not.toHaveBeenCalled();
+      expect(allMock).toHaveBeenCalled();
+    });
   });
 
   describe('getVideoById', () => {
@@ -447,6 +484,21 @@ describe('StorageService', () => {
       });
 
       const result = storageService.getVideoById('1');
+      expect(result).toBeUndefined();
+    });
+
+    it('should treat hidden videos as not found for a visitor', () => {
+      // The visitor path adds a visibility filter; a hidden row is excluded.
+      const getMock = vi.fn().mockReturnValue(null);
+      const whereMock = vi.fn().mockReturnValue({ get: getMock });
+      (db.select as any).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: whereMock,
+        }),
+      });
+
+      const result = storageService.getVideoById('hidden-1', 'visitor');
+      expect(whereMock).toHaveBeenCalledTimes(1);
       expect(result).toBeUndefined();
     });
   });

--- a/backend/src/controllers/cloudStorageController.ts
+++ b/backend/src/controllers/cloudStorageController.ts
@@ -8,6 +8,7 @@ import {
 } from "../services/cloudStorage/cloudThumbnailCache";
 import { resolveAbsolutePath } from "../services/cloudStorage/pathUtils";
 import { CloudStorageService } from "../services/CloudStorageService";
+import { isLoginRequired } from "../services/passwordService";
 import { getVideos, isCloudFileVisibleToVisitor } from "../services/storageService";
 import { logger } from "../utils/logger";
 
@@ -35,7 +36,11 @@ export const getSignedUrl = async (
   // Visitor scoping (GHSA-hcm6-w6x8-6jhr): do not hand a visitor a signed URL
   // (or a local cache URL) for a cloud file that belongs to a hidden video.
   // Uses the same shared rule as the cloud redirect routes.
-  if (req.user?.role === "visitor" && !isCloudFileVisibleToVisitor(filename)) {
+  if (
+    isLoginRequired() &&
+    req.user?.role === "visitor" &&
+    !isCloudFileVisibleToVisitor(filename)
+  ) {
     res.status(404).json({
       success: false,
       message: "File not found",

--- a/backend/src/controllers/cloudStorageController.ts
+++ b/backend/src/controllers/cloudStorageController.ts
@@ -8,7 +8,7 @@ import {
 } from "../services/cloudStorage/cloudThumbnailCache";
 import { resolveAbsolutePath } from "../services/cloudStorage/pathUtils";
 import { CloudStorageService } from "../services/CloudStorageService";
-import { getVideos } from "../services/storageService";
+import { getVideos, isCloudFileVisibleToVisitor } from "../services/storageService";
 import { logger } from "../utils/logger";
 
 /**
@@ -34,22 +34,13 @@ export const getSignedUrl = async (
 
   // Visitor scoping (GHSA-hcm6-w6x8-6jhr): do not hand a visitor a signed URL
   // (or a local cache URL) for a cloud file that belongs to a hidden video.
-  if (req.user?.role === "visitor") {
-    const cloudRef = `cloud:${filename}`;
-    const allowed = getVideos().some((video) => {
-      const isPublic = (video as { visibility?: number | null }).visibility !== 0;
-      if (!isPublic) return false;
-      return fileType === "video"
-        ? video.videoPath === cloudRef
-        : video.thumbnailPath === cloudRef;
+  // Uses the same shared rule as the cloud redirect routes.
+  if (req.user?.role === "visitor" && !isCloudFileVisibleToVisitor(filename)) {
+    res.status(404).json({
+      success: false,
+      message: "File not found",
     });
-    if (!allowed) {
-      res.status(404).json({
-        success: false,
-        message: "File not found",
-      });
-      return;
-    }
+    return;
   }
 
   // For thumbnails, check local cache first

--- a/backend/src/controllers/cloudStorageController.ts
+++ b/backend/src/controllers/cloudStorageController.ts
@@ -32,6 +32,26 @@ export const getSignedUrl = async (
 
   const fileType = (type as "video" | "thumbnail") || "video";
 
+  // Visitor scoping (GHSA-hcm6-w6x8-6jhr): do not hand a visitor a signed URL
+  // (or a local cache URL) for a cloud file that belongs to a hidden video.
+  if (req.user?.role === "visitor") {
+    const cloudRef = `cloud:${filename}`;
+    const allowed = getVideos().some((video) => {
+      const isPublic = (video as { visibility?: number | null }).visibility !== 0;
+      if (!isPublic) return false;
+      return fileType === "video"
+        ? video.videoPath === cloudRef
+        : video.thumbnailPath === cloudRef;
+    });
+    if (!allowed) {
+      res.status(404).json({
+        success: false,
+        message: "File not found",
+      });
+      return;
+    }
+  }
+
   // For thumbnails, check local cache first
   if (fileType === "thumbnail") {
     const cloudPath = `cloud:${filename}`;

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -8,6 +8,7 @@ import sanitizeFilename from "sanitize-filename";
 import { IMAGES_DIR, SUBTITLES_DIR, VIDEOS_DIR } from "../config/paths";
 import { NotFoundError, ValidationError } from "../errors/DownloadErrors";
 import { syncMediaServerArtifactsForRecord } from "../services/mediaServerExport";
+import { isLoginRequired } from "../services/passwordService";
 import * as storageService from "../services/storageService";
 import {
   deleteSmallThumbnailMirrorSync,
@@ -45,6 +46,26 @@ import {
   unlinkSafeSync,
   writeFileSafeSync,
 } from "../utils/security";
+
+/**
+ * Resolve the caller role to pass into the visibility-aware storage queries
+ * (`getVideos`/`getVideoById`). When login is disabled (single-user mode) every
+ * caller is owner-equivalent, so any stale visitor session/JWT role left on the
+ * request must be ignored — otherwise hidden videos would wrongly 404 / vanish
+ * right after login is turned off. Only scope by role while login is enforced.
+ */
+const getVisibilityScopedRole = (
+  req: Request
+):
+  | import("../services/storageService").VideoCallerRole
+  | undefined => {
+  if (!isLoginRequired()) {
+    return undefined;
+  }
+  return req.user?.role as
+    | import("../services/storageService").VideoCallerRole
+    | undefined;
+};
 
 const MAX_VIDEO_UPLOAD_FILE_SIZE = 100 * 1024 * 1024 * 1024;
 const MAX_BATCH_UPLOAD_FILES = 100;
@@ -532,11 +553,7 @@ export const getVideos = async (
   // Visitors must only see public (visibility=1) videos. The query layer
   // enforces this so the frontend filter (VideoContext) is no longer the only
   // gate. Fixes GHSA-hcm6-w6x8-6jhr.
-  const videos = storageService.getVideos(
-    req.user?.role as
-      | import("../services/storageService").VideoCallerRole
-      | undefined
-  );
+  const videos = storageService.getVideos(getVisibilityScopedRole(req));
   // Return array directly for backward compatibility (frontend expects response.data to be Video[])
   sendData(res, videos);
 };
@@ -553,12 +570,7 @@ export const getVideoById = async (
   const id = getStringParam(req.params.id) ?? "";
   // Visitors are restricted to public videos; a hidden video is treated as
   // "not found" for them. Fixes GHSA-hcm6-w6x8-6jhr.
-  const video = storageService.getVideoById(
-    id,
-    req.user?.role as
-      | import("../services/storageService").VideoCallerRole
-      | undefined
-  );
+  const video = storageService.getVideoById(id, getVisibilityScopedRole(req));
 
   if (!video) {
     throw new NotFoundError("Video", id);
@@ -674,6 +686,14 @@ export const getVideoComments = async (
   res: Response
 ): Promise<void> => {
   const id = getStringParam(req.params.id) ?? "";
+  // Don't reveal a hidden video's comments to visitors: a hidden video is
+  // treated as "not found" for them. The query-layer role filter returns
+  // undefined for a hidden id when the caller is a visitor (and ignores stale
+  // roles when login is disabled). Fixes GHSA-hcm6-w6x8-6jhr.
+  const role = getVisibilityScopedRole(req);
+  if (role === "visitor" && !storageService.getVideoById(id, role)) {
+    throw new NotFoundError("Video", id);
+  }
   const comments = await import("../services/commentService").then((m) =>
     m.getComments(id)
   );
@@ -1228,12 +1248,7 @@ export const serveMountVideo = async (
 ): Promise<void> => {
   const id = getStringParam(req.params.id) ?? "";
   // Visitors must not be able to stream hidden mount-directory videos.
-  const video = storageService.getVideoById(
-    id,
-    req.user?.role as
-      | import("../services/storageService").VideoCallerRole
-      | undefined
-  );
+  const video = storageService.getVideoById(id, getVisibilityScopedRole(req));
 
   if (!video) {
     throw new NotFoundError("Video", id);

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -526,10 +526,17 @@ const resolveVideoWebPath = (absoluteVideoPath: string): string | null => {
  * Note: Returns array directly for backward compatibility with frontend
  */
 export const getVideos = async (
-  _req: Request,
+  req: Request,
   res: Response
 ): Promise<void> => {
-  const videos = storageService.getVideos();
+  // Visitors must only see public (visibility=1) videos. The query layer
+  // enforces this so the frontend filter (VideoContext) is no longer the only
+  // gate. Fixes GHSA-hcm6-w6x8-6jhr.
+  const videos = storageService.getVideos(
+    req.user?.role as
+      | import("../services/storageService").VideoCallerRole
+      | undefined
+  );
   // Return array directly for backward compatibility (frontend expects response.data to be Video[])
   sendData(res, videos);
 };
@@ -544,7 +551,14 @@ export const getVideoById = async (
   res: Response
 ): Promise<void> => {
   const id = getStringParam(req.params.id) ?? "";
-  const video = storageService.getVideoById(id);
+  // Visitors are restricted to public videos; a hidden video is treated as
+  // "not found" for them. Fixes GHSA-hcm6-w6x8-6jhr.
+  const video = storageService.getVideoById(
+    id,
+    req.user?.role as
+      | import("../services/storageService").VideoCallerRole
+      | undefined
+  );
 
   if (!video) {
     throw new NotFoundError("Video", id);
@@ -1213,7 +1227,13 @@ export const serveMountVideo = async (
   res: Response
 ): Promise<void> => {
   const id = getStringParam(req.params.id) ?? "";
-  const video = storageService.getVideoById(id);
+  // Visitors must not be able to stream hidden mount-directory videos.
+  const video = storageService.getVideoById(
+    id,
+    req.user?.role as
+      | import("../services/storageService").VideoCallerRole
+      | undefined
+  );
 
   if (!video) {
     throw new NotFoundError("Video", id);

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -14,6 +14,7 @@ import {
   normalizeSurface,
   platformFromUrl,
 } from "../services/statistics";
+import { isLoginRequired } from "../services/passwordService";
 import * as storageService from "../services/storageService";
 import {
   extractBilibiliVideoId,
@@ -42,6 +43,15 @@ function isDownloadStillQueued(downloadId: string): boolean {
     return false;
   }
 }
+
+const getVisibilityScopedRole = (
+  req: Request
+): storageService.VideoCallerRole | undefined => {
+  if (!isLoginRequired()) {
+    return undefined;
+  }
+  return req.user?.role as storageService.VideoCallerRole | undefined;
+};
 
 /**
  * Search for videos
@@ -105,10 +115,24 @@ export const checkVideoDownloadStatus = async (
     storageService.checkVideoDownloadBySourceId(sourceVideoId, platform);
 
   if (downloadCheck.found) {
+    const visibilityScopedRole = getVisibilityScopedRole(req);
+    const getVisibleVideoById = (videoId: string) =>
+      storageService.getVideoById(videoId, visibilityScopedRole);
+
+    if (
+      visibilityScopedRole === "visitor" &&
+      downloadCheck.status === "exists" &&
+      downloadCheck.videoId &&
+      !getVisibleVideoById(downloadCheck.videoId)
+    ) {
+      sendData(res, { found: false });
+      return;
+    }
+
     // Verify video exists if status is "exists"
     const verification = storageService.verifyVideoExists(
       downloadCheck,
-      storageService.getVideoById,
+      getVisibleVideoById,
     );
 
     if (verification.updatedCheck) {

--- a/backend/src/middleware/mediaAuthMiddleware.ts
+++ b/backend/src/middleware/mediaAuthMiddleware.ts
@@ -1,0 +1,90 @@
+import { NextFunction, Request, Response } from "express";
+import { isLoginRequired } from "../services/passwordService";
+import { getRssToken } from "../services/rssService";
+import { logger } from "../utils/logger";
+
+// Cookie/query key that carries an RSS feed token so media URLs emitted by the
+// RSS feed (which have no session cookie) can still authenticate against the
+// media routes when login is enabled. The token id is already the feed's
+// secret credential, so this introduces no new secret surface.
+export const RSS_MEDIA_TOKEN_COOKIE = "mytube_rss_token";
+export const RSS_MEDIA_TOKEN_QUERY = "rss";
+
+// Minimum length a token id must have before we bother hitting the database.
+// Matches the feed route's own sanity check in rssController.serveFeed.
+const MIN_RSS_TOKEN_LENGTH = 10;
+
+const isLikelyRssToken = (value: unknown): value is string =>
+  typeof value === "string" && value.length >= MIN_RSS_TOKEN_LENGTH;
+
+/**
+ * Resolve an RSS token from the request (query param first, then cookie).
+ * RSS readers fetch feed-emitted image URLs as plain GETs with no session
+ * cookie, so the feed appends `?rss=<token>` to those URLs (see rssService).
+ */
+const getRssTokenFromRequest = (req: Request): string | undefined => {
+  const fromQuery = req.query[RSS_MEDIA_TOKEN_QUERY];
+  if (isLikelyRssToken(fromQuery)) {
+    return fromQuery;
+  }
+
+  const fromCookie = req.cookies?.[RSS_MEDIA_TOKEN_COOKIE];
+  return isLikelyRssToken(fromCookie) ? fromCookie : undefined;
+};
+
+/**
+ * Guard for static + cloud media routes (videos/images/subtitles/cloud files).
+ *
+ * When `loginEnabled` is false (single-user mode), every caller is
+ * owner-equivalent and media is served as before.
+ *
+ * When `loginEnabled` is true, media access requires one of:
+ *  - an authenticated session (req.user, admin or visitor — visitor scoping
+ *    for hidden content is enforced separately in the video query layer), or
+ *  - a valid API key (req.apiKeyAuthenticated), or
+ *  - a valid, active RSS feed token (query `?rss=` or cookie), so that media
+ *    URLs emitted by an RSS feed keep resolving for RSS readers.
+ *
+ * Must be mounted AFTER `authMiddleware` (which populates req.user /
+ * req.apiKeyAuthenticated) and AFTER cookieParser.
+ *
+ * Fixes GHSA-rwwf-29mq-5j43: static and cloud media routes were registered
+ * before the auth stack and were fully unauthenticated, bypassing the login
+ * wall that the frontend enforces.
+ */
+export const requireAuthenticatedMediaAccess = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (!isLoginRequired()) {
+    next();
+    return;
+  }
+
+  if (req.user || req.apiKeyAuthenticated === true) {
+    next();
+    return;
+  }
+
+  // RSS readers don't carry a session cookie; allow a feed token.
+  const rssTokenId = getRssTokenFromRequest(req);
+  if (rssTokenId) {
+    try {
+      const token = await getRssToken(rssTokenId);
+      if (token?.isActive) {
+        next();
+        return;
+      }
+    } catch (error) {
+      logger.warn("Failed to validate RSS media token", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  res.status(401).json({
+    success: false,
+    error: "Authentication required. Please log in to access this resource.",
+  });
+};

--- a/backend/src/middleware/mediaAuthMiddleware.ts
+++ b/backend/src/middleware/mediaAuthMiddleware.ts
@@ -126,15 +126,27 @@ const safeDecode = (value: string): string => {
   }
 };
 
+const isSubtitlePath = (value: string): boolean =>
+  /\.(ass|srt|ssa|vtt)$/i.test(value);
+
 const classifyMediaRequest = (
   kind: MediaKind,
   req: Request
 ): storageService.MediaVisibility => {
   switch (kind) {
-    case "videos":
-      return storageService.classifyMediaVisibility({
-        exactPaths: [`/videos${safeDecode(req.path)}`],
-      });
+    case "videos": {
+      const mediaPath = `/videos${safeDecode(req.path)}`;
+      const opts: {
+        exactPaths: string[];
+        subtitlePaths?: string[];
+      } = {
+        exactPaths: [mediaPath],
+      };
+      if (isSubtitlePath(mediaPath)) {
+        opts.subtitlePaths = [mediaPath];
+      }
+      return storageService.classifyMediaVisibility(opts);
+    }
     case "images":
       return storageService.classifyMediaVisibility({
         exactPaths: [`/images${safeDecode(req.path)}`],

--- a/backend/src/middleware/mediaAuthMiddleware.ts
+++ b/backend/src/middleware/mediaAuthMiddleware.ts
@@ -1,6 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import { isLoginRequired } from "../services/passwordService";
 import { getRssToken } from "../services/rssService";
+import * as storageService from "../services/storageService";
+import { getStringParam } from "../utils/paramUtils";
 import { logger } from "../utils/logger";
 
 // Cookie/query key that carries an RSS feed token so media URLs emitted by the
@@ -88,3 +90,99 @@ export const requireAuthenticatedMediaAccess = async (
     error: "Authentication required. Please log in to access this resource.",
   });
 };
+
+// The static media mounts strip their route prefix from req.path, so it is
+// re-added here to reconstruct the stored web path (e.g. videoPath
+// "/videos/foo.mp4"). Cloud routes carry the cloud filename as a route param.
+type MediaKind =
+  | "videos"
+  | "images"
+  | "images-small"
+  | "subtitles"
+  | "cloud-video"
+  | "cloud-image";
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const classifyMediaRequest = (
+  kind: MediaKind,
+  req: Request
+): storageService.MediaVisibility => {
+  switch (kind) {
+    case "videos":
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`/videos${safeDecode(req.path)}`],
+      });
+    case "images":
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`/images${safeDecode(req.path)}`],
+      });
+    case "images-small": {
+      // Small thumbnails mirror the original thumbnail, which may live under
+      // either /images or /videos. Check both candidate originals.
+      const sub = safeDecode(req.path);
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`/images${sub}`, `/videos${sub}`],
+      });
+    }
+    case "subtitles":
+      return storageService.classifyMediaVisibility({
+        subtitlePaths: [`/subtitles${safeDecode(req.path)}`],
+      });
+    case "cloud-video":
+    case "cloud-image": {
+      const filename = getStringParam(req.params.filename) ?? "";
+      return storageService.classifyMediaVisibility({
+        exactPaths: [`cloud:${filename}`],
+      });
+    }
+    default:
+      return "unknown";
+  }
+};
+
+/**
+ * Defense-in-depth per-file visibility guard for static + cloud media routes.
+ *
+ * `requireAuthenticatedMediaAccess` only enforces *authentication* (the login
+ * wall). A logged-in visitor passes that wall, so without this guard they could
+ * still fetch a hidden video's file by a known path. This guard closes that gap
+ * by classifying the requested media against the videos that reference it and
+ * blocking non-admin callers from media that belongs solely to hidden videos.
+ * Public/unknown (orphan, shared, frontend asset) media stays reachable, so RSS
+ * clients keep working. Part of GHSA-hcm6-w6x8-6jhr.
+ *
+ * Must be mounted AFTER `authMiddleware` (so `req.user` / `req.apiKeyAuthenticated`
+ * are populated) and AFTER `requireAuthenticatedMediaAccess`.
+ */
+export const requireVisibleMediaForVisitors =
+  (kind: MediaKind) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    // Single-user mode: no roles, owner-equivalent access to everything.
+    if (!isLoginRequired()) {
+      next();
+      return;
+    }
+
+    // Admins and API-key automation (admin-configured owner access) may always
+    // reach hidden media.
+    if (req.user?.role === "admin" || req.apiKeyAuthenticated === true) {
+      next();
+      return;
+    }
+
+    // Visitors and RSS-token callers: serve public/unknown media, but never
+    // media that belongs solely to a hidden video.
+    if (classifyMediaRequest(kind, req) === "hidden") {
+      res.status(404).send("Not Found");
+      return;
+    }
+
+    next();
+  };

--- a/backend/src/middleware/mediaAuthMiddleware.ts
+++ b/backend/src/middleware/mediaAuthMiddleware.ts
@@ -5,6 +5,14 @@ import * as storageService from "../services/storageService";
 import { getStringParam } from "../utils/paramUtils";
 import { logger } from "../utils/logger";
 
+declare global {
+  namespace Express {
+    interface Request {
+      rssTokenRole?: storageService.VideoCallerRole;
+    }
+  }
+}
+
 // Cookie/query key that carries an RSS feed token so media URLs emitted by the
 // RSS feed (which have no session cookie) can still authenticate against the
 // media routes when login is enabled. The token id is already the feed's
@@ -64,17 +72,19 @@ export const requireAuthenticatedMediaAccess = async (
     return;
   }
 
-  if (req.user || req.apiKeyAuthenticated === true) {
+  if (req.user?.role === "admin" || req.apiKeyAuthenticated === true) {
     next();
     return;
   }
 
-  // RSS readers don't carry a session cookie; allow a feed token.
+  // RSS readers don't carry a session cookie; allow a feed token and preserve
+  // its role so admin RSS feeds can resolve hidden media URLs they emit.
   const rssTokenId = getRssTokenFromRequest(req);
   if (rssTokenId) {
     try {
       const token = await getRssToken(rssTokenId);
       if (token?.isActive) {
+        req.rssTokenRole = token.role;
         next();
         return;
       }
@@ -83,6 +93,11 @@ export const requireAuthenticatedMediaAccess = async (
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  if (req.user) {
+    next();
+    return;
   }
 
   res.status(401).json({
@@ -100,7 +115,8 @@ type MediaKind =
   | "images-small"
   | "subtitles"
   | "cloud-video"
-  | "cloud-image";
+  | "cloud-image"
+  | "cloud-thumbnail-cache";
 
 const safeDecode = (value: string): string => {
   try {
@@ -126,7 +142,8 @@ const classifyMediaRequest = (
     case "images-small": {
       // Small thumbnails mirror the original thumbnail, which may live under
       // either /images or /videos. Check both candidate originals.
-      const sub = safeDecode(req.path);
+      const wildcardPath = getStringParam(req.params["0"]);
+      const sub = safeDecode(wildcardPath ? `/${wildcardPath}` : req.path);
       return storageService.classifyMediaVisibility({
         exactPaths: [`/images${sub}`, `/videos${sub}`],
       });
@@ -142,6 +159,10 @@ const classifyMediaRequest = (
         exactPaths: [`cloud:${filename}`],
       });
     }
+    case "cloud-thumbnail-cache":
+      return storageService.classifyMediaVisibility({
+        cloudThumbnailCacheKeys: [safeDecode(req.path)],
+      });
     default:
       return "unknown";
   }
@@ -172,7 +193,11 @@ export const requireVisibleMediaForVisitors =
 
     // Admins and API-key automation (admin-configured owner access) may always
     // reach hidden media.
-    if (req.user?.role === "admin" || req.apiKeyAuthenticated === true) {
+    if (
+      req.user?.role === "admin" ||
+      req.rssTokenRole === "admin" ||
+      req.apiKeyAuthenticated === true
+    ) {
       next();
       return;
     }

--- a/backend/src/server/cloudRoutes.ts
+++ b/backend/src/server/cloudRoutes.ts
@@ -13,6 +13,39 @@ import {
   validateCloudThumbnailCachePath,
   validateRedirectUrl,
 } from "../utils/security";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { requireAuthenticatedMediaAccess } from "../middleware/mediaAuthMiddleware";
+
+/**
+ * Determine whether a cloud-stored file belongs to at least one public video
+ * the visitor is allowed to see. Videos (fileType "video") match on
+ * videoPath === "cloud:<filename>"; thumbnails (fileType "image") match on
+ * thumbnailPath === "cloud:<filename>". Orphan files with no matching record
+ * are treated as public (non-blocking) so cached thumbnails still resolve.
+ *
+ * Part of the visitor scoping fix for GHSA-hcm6-w6x8-6jhr.
+ */
+const cloudFilenameIsPublic = (
+  filename: string,
+  fileType: "video" | "image"
+): boolean => {
+  if (!filename) return true;
+  const cloudRef = `cloud:${filename}`;
+  try {
+    const videos = storageService.getVideos();
+    return videos.some((video) => {
+      const isPublic = (video as { visibility?: number | null }).visibility !== 0;
+      if (!isPublic) return false;
+      return fileType === "video"
+        ? video.videoPath === cloudRef
+        : video.thumbnailPath === cloudRef;
+    });
+  } catch {
+    // Be non-blocking on lookup failure; the media auth guard already verified
+    // the caller is a logged-in visitor.
+    return true;
+  }
+};
 
 const redirectCloudFile = async (
   req: Request,
@@ -29,6 +62,17 @@ const redirectCloudFile = async (
       !settings.openListToken
     ) {
       res.status(404).send("Cloud storage not configured");
+      return;
+    }
+
+    // Visitor scoping (GHSA-hcm6-w6x8-6jhr): a visitor may only fetch cloud
+    // media for videos they are allowed to see (visibility=1). Admins and any
+    // RSS-token-authenticated caller (which already passed the feed's own
+    // visitor/public filter when building the URL) are allowed. We look the
+    // filename up against video records; if no record matches we do not block,
+    // since orphan thumbnails can still be cached.
+    if (req.user?.role === "visitor" && !cloudFilenameIsPublic(filename, fileType)) {
+      res.status(404).send("File not found");
       return;
     }
 
@@ -127,12 +171,25 @@ const redirectCloudFile = async (
 };
 
 export const registerCloudRoutes = (app: Express): void => {
-  app.get("/cloud/videos/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "video");
-  });
-  app.get("/cloud/images/:filename", (req, res) => {
-    void redirectCloudFile(req, res, "image");
-  });
+  // Cloud media routes were registered before the auth stack and were fully
+  // unauthenticated (GHSA-rwwf-29mq-5j43). The media auth stack enforces login
+  // when loginEnabled=true (session, API key, or RSS feed token).
+  const cloudMediaAuth = [authMiddleware, requireAuthenticatedMediaAccess];
+
+  app.get(
+    "/cloud/videos/:filename",
+    ...cloudMediaAuth,
+    (req, res) => {
+      void redirectCloudFile(req, res, "video");
+    }
+  );
+  app.get(
+    "/cloud/images/:filename",
+    ...cloudMediaAuth,
+    (req, res) => {
+      void redirectCloudFile(req, res, "image");
+    }
+  );
 };
 
 export const startCloudflaredIfEnabled = (port: number): void => {

--- a/backend/src/server/cloudRoutes.ts
+++ b/backend/src/server/cloudRoutes.ts
@@ -14,38 +14,10 @@ import {
   validateRedirectUrl,
 } from "../utils/security";
 import { authMiddleware } from "../middleware/authMiddleware";
-import { requireAuthenticatedMediaAccess } from "../middleware/mediaAuthMiddleware";
-
-/**
- * Determine whether a cloud-stored file belongs to at least one public video
- * the visitor is allowed to see. Videos (fileType "video") match on
- * videoPath === "cloud:<filename>"; thumbnails (fileType "image") match on
- * thumbnailPath === "cloud:<filename>". Orphan files with no matching record
- * are treated as public (non-blocking) so cached thumbnails still resolve.
- *
- * Part of the visitor scoping fix for GHSA-hcm6-w6x8-6jhr.
- */
-const cloudFilenameIsPublic = (
-  filename: string,
-  fileType: "video" | "image"
-): boolean => {
-  if (!filename) return true;
-  const cloudRef = `cloud:${filename}`;
-  try {
-    const videos = storageService.getVideos();
-    return videos.some((video) => {
-      const isPublic = (video as { visibility?: number | null }).visibility !== 0;
-      if (!isPublic) return false;
-      return fileType === "video"
-        ? video.videoPath === cloudRef
-        : video.thumbnailPath === cloudRef;
-    });
-  } catch {
-    // Be non-blocking on lookup failure; the media auth guard already verified
-    // the caller is a logged-in visitor.
-    return true;
-  }
-};
+import {
+  requireAuthenticatedMediaAccess,
+  requireVisibleMediaForVisitors,
+} from "../middleware/mediaAuthMiddleware";
 
 const redirectCloudFile = async (
   req: Request,
@@ -65,16 +37,9 @@ const redirectCloudFile = async (
       return;
     }
 
-    // Visitor scoping (GHSA-hcm6-w6x8-6jhr): a visitor may only fetch cloud
-    // media for videos they are allowed to see (visibility=1). Admins and any
-    // RSS-token-authenticated caller (which already passed the feed's own
-    // visitor/public filter when building the URL) are allowed. We look the
-    // filename up against video records; if no record matches we do not block,
-    // since orphan thumbnails can still be cached.
-    if (req.user?.role === "visitor" && !cloudFilenameIsPublic(filename, fileType)) {
-      res.status(404).send("File not found");
-      return;
-    }
+    // Visitor scoping (GHSA-hcm6-w6x8-6jhr) is enforced by the
+    // requireVisibleMediaForVisitors guard on the route, which blocks non-admin
+    // callers from cloud files that belong solely to hidden videos.
 
     if (fileType === "image") {
       const cloudPath = `cloud:${filename}`;
@@ -179,6 +144,7 @@ export const registerCloudRoutes = (app: Express): void => {
   app.get(
     "/cloud/videos/:filename",
     ...cloudMediaAuth,
+    requireVisibleMediaForVisitors("cloud-video"),
     (req, res) => {
       void redirectCloudFile(req, res, "video");
     }
@@ -186,6 +152,7 @@ export const registerCloudRoutes = (app: Express): void => {
   app.get(
     "/cloud/images/:filename",
     ...cloudMediaAuth,
+    requireVisibleMediaForVisitors("cloud-image"),
     (req, res) => {
       void redirectCloudFile(req, res, "image");
     }

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -210,6 +210,7 @@ export const registerStaticRoutes = (
   app.use(
     "/api/cloud/thumbnail-cache",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("cloud-thumbnail-cache"),
     express.static(CLOUD_THUMBNAIL_CACHE_DIR, {
       fallthrough: false,
     })

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -9,6 +9,8 @@ import {
   SUBTITLES_DIR,
   VIDEOS_DIR,
 } from "../config/paths";
+import { authMiddleware } from "../middleware/authMiddleware";
+import { requireAuthenticatedMediaAccess } from "../middleware/mediaAuthMiddleware";
 import {
   ensureSmallThumbnailForRelativePath,
   getThumbnailRelativePath,
@@ -17,6 +19,13 @@ import {
   normalizeSafeAbsolutePath,
   resolveSafeChildPath,
 } from "../utils/security";
+
+// Media-serving routes were historically mounted before the API auth stack,
+// leaving them fully unauthenticated (GHSA-rwwf-29mq-5j43). These two
+// middlewares re-introduce the credential check for media access:
+//  - authMiddleware: resolves req.user / req.apiKeyAuthenticated (does not block)
+//  - requireAuthenticatedMediaAccess: enforces login when loginEnabled=true
+const mediaAuthStack = [authMiddleware, requireAuthenticatedMediaAccess];
 
 const setCommonImageHeaders = (res: Response): void => {
   res.setHeader("Access-Control-Allow-Origin", "*");
@@ -113,6 +122,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/videos",
+    ...mediaAuthStack,
     express.static(VIDEOS_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {
@@ -157,18 +167,24 @@ export const registerStaticRoutes = (
 
   app.use(
     "/images",
+    ...mediaAuthStack,
     express.static(IMAGES_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
     })
   );
 
-  app.get("/images-small/*", (req, res, next) => {
-    void ensureSmallThumbnail(req, res, next);
-  });
+  app.get(
+    "/images-small/*",
+    ...mediaAuthStack,
+    (req, res, next) => {
+      void ensureSmallThumbnail(req, res, next);
+    }
+  );
 
   app.use(
     "/images-small",
+    ...mediaAuthStack,
     express.static(IMAGES_SMALL_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
@@ -177,6 +193,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/avatars",
+    ...mediaAuthStack,
     express.static(AVATARS_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
@@ -185,6 +202,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/api/cloud/thumbnail-cache",
+    ...mediaAuthStack,
     express.static(CLOUD_THUMBNAIL_CACHE_DIR, {
       fallthrough: false,
     })
@@ -192,6 +210,7 @@ export const registerStaticRoutes = (
 
   app.use(
     "/subtitles",
+    ...mediaAuthStack,
     express.static(SUBTITLES_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -10,7 +10,10 @@ import {
   VIDEOS_DIR,
 } from "../config/paths";
 import { authMiddleware } from "../middleware/authMiddleware";
-import { requireAuthenticatedMediaAccess } from "../middleware/mediaAuthMiddleware";
+import {
+  requireAuthenticatedMediaAccess,
+  requireVisibleMediaForVisitors,
+} from "../middleware/mediaAuthMiddleware";
 import {
   ensureSmallThumbnailForRelativePath,
   getThumbnailRelativePath,
@@ -123,6 +126,7 @@ export const registerStaticRoutes = (
   app.use(
     "/videos",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("videos"),
     express.static(VIDEOS_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {
@@ -168,6 +172,7 @@ export const registerStaticRoutes = (
   app.use(
     "/images",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("images"),
     express.static(IMAGES_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
@@ -177,6 +182,7 @@ export const registerStaticRoutes = (
   app.get(
     "/images-small/*",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("images-small"),
     (req, res, next) => {
       void ensureSmallThumbnail(req, res, next);
     }
@@ -185,6 +191,7 @@ export const registerStaticRoutes = (
   app.use(
     "/images-small",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("images-small"),
     express.static(IMAGES_SMALL_DIR, {
       fallthrough: false,
       setHeaders: setCommonImageHeaders,
@@ -211,6 +218,7 @@ export const registerStaticRoutes = (
   app.use(
     "/subtitles",
     ...mediaAuthStack,
+    requireVisibleMediaForVisitors("subtitles"),
     express.static(SUBTITLES_DIR, {
       fallthrough: false,
       setHeaders: (res, filePath) => {

--- a/backend/src/services/rssService.ts
+++ b/backend/src/services/rssService.ts
@@ -456,19 +456,34 @@ function buildAbsoluteUrl(baseUrl: string, webPath: string): string {
   return `${baseUrl}${webPath.startsWith("/") ? webPath : `/${webPath}`}`;
 }
 
+// Appends the feed token as a query param so media URLs emitted by the feed can
+// authenticate against the now-auth-gated media routes when login is enabled
+// (see mediaAuthMiddleware). The token id is already the feed's secret
+// credential, so this adds no new secret surface. External absolute URLs are
+// left untouched.
+function attachRssToken(url: string, tokenId: string): string {
+  if (!tokenId) return url;
+  const separator = url.includes("?") ? "&" : "?";
+  return `${url}${separator}rss=${encodeURIComponent(tokenId)}`;
+}
+
 export function buildRssFeedUrl(baseUrl: string, tokenId: string): string {
   return `${baseUrl}${RSS_FEED_PATH_PREFIX}/${tokenId}`;
 }
 
 function buildThumbnailUrl(
   video: typeof videos.$inferSelect,
-  baseUrl: string
+  baseUrl: string,
+  tokenId: string
 ): string | null {
   const rawPath = video.thumbnailPath || video.thumbnailUrl;
   if (!rawPath) return null;
 
   if (rawPath.startsWith("cloud:")) {
-    return `${baseUrl}/cloud/images/${encodeURIComponent(rawPath.slice("cloud:".length))}`;
+    return attachRssToken(
+      `${baseUrl}/cloud/images/${encodeURIComponent(rawPath.slice("cloud:".length))}`,
+      tokenId
+    );
   }
 
   if (
@@ -476,12 +491,15 @@ function buildThumbnailUrl(
     rawPath.startsWith("/images-small/") ||
     rawPath.startsWith("/videos/")
   ) {
-    return buildAbsoluteUrl(baseUrl, rawPath);
+    return attachRssToken(buildAbsoluteUrl(baseUrl, rawPath), tokenId);
   }
 
   if (/^https?:\/\//i.test(rawPath)) return rawPath;
 
-  return buildAbsoluteUrl(baseUrl, rawPath.replace(/^\/+/, ""));
+  return attachRssToken(
+    buildAbsoluteUrl(baseUrl, rawPath.replace(/^\/+/, "")),
+    tokenId
+  );
 }
 
 function inferThumbnailMimeType(url: string): string | null {
@@ -569,7 +587,7 @@ export function buildRssXml(
     }
 
     const videoLink = `${baseUrl}/video/${video.id}`;
-    const thumbnailUrl = buildThumbnailUrl(video, baseUrl);
+    const thumbnailUrl = buildThumbnailUrl(video, baseUrl, token.id);
 
     let parsedTags: string[] = [];
     try {

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -755,6 +755,13 @@ describe("storageService videos", () => {
       ).toBe("hidden");
     });
 
+    it("checks legacy thumbnailUrl values for exact media paths", () => {
+      mockClassifyRows([{ visibility: 0 }]);
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/images/legacy-secret.jpg"] })
+      ).toBe("hidden");
+    });
+
     it("returns 'public' when any referencing video is visible (shared thumbnail)", () => {
       mockClassifyRows([{ visibility: 0 }, { visibility: 1 }]);
       expect(
@@ -804,6 +811,21 @@ describe("storageService videos", () => {
       expect(
         classifyMediaVisibility({ cloudThumbnailCacheKeys: [key] })
       ).toBe("unknown");
+    });
+
+    it("classifies cached cloud thumbnails from legacy thumbnailUrl values", () => {
+      const key = cacheKeyFor("cloud:legacy-secret-thumb.jpg");
+      mockCachedCloudThumbnailRows([
+        {
+          thumbnailPath: null,
+          thumbnailUrl: "cloud:legacy-secret-thumb.jpg",
+          visibility: 0,
+        },
+      ]);
+
+      expect(
+        classifyMediaVisibility({ cloudThumbnailCacheKeys: [key] })
+      ).toBe("hidden");
     });
   });
 

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import crypto from "crypto";
 import path from "path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AVATARS_DIR, IMAGES_DIR, SUBTITLES_DIR, VIDEOS_DIR } from "../../../config/paths";
@@ -723,6 +724,19 @@ describe("storageService videos", () => {
       return allMock;
     };
 
+    const cacheKeyFor = (cloudPath: string) =>
+      `${crypto.createHash("sha256").update(cloudPath).digest("hex")}.jpg`;
+
+    const mockCachedCloudThumbnailRows = (rows: any[]) => {
+      const allMock = vi.fn().mockReturnValue(rows);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ all: allMock }),
+        }),
+      } as any);
+      return allMock;
+    };
+
     it("returns 'unknown' when no candidate paths are supplied", () => {
       expect(classifyMediaVisibility({})).toBe("unknown");
     });
@@ -755,6 +769,41 @@ describe("storageService videos", () => {
       expect(
         classifyMediaVisibility({ exactPaths: ["/videos/secret.mp4"] })
       ).toBe("hidden");
+    });
+
+    it("classifies cloud thumbnail cache keys by matching cloud thumbnail paths", () => {
+      const key = cacheKeyFor("cloud:secret-thumb.jpg");
+      mockCachedCloudThumbnailRows([
+        { thumbnailPath: "cloud:secret-thumb.jpg", visibility: 0 },
+        { thumbnailPath: "cloud:public-thumb.jpg", visibility: 1 },
+      ]);
+
+      expect(
+        classifyMediaVisibility({ cloudThumbnailCacheKeys: [`/${key}`] })
+      ).toBe("hidden");
+    });
+
+    it("treats a cached cloud thumbnail as public when any matching video is public", () => {
+      const key = cacheKeyFor("cloud:shared-thumb.jpg");
+      mockCachedCloudThumbnailRows([
+        { thumbnailPath: "cloud:shared-thumb.jpg", visibility: 0 },
+        { thumbnailPath: "cloud:shared-thumb.jpg", visibility: 1 },
+      ]);
+
+      expect(
+        classifyMediaVisibility({ cloudThumbnailCacheKeys: [key] })
+      ).toBe("public");
+    });
+
+    it("returns 'unknown' for cached cloud thumbnails with no matching video", () => {
+      const key = cacheKeyFor("cloud:orphan-thumb.jpg");
+      mockCachedCloudThumbnailRows([
+        { thumbnailPath: "cloud:other-thumb.jpg", visibility: 0 },
+      ]);
+
+      expect(
+        classifyMediaVisibility({ cloudThumbnailCacheKeys: [key] })
+      ).toBe("unknown");
     });
   });
 

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -10,12 +10,15 @@ import * as fileHelpers from "../fileHelpers";
 import { markDownloadHistoryDeletedByVideoId } from "../downloadHistory";
 import { markVideoDownloadDeleted } from "../videoDownloadTracking";
 import {
+  classifyMediaVisibility,
   deleteVideo,
   formatLegacyFilenames,
   getVideoById,
   getVideoBySourceUrl,
   getVideoPartBySourceUrl,
   getVideos,
+  isCloudFileVisibleToVisitor,
+  isVideoPublic,
   saveVideo,
   updateVideo,
 } from "../videos";
@@ -697,6 +700,90 @@ describe("storageService videos", () => {
         throw new Error("db fail");
       });
       expect(() => deleteVideo("1")).toThrow(DatabaseError);
+    });
+  });
+
+  describe("isVideoPublic", () => {
+    it("treats visibility 1, null and undefined as public; 0 as hidden", () => {
+      expect(isVideoPublic({ visibility: 1 })).toBe(true);
+      expect(isVideoPublic({ visibility: null })).toBe(true);
+      expect(isVideoPublic({})).toBe(true);
+      expect(isVideoPublic({ visibility: 0 })).toBe(false);
+    });
+  });
+
+  describe("classifyMediaVisibility", () => {
+    const mockClassifyRows = (rows: any[]) => {
+      const allMock = vi.fn().mockReturnValue(rows);
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ all: allMock }),
+        }),
+      } as any);
+      return allMock;
+    };
+
+    it("returns 'unknown' when no candidate paths are supplied", () => {
+      expect(classifyMediaVisibility({})).toBe("unknown");
+    });
+
+    it("returns 'unknown' for an orphan file with no matching video", () => {
+      mockClassifyRows([]);
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/orphan.mp4"] })
+      ).toBe("unknown");
+    });
+
+    it("returns 'hidden' when every referencing video is hidden", () => {
+      mockClassifyRows([{ visibility: 0 }]);
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/secret.mp4"] })
+      ).toBe("hidden");
+    });
+
+    it("returns 'public' when any referencing video is visible (shared thumbnail)", () => {
+      mockClassifyRows([{ visibility: 0 }, { visibility: 1 }]);
+      expect(
+        classifyMediaVisibility({ subtitlePaths: ["/subtitles/shared.vtt"] })
+      ).toBe("public");
+    });
+
+    it("fails closed to 'hidden' on a database error", () => {
+      vi.mocked(db.select).mockImplementation(() => {
+        throw new Error("db down");
+      });
+      expect(
+        classifyMediaVisibility({ exactPaths: ["/videos/secret.mp4"] })
+      ).toBe("hidden");
+    });
+  });
+
+  describe("isCloudFileVisibleToVisitor", () => {
+    const mockClassifyRows = (rows: any[]) => {
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ all: vi.fn().mockReturnValue(rows) }),
+        }),
+      } as any);
+    };
+
+    it("allows an empty filename (non-blocking)", () => {
+      expect(isCloudFileVisibleToVisitor("")).toBe(true);
+    });
+
+    it("blocks a cloud file that belongs solely to a hidden video", () => {
+      mockClassifyRows([{ visibility: 0 }]);
+      expect(isCloudFileVisibleToVisitor("secret.mp4")).toBe(false);
+    });
+
+    it("allows a cloud file referenced by a public video", () => {
+      mockClassifyRows([{ visibility: 1 }]);
+      expect(isCloudFileVisibleToVisitor("pub.mp4")).toBe(true);
+    });
+
+    it("allows an orphan cloud file (no matching video)", () => {
+      mockClassifyRows([]);
+      expect(isCloudFileVisibleToVisitor("orphan.jpg")).toBe(true);
     });
   });
 });

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -64,6 +64,7 @@ export {
     saveVideoWithInsertFlag,
     updateVideo
 } from "./videos";
+export type { VideoCallerRole } from "./videos";
 
 // Collections
 export {

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -53,18 +53,21 @@ export {
 
 // Videos
 export {
+    classifyMediaVisibility,
     deleteVideo,
     formatLegacyFilenames,
     getVideoById,
     getVideoBySourceUrl,
     getVideos,
+    isCloudFileVisibleToVisitor,
     isThumbnailReferencedByOtherVideo,
+    isVideoPublic,
     saveVideo,
     saveVideoIfAbsent,
     saveVideoWithInsertFlag,
     updateVideo
 } from "./videos";
-export type { VideoCallerRole } from "./videos";
+export type { MediaVisibility, VideoCallerRole } from "./videos";
 
 // Collections
 export {

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, or, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, isNull, or, sql, type SQL } from "drizzle-orm";
 import crypto from "crypto";
 import path from "path";
 import {
@@ -39,9 +39,13 @@ export type VideoCallerRole = "admin" | "visitor";
 // Visibility: 0 = hidden, 1 = public (see db/schema.ts). Visitors are only
 // allowed to see public videos; admins see everything. Mirrors the existing
 // RSS feed filter (rssService.ts). Used to fix GHSA-hcm6-w6x8-6jhr.
+// A NULL visibility is treated as public to match the `(visibility ?? 1) === 1`
+// contract in isVideoPublic and the media classifier; a plain `= 1` would hide
+// imported/legacy rows that wrote NULL from visitors only.
 // Built lazily so the schema reference is not evaluated at module load time
 // (which would break tests that partially mock the db schema).
-const publicOnlyVisitorFilter = () => eq(videos.visibility, 1);
+const publicOnlyVisitorFilter = () =>
+  or(eq(videos.visibility, 1), isNull(videos.visibility));
 
 export function getVideos(
   role?: VideoCallerRole

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -171,18 +171,26 @@ const getCachedCloudThumbnailVisibilityRows = (
   const rows = db
     .select({
       thumbnailPath: videos.thumbnailPath,
+      thumbnailUrl: videos.thumbnailUrl,
       visibility: videos.visibility,
     })
     .from(videos)
-    .where(sql`${videos.thumbnailPath} LIKE ${"cloud:%"}`)
+    .where(
+      or(
+        sql`${videos.thumbnailPath} LIKE ${"cloud:%"}`,
+        sql`${videos.thumbnailUrl} LIKE ${"cloud:%"}`
+      )
+    )
     .all();
 
   return rows
     .filter((row) => {
-      if (!row.thumbnailPath) {
-        return false;
-      }
-      return cacheKeys.has(getCloudThumbnailCacheKey(row.thumbnailPath));
+      const candidates = [row.thumbnailPath, row.thumbnailUrl].filter(
+        (value): value is string => typeof value === "string" && value.length > 0
+      );
+      return candidates.some((candidate) =>
+        cacheKeys.has(getCloudThumbnailCacheKey(candidate))
+      );
     })
     .map((row) => ({ visibility: row.visibility }));
 };
@@ -194,7 +202,7 @@ const getCachedCloudThumbnailVisibilityRows = (
  * hidden videos must not be served to non-admin callers, while public media
  * stays reachable (e.g. for RSS clients).
  *
- * - `exactPaths` are matched against `videoPath`/`thumbnailPath`.
+ * - `exactPaths` are matched against `videoPath`/`thumbnailPath`/`thumbnailUrl`.
  * - `subtitlePaths` are matched against entries inside the `subtitles` JSON.
  * - `cloudThumbnailCacheKeys` are matched by recomputing the stable cache key
  *   for cloud thumbnail paths, which lets the static cache route enforce the
@@ -220,6 +228,7 @@ export function classifyMediaVisibility(opts: {
     if (!candidate) continue;
     conditions.push(eq(videos.videoPath, candidate));
     conditions.push(eq(videos.thumbnailPath, candidate));
+    conditions.push(eq(videos.thumbnailUrl, candidate));
   }
 
   for (const candidate of opts.subtitlePaths ?? []) {

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, or, sql, type SQL } from "drizzle-orm";
 import path from "path";
 import {
     AVATARS_DIR,
@@ -133,6 +133,95 @@ export function getVideoById(
       "getVideoById"
     );
   }
+}
+
+/**
+ * A video is treated as publicly visible unless visibility is explicitly 0.
+ * Mirrors the frontend contract `(visibility ?? 1) === 1`.
+ */
+export function isVideoPublic(video: {
+  visibility?: number | null;
+}): boolean {
+  return (video.visibility ?? 1) === 1;
+}
+
+export type MediaVisibility = "public" | "hidden" | "unknown";
+
+const escapeLikePattern = (value: string): string =>
+  value.replace(/[\\%_]/g, "\\$&");
+
+/**
+ * Classify a piece of static media by the visibility of the video(s) that
+ * reference it. Used as defense-in-depth on the static/cloud media routes
+ * (GHSA-hcm6-w6x8-6jhr): even after the login wall, media that belongs only to
+ * hidden videos must not be served to non-admin callers, while public media
+ * stays reachable (e.g. for RSS clients).
+ *
+ * - `exactPaths` are matched against `videoPath`/`thumbnailPath`.
+ * - `subtitlePaths` are matched against entries inside the `subtitles` JSON.
+ *
+ * Returns "public" if any referencing video is visible, "hidden" if every
+ * referencing video is hidden, and "unknown" if no video references the media
+ * (orphan files, frontend assets, avatars — left untouched).
+ */
+export function classifyMediaVisibility(opts: {
+  exactPaths?: string[];
+  subtitlePaths?: string[];
+}): MediaVisibility {
+  const conditions: SQL[] = [];
+
+  for (const candidate of opts.exactPaths ?? []) {
+    if (!candidate) continue;
+    conditions.push(eq(videos.videoPath, candidate));
+    conditions.push(eq(videos.thumbnailPath, candidate));
+  }
+
+  for (const candidate of opts.subtitlePaths ?? []) {
+    if (!candidate) continue;
+    const pattern = `%"${escapeLikePattern(candidate)}"%`;
+    conditions.push(sql`${videos.subtitles} LIKE ${pattern} ESCAPE '\\'`);
+  }
+
+  if (conditions.length === 0) {
+    return "unknown";
+  }
+
+  try {
+    const rows = db
+      .select({ visibility: videos.visibility })
+      .from(videos)
+      .where(or(...conditions))
+      .all();
+
+    if (rows.length === 0) {
+      return "unknown";
+    }
+
+    // Any visible reference makes the file public (a thumbnail could be shared);
+    // only block when every match is hidden.
+    return rows.some((row) => isVideoPublic(row)) ? "public" : "hidden";
+  } catch (error) {
+    logger.error(
+      "Error classifying media visibility",
+      error instanceof Error ? error : new Error(String(error))
+    );
+    // Fail closed: treat as hidden so a transient DB error can't leak media.
+    return "hidden";
+  }
+}
+
+/**
+ * Whether a visitor may access a cloud-stored file. Shared by the cloud
+ * redirect routes and the signed-url controller so the "is this `cloud:` ref
+ * hidden?" rule lives in exactly one place. A file is visitor-accessible unless
+ * every video referencing it is hidden; orphan files (no match) stay reachable
+ * so cached thumbnails keep resolving. Part of GHSA-hcm6-w6x8-6jhr.
+ */
+export function isCloudFileVisibleToVisitor(filename: string): boolean {
+  if (!filename) return true;
+  return (
+    classifyMediaVisibility({ exactPaths: [`cloud:${filename}`] }) !== "hidden"
+  );
 }
 
 /**

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, or, sql, type SQL } from "drizzle-orm";
+import crypto from "crypto";
 import path from "path";
 import {
     AVATARS_DIR,
@@ -150,6 +151,42 @@ export type MediaVisibility = "public" | "hidden" | "unknown";
 const escapeLikePattern = (value: string): string =>
   value.replace(/[\\%_]/g, "\\$&");
 
+const CLOUD_THUMBNAIL_CACHE_KEY_PATTERN = /^[a-f0-9]{64}\.jpg$/;
+
+const normalizeCloudThumbnailCacheKey = (value: string): string | null => {
+  const key = path.posix.basename(value).toLowerCase();
+  return CLOUD_THUMBNAIL_CACHE_KEY_PATTERN.test(key) ? key : null;
+};
+
+const getCloudThumbnailCacheKey = (cloudPath: string): string =>
+  `${crypto.createHash("sha256").update(cloudPath).digest("hex")}.jpg`;
+
+const getCachedCloudThumbnailVisibilityRows = (
+  cacheKeys: Set<string>
+): Array<{ visibility: number | null }> => {
+  if (cacheKeys.size === 0) {
+    return [];
+  }
+
+  const rows = db
+    .select({
+      thumbnailPath: videos.thumbnailPath,
+      visibility: videos.visibility,
+    })
+    .from(videos)
+    .where(sql`${videos.thumbnailPath} LIKE ${"cloud:%"}`)
+    .all();
+
+  return rows
+    .filter((row) => {
+      if (!row.thumbnailPath) {
+        return false;
+      }
+      return cacheKeys.has(getCloudThumbnailCacheKey(row.thumbnailPath));
+    })
+    .map((row) => ({ visibility: row.visibility }));
+};
+
 /**
  * Classify a piece of static media by the visibility of the video(s) that
  * reference it. Used as defense-in-depth on the static/cloud media routes
@@ -159,6 +196,9 @@ const escapeLikePattern = (value: string): string =>
  *
  * - `exactPaths` are matched against `videoPath`/`thumbnailPath`.
  * - `subtitlePaths` are matched against entries inside the `subtitles` JSON.
+ * - `cloudThumbnailCacheKeys` are matched by recomputing the stable cache key
+ *   for cloud thumbnail paths, which lets the static cache route enforce the
+ *   same visibility rule even though its URL only contains a hash filename.
  *
  * Returns "public" if any referencing video is visible, "hidden" if every
  * referencing video is hidden, and "unknown" if no video references the media
@@ -167,8 +207,14 @@ const escapeLikePattern = (value: string): string =>
 export function classifyMediaVisibility(opts: {
   exactPaths?: string[];
   subtitlePaths?: string[];
+  cloudThumbnailCacheKeys?: string[];
 }): MediaVisibility {
   const conditions: SQL[] = [];
+  const cloudThumbnailCacheKeys = new Set(
+    (opts.cloudThumbnailCacheKeys ?? [])
+      .map(normalizeCloudThumbnailCacheKey)
+      .filter((key): key is string => key != null)
+  );
 
   for (const candidate of opts.exactPaths ?? []) {
     if (!candidate) continue;
@@ -182,16 +228,21 @@ export function classifyMediaVisibility(opts: {
     conditions.push(sql`${videos.subtitles} LIKE ${pattern} ESCAPE '\\'`);
   }
 
-  if (conditions.length === 0) {
+  if (conditions.length === 0 && cloudThumbnailCacheKeys.size === 0) {
     return "unknown";
   }
 
   try {
-    const rows = db
-      .select({ visibility: videos.visibility })
-      .from(videos)
-      .where(or(...conditions))
-      .all();
+    const rows: Array<{ visibility: number | null }> =
+      conditions.length > 0
+        ? db
+            .select({ visibility: videos.visibility })
+            .from(videos)
+            .where(or(...conditions))
+            .all()
+        : [];
+
+    rows.push(...getCachedCloudThumbnailVisibilityRows(cloudThumbnailCacheKeys));
 
     if (rows.length === 0) {
       return "unknown";

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import path from "path";
 import {
     AVATARS_DIR,
@@ -33,13 +33,27 @@ import {
   resolveManagedThumbnailWebPathFromAbsolutePath,
 } from "../thumbnailMirrorService";
 
-export function getVideos(): import("./types").Video[] {
+export type VideoCallerRole = "admin" | "visitor";
+
+// Visibility: 0 = hidden, 1 = public (see db/schema.ts). Visitors are only
+// allowed to see public videos; admins see everything. Mirrors the existing
+// RSS feed filter (rssService.ts). Used to fix GHSA-hcm6-w6x8-6jhr.
+// Built lazily so the schema reference is not evaluated at module load time
+// (which would break tests that partially mock the db schema).
+const publicOnlyVisitorFilter = () => eq(videos.visibility, 1);
+
+export function getVideos(
+  role?: VideoCallerRole
+): import("./types").Video[] {
   try {
-    const allVideos = db
+    const baseQuery = db
       .select()
       .from(videos)
-      .orderBy(desc(videos.createdAt))
-      .all();
+      .orderBy(desc(videos.createdAt));
+    const allVideos =
+      role === "visitor"
+        ? baseQuery.where(publicOnlyVisitorFilter()).all()
+        : baseQuery.all();
     return allVideos.map((v) => ({
       ...v,
       tags: v.tags ? JSON.parse(v.tags) : [],
@@ -86,9 +100,20 @@ export function getVideoBySourceUrl(
   }
 }
 
-export function getVideoById(id: string): import("./types").Video | undefined {
+export function getVideoById(
+  id: string,
+  role?: VideoCallerRole
+): import("./types").Video | undefined {
   try {
-    const video = db.select().from(videos).where(eq(videos.id, id)).get();
+    const baseQuery = db.select().from(videos);
+    const video =
+      role === "visitor"
+        ? baseQuery
+            .where(
+              and(eq(videos.id, id), publicOnlyVisitorFilter())
+            )
+            .get()
+        : baseQuery.where(eq(videos.id, id)).get();
     if (video) {
       return {
         ...video,


### PR DESCRIPTION
## Summary

Fixes the **two open `triage` security advisories** verified against current `master` (v1.10.2).

### GHSA-rwwf-29mq-5j43 — Unauthenticated Media Access via Static Routes (HIGH, CWE-306)

Static and cloud media routes were registered before the API auth stack and were **fully unauthenticated** — the login wall was frontend-only and trivially bypassed (`curl http://host/videos/secret.mp4` → `200`, `curl /subtitles/x.vtt` → `200`, while `curl /api/videos` correctly → `401`).

Affected: `/videos/*`, `/images/*`, `/images-small/*`, `/avatars/*`, `/subtitles/*`, `/api/cloud/thumbnail-cache/*`, `/cloud/videos/:filename`, `/cloud/images/:filename`.

**Fix:** new `mediaAuthMiddleware` mounted ahead of every media handler. When `loginEnabled=true`, a request needs a valid **session** (admin or visitor), **API key**, or an **active RSS feed token**. When `loginEnabled=false` (single-user mode, the default) media stays open as before — no behavior change. The frontend bundle (`/assets`, SPA fallback) is intentionally left open so the login page itself loads.

### GHSA-hcm6-w6x8-6jhr — Visitor Can Access Hidden Video Metadata and Content (HIGH, CWE-862)

The visitor role's "public videos only" restriction was enforced **only on the frontend** (`VideoContext.tsx`). `getVideos()` did `SELECT *` and `getVideoById(id)` queried by id only — no `visibility` filter. (The RSS feed already filtered `visibility=1` for visitors, confirming this is intended.)

**Fix:** thread the caller's role through the query layer:
- `getVideos(role)` / `getVideoById(id, role)` add `WHERE visibility = 1` for visitors.
- `getVideoById` and `serveMountVideo` return **404** (not 403) for a hidden video requested by a visitor — "doesn't exist for you" semantics.
- Cloud file access (`/cloud/{videos,images}`, `/api/cloud/signed-url`) is gated so a visitor can't fetch or obtain a signed URL for a hidden cloud video.

## Compatibility

- **Single-user mode (`loginEnabled=false`):** unchanged. Only multi-user deployments gain enforcement.
- **RSS feed:** the feed emits bare absolute image URLs that RSS readers fetch **without** a session cookie, so gating `/images`, `/images-small`, `/videos`, `/cloud/images` naively would break RSS thumbnails. The feed now appends `?rss=<tokenId>` to those URLs, and the media guard accepts a valid RSS token from the query param or `mytube_rss_token` cookie. The token id is already the feed's secret credential (it's the feed URL itself), so **no new secret surface** is introduced.
- **Media-server export (Plex/Emby/Jellyfin):** purely filesystem-based — writes real files + `.nfo` sidecars with local filenames, never any HTTP URL back into MyTube. **Unaffected.**

## Residual note (local file routes)

For the local `/videos/*`, `/images/*`, `/subtitles/*` direct routes, full path→video mapping isn't feasible (filenames aren't unique keys and the codebase has no such index). The primary exposure — hidden-video metadata/path leakage — is closed at the source (the API no longer returns hidden paths to visitors), and anonymous access is removed by Part 1. The cloud and mount-video routes (which have clean filename/id lookups) are fully visitor-scoped. I deliberately did not over-engineer a filename-based ACL for local files.

## Tests

- Backend: full suite **green (2091 tests)**, `tsc --noEmit` clean.
- Added `mediaAuthMiddleware.test.ts` (guard matrix: login-off, session, API key, RSS token query/cookie, inactive/short/throwing token, unauthenticated reject).
- Added visitor-visibility coverage in `storageService`, `videoController`, `cloudRoutes`.
- Updated `staticRoutes`, `cloudRoutes`, `rssService` assertions for the new auth stack + `?rss=` URLs.

## Files changed
- `backend/src/middleware/mediaAuthMiddleware.ts` (new) + test
- `backend/src/server/staticRoutes.ts`, `cloudRoutes.ts`
- `backend/src/services/storageService/videos.ts` + index re-export
- `backend/src/controllers/videoController.ts`, `cloudStorageController.ts`
- `backend/src/services/rssService.ts`
- test files

## Notes

I did **not** touch the GitHub advisory records themselves (triage status / CVE publication / patched-versions). As repo owner you can attach `patched_versions` and publish/close them after merging.

🤖 Generated with ZCode