### PR TITLE
fix(missav): survive navigation timeouts and disable IPv6 in containers

### DIFF
--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -758,6 +758,49 @@ describe("videoDownloadController extra coverage", () => {
     expect(downloadManager.updateTaskTitle).not.toHaveBeenCalled();
   });
 
+  it("downloadVideo skips queued MissAV title lookup to avoid extra Puppeteer work", async () => {
+    req.body = { youtubeUrl: "https://missav.ws/cn/san-467" };
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://missav.ws/cn/san-467",
+      sourceVideoId: "san-467",
+      platform: "missav",
+    } as any);
+    vi.mocked(isMissAVUrl).mockReturnValue(true);
+    vi.mocked(getMissAVPlaceholderTitle).mockReturnValue("MissAV: SAN-467");
+    vi.mocked(downloadService.downloadMissAVVideo).mockResolvedValue({
+      id: "video-missav",
+      title: "Real MissAV Title",
+    } as any);
+    vi.mocked(storageService.getDownloadStatus).mockReturnValue({
+      activeDownloads: [],
+      queuedDownloads: [
+        { id: "queued-missav", title: "MissAV: SAN-467", timestamp: Date.now() },
+      ],
+    } as any);
+
+    await downloadVideo(req as Request, res as Response);
+    await flushBackgroundTasks();
+
+    expect(downloadManager.addDownload).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(String),
+      "MissAV: SAN-467",
+      "https://missav.ws/cn/san-467",
+      "missav",
+      expect.objectContaining({
+        actorRole: "admin",
+        surface: "web",
+        sourceKind: "manual",
+      }),
+      undefined,
+    );
+    expect(downloadService.getVideoInfo).not.toHaveBeenCalled();
+    expect(downloadManager.updateTaskTitle).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, message: "Download queued" })
+    );
+  });
+
   it("downloadVideo handles bilibili collection download task", async () => {
     req.body = {
       youtubeUrl: "https://www.bilibili.com/video/BV1xx",

--- a/backend/src/__tests__/services/downloadManager.test.ts
+++ b/backend/src/__tests__/services/downloadManager.test.ts
@@ -1095,20 +1095,31 @@ describe('DownloadManager', () => {
 
     it('should clear queue explicitly', async () => {
       downloadManager.setMaxConcurrentDownloads(0);
-      downloadManager.addDownload(
-        vi.fn().mockResolvedValue({ success: true }),
+      const queuedOneFn = vi.fn().mockResolvedValue({ success: true });
+      const queuedTwoFn = vi.fn().mockResolvedValue({ success: true });
+      const queuedOne = downloadManager.addDownload(
+        queuedOneFn,
         'queued-1',
         'Queued 1',
       );
-      downloadManager.addDownload(
-        vi.fn().mockResolvedValue({ success: true }),
+      const queuedTwo = downloadManager.addDownload(
+        queuedTwoFn,
         'queued-2',
         'Queued 2',
       );
       await waitForQueue();
+      const queuedOneRejection = expect(queuedOne).rejects.toThrow(
+        'Download cancelled by user',
+      );
+      const queuedTwoRejection = expect(queuedTwo).rejects.toThrow(
+        'Download cancelled by user',
+      );
 
       downloadManager.clearQueue();
 
+      await Promise.all([queuedOneRejection, queuedTwoRejection]);
+      expect(queuedOneFn).not.toHaveBeenCalled();
+      expect(queuedTwoFn).not.toHaveBeenCalled();
       expect(downloadManager.getStatus().queued).toBe(0);
       expect(storageService.setQueuedDownloads).toHaveBeenCalled();
     });

--- a/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
+++ b/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
@@ -7,6 +7,7 @@ import { MissAVDownloader } from '../../../services/downloaders/MissAVDownloader
 import { cleanupTemporaryFiles, isCancellationError } from '../../../utils/downloadUtils';
 import { flagsToArgs, isYtDlpImpersonateAvailable } from '../../../utils/ytDlpUtils';
 import * as security from '../../../utils/security';
+import { logger } from '../../../utils/logger';
 
 vi.mock('puppeteer');
 vi.mock('../../../services/storageService', () => ({
@@ -282,6 +283,12 @@ describe('MissAVDownloader', () => {
       return err;
     }
 
+    function makeNavigationTimeoutError(): Error {
+      const err = new Error('Navigation timeout of 60000 ms exceeded');
+      err.name = 'TimeoutError';
+      return err;
+    }
+
     function buildPageMock(
       waitForResponseResult: 'timeout' | 'non-timeout' | 'success',
       requestCallback?: { capture: (cb: (req: { url(): string }) => void) => void },
@@ -500,6 +507,90 @@ describe('MissAVDownloader', () => {
       await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
 
       expect(mockPage.waitForResponse).not.toHaveBeenCalled();
+    });
+
+    it('continues with captured m3u8 URLs when navigation times out after capture', async () => {
+      let capturedCb: ((req: { url(): string }) => void) | null = null;
+      const requestHook = { capture: (cb: (req: { url(): string }) => void) => { capturedCb = cb; } };
+
+      const mockPage = buildPageMock('timeout', requestHook);
+      mockPage.goto.mockImplementation(async () => {
+        capturedCb?.({ url: () => 'https://surrit.com/playlist.m3u8' });
+        throw makeNavigationTimeoutError();
+      });
+
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
+
+      expect(mockPage.waitForResponse).not.toHaveBeenCalled();
+      expect(spawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.arrayContaining(['https://surrit.com/playlist.m3u8']),
+      );
+      expect(mockBrowser.close).toHaveBeenCalled();
+    });
+
+    it('re-throws navigation timeouts when no m3u8 URL was captured', async () => {
+      const mockPage = buildPageMock('timeout');
+      mockPage.goto.mockRejectedValue(makeNavigationTimeoutError());
+
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      await expect(
+        MissAVDownloader.downloadVideo('https://missav.com/test-video'),
+      ).rejects.toThrow('Navigation timeout of 60000 ms exceeded');
+
+      expect(mockPage.waitForResponse).not.toHaveBeenCalled();
+      expect(mockBrowser.close).toHaveBeenCalled();
+    });
+
+    it('logs failed browser requests before surfacing an early connection reset', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      let requestFailedCb: ((req: {
+        url(): string;
+        resourceType(): string;
+        method(): string;
+        failure(): { errorText: string };
+      }) => void) | null = null;
+
+      const resetError = new Error('net::ERR_CONNECTION_RESET at https://missav.com/test-video');
+      const mockPage = {
+        on: vi.fn((event: string, cb: typeof requestFailedCb) => {
+          if (event === 'requestfailed') requestFailedCb = cb;
+        }),
+        goto: vi.fn().mockImplementation(async () => {
+          requestFailedCb?.({
+            url: () => 'https://missav.com/test-video',
+            resourceType: () => 'document',
+            method: () => 'GET',
+            failure: () => ({ errorText: 'net::ERR_CONNECTION_RESET' }),
+          });
+          throw resetError;
+        }),
+        title: vi.fn().mockResolvedValue('Test Title'),
+        waitForFunction: vi.fn().mockResolvedValue(undefined),
+        waitForResponse: vi.fn(),
+        content: vi.fn().mockResolvedValue('<html><head></head><body></body></html>'),
+      };
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      try {
+        await expect(
+          MissAVDownloader.downloadVideo('https://missav.com/test-video'),
+        ).rejects.toThrow('net::ERR_CONNECTION_RESET');
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[MissAV request failed] resource=document method=GET error=net::ERR_CONNECTION_RESET https://missav.com/test-video',
+        );
+        expect(mockPage.waitForResponse).not.toHaveBeenCalled();
+        expect(mockBrowser.close).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('surfaces a Cloudflare challenge as a specific error', async () => {

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -448,6 +448,16 @@ export const downloadVideo = async (
       let videoTitle = initialTitle;
 
       try {
+        // MissAV metadata extraction uses Puppeteer. Running it while the task is
+        // still queued can launch extra Chromium instances on weak hosts; the
+        // MissAV downloader fetches and applies the real title when the task starts.
+        if (isMissAVUrl(resolvedUrl)) {
+          logger.debug(
+            "Skipping queued MissAV title lookup; metadata will be fetched when the download starts.",
+          );
+          return;
+        }
+
         // Active downloads fetch metadata inside the downloader. Only queued tasks
         // need this lightweight background lookup to improve their displayed title.
         if (!isDownloadStillQueued(downloadId)) {

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -499,6 +499,9 @@ class DownloadManager {
           "Retry removed from queue by user"
         );
         task.reject(new Error("Retry removed from queue by user"));
+      } else if (!task.cancellationRejected) {
+        task.cancellationRejected = true;
+        task.reject(DownloadCancelledError.create());
       }
     }
     this.updateQueuedDownloads();

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -47,6 +47,12 @@ import {
 import { selectBestM3u8Url } from "./missav/m3u8";
 import { planMissAvOutputPaths } from "./missav/outputPaths";
 
+const MISSAV_FAILED_REQUEST_LOG_LIMIT = 10;
+
+function isPuppeteerTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === "TimeoutError";
+}
+
 export class MissAVDownloader extends BaseDownloader {
   // Implementation of IDownloader.getVideoInfo
   async getVideoInfo(url: string): Promise<VideoInfo> {
@@ -155,6 +161,7 @@ export class MissAVDownloader extends BaseDownloader {
       // Declared before try so they are accessible after browser is closed.
       const m3u8Urls: string[] = [];
       const isM3u8 = (u: string) => u.includes(".m3u8") && !u.includes("preview");
+      let failedRequestLogCount = 0;
       let html = "";
 
       try {
@@ -187,7 +194,35 @@ export class MissAVDownloader extends BaseDownloader {
           );
         });
 
-        await navigateMissAvPage(page, safeNavigationUrl);
+        page.on("requestfailed", (request) => {
+          if (failedRequestLogCount >= MISSAV_FAILED_REQUEST_LOG_LIMIT) return;
+          failedRequestLogCount += 1;
+
+          const failure = request.failure();
+          logger.warn(
+            `[MissAV request failed] resource=${request.resourceType()} ` +
+              `method=${request.method()} ` +
+              `error=${failure?.errorText ?? "unknown"} ${request.url()}`,
+          );
+
+          if (failedRequestLogCount === MISSAV_FAILED_REQUEST_LOG_LIMIT) {
+            logger.warn(
+              `[MissAV request failed] further failures suppressed after ${MISSAV_FAILED_REQUEST_LOG_LIMIT} entries.`,
+            );
+          }
+        });
+
+        try {
+          await navigateMissAvPage(page, safeNavigationUrl);
+        } catch (error) {
+          if (isPuppeteerTimeoutError(error) && m3u8Urls.length > 0) {
+            logger.warn(
+              "MissAV page navigation timed out after m3u8 capture; continuing with captured stream URLs.",
+            );
+          } else {
+            throw error;
+          }
+        }
 
         // Extra wait is created AFTER networkidle2, so the full 20 s budget
         // belongs entirely to player initialisation — not shared with page load.

--- a/stacks/docker-compose.host-network.yml
+++ b/stacks/docker-compose.host-network.yml
@@ -29,6 +29,9 @@ services:
     restart: unless-stopped
     # Note: In host mode, the container uses the host's network stack directly
     # The backend will be accessible at localhost:5551 on the host
+    # Docker cannot apply net.* sysctls to host-network containers. If the host
+    # has half-enabled IPv6 and Chromium navigation times out on dual-stack
+    # domains, disable IPv6 on the host itself with sysctl.
 
   frontend:
     image: franklioxygen/mytube:frontend-latest

--- a/stacks/docker-compose.single-container.yml
+++ b/stacks/docker-compose.single-container.yml
@@ -25,3 +25,7 @@ services:
       # Docs: documents/en/deployment-security-model.md
       - MYTUBE_ADMIN_TRUST_LEVEL=container
     restart: unless-stopped
+    # Avoid Chromium/Puppeteer stalls on hosts with half-enabled IPv6.
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+      - net.ipv6.conf.default.disable_ipv6=1

--- a/stacks/docker-compose.yml
+++ b/stacks/docker-compose.yml
@@ -28,7 +28,9 @@ services:
       - net.ipv6.conf.all.disable_ipv6=1
       - net.ipv6.conf.default.disable_ipv6=1
     # For OpenWrt/iStoreOS systems where bridge network cannot access internet,
-    # uncomment the following lines to use host network mode:
+    # prefer stacks/docker-compose.host-network.yml. If adapting this file
+    # manually, remove the backend networks and sysctls blocks before enabling
+    # host networking; Docker rejects net.* sysctls with network_mode: host.
     # network_mode: host
     # Then set NGINX_BACKEND_URL=http://localhost:5551 for frontend service
 

--- a/stacks/docker-compose.yml
+++ b/stacks/docker-compose.yml
@@ -23,6 +23,10 @@ services:
     restart: unless-stopped
     networks:
       - mytube-network
+    # Avoid Chromium/Puppeteer stalls on hosts with half-enabled IPv6.
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+      - net.ipv6.conf.default.disable_ipv6=1
     # For OpenWrt/iStoreOS systems where bridge network cannot access internet,
     # uncomment the following lines to use host network mode:
     # network_mode: host


### PR DESCRIPTION
## Description

MissAV downloads stalled or failed outright on hosts with half-enabled IPv6, where Chromium navigation to dual-stack domains could time out. This change hardens the downloader and the container environment to recover from those failures.

- **MissAVDownloader**: log failed browser requests (capped at 10 entries) with resource type, method, error text, and URL for diagnostics.
- **MissAVDownloader**: when page navigation times out *after* the m3u8 stream URL has already been captured, continue with the captured URL instead of failing the download. Timeouts with no capture still surface to the caller.
- **docker-compose**: disable IPv6 via sysctls in the single-container and default stacks to avoid Chromium/Puppeteer stalls on half-enabled IPv6 hosts; document the host-network limitation where Docker cannot apply `net.*` sysctls.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test: continues with captured m3u8 URLs when navigation times out after capture
- [x] Unit test: re-throws navigation timeouts when no m3u8 URL was captured
- [x] Unit test: logs failed browser requests before surfacing an early connection reset

## Checklist:

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works