### PR TITLE
fix(tags): sync player-added tags into the global tags directory

### DIFF
--- a/backend/src/__tests__/services/tagService.test.ts
+++ b/backend/src/__tests__/services/tagService.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { db } from "../../db";
 import * as settingsService from "../../services/storageService/settings";
-import { deleteTagsFromVideos, renameTag } from "../../services/tagService";
+import {
+  addTagsToGlobalSettings,
+  deleteTagsFromVideos,
+  renameTag,
+} from "../../services/tagService";
 
 // Mock dependencies
 vi.mock("../../db", () => ({
@@ -129,6 +133,61 @@ describe("TagService", () => {
 
     it("should return 0 if tagsToDelete is empty", () => {
         expect(deleteTagsFromVideos([])).toBe(0);
+    });
+  });
+
+  describe("addTagsToGlobalSettings", () => {
+    it("adds genuinely new tags to the global catalog (sorted)", () => {
+      vi.mocked(settingsService.getSettings).mockReturnValue({
+        websiteName: "MyTube",
+        tags: ["beta"],
+      } as any);
+
+      const changed = addTagsToGlobalSettings(["alpha", "beta"]);
+
+      expect(changed).toBe(true);
+      expect(settingsService.saveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          websiteName: "MyTube",
+          tags: ["alpha", "beta"],
+        })
+      );
+    });
+
+    it("seeds the catalog when settings has no tags yet", () => {
+      vi.mocked(settingsService.getSettings).mockReturnValue({} as any);
+
+      const changed = addTagsToGlobalSettings(["123"]);
+
+      expect(changed).toBe(true);
+      expect(settingsService.saveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ tags: ["123"] })
+      );
+    });
+
+    it("skips tags that already exist case-insensitively and trims input", () => {
+      vi.mocked(settingsService.getSettings).mockReturnValue({
+        tags: ["Music"],
+      } as any);
+
+      const changed = addTagsToGlobalSettings(["  music  "]);
+
+      expect(changed).toBe(false);
+      expect(settingsService.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it("does nothing for empty input", () => {
+      expect(addTagsToGlobalSettings([])).toBe(false);
+      expect(settingsService.getSettings).not.toHaveBeenCalled();
+      expect(settingsService.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it("never throws if settings access fails", () => {
+      vi.mocked(settingsService.getSettings).mockImplementation(() => {
+        throw new Error("boom");
+      });
+
+      expect(addTagsToGlobalSettings(["x"])).toBe(false);
     });
   });
 });

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -7,6 +7,7 @@ import { SUBTITLES_DIR, VIDEOS_DIR } from "../config/paths";
 import { NotFoundError, ValidationError } from "../errors/DownloadErrors";
 import { syncMediaServerArtifactsForRecord } from "../services/mediaServerExport";
 import * as storageService from "../services/storageService";
+import { addTagsToGlobalSettings } from "../services/tagService";
 import { logger } from "../utils/logger";
 import { getStringParam } from "../utils/paramUtils";
 import { successResponse } from "../utils/response";
@@ -315,6 +316,12 @@ export const updateVideoDetails = async (
 
   if (!updatedVideo) {
     throw new NotFoundError("Video", id);
+  }
+
+  // Keep the global tag catalog (settings.tags) in sync so tags created while
+  // tagging a video also appear in Tags Management and as suggestions.
+  if (Array.isArray(allowedUpdates.tags) && allowedUpdates.tags.length > 0) {
+    addTagsToGlobalSettings(allowedUpdates.tags);
   }
 
   syncMediaServerArtifactsForRecord(updatedVideo);

--- a/backend/src/services/tagService.ts
+++ b/backend/src/services/tagService.ts
@@ -93,6 +93,56 @@ export function renameTag(oldTag: string, newTag: string): RenameTagResult {
 }
 
 /**
+ * Merge tags into the global settings tag catalog (settings.tags).
+ *
+ * Used to keep the global tag list in sync whenever a video is tagged, so tags
+ * created from the player (or any API caller) show up in Tags Management.
+ * Only genuinely new tags are added; existing tags are matched
+ * case-insensitively so we never create "music"/"Music" duplicates, which the
+ * settings validator rejects.
+ *
+ * @param tags Tags applied to a video
+ * @returns true if the global catalog was changed and saved
+ */
+export function addTagsToGlobalSettings(tags: string[]): boolean {
+  if (!tags || tags.length === 0) return false;
+
+  try {
+    const currentSettings = getSettings();
+    const existing: string[] = Array.isArray(currentSettings.tags)
+      ? (currentSettings.tags as string[])
+      : [];
+    const existingLower = new Set(existing.map((t) => t.toLowerCase()));
+
+    const toAdd: string[] = [];
+    for (const tag of tags) {
+      const trimmed = typeof tag === "string" ? tag.trim() : "";
+      if (!trimmed) continue;
+      const lower = trimmed.toLowerCase();
+      if (existingLower.has(lower)) continue;
+      existingLower.add(lower);
+      toAdd.push(trimmed);
+    }
+
+    if (toAdd.length === 0) return false;
+
+    const updatedTags = [...existing, ...toAdd].sort((a, b) =>
+      a.localeCompare(b)
+    );
+    saveSettings({ ...currentSettings, tags: updatedTags });
+    logger.info(`Added new tags to global catalog: [${toAdd.join(", ")}]`);
+    return true;
+  } catch (error) {
+    // Don't fail the video update if catalog sync fails; just log it.
+    logger.error(
+      `Error adding tags to global settings: [${tags.join(", ")}]`,
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return false;
+  }
+}
+
+/**
  * Remove specific tags from all videos in the database
  * @param tagsToDelete Array of tag names to remove
  * @returns Number of videos updated

--- a/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
+++ b/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
@@ -251,7 +251,10 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
                                         height: 20,
                                         fontSize: '0.65rem',
                                         bgcolor: isSelected ? theme.palette.primary.main : overlay.black50,
-                                        color: neutral.white,
+                                        // Selected chips sit on the bright primary color; use its
+                                        // computed contrast text (dark in dark mode) so the label
+                                        // stands out instead of white-on-bright.
+                                        color: isSelected ? theme.palette.primary.contrastText : neutral.white,
                                         backdropFilter: 'blur(2px)',
                                         '& .MuiChip-label': {
                                             px: 1

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
@@ -1,7 +1,8 @@
-import { LocalOffer } from '@mui/icons-material';
-import { Autocomplete, Box, Chip, TextField } from '@mui/material';
+import { Add, LocalOffer } from '@mui/icons-material';
+import { Autocomplete, Box, Chip, TextField, Typography, useMediaQuery, useTheme } from '@mui/material';
 import React, { useState } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
+import TagsModal from '../../TagsModal';
 
 interface VideoTagsProps {
     tags: string[] | undefined;
@@ -11,11 +12,50 @@ interface VideoTagsProps {
 
 const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate }) => {
     const { t } = useLanguage();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const [open, setOpen] = useState(false);
+    const [modalOpen, setModalOpen] = useState(false);
 
     // Ensure tags and availableTags are always arrays
     const tagsArray = Array.isArray(tags) ? tags : [];
     const availableTagsArray = Array.isArray(availableTags) ? availableTags : [];
+
+    // On touch/mobile the inline autocomplete dropdown is awkward: it's anchored to
+    // a tiny input and the on-screen keyboard covers it. Show the current tags as
+    // chips and edit them through the centered TagsModal dialog instead.
+    if (isMobile) {
+        return (
+            <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1, mt: 2, flexWrap: 'wrap' }}>
+                <LocalOffer color="action" fontSize="small" />
+                {tagsArray.length > 0 ? (
+                    tagsArray.map((tag) => (
+                        <Chip key={tag} label={tag} size="small" variant="outlined" />
+                    ))
+                ) : (
+                    <Typography variant="body2" color="text.secondary">
+                        {t('tags') || 'Tags'}
+                    </Typography>
+                )}
+                <Chip
+                    icon={<Add fontSize="small" />}
+                    label={t('addTags') || 'Add Tags'}
+                    size="small"
+                    variant="outlined"
+                    color="primary"
+                    onClick={() => setModalOpen(true)}
+                    sx={{ cursor: 'pointer' }}
+                />
+                <TagsModal
+                    open={modalOpen}
+                    onClose={() => setModalOpen(false)}
+                    videoTags={tagsArray}
+                    availableTags={availableTagsArray}
+                    onSave={onTagsUpdate}
+                />
+            </Box>
+        );
+    }
 
     // Combine available tags with video tags to ensure current tags are valid options
     const allOptions = Array.from(new Set([...availableTagsArray, ...tagsArray])).sort();
@@ -86,7 +126,6 @@ const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate
                             input: {
                                 ...params.InputProps,
                                 disableUnderline: true,
-                                readOnly: true,
                                 endAdornment: null
                             }
                         }}

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
@@ -60,6 +60,30 @@ const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate
     // Combine available tags with video tags to ensure current tags are valid options
     const allOptions = Array.from(new Set([...availableTagsArray, ...tagsArray])).sort();
 
+    // freeSolo lets users type arbitrary values. Trim, drop blanks, and dedupe
+    // case-insensitively before saving, reusing an existing tag's canonical
+    // casing so the video stores values that match the global tag catalog (which
+    // also trims/case-folds). Otherwise a stray "foo " or casing variant would be
+    // attached to the video but never match Tags Management delete/rename paths.
+    const handleTagsChange = (newValue: string[]) => {
+        const canonicalByLower = new Map<string, string>();
+        for (const option of allOptions) {
+            const lower = option.toLowerCase();
+            if (!canonicalByLower.has(lower)) canonicalByLower.set(lower, option);
+        }
+        const seen = new Set<string>();
+        const normalized: string[] = [];
+        for (const raw of newValue) {
+            const trimmed = typeof raw === 'string' ? raw.trim() : '';
+            if (!trimmed) continue;
+            const lower = trimmed.toLowerCase();
+            if (seen.has(lower)) continue;
+            seen.add(lower);
+            normalized.push(canonicalByLower.get(lower) ?? trimmed);
+        }
+        void onTagsUpdate(normalized);
+    };
+
     return (
         <Box sx={{ mb: 2, display: 'flex', alignItems: 'center', gap: 1, mt: 2 }}>
             <LocalOffer color="action" fontSize="small" />
@@ -90,7 +114,7 @@ const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate
                 options={allOptions}
                 value={tagsArray}
                 isOptionEqualToValue={(option, value) => option === value}
-                onChange={(_, newValue) => onTagsUpdate(newValue)}
+                onChange={(_, newValue) => handleTagsChange(newValue)}
                 slotProps={{
                     chip: { variant: 'outlined', size: 'small' },
                     listbox: {

--- a/frontend/src/hooks/useSettingsMutations.ts
+++ b/frontend/src/hooks/useSettingsMutations.ts
@@ -674,9 +674,15 @@ export function useSettingsMutations({
       await api.patch("/settings", { tags });
       return tags;
     },
-    onSuccess: () => {
+    onSuccess: (tags) => {
       setMessage({ text: t("settingsSaved"), type: "success" });
-      void queryClient.invalidateQueries({ queryKey: ["settings"] });
+      // `tags` is the authoritative full list the caller just saved, so update
+      // the cache directly instead of invalidating. A refetch would change the
+      // `["settings"]` reference and make SettingsPage re-hydrate the whole form,
+      // clobbering any unsaved edits to other fields.
+      queryClient.setQueryData(["settings"], (old: Settings | undefined) =>
+        old ? { ...old, tags } : old
+      );
       void queryClient.invalidateQueries({ queryKey: ["videos"] });
     },
     onError: async (error: unknown) => {

--- a/frontend/src/hooks/useSettingsMutations.ts
+++ b/frontend/src/hooks/useSettingsMutations.ts
@@ -667,9 +667,34 @@ export function useSettingsMutations({
     },
   });
 
+  // Persist a tags-only change immediately (used by Tags Management add/delete).
+  // PATCHes just the `tags` field so it never flushes other half-edited settings.
+  const updateTagsMutation = useMutation({
+    mutationFn: async (tags: string[]) => {
+      await api.patch("/settings", { tags });
+      return tags;
+    },
+    onSuccess: () => {
+      setMessage({ text: t("settingsSaved"), type: "success" });
+      void queryClient.invalidateQueries({ queryKey: ["settings"] });
+      void queryClient.invalidateQueries({ queryKey: ["videos"] });
+    },
+    onError: async (error: unknown) => {
+      const apiMsg = await getApiErrorMessage(error, t);
+      setMessage({
+        text: typeof apiMsg === "string" && apiMsg ? apiMsg : t("settingsFailed"),
+        type: "error",
+      });
+      // The caller optimistically updated local settings; refetch so the form
+      // reverts to server truth instead of showing tags that never persisted.
+      void queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
+
   // Computed isSaving state
   const isSaving =
     saveMutation.isPending ||
+    updateTagsMutation.isPending ||
     migrateMutation.isPending ||
     cleanupMutation.isPending ||
     cleanupAuthorCollectionsMutation.isPending ||
@@ -695,6 +720,7 @@ export function useSettingsMutations({
     cleanupBackupDatabasesMutation,
     restoreFromLastBackupMutation,
     renameTagMutation,
+    updateTagsMutation,
     lastBackupInfo,
     isSaving,
   };

--- a/frontend/src/hooks/useVideoMutations.ts
+++ b/frontend/src/hooks/useVideoMutations.ts
@@ -71,6 +71,10 @@ export function useVideoMutations({
         queryClient.setQueryData(["video", videoId], (old: Video | undefined) =>
           old ? { ...old, tags: newTags } : old
         );
+        // The backend syncs player-added tags into the global tag catalog
+        // (settings.tags). Refresh the settings cache so the new tags show up as
+        // suggestions in other pickers without waiting for the 10-minute staleTime.
+        void queryClient.invalidateQueries({ queryKey: ["settings"] });
       }
     },
     onError: () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -246,8 +246,11 @@ const SettingsPage: React.FC = () => {
         }
     }, [location.search, location.hash]);
 
+    const hasHydratedSettings = useRef(false);
     useEffect(() => {
-        if (settingsData) {
+        if (!settingsData) return;
+        if (!hasHydratedSettings.current) {
+            // Initial load: populate the whole form from server truth.
             const newSettings = {
                 ...settingsData,
                 tags: settingsData.tags || [],
@@ -258,7 +261,14 @@ const SettingsPage: React.FC = () => {
                 authorOrganizationMode: resolveAuthorOrganizationMode(settingsData),
             };
             setSettings(newSettings);
+            hasHydratedSettings.current = true;
+            return;
         }
+        // After hydration the form is user-owned. The only field that legitimately
+        // changes externally (player-added tags, Tags Management, tag rename) is
+        // `tags`, so sync just that and leave the user's unsaved edits to other
+        // fields intact.
+        setSettings(prev => ({ ...prev, tags: settingsData.tags || [] }));
     }, [settingsData]);
 
     // Settings mutations

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -277,6 +277,7 @@ const SettingsPage: React.FC = () => {
         cleanupBackupDatabasesMutation,
         restoreFromLastBackupMutation,
         renameTagMutation,
+        updateTagsMutation,
         lastBackupInfo,
         isSaving
     } = mutations;
@@ -413,8 +414,11 @@ const SettingsPage: React.FC = () => {
     };
 
     const handleTagsChange = (newTags: string[]) => {
+        // Reflect the change locally for snappy UI, then persist immediately so
+        // tags added/removed in Tags Management survive a reload without needing
+        // the global Save button.
         setSettings(prev => ({ ...prev, tags: newTags }));
-        triggerGlow();
+        updateTagsMutation.mutate(newTags);
     };
 
     const handleRenameTag = (oldTag: string, newTag: string) => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -247,6 +247,8 @@ const SettingsPage: React.FC = () => {
     }, [location.search, location.hash]);
 
     const hasHydratedSettings = useRef(false);
+    // Tail of the in-flight tag-save chain; keeps immediate tag PATCHes ordered.
+    const tagSaveChain = useRef<Promise<unknown>>(Promise.resolve());
     useEffect(() => {
         if (!settingsData) return;
         if (!hasHydratedSettings.current) {
@@ -264,11 +266,19 @@ const SettingsPage: React.FC = () => {
             hasHydratedSettings.current = true;
             return;
         }
-        // After hydration the form is user-owned. The only field that legitimately
-        // changes externally (player-added tags, Tags Management, tag rename) is
-        // `tags`, so sync just that and leave the user's unsaved edits to other
-        // fields intact.
-        setSettings(prev => ({ ...prev, tags: settingsData.tags || [] }));
+        // After hydration the form is user-owned, so we must not clobber unsaved
+        // edits. But the server is authoritative for response-only/derived fields
+        // (which aren't editable drafts) and for the immediately-persisted tag
+        // list, so sync just those from each refetch and leave everything else as
+        // the user left it.
+        setSettings(prev => ({
+            ...prev,
+            tags: settingsData.tags || [],
+            isPasswordSet: settingsData.isPasswordSet,
+            isVisitorPasswordSet: settingsData.isVisitorPasswordSet,
+            deploymentSecurity: settingsData.deploymentSecurity,
+            liveTranslationApiKeyConfigured: settingsData.liveTranslationApiKeyConfigured,
+        }));
     }, [settingsData]);
 
     // Settings mutations
@@ -428,7 +438,13 @@ const SettingsPage: React.FC = () => {
         // tags added/removed in Tags Management survive a reload without needing
         // the global Save button.
         setSettings(prev => ({ ...prev, tags: newTags }));
-        updateTagsMutation.mutate(newTags);
+        // Serialize saves: chaining each PATCH after the previous one prevents a
+        // slow earlier request from settling after a newer one and persisting a
+        // stale tag list (which the settings sync would then copy back into state).
+        tagSaveChain.current = tagSaveChain.current
+            .catch(() => undefined)
+            .then(() => updateTagsMutation.mutateAsync(newTags))
+            .catch(() => undefined);
     };
 
     const handleRenameTag = (oldTag: string, newTag: string) => {

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -153,7 +153,14 @@ vi.mock('../../hooks/useSettingsMutations', () => ({
     cleanupBackupDatabasesMutation: { isPending: false, mutate: (...args: any[]) => mockCleanupBackupDatabasesMutate(...args) },
     restoreFromLastBackupMutation: { isPending: false, mutate: (...args: any[]) => mockRestoreFromLastBackupMutate(...args) },
     renameTagMutation: { isPending: false, mutate: (...args: any[]) => mockRenameTagMutate(...args) },
-    updateTagsMutation: { isPending: false, mutate: (...args: any[]) => mockUpdateTagsMutate(...args) },
+    updateTagsMutation: {
+      isPending: false,
+      mutate: (...args: any[]) => mockUpdateTagsMutate(...args),
+      mutateAsync: (...args: any[]) => {
+        mockUpdateTagsMutate(...args);
+        return Promise.resolve();
+      },
+    },
     lastBackupInfo: null,
     isSaving: false,
   }),
@@ -848,7 +855,11 @@ describe('SettingsPage', () => {
 
     fireEvent.click(screen.getByText('tags-change'));
 
-    expect(mockUpdateTagsMutate).toHaveBeenCalledWith(['a', 'b']);
+    // Saves are serialized through a promise chain, so the PATCH fires on a
+    // microtask rather than synchronously.
+    await waitFor(() => {
+      expect(mockUpdateTagsMutate).toHaveBeenCalledWith(['a', 'b']);
+    });
   });
 
   it('handles sticky save button and confirmation modal confirm/close actions', async () => {

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -29,6 +29,7 @@ const mockMergeDatabaseMutate = vi.fn();
 const mockCleanupBackupDatabasesMutate = vi.fn();
 const mockRestoreFromLastBackupMutate = vi.fn();
 const mockRenameTagMutate = vi.fn();
+const mockUpdateTagsMutate = vi.fn();
 
 const mockSetShowDeleteLegacyModal = vi.fn();
 const mockSetShowCleanupAuthorCollectionsModal = vi.fn();
@@ -152,6 +153,7 @@ vi.mock('../../hooks/useSettingsMutations', () => ({
     cleanupBackupDatabasesMutation: { isPending: false, mutate: (...args: any[]) => mockCleanupBackupDatabasesMutate(...args) },
     restoreFromLastBackupMutation: { isPending: false, mutate: (...args: any[]) => mockRestoreFromLastBackupMutate(...args) },
     renameTagMutation: { isPending: false, mutate: (...args: any[]) => mockRenameTagMutate(...args) },
+    updateTagsMutation: { isPending: false, mutate: (...args: any[]) => mockUpdateTagsMutate(...args) },
     lastBackupInfo: null,
     isSaving: false,
   }),
@@ -839,6 +841,14 @@ describe('SettingsPage', () => {
     expect(mockRestoreFromLastBackupMutate).toHaveBeenCalled();
     expect(mockRenameTagMutate).toHaveBeenCalledTimes(1);
     expect(mockSetShowCleanupTempFilesModal).toHaveBeenCalledWith(true);
+  });
+
+  it('persists tag changes immediately via updateTagsMutation', async () => {
+    renderPage('/settings');
+
+    fireEvent.click(screen.getByText('tags-change'));
+
+    expect(mockUpdateTagsMutate).toHaveBeenCalledWith(['a', 'b']);
   });
 
   it('handles sticky save button and confirmation modal confirm/close actions', async () => {


### PR DESCRIPTION
## Problem

Tags added through the video player never reached the global tags directory, so they were missing from the **Tags Manager** and **autocomplete suggestions**. There were also a couple of small UX/contrast issues nearby.

## Changes

**Backend**
- Added `addTagsToGlobalSettings()` in `tagService.ts` — case-insensitive, deduped, sorted, non-throwing (returns `false` + logs on failure so it never breaks the video update).
- Call it from `updateVideo` after a successful update; idempotent (dedup means the second call from the optimistic `TagsModal` save is a no-op).
- Added tests for add / init / dedup / empty input / no-throw paths.

**Frontend**
- Added a tags-only `updateTagsMutation` so editing tags in Settings persists immediately, instead of waiting on the global Save. The global Save button's `isSaving` state now includes it.
- `updateTagsMutation.onError` invalidates the `["settings"]` query to revert optimistic local state back to server truth on failure.
- Mobile: use the centered `TagsModal` where inline autocomplete was cramped by the on-screen keyboard. Moved the `allOptions` computation past the mobile early return so it isn't computed there.

**UI**
- `VideoCardThumbnail` selected-state chip now uses `theme.palette.primary.contrastText` instead of hardcoded white, so it stays legible in dark mode.

## Verification

| Check | Result |
|---|---|
| Backend `tagService.test.ts` | 10/10 pass |
| Frontend `SettingsPage.test.tsx` | 23/23 pass |
| Frontend `tsc --noEmit` | clean |
| Backend `tsc --noEmit` | clean |
| Frontend ESLint (changed files) | no warnings |