### PR TITLE
[codex] fix subtitle srclang warning

### DIFF
--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { neutral, overlay } from '../../../theme/colors';
 import { getBackendUrl } from '../../../utils/apiUrl';
-import { getSubtitleLanguageLabel } from '../../../utils/formatUtils';
+import { getSubtitleLanguageLabel, getSubtitleTrackLanguage } from '../../../utils/formatUtils';
 import { getMediaCrossOriginAttr } from '../../../utils/mediaOrigin';
 
 type GlobalVideoCounterScope = typeof globalThis & {
@@ -249,7 +249,7 @@ const VideoElement: React.FC<VideoElementProps> = ({
                         key={`${subtitle.language}-${index}`}
                         kind="subtitles"
                         src={`${getBackendUrl()}${subtitle.path}`}
-                        srcLang={subtitle.language}
+                        srcLang={getSubtitleTrackLanguage(subtitle.language, subtitle.path)}
                         label={getSubtitleLanguageLabel(subtitle.language, subtitle.path)}
                     />
                 ))}

--- a/frontend/src/components/VideoPlayer/VideoControls/__tests__/VideoElement.test.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/__tests__/VideoElement.test.tsx
@@ -1,0 +1,66 @@
+import type { ComponentProps } from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import VideoElement from '../VideoElement';
+
+vi.mock('../../../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+const defaultProps: ComponentProps<typeof VideoElement> = {
+    videoRef: { current: null },
+    src: '/videos/video.mp4',
+    isLoading: false,
+    loadError: null,
+    subtitles: [],
+    onClick: vi.fn(),
+    onPlay: vi.fn(),
+    onPause: vi.fn(),
+    onTimeUpdate: vi.fn(),
+    onLoadedMetadata: vi.fn(),
+    onError: vi.fn(),
+    onLoadStart: vi.fn(),
+    onCanPlay: vi.fn(),
+    onLoadedData: vi.fn(),
+    onSubtitleInit: vi.fn(),
+};
+
+describe('VideoElement', () => {
+    it('renders legacy unknown subtitle language as the valid undetermined srclang tag', () => {
+        const { container } = render(
+            <VideoElement
+                {...defaultProps}
+                subtitles={[
+                    {
+                        language: 'unknown',
+                        filename: 'video.unknown.vtt',
+                        path: '/subtitles/video.unknown.vtt',
+                    },
+                ]}
+            />
+        );
+
+        const track = container.querySelector('track');
+        expect(track).toHaveAttribute('srclang', 'und');
+        expect(track).toHaveAttribute('label', 'Unknown');
+    });
+
+    it('uses a subtitle filename language when stored metadata is ambiguous', () => {
+        const { container } = render(
+            <VideoElement
+                {...defaultProps}
+                subtitles={[
+                    {
+                        language: 'unknown',
+                        filename: 'video.en.vtt',
+                        path: '/subtitles/video.en.vtt',
+                    },
+                ]}
+            />
+        );
+
+        const track = container.querySelector('track');
+        expect(track).toHaveAttribute('srclang', 'en');
+        expect(track).toHaveAttribute('label', 'English');
+    });
+});

--- a/frontend/src/utils/__tests__/formatUtils.test.ts
+++ b/frontend/src/utils/__tests__/formatUtils.test.ts
@@ -7,6 +7,9 @@ import {
   formatDuration,
   formatRelativeDownloadTime,
   formatSize,
+  getLanguageFromSubtitlePath,
+  getSubtitleLanguageLabel,
+  getSubtitleTrackLanguage,
   parseDuration,
 } from "../formatUtils";
 
@@ -365,6 +368,43 @@ describe("formatUtils", () => {
         mockTranslation
       );
       expect(result).toBe("2022-11-20");
+    });
+  });
+
+  describe("subtitle language helpers", () => {
+    it("extracts subtitle language from the filename segment before the extension", () => {
+      expect(getLanguageFromSubtitlePath("/subtitles/video.en.vtt")).toBe("en");
+      expect(getLanguageFromSubtitlePath("video.pt-BR.srt")).toBe("pt-BR");
+      expect(getLanguageFromSubtitlePath("video.zh-Hans.vtt")).toBe("zh-Hans");
+      expect(getLanguageFromSubtitlePath("video.unknown.vtt")).toBeNull();
+    });
+
+    it("normalizes legacy unknown subtitle language to a valid srclang tag", () => {
+      expect(
+        getSubtitleTrackLanguage("unknown", "/subtitles/video.unknown.vtt")
+      ).toBe("und");
+      expect(getSubtitleTrackLanguage("", "/subtitles/video.vtt")).toBe("und");
+      expect(getSubtitleTrackLanguage(undefined, "/subtitles/video.vtt")).toBe(
+        "und"
+      );
+    });
+
+    it("uses a filename language before falling back to undetermined", () => {
+      expect(
+        getSubtitleTrackLanguage("unknown", "/subtitles/video.fr.vtt")
+      ).toBe("fr");
+      expect(getSubtitleTrackLanguage("is", "/subtitles/video.en.vtt")).toBe(
+        "en"
+      );
+    });
+
+    it("labels undetermined subtitle languages as unknown", () => {
+      expect(
+        getSubtitleLanguageLabel("unknown", "/subtitles/video.unknown.vtt")
+      ).toBe("Unknown");
+      expect(getSubtitleLanguageLabel("und", "/subtitles/video.und.vtt")).toBe(
+        "Unknown"
+      );
     });
   });
 });

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -327,7 +327,46 @@ export function getLanguageFromSubtitlePath(
   if (lastDot <= 0) return null;
   const withoutExt = basename.slice(0, lastDot);
   const segment = withoutExt.split(".").pop() ?? "";
-  return /^[a-z]{2}(-[A-Z]{2})?$/.test(segment) ? segment : null;
+  return /^[a-z]{2,3}(?:-[a-z]{4})?(?:-(?:[a-z]{2}|\d{3}))?$/i.test(segment)
+    ? segment
+    : null;
+}
+
+const UNKNOWN_SUBTITLE_LANGUAGE_CODES = new Set(["unknown", "und"]);
+
+function getSubtitleLanguageCode(
+  lang: string | null | undefined,
+  pathOrFilename?: string,
+): string {
+  let code = typeof lang === "string" ? lang.trim() : "";
+  const normalizedCode = code.toLowerCase();
+  if (
+    (!code ||
+      UNKNOWN_SUBTITLE_LANGUAGE_CODES.has(normalizedCode) ||
+      normalizedCode === "is") &&
+    pathOrFilename
+  ) {
+    const fromPath = getLanguageFromSubtitlePath(pathOrFilename);
+    if (fromPath) code = fromPath;
+  }
+  return code;
+}
+
+/**
+ * Normalize a subtitle language for HTMLTrackElement.srclang.
+ *
+ * Stored subtitle metadata can contain the legacy sentinel "unknown", but
+ * browsers validate srclang as BCP 47 and warn on that value. BCP 47's "und"
+ * tag represents an undetermined language and keeps the track valid.
+ */
+export function getSubtitleTrackLanguage(
+  lang: string | null | undefined,
+  pathOrFilename?: string,
+): string {
+  const code = getSubtitleLanguageCode(lang, pathOrFilename);
+  return !code || UNKNOWN_SUBTITLE_LANGUAGE_CODES.has(code.toLowerCase())
+    ? "und"
+    : code;
 }
 
 /**
@@ -336,15 +375,12 @@ export function getLanguageFromSubtitlePath(
  * Falls back to uppercase code if Intl is unavailable or code is unknown.
  */
 export function getSubtitleLanguageLabel(
-  lang: string,
+  lang: string | null | undefined,
   pathOrFilename?: string,
 ): string {
-  let code = lang;
-  if ((!code || code === "unknown" || code === "is") && pathOrFilename) {
-    const fromPath = getLanguageFromSubtitlePath(pathOrFilename);
-    if (fromPath) code = fromPath;
-  }
-  if (!code || code === "unknown") return code === "unknown" ? "Unknown" : "";
+  const code = getSubtitleLanguageCode(lang, pathOrFilename);
+  if (!code) return "";
+  if (UNKNOWN_SUBTITLE_LANGUAGE_CODES.has(code.toLowerCase())) return "Unknown";
   try {
     const display = new Intl.DisplayNames(undefined, { type: "language" });
     return display.of(code) ?? code.toUpperCase();


### PR DESCRIPTION
## What changed
- Normalize subtitle `srclang` values before rendering `<track>` elements.
- Map legacy stored `unknown` subtitle languages to BCP 47 `und` for the browser while keeping the UI label as `Unknown`.
- Recover real subtitle language codes from filenames when the stored value is ambiguous.
- Add utility and component regression tests for the `unknown` subtitle case.

## Why
Some downloaded videos store subtitle metadata with `language: "unknown"`. WebKit validates `<track srclang>` as a BCP 47 language tag and warns because `unknown` is not valid. `und` is the valid BCP 47 undetermined-language tag.

## Impact
Opening videos with legacy unknown subtitle metadata should no longer produce the console warning, and subtitle labels remain readable.

## Validation
- `npm run test -- formatUtils.test.ts VideoElement.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `git diff --check`