### PR TITLE
[codex] Fix security advisory triage findings

### DIFF
--- a/backend/src/__tests__/controllers/statisticsController.test.ts
+++ b/backend/src/__tests__/controllers/statisticsController.test.ts
@@ -433,7 +433,7 @@ describe("statisticsController", () => {
     expect(res.status).toHaveBeenCalledWith(400);
   });
 
-  it("overwrites visitor-controlled statistics dimensions before ingest", async () => {
+  it("passes a server-derived visitor session to the batch ingester", async () => {
     const req: any = {
       body: {
         events: [
@@ -457,16 +457,19 @@ describe("statisticsController", () => {
     await ingestEvents(req, res);
 
     const [eventsArg, optionsArg] = mockIngestBatch.mock.calls[0];
-    expect(optionsArg).toEqual({ actorRole: "visitor", surface: "web" });
+    expect(optionsArg).toEqual({
+      actorRole: "visitor",
+      surface: "web",
+      serverSessionId: expect.stringMatching(/^web:[a-f0-9]{32}$/),
+    });
     expect(eventsArg[0]).toMatchObject({
       eventType: "video_play_started",
-      sessionId: expect.stringMatching(/^web:[a-f0-9]{32}$/),
-      platform: "unknown",
-      sourceKind: "unknown",
-      surface: "web",
+      sessionId: "attacker-session",
+      platform: "youtube",
+      sourceKind: "subscription",
+      surface: "api",
       videoId: "video-1",
     });
-    expect(eventsArg[0].sessionId).not.toBe("attacker-session");
   });
 
   it("preserves admin statistics dimensions for normal dashboard analytics", async () => {

--- a/backend/src/__tests__/controllers/statisticsController.test.ts
+++ b/backend/src/__tests__/controllers/statisticsController.test.ts
@@ -432,4 +432,118 @@ describe("statisticsController", () => {
 
     expect(res.status).toHaveBeenCalledWith(400);
   });
+
+  it("overwrites visitor-controlled statistics dimensions before ingest", async () => {
+    const req: any = {
+      body: {
+        events: [
+          {
+            eventType: "video_play_started",
+            sessionId: "attacker-session",
+            platform: "youtube",
+            sourceKind: "subscription",
+            surface: "api",
+            videoId: "video-1",
+          },
+        ],
+      },
+      headers: { "x-mytube-client": "extension" },
+      cookies: { mytube_auth_session: "server-session-1" },
+      user: { role: "visitor", id: "visitor-1" },
+      apiKeyAuthenticated: false,
+    };
+    const res = createResponse();
+
+    await ingestEvents(req, res);
+
+    const [eventsArg, optionsArg] = mockIngestBatch.mock.calls[0];
+    expect(optionsArg).toEqual({ actorRole: "visitor", surface: "web" });
+    expect(eventsArg[0]).toMatchObject({
+      eventType: "video_play_started",
+      sessionId: expect.stringMatching(/^web:[a-f0-9]{32}$/),
+      platform: "unknown",
+      sourceKind: "unknown",
+      surface: "web",
+      videoId: "video-1",
+    });
+    expect(eventsArg[0].sessionId).not.toBe("attacker-session");
+  });
+
+  it("preserves admin statistics dimensions for normal dashboard analytics", async () => {
+    const req: any = {
+      body: {
+        events: [
+          {
+            eventType: "search_submitted",
+            sessionId: "admin-session",
+            platform: "youtube",
+            sourceKind: "search_result",
+            surface: "web",
+          },
+        ],
+      },
+      headers: {},
+      user: { role: "admin" },
+      apiKeyAuthenticated: false,
+    };
+    const res = createResponse();
+
+    await ingestEvents(req, res);
+
+    const [eventsArg, optionsArg] = mockIngestBatch.mock.calls[0];
+    expect(optionsArg).toEqual({ actorRole: "admin", surface: "web" });
+    expect(eventsArg[0]).toMatchObject({
+      sessionId: "admin-session",
+      platform: "youtube",
+      sourceKind: "search_result",
+      surface: "web",
+    });
+  });
+
+  it("rate limits visitor events by server-derived session, not client sessionId", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:02:00Z"));
+
+    try {
+      for (let i = 0; i < 6; i += 1) {
+        const req: any = {
+          body: { events: createEvents(50, `forged-session-${i}`) },
+          headers: {},
+          cookies: { mytube_auth_session: "visitor-rate-limit-session" },
+          user: { role: "visitor", id: "visitor-1" },
+          apiKeyAuthenticated: false,
+        };
+        const res = createResponse();
+
+        await ingestEvents(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(202);
+        expect(res.json).toHaveBeenCalledWith({
+          acceptedCount: 50,
+          droppedCount: 0,
+          sealedDayDropCount: 0,
+        });
+      }
+
+      const req: any = {
+        body: { events: createEvents(1, "fresh-forged-session") },
+        headers: {},
+        cookies: { mytube_auth_session: "visitor-rate-limit-session" },
+        user: { role: "visitor", id: "visitor-1" },
+        apiKeyAuthenticated: false,
+      };
+      const res = createResponse();
+
+      await ingestEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({
+        acceptedCount: 0,
+        droppedCount: 1,
+        sealedDayDropCount: 0,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/backend/src/__tests__/middleware/csrfMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/csrfMiddleware.test.ts
@@ -1,15 +1,27 @@
 import cookieParser from "cookie-parser";
 import express from "express";
 import request from "supertest";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   csrfProtection,
   csrfTokenProvider,
   refreshCsrfTokenForSession,
 } from "../../middleware/csrfMiddleware";
 import { clearAuthCookie, setAuthCookie } from "../../services/authService";
+import { getSettings } from "../../services/storageService";
+
+vi.mock("../../services/storageService", () => ({
+  getSettings: vi.fn(),
+}));
 
 describe("csrfMiddleware", () => {
+  beforeEach(() => {
+    vi.mocked(getSettings).mockReturnValue({
+      apiKeyEnabled: true,
+      apiKey: "automation-key",
+    } as any);
+  });
+
   const buildApp = () => {
     const app = express();
     app.use(cookieParser());
@@ -124,7 +136,7 @@ describe("csrfMiddleware", () => {
     expect(loginAgainResponse.status).toBe(200);
   });
 
-  it("lets non-RSS API-key requests bypass CSRF but still protects RSS management", async () => {
+  it("lets valid non-RSS API-key requests bypass CSRF but still protects RSS management", async () => {
     const agent = request.agent(buildApp());
 
     const protectedResponse = await agent
@@ -140,5 +152,16 @@ describe("csrfMiddleware", () => {
       .send({});
 
     expect(rssManagementResponse.status).toBe(403);
+  });
+
+  it("does not bypass CSRF for an arbitrary X-API-Key header value", async () => {
+    const agent = request.agent(buildApp());
+
+    const protectedResponse = await agent
+      .post("/api/protected")
+      .set("X-API-Key", "wrong-key")
+      .send({});
+
+    expect(protectedResponse.status).toBe(403);
   });
 });

--- a/backend/src/__tests__/services/statistics/collector.test.ts
+++ b/backend/src/__tests__/services/statistics/collector.test.ts
@@ -338,6 +338,46 @@ describe("statistics collector", () => {
 
       expect(result.acceptedCount).toBe(1);
     });
+
+    it("neutralizes visitor-controlled classification and numeric fields", () => {
+      const runMock = vi.fn();
+      vi.mocked(sqlite.prepare)
+        .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
+        .mockReturnValueOnce(makeStmt({ get: undefined }) as any)     // isDaySealed
+        .mockReturnValueOnce(makeStmt() as any)                       // markDayDirty
+        .mockReturnValueOnce(makeStmt() as any);                      // bumpIngestionMinute
+
+      const result = ingestBatch(
+        [
+          {
+            eventType: "video_watch_chunk_recorded",
+            sessionId: "attacker-session",
+            platform: "youtube",
+            sourceKind: "subscription",
+            surface: "api",
+            videoId: "video-1",
+            durationSeconds: 86_400,
+            value: 999,
+            payload: { forged: true },
+          },
+        ],
+        {
+          actorRole: "visitor",
+          surface: "web",
+          serverSessionId: "web:server-derived-session",
+        }
+      );
+
+      expect(result.acceptedCount).toBe(1);
+      const insertedArgs = runMock.mock.calls[0];
+      expect(insertedArgs[7]).toBe("web");
+      expect(insertedArgs[8]).toBe("web:server-derived-session");
+      expect(insertedArgs[14]).toBe("unknown");
+      expect(insertedArgs[15]).toBe("unknown");
+      expect(insertedArgs[16]).toBeNull();
+      expect(insertedArgs[17]).toBeNull();
+      expect(insertedArgs[18]).toBe("{}");
+    });
   });
 
   describe("invalidateStatisticsSettingsCache", () => {

--- a/backend/src/__tests__/services/statistics/collector.test.ts
+++ b/backend/src/__tests__/services/statistics/collector.test.ts
@@ -339,7 +339,7 @@ describe("statistics collector", () => {
       expect(result.acceptedCount).toBe(1);
     });
 
-    it("neutralizes visitor-controlled classification and numeric fields", () => {
+    it("neutralizes visitor-controlled classification and bounds watch duration", () => {
       const runMock = vi.fn();
       vi.mocked(sqlite.prepare)
         .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
@@ -374,9 +374,50 @@ describe("statistics collector", () => {
       expect(insertedArgs[8]).toBe("web:server-derived-session");
       expect(insertedArgs[14]).toBe("unknown");
       expect(insertedArgs[15]).toBe("unknown");
-      expect(insertedArgs[16]).toBeNull();
+      expect(insertedArgs[16]).toBe(120);
       expect(insertedArgs[17]).toBeNull();
       expect(insertedArgs[18]).toBe("{}");
+    });
+
+    it("preserves bounded visitor search result counts without query text", () => {
+      const runMock = vi.fn();
+      vi.mocked(sqlite.prepare)
+        .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
+        .mockReturnValueOnce(makeStmt({ get: undefined }) as any)     // isDaySealed
+        .mockReturnValueOnce(makeStmt() as any)                       // markDayDirty
+        .mockReturnValueOnce(makeStmt() as any);                      // bumpIngestionMinute
+
+      const result = ingestBatch(
+        [
+          {
+            eventType: "search_submitted",
+            sessionId: "attacker-session",
+            platform: "youtube",
+            sourceKind: "subscription",
+            surface: "api",
+            payload: {
+              queryText: "private search",
+              localResultCount: 2.4,
+              externalResultCount: 99_999,
+              extra: "dropped",
+            },
+          },
+        ],
+        {
+          actorRole: "visitor",
+          surface: "web",
+          serverSessionId: "web:server-derived-session",
+        }
+      );
+
+      expect(result.acceptedCount).toBe(1);
+      const insertedArgs = runMock.mock.calls[0];
+      expect(insertedArgs[14]).toBe("unknown");
+      expect(insertedArgs[15]).toBe("unknown");
+      expect(JSON.parse(insertedArgs[18])).toEqual({
+        localResultCount: 2,
+        externalResultCount: 10_000,
+      });
     });
   });
 

--- a/backend/src/__tests__/utils/apiKeyAuth.test.ts
+++ b/backend/src/__tests__/utils/apiKeyAuth.test.ts
@@ -1,0 +1,43 @@
+import { Request } from "express";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isApiKeyAuthorized } from "../../utils/apiKeyAuth";
+import { getSettings } from "../../services/storageService";
+
+vi.mock("../../services/storageService", () => ({
+  getSettings: vi.fn(),
+}));
+
+describe("apiKeyAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSettings).mockReturnValue({
+      apiKeyEnabled: true,
+      apiKey: "valid-key",
+    } as any);
+  });
+
+  it("caches authorization on the request object", () => {
+    const req = {
+      headers: { "x-api-key": "valid-key" },
+    } as unknown as Request;
+
+    expect(isApiKeyAuthorized(req)).toBe(true);
+    expect(isApiKeyAuthorized(req)).toBe(true);
+
+    expect(getSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share cached authorization across requests", () => {
+    const firstReq = {
+      headers: { "x-api-key": "valid-key" },
+    } as unknown as Request;
+    const secondReq = {
+      headers: { "x-api-key": "valid-key" },
+    } as unknown as Request;
+
+    expect(isApiKeyAuthorized(firstReq)).toBe(true);
+    expect(isApiKeyAuthorized(secondReq)).toBe(true);
+
+    expect(getSettings).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/controllers/statisticsController.ts
+++ b/backend/src/controllers/statisticsController.ts
@@ -13,7 +13,6 @@ import {
   recomputeAllUnsealedDays,
   shouldTrackVisitorActivity,
 } from "../services/statistics";
-import { getAuthCookieName } from "../services/authService";
 import { getClientIp } from "../utils/security";
 import { logger } from "../utils/logger";
 import { getLimitParam, getPositiveIntegerParam } from "../utils/paramUtils";
@@ -104,13 +103,14 @@ const getServerDerivedSessionId = (
   req: Request,
   surface: "web" | "extension" | "api"
 ): string => {
-  const authCookieName = getAuthCookieName();
-  const authSessionCookie =
-    typeof req.cookies?.[authCookieName] === "string"
-      ? req.cookies[authCookieName]
-      : "";
+  // req.user is only ever populated by authMiddleware after verifying the
+  // session cookie server-side or checking a JWT signature, so it's the only
+  // safe identity source here. The raw `req.cookies` value must not be used:
+  // a request can carry an unverified/stale auth cookie alongside a valid
+  // Bearer token, and authMiddleware still resolves req.user from the token
+  // in that case, leaving the raw cookie value attacker-controlled.
   const userId = typeof req.user?.id === "string" ? req.user.id : "";
-  const basis = authSessionCookie || userId || getClientIp(req);
+  const basis = userId || getClientIp(req);
   return `${surface}:${hashServerSessionBasis(basis)}`;
 };
 

--- a/backend/src/controllers/statisticsController.ts
+++ b/backend/src/controllers/statisticsController.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import express, { Request, RequestHandler, Response } from "express";
 import {
   clearAllStatisticsData,
@@ -22,6 +23,7 @@ const MAX_REQUEST_SIZE_BYTES = 128 * 1024;
 const MAX_REQUEST_SIZE_LABEL = "128kb";
 const MAX_EVENTS_PER_SESSION_PER_MINUTE = 300;
 const EXPORT_FILENAME_BASE = "statistics-export";
+const SERVER_SESSION_HASH_LENGTH = 32;
 
 type SessionEventQuota = {
   count: number;
@@ -88,6 +90,55 @@ const detectSurface = (req: Request): "web" | "extension" | "api" => {
   }
   if (req.apiKeyAuthenticated === true) return "api";
   return "web";
+};
+
+const hashServerSessionBasis = (basis: string): string =>
+  crypto
+    .createHash("sha256")
+    .update(basis)
+    .digest("hex")
+    .slice(0, SERVER_SESSION_HASH_LENGTH);
+
+const getServerDerivedSessionId = (
+  req: Request,
+  surface: "web" | "extension" | "api"
+): string => {
+  const authSessionCookie =
+    typeof req.cookies?.mytube_auth_session === "string"
+      ? req.cookies.mytube_auth_session
+      : "";
+  const userId = typeof req.user?.id === "string" ? req.user.id : "";
+  const basis = authSessionCookie || userId || getClientIp(req);
+  return `${surface}:${hashServerSessionBasis(basis)}`;
+};
+
+const sanitizeVisitorEvent = (
+  event: unknown,
+  serverSessionId: string,
+  surface: "web" | "extension" | "api"
+): unknown => {
+  if (typeof event !== "object" || event === null) {
+    return event;
+  }
+
+  return {
+    ...(event as Record<string, unknown>),
+    sessionId: serverSessionId,
+    platform: "unknown",
+    sourceKind: "unknown",
+    surface,
+  };
+};
+
+const sanitizeVisitorEvents = (
+  events: unknown[],
+  req: Request,
+  surface: "web" | "extension" | "api"
+): unknown[] => {
+  const serverSessionId = getServerDerivedSessionId(req, surface);
+  return events.map((event) =>
+    sanitizeVisitorEvent(event, serverSessionId, surface)
+  );
 };
 
 const cleanupExpiredSessionQuotas = (currentMinuteBucket: number): void => {
@@ -180,10 +231,16 @@ export const ingestEvents = async (
   }
 
   const actorRole: "admin" | "visitor" = isVisitorCaller(req) ? "visitor" : "admin";
-  const surface = detectSurface(req);
-  const fallbackSessionKey = `${surface}:${getClientIp(req)}`;
+  const detectedSurface = detectSurface(req);
+  const surface = actorRole === "visitor" ? "web" : detectedSurface;
+  const eventsForIngestion =
+    actorRole === "visitor" ? sanitizeVisitorEvents(events, req, surface) : events;
+  const fallbackSessionKey =
+    actorRole === "visitor"
+      ? getServerDerivedSessionId(req, surface)
+      : `${surface}:${getClientIp(req)}`;
   const { allowedEvents, droppedCount: rateLimitedDropCount } =
-    takeSessionEventQuota(events, fallbackSessionKey);
+    takeSessionEventQuota(eventsForIngestion, fallbackSessionKey);
   const result =
     allowedEvents.length > 0
       ? ingestBatch(allowedEvents as Parameters<typeof ingestBatch>[0], {

--- a/backend/src/controllers/statisticsController.ts
+++ b/backend/src/controllers/statisticsController.ts
@@ -13,6 +13,7 @@ import {
   recomputeAllUnsealedDays,
   shouldTrackVisitorActivity,
 } from "../services/statistics";
+import { getAuthCookieName } from "../services/authService";
 import { getClientIp } from "../utils/security";
 import { logger } from "../utils/logger";
 import { getLimitParam, getPositiveIntegerParam } from "../utils/paramUtils";
@@ -103,42 +104,14 @@ const getServerDerivedSessionId = (
   req: Request,
   surface: "web" | "extension" | "api"
 ): string => {
+  const authCookieName = getAuthCookieName();
   const authSessionCookie =
-    typeof req.cookies?.mytube_auth_session === "string"
-      ? req.cookies.mytube_auth_session
+    typeof req.cookies?.[authCookieName] === "string"
+      ? req.cookies[authCookieName]
       : "";
   const userId = typeof req.user?.id === "string" ? req.user.id : "";
   const basis = authSessionCookie || userId || getClientIp(req);
   return `${surface}:${hashServerSessionBasis(basis)}`;
-};
-
-const sanitizeVisitorEvent = (
-  event: unknown,
-  serverSessionId: string,
-  surface: "web" | "extension" | "api"
-): unknown => {
-  if (typeof event !== "object" || event === null) {
-    return event;
-  }
-
-  return {
-    ...(event as Record<string, unknown>),
-    sessionId: serverSessionId,
-    platform: "unknown",
-    sourceKind: "unknown",
-    surface,
-  };
-};
-
-const sanitizeVisitorEvents = (
-  events: unknown[],
-  req: Request,
-  surface: "web" | "extension" | "api"
-): unknown[] => {
-  const serverSessionId = getServerDerivedSessionId(req, surface);
-  return events.map((event) =>
-    sanitizeVisitorEvent(event, serverSessionId, surface)
-  );
 };
 
 const cleanupExpiredSessionQuotas = (currentMinuteBucket: number): void => {
@@ -151,7 +124,8 @@ const cleanupExpiredSessionQuotas = (currentMinuteBucket: number): void => {
 
 const takeSessionEventQuota = (
   events: unknown[],
-  fallbackSessionKey: string
+  fallbackSessionKey: string,
+  options: { forceFallbackSessionKey?: boolean } = {}
 ): { allowedEvents: unknown[]; droppedCount: number } => {
   const currentMinuteBucket = Math.floor(Date.now() / 60_000);
   cleanupExpiredSessionQuotas(currentMinuteBucket);
@@ -160,13 +134,16 @@ const takeSessionEventQuota = (
   let droppedCount = 0;
 
   for (const event of events) {
-    const eventSessionId =
+    let eventSessionId = fallbackSessionKey;
+    if (
+      options.forceFallbackSessionKey !== true &&
       typeof event === "object" &&
       event !== null &&
       typeof (event as { sessionId?: unknown }).sessionId === "string" &&
       (event as { sessionId: string }).sessionId.trim().length > 0
-        ? (event as { sessionId: string }).sessionId.trim()
-        : fallbackSessionKey;
+    ) {
+      eventSessionId = (event as { sessionId: string }).sessionId.trim();
+    }
 
     const currentQuota = sessionEventQuotaByKey.get(eventSessionId);
     const quota: SessionEventQuota =
@@ -233,19 +210,22 @@ export const ingestEvents = async (
   const actorRole: "admin" | "visitor" = isVisitorCaller(req) ? "visitor" : "admin";
   const detectedSurface = detectSurface(req);
   const surface = actorRole === "visitor" ? "web" : detectedSurface;
-  const eventsForIngestion =
-    actorRole === "visitor" ? sanitizeVisitorEvents(events, req, surface) : events;
+  const visitorServerSessionId =
+    actorRole === "visitor" ? getServerDerivedSessionId(req, surface) : undefined;
   const fallbackSessionKey =
-    actorRole === "visitor"
-      ? getServerDerivedSessionId(req, surface)
-      : `${surface}:${getClientIp(req)}`;
+    visitorServerSessionId ?? `${surface}:${getClientIp(req)}`;
   const { allowedEvents, droppedCount: rateLimitedDropCount } =
-    takeSessionEventQuota(eventsForIngestion, fallbackSessionKey);
+    takeSessionEventQuota(events, fallbackSessionKey, {
+      forceFallbackSessionKey: actorRole === "visitor",
+    });
   const result =
     allowedEvents.length > 0
       ? ingestBatch(allowedEvents as Parameters<typeof ingestBatch>[0], {
           actorRole,
           surface,
+          ...(visitorServerSessionId
+            ? { serverSessionId: visitorServerSessionId }
+            : {}),
         })
       : {
           acceptedCount: 0,

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import {
+  getAuthCookieName,
   getUserPayloadFromSession,
   UserPayload,
   verifyToken,
@@ -28,7 +29,7 @@ export const authMiddleware = (
   next: NextFunction
 ): void => {
   // First, try to get user from HTTP-only session cookie (preferred method)
-  const sessionIdFromCookie = req.cookies?.mytube_auth_session;
+  const sessionIdFromCookie = req.cookies?.[getAuthCookieName()];
 
   // Security: session IDs are opaque random values. User identity is resolved
   // from trusted in-memory server-side session state only.

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -1,12 +1,10 @@
 import { NextFunction, Request, Response } from "express";
-import crypto from "crypto";
 import {
   getUserPayloadFromSession,
   UserPayload,
   verifyToken,
 } from "../services/authService";
-import * as storageService from "../services/storageService";
-import { defaultSettings } from "../types/settings";
+import { isApiKeyAuthorized } from "../utils/apiKeyAuth";
 
 // Extend Express Request type to include user property
 declare global {
@@ -17,77 +15,6 @@ declare global {
     }
   }
 }
-
-const readHeaderValue = (
-  value: string | string[] | undefined
-): string | undefined => {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (Array.isArray(value) && value.length > 0) {
-    return value[0];
-  }
-  return undefined;
-};
-
-const getApiKeyFromRequest = (req: Request): string | null => {
-  const directHeaderKey = readHeaderValue(req.headers["x-api-key"]);
-  if (typeof directHeaderKey === "string" && directHeaderKey.trim().length > 0) {
-    return directHeaderKey.trim();
-  }
-
-  const authorizationHeader = readHeaderValue(req.headers.authorization);
-  if (
-    typeof authorizationHeader === "string" &&
-    authorizationHeader.startsWith("ApiKey ")
-  ) {
-    const apiKey = authorizationHeader.slice("ApiKey ".length).trim();
-    return apiKey.length > 0 ? apiKey : null;
-  }
-
-  return null;
-};
-
-const isApiKeyMatch = (providedApiKey: string, storedApiKey: string): boolean => {
-  // Compare API keys in constant time without using a password-hash primitive.
-  // Buffers are zero-padded to equal length so timingSafeEqual can be used safely.
-  const providedBuffer = Buffer.from(providedApiKey, "utf8");
-  const storedBuffer = Buffer.from(storedApiKey, "utf8");
-  const maxLength = Math.max(providedBuffer.length, storedBuffer.length);
-
-  const paddedProvided = Buffer.alloc(maxLength);
-  const paddedStored = Buffer.alloc(maxLength);
-  providedBuffer.copy(paddedProvided);
-  storedBuffer.copy(paddedStored);
-
-  const sameLength = providedBuffer.length === storedBuffer.length;
-  const equal = crypto.timingSafeEqual(paddedProvided, paddedStored);
-
-  return sameLength && equal;
-};
-
-const isApiKeyAuthorized = (req: Request): boolean => {
-  const providedApiKey = getApiKeyFromRequest(req);
-  if (!providedApiKey) {
-    return false;
-  }
-
-  const settings = storageService.getSettings();
-  const mergedSettings = { ...defaultSettings, ...settings };
-  if (mergedSettings.apiKeyEnabled !== true) {
-    return false;
-  }
-
-  const storedApiKey =
-    typeof mergedSettings.apiKey === "string"
-      ? mergedSettings.apiKey.trim()
-      : "";
-  if (storedApiKey.length === 0) {
-    return false;
-  }
-
-  return isApiKeyMatch(providedApiKey, storedApiKey);
-};
 
 /**
  * Middleware to resolve authenticated user and attach user to request

--- a/backend/src/middleware/csrfConfig.ts
+++ b/backend/src/middleware/csrfConfig.ts
@@ -1,5 +1,6 @@
 import { Request } from "express";
 import crypto from "crypto";
+import { isApiKeyAuthorized } from "../utils/apiKeyAuth";
 
 export const CSRF_SECRET =
   process.env.CSRF_SECRET || crypto.randomBytes(32).toString("hex");
@@ -34,12 +35,5 @@ export const isRssManagementRequest = (req: Request): boolean => {
   );
 };
 
-export const isApiKeyRequest = (req: Request): boolean => {
-  return Boolean(
-    req.headers["x-api-key"] ||
-      req.headers.authorization?.startsWith("ApiKey ")
-  );
-};
-
 export const shouldSkipCsrfProtection = (req: Request): boolean =>
-  !isRssManagementRequest(req) && isApiKeyRequest(req);
+  !isRssManagementRequest(req) && isApiKeyAuthorized(req);

--- a/backend/src/middleware/csrfConfig.ts
+++ b/backend/src/middleware/csrfConfig.ts
@@ -1,5 +1,6 @@
 import { Request } from "express";
 import crypto from "crypto";
+import { getAuthCookieName } from "../services/authService";
 import { isApiKeyAuthorized } from "../utils/apiKeyAuth";
 
 export const CSRF_SECRET =
@@ -17,7 +18,7 @@ export const csrfCookieOptions = {
 };
 
 export const getCsrfSessionIdentifier = (req: Request): string =>
-  req.cookies?.mytube_auth_session ?? "anonymous";
+  req.cookies?.[getAuthCookieName()] ?? "anonymous";
 
 export const getCsrfTokenFromRequest = (
   req: Request

--- a/backend/src/middleware/csrfMiddleware.ts
+++ b/backend/src/middleware/csrfMiddleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { doubleCsrf } from "csrf-csrf";
+import { getAuthCookieName } from "../services/authService";
 import {
   CSRF_COOKIE_NAME,
   CSRF_IGNORED_METHODS,
@@ -89,11 +90,12 @@ export const refreshCsrfTokenForSession = (
   // Keep req.cookies aligned with the session cookie we just issued/cleared on
   // the response so the regenerated CSRF token is bound to the new session.
   req.cookies = req.cookies ?? {};
+  const authCookieName = getAuthCookieName();
 
   if (sessionId) {
-    req.cookies.mytube_auth_session = sessionId;
+    req.cookies[authCookieName] = sessionId;
   } else {
-    req.cookies.mytube_auth_session = undefined;
+    req.cookies[authCookieName] = undefined;
   }
 
   return setCsrfTokenHeader(req, res, { overwrite: true });

--- a/backend/src/middleware/requireAdmin.ts
+++ b/backend/src/middleware/requireAdmin.ts
@@ -1,9 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { isLoginRequired } from "../services/passwordService";
-
-const hasApiKeyCredential = (req: Request): boolean =>
-  Boolean(req.headers["x-api-key"]) ||
-  req.headers.authorization?.startsWith("ApiKey ") === true;
+import { hasApiKeyCredential } from "../utils/apiKeyAuth";
 
 export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
   if (req.apiKeyAuthenticated === true || hasApiKeyCredential(req)) {

--- a/backend/src/services/statistics/collector.ts
+++ b/backend/src/services/statistics/collector.ts
@@ -377,16 +377,42 @@ export interface BatchIngestResult {
   sealedDayDropCount: number;
 }
 
+interface BatchIngestOptions {
+  actorRole: "admin" | "visitor";
+  surface: string;
+  serverSessionId?: string;
+}
+
 const FRONTEND_ALLOWED_TYPES: ReadonlySet<StatisticsEventType> = new Set<StatisticsEventType>([
   "search_submitted",
   "video_play_started",
   "video_watch_chunk_recorded",
 ]);
 
+function sanitizeBatchEventForActor(
+  event: BatchIngestEvent,
+  options: BatchIngestOptions
+): BatchIngestEvent {
+  if (options.actorRole !== "visitor") {
+    return event;
+  }
+
+  return {
+    ...event,
+    sessionId: options.serverSessionId,
+    platform: "unknown",
+    sourceKind: "unknown",
+    surface: normalizeSurface(options.surface),
+    durationSeconds: undefined,
+    value: undefined,
+    payload: undefined,
+  };
+}
+
 // Best-effort batch ingestion for the dedicated POST /api/statistics/events route.
 export function ingestBatch(
   events: BatchIngestEvent[],
-  options: { actorRole: "admin" | "visitor"; surface: string }
+  options: BatchIngestOptions
 ): BatchIngestResult {
   const result: BatchIngestResult = {
     acceptedCount: 0,
@@ -413,6 +439,7 @@ export function ingestBatch(
         continue;
       }
       try {
+        const safeEvent = sanitizeBatchEventForActor(evt, options);
         const recordedAt = Date.now();
         const day = dayBucket(recordedAt, tz);
         if (isDaySealed(day)) {
@@ -424,18 +451,18 @@ export function ingestBatch(
           ins,
           buildPersistedStatisticsEvent(
             {
-              ...evt,
+              ...safeEvent,
               actorRole: options.actorRole,
-              eventType: evt.eventType,
-              platform: evt.platform ? normalizePlatform(evt.platform) : null,
-              sourceKind: evt.sourceKind ? normalizeSourceKind(evt.sourceKind) : null,
+              eventType: safeEvent.eventType,
+              platform: safeEvent.platform ? normalizePlatform(safeEvent.platform) : null,
+              sourceKind: safeEvent.sourceKind ? normalizeSourceKind(safeEvent.sourceKind) : null,
               surface: normalizeSurface(options.surface),
             },
             {
               recordedAt,
               day,
-              clientOccurredAt: sanitizeClientOccurredAt(evt.clientOccurredAt, recordedAt),
-              surface: normalizeSurface(evt.surface ?? options.surface ?? "web"),
+              clientOccurredAt: sanitizeClientOccurredAt(safeEvent.clientOccurredAt, recordedAt),
+              surface: normalizeSurface(safeEvent.surface ?? options.surface ?? "web"),
               subscriptionId: null,
               rssTokenId: null,
             }

--- a/backend/src/services/statistics/collector.ts
+++ b/backend/src/services/statistics/collector.ts
@@ -389,6 +389,49 @@ const FRONTEND_ALLOWED_TYPES: ReadonlySet<StatisticsEventType> = new Set<Statist
   "video_watch_chunk_recorded",
 ]);
 
+const MAX_VISITOR_WATCH_CHUNK_SECONDS = 120;
+const MAX_VISITOR_SEARCH_RESULT_COUNT = 10_000;
+
+function sanitizeBoundedInteger(
+  value: unknown,
+  maxValue: number
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  return Math.min(Math.max(Math.round(value), 0), maxValue);
+}
+
+function sanitizeVisitorDurationSeconds(event: BatchIngestEvent): number | undefined {
+  if (event.eventType !== "video_watch_chunk_recorded") {
+    return undefined;
+  }
+  return sanitizeBoundedInteger(
+    event.durationSeconds,
+    MAX_VISITOR_WATCH_CHUNK_SECONDS
+  );
+}
+
+function sanitizeVisitorPayload(event: BatchIngestEvent): Record<string, unknown> | undefined {
+  if (event.eventType !== "search_submitted") {
+    return undefined;
+  }
+
+  const payload = event.payload ?? {};
+  return {
+    localResultCount:
+      sanitizeBoundedInteger(
+        payload.localResultCount,
+        MAX_VISITOR_SEARCH_RESULT_COUNT
+      ) ?? 0,
+    externalResultCount:
+      sanitizeBoundedInteger(
+        payload.externalResultCount,
+        MAX_VISITOR_SEARCH_RESULT_COUNT
+      ) ?? 0,
+  };
+}
+
 function sanitizeBatchEventForActor(
   event: BatchIngestEvent,
   options: BatchIngestOptions
@@ -403,9 +446,9 @@ function sanitizeBatchEventForActor(
     platform: "unknown",
     sourceKind: "unknown",
     surface: normalizeSurface(options.surface),
-    durationSeconds: undefined,
+    durationSeconds: sanitizeVisitorDurationSeconds(event),
     value: undefined,
-    payload: undefined,
+    payload: sanitizeVisitorPayload(event),
   };
 }
 

--- a/backend/src/utils/apiKeyAuth.ts
+++ b/backend/src/utils/apiKeyAuth.ts
@@ -1,0 +1,75 @@
+import { Request } from "express";
+import crypto from "crypto";
+import * as storageService from "../services/storageService";
+import { defaultSettings } from "../types/settings";
+
+export const readHeaderValue = (
+  value: string | string[] | undefined
+): string | undefined => {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value) && value.length > 0) {
+    return value[0];
+  }
+  return undefined;
+};
+
+export const getApiKeyFromRequest = (req: Request): string | null => {
+  const directHeaderKey = readHeaderValue(req.headers["x-api-key"]);
+  if (typeof directHeaderKey === "string" && directHeaderKey.trim().length > 0) {
+    return directHeaderKey.trim();
+  }
+
+  const authorizationHeader = readHeaderValue(req.headers.authorization);
+  if (
+    typeof authorizationHeader === "string" &&
+    authorizationHeader.startsWith("ApiKey ")
+  ) {
+    const apiKey = authorizationHeader.slice("ApiKey ".length).trim();
+    return apiKey.length > 0 ? apiKey : null;
+  }
+
+  return null;
+};
+
+const isApiKeyMatch = (providedApiKey: string, storedApiKey: string): boolean => {
+  // Compare API keys in constant time without using a password-hash primitive.
+  // Buffers are zero-padded to equal length so timingSafeEqual can be used safely.
+  const providedBuffer = Buffer.from(providedApiKey, "utf8");
+  const storedBuffer = Buffer.from(storedApiKey, "utf8");
+  const maxLength = Math.max(providedBuffer.length, storedBuffer.length);
+
+  const paddedProvided = Buffer.alloc(maxLength);
+  const paddedStored = Buffer.alloc(maxLength);
+  providedBuffer.copy(paddedProvided);
+  storedBuffer.copy(paddedStored);
+
+  const sameLength = providedBuffer.length === storedBuffer.length;
+  const equal = crypto.timingSafeEqual(paddedProvided, paddedStored);
+
+  return sameLength && equal;
+};
+
+export const isApiKeyAuthorized = (req: Request): boolean => {
+  const providedApiKey = getApiKeyFromRequest(req);
+  if (!providedApiKey) {
+    return false;
+  }
+
+  const settings = storageService.getSettings();
+  const mergedSettings = { ...defaultSettings, ...settings };
+  if (mergedSettings.apiKeyEnabled !== true) {
+    return false;
+  }
+
+  const storedApiKey =
+    typeof mergedSettings.apiKey === "string"
+      ? mergedSettings.apiKey.trim()
+      : "";
+  if (storedApiKey.length === 0) {
+    return false;
+  }
+
+  return isApiKeyMatch(providedApiKey, storedApiKey);
+};

--- a/backend/src/utils/apiKeyAuth.ts
+++ b/backend/src/utils/apiKeyAuth.ts
@@ -3,6 +3,8 @@ import crypto from "crypto";
 import * as storageService from "../services/storageService";
 import { defaultSettings } from "../types/settings";
 
+const requestApiKeyAuthorizationCache = new WeakMap<Request, boolean>();
+
 export const readHeaderValue = (
   value: string | string[] | undefined
 ): string | undefined => {
@@ -33,6 +35,19 @@ export const getApiKeyFromRequest = (req: Request): string | null => {
   return null;
 };
 
+export const hasApiKeyCredential = (req: Request): boolean => {
+  const directHeaderKey = readHeaderValue(req.headers["x-api-key"]);
+  if (typeof directHeaderKey === "string" && directHeaderKey.trim().length > 0) {
+    return true;
+  }
+
+  const authorizationHeader = readHeaderValue(req.headers.authorization);
+  return (
+    typeof authorizationHeader === "string" &&
+    authorizationHeader.startsWith("ApiKey ")
+  );
+};
+
 const isApiKeyMatch = (providedApiKey: string, storedApiKey: string): boolean => {
   // Compare API keys in constant time without using a password-hash primitive.
   // Buffers are zero-padded to equal length so timingSafeEqual can be used safely.
@@ -52,14 +67,21 @@ const isApiKeyMatch = (providedApiKey: string, storedApiKey: string): boolean =>
 };
 
 export const isApiKeyAuthorized = (req: Request): boolean => {
+  const cachedResult = requestApiKeyAuthorizationCache.get(req);
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
   const providedApiKey = getApiKeyFromRequest(req);
   if (!providedApiKey) {
+    requestApiKeyAuthorizationCache.set(req, false);
     return false;
   }
 
   const settings = storageService.getSettings();
   const mergedSettings = { ...defaultSettings, ...settings };
   if (mergedSettings.apiKeyEnabled !== true) {
+    requestApiKeyAuthorizationCache.set(req, false);
     return false;
   }
 
@@ -68,8 +90,11 @@ export const isApiKeyAuthorized = (req: Request): boolean => {
       ? mergedSettings.apiKey.trim()
       : "";
   if (storedApiKey.length === 0) {
+    requestApiKeyAuthorizationCache.set(req, false);
     return false;
   }
 
-  return isApiKeyMatch(providedApiKey, storedApiKey);
+  const isAuthorized = isApiKeyMatch(providedApiKey, storedApiKey);
+  requestApiKeyAuthorizationCache.set(req, isAuthorized);
+  return isAuthorized;
 };


### PR DESCRIPTION
## Summary

Fixes the two MyTube-applicable security advisory findings from the 2026-06-30 triage report.

- Validate configured API keys before allowing requests to bypass CSRF protection, so arbitrary `X-API-Key` header values no longer skip CSRF checks.
- Sanitize visitor statistics ingestion by deriving visitor session identity server-side and overwriting visitor-controlled analytics classification fields.
- Confirmed the remaining three open triage advisories are not applicable to this repository because they target unrelated Go/C# projects and paths absent from MyTube.

## Root Cause

The CSRF skip logic previously checked only for API-key header presence before authentication middleware validated the key value. Visitor statistics ingestion also trusted client-supplied `sessionId`, `platform`, `sourceKind`, and `surface` fields when visitor activity tracking was enabled.

## Validation

- `cd backend && npm run build`
- `cd backend && npm test`