### PR TITLE
[codex] improve Safari WebM seek performance

### DIFF
--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -5,51 +5,10 @@ import { neutral, overlay } from '../../../theme/colors';
 import { getBackendUrl } from '../../../utils/apiUrl';
 import { getSubtitleLanguageLabel } from '../../../utils/formatUtils';
 import { getMediaCrossOriginAttr } from '../../../utils/mediaOrigin';
+import { computePreloadStrategy } from '../../../utils/preloadStrategy';
 
 type GlobalVideoCounterScope = typeof globalThis & {
     __videoControlCounter?: number;
-};
-
-type NetworkInformationLike = {
-    effectiveType?: string;
-    saveData?: boolean;
-};
-
-type NavigatorWithConnection = Navigator & {
-    connection?: NetworkInformationLike;
-    mozConnection?: NetworkInformationLike;
-    webkitConnection?: NetworkInformationLike;
-};
-
-const isLikelyMobileUserAgent = (): boolean =>
-    /iPhone|iPod|Android.*Mobile|Mobi/i.test(navigator.userAgent);
-
-const computePreloadStrategy = (): 'auto' | 'metadata' | 'none' => {
-    const navigatorWithConnection = navigator as NavigatorWithConnection;
-    const connection =
-        navigatorWithConnection.connection ||
-        navigatorWithConnection.mozConnection ||
-        navigatorWithConnection.webkitConnection;
-
-    if (connection) {
-        const type = connection.effectiveType; // 'slow-2g', '2g', '3g', '4g'
-        const saveData = connection.saveData;
-
-        if (saveData) {
-            return 'none'; // Save data mode -> minimal loading
-        }
-        if (type === '4g') {
-            return 'auto'; // Good connection -> auto preload
-        }
-        return 'metadata'; // Slower connection -> metadata only
-    }
-
-    // Browsers without the Network Information API (Safari, Firefox).
-    // Desktop gets 'auto': read-ahead buffering is what makes timeline
-    // seeks land in already-buffered data — critical for Safari, whose
-    // native WebM pipeline downloads linearly and cannot byte-range
-    // seek. Mobile stays conservative to avoid burning cellular data.
-    return isLikelyMobileUserAgent() ? 'metadata' : 'auto';
 };
 
 interface VideoElementProps {

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -21,6 +21,37 @@ type NavigatorWithConnection = Navigator & {
     webkitConnection?: NetworkInformationLike;
 };
 
+const isLikelyMobileUserAgent = (): boolean =>
+    /iPhone|iPod|Android.*Mobile|Mobi/i.test(navigator.userAgent);
+
+const computePreloadStrategy = (): 'auto' | 'metadata' | 'none' => {
+    const navigatorWithConnection = navigator as NavigatorWithConnection;
+    const connection =
+        navigatorWithConnection.connection ||
+        navigatorWithConnection.mozConnection ||
+        navigatorWithConnection.webkitConnection;
+
+    if (connection) {
+        const type = connection.effectiveType; // 'slow-2g', '2g', '3g', '4g'
+        const saveData = connection.saveData;
+
+        if (saveData) {
+            return 'none'; // Save data mode -> minimal loading
+        }
+        if (type === '4g') {
+            return 'auto'; // Good connection -> auto preload
+        }
+        return 'metadata'; // Slower connection -> metadata only
+    }
+
+    // Browsers without the Network Information API (Safari, Firefox).
+    // Desktop gets 'auto': read-ahead buffering is what makes timeline
+    // seeks land in already-buffered data — critical for Safari, whose
+    // native WebM pipeline downloads linearly and cannot byte-range
+    // seek. Mobile stays conservative to avoid burning cellular data.
+    return isLikelyMobileUserAgent() ? 'metadata' : 'auto';
+};
+
 interface VideoElementProps {
     videoRef: React.RefObject<HTMLVideoElement | null>;
     src: string;
@@ -82,39 +113,18 @@ const VideoElement: React.FC<VideoElementProps> = ({
         return `video-controls-${Date.now()}-${counter}`;
     }, []);
 
-    const [preloadStrategy, setPreloadStrategy] = React.useState<'auto' | 'metadata' | 'none'>('metadata');
+    // Computed once per mount: the connection info the strategy depends on
+    // does not change mid-playback, and a lazy initializer guarantees the
+    // <video> element never starts loading with a downgraded placeholder.
+    const [preloadStrategy] = React.useState<'auto' | 'metadata' | 'none'>(
+        computePreloadStrategy
+    );
     const [mobileAspectRatio, setMobileAspectRatio] = React.useState<string>('16/9');
 
     React.useEffect(() => {
         // Reset to default ratio while new source metadata is loading
         setMobileAspectRatio('16/9');
     }, [src]);
-
-    React.useEffect(() => {
-        // Dynamic preload strategy based on connection
-        const navigatorWithConnection = navigator as NavigatorWithConnection;
-        const connection =
-            navigatorWithConnection.connection ||
-            navigatorWithConnection.mozConnection ||
-            navigatorWithConnection.webkitConnection;
-
-        if (connection) {
-            // If we have connection info
-            const type = connection.effectiveType; // 'slow-2g', '2g', '3g', '4g'
-            const saveData = connection.saveData; // boolean
-
-            if (saveData) {
-                setPreloadStrategy('none'); // Save data mode -> minimal loading
-            } else if (type === '4g' && !saveData) {
-                setPreloadStrategy('auto'); // Good connection -> auto preload
-            } else {
-                setPreloadStrategy('metadata'); // Slower connection -> metadata only
-            }
-        } else {
-            // Fallback for browsers without Network Information API
-            setPreloadStrategy('metadata');
-        }
-    }, []);
 
     return (
         <Box

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -14,6 +14,7 @@ type GlobalVideoCounterScope = typeof globalThis & {
 interface VideoElementProps {
     videoRef: React.RefObject<HTMLVideoElement | null>;
     src: string;
+    mediaPath?: string | null;
     poster?: string;
     isLoading: boolean;
     loadError: string | null;
@@ -40,6 +41,7 @@ interface VideoElementProps {
 const VideoElement: React.FC<VideoElementProps> = ({
     videoRef,
     src,
+    mediaPath,
     poster,
     isLoading,
     loadError,
@@ -72,11 +74,11 @@ const VideoElement: React.FC<VideoElementProps> = ({
         return `video-controls-${Date.now()}-${counter}`;
     }, []);
 
-    // Computed once per mount: the connection info the strategy depends on
-    // does not change mid-playback, and a lazy initializer guarantees the
-    // <video> element never starts loading with a downgraded placeholder.
-    const [preloadStrategy] = React.useState<'auto' | 'metadata' | 'none'>(
-        computePreloadStrategy
+    // Compute during render so the <video> element never starts loading
+    // with a downgraded placeholder, and recalculate when the media changes.
+    const preloadStrategy = useMemo<'auto' | 'metadata' | 'none'>(
+        () => computePreloadStrategy({ src, mediaPath }),
+        [src, mediaPath]
     );
     const [mobileAspectRatio, setMobileAspectRatio] = React.useState<string>('16/9');
 

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
@@ -43,7 +43,7 @@ describe("useVideoPlayer seek behavior", () => {
     });
   });
 
-  it("should use fastSeek when seeking to a non-zero time if available", () => {
+  it("seeks via a single currentTime assignment, never fastSeek", () => {
     const { result } = renderHook(() => useVideoPlayer({ src: "test.mp4" }));
 
     // Manually set the current ref value since renderHook won't attach it to our mock
@@ -63,7 +63,10 @@ describe("useVideoPlayer seek behavior", () => {
       result.current.handleSeek(-40); // 50 - 40 = 10
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(10);
+    expect(videoElement.currentTime).toBe(10);
+    // Safari silently ignores fastSeek() for the saved-progress seek
+    // issued right after loadedmetadata, so it must never be used.
+    expect(videoElement.fastSeek).not.toHaveBeenCalled();
   });
 
   it("should allow seeking to 0 via handleSeek", () => {
@@ -84,8 +87,8 @@ describe("useVideoPlayer seek behavior", () => {
       result.current.handleSeek(-60); // max(0, 50 - 60) = 0
     });
 
-    // fastSeek should be called with 0
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(0);
+    expect(videoElement.currentTime).toBe(0);
+    expect(videoElement.fastSeek).not.toHaveBeenCalled();
   });
 
   it("should allow seeking to 0 via slider", () => {
@@ -106,8 +109,8 @@ describe("useVideoPlayer seek behavior", () => {
       result.current.handleProgressChangeCommitted(0);
     });
 
-    // fastSeek should be called with 0
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(0);
+    expect(videoElement.currentTime).toBe(0);
+    expect(videoElement.fastSeek).not.toHaveBeenCalled();
   });
 
   it("treats progress slider values as seconds instead of percent", () => {
@@ -127,7 +130,7 @@ describe("useVideoPlayer seek behavior", () => {
       result.current.handleProgressChangeCommitted(50);
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(50);
+    expect(videoElement.currentTime).toBe(50);
   });
 
   it("does not seek progress slider commits to the exact end", () => {
@@ -143,7 +146,7 @@ describe("useVideoPlayer seek behavior", () => {
       result.current.handleProgressChangeCommitted(100);
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(99.75);
+    expect(videoElement.currentTime).toBe(99.75);
   });
 });
 
@@ -175,9 +178,10 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    // startTime should be applied with a single seek
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
-    expect(videoElement.fastSeek).toHaveBeenCalledTimes(1);
+    // startTime must be applied via currentTime: Safari silently ignores
+    // fastSeek() for this restore seek and playback would start from 0.
+    expect(videoElement.currentTime).toBe(30);
+    expect(videoElement.fastSeek).not.toHaveBeenCalled();
   });
 
   it("should apply startTime only once via handleCanPlay", () => {
@@ -192,7 +196,7 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleCanPlay();
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
+    expect(videoElement.currentTime).toBe(30);
 
     // Reset currentTime to 0 (simulating user seek to 0)
     videoElement.currentTime = 0;
@@ -202,8 +206,7 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleCanPlay();
     });
 
-    // No second seek back to startTime
-    expect(videoElement.fastSeek).toHaveBeenCalledTimes(1);
+    // currentTime should remain at 0, not reset to 30
     expect(videoElement.currentTime).toBe(0);
   });
 
@@ -219,23 +222,21 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
+    expect(videoElement.currentTime).toBe(30);
 
     // User seeks to 0
     act(() => {
       result.current.handleProgressChangeCommitted(0);
     });
 
-    expect(videoElement.fastSeek).toHaveBeenLastCalledWith(0);
+    expect(videoElement.currentTime).toBe(0);
 
     // Simulate canplay event after seek
-    videoElement.currentTime = 0;
     act(() => {
       result.current.handleCanPlay();
     });
 
     // Should stay at 0, not seek back to startTime
-    expect(videoElement.fastSeek).toHaveBeenCalledTimes(2);
     expect(videoElement.currentTime).toBe(0);
   });
 
@@ -260,8 +261,8 @@ describe("useVideoPlayer startTime behavior", () => {
     // Simulate fetch completing and updating startTime to 45
     rerender({ src: "test.mp4", startTime: 45 });
 
-    // Should update to new startTime using fastSeek
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(45);
+    // Should update to new startTime
+    expect(videoElement.currentTime).toBe(45);
   });
 
   it("should apply a fresher positive startTime while playback is still near the previous resume point", () => {
@@ -280,14 +281,13 @@ describe("useVideoPlayer startTime behavior", () => {
       } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(10);
+    expect(videoElement.currentTime).toBe(10);
 
-    videoElement.fastSeek = vi.fn();
     videoElement.currentTime = 10.4;
 
     rerender({ src: "test.mp4", startTime: 45 });
 
-    expect(videoElement.fastSeek).toHaveBeenCalledWith(45);
+    expect(videoElement.currentTime).toBe(45);
   });
 
   it("should not seek again when startTime changes during active playback", () => {
@@ -539,7 +539,7 @@ describe("useVideoPlayer lifecycle and interaction behavior", () => {
     expect(result.current.isLooping).toBe(true);
   });
 
-  it("falls back to currentTime when fastSeek is unavailable", () => {
+  it("seeks via currentTime when fastSeek is not defined on the element", () => {
     const { result } = renderHook(() => useVideoPlayer({ src: "test.mp4" }));
     const player = document.createElement("video");
     Object.defineProperty(player, "duration", {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
@@ -175,8 +175,9 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    // startTime should be applied
-    expect(videoElement.currentTime).toBe(30);
+    // startTime should be applied with a single seek
+    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
+    expect(videoElement.fastSeek).toHaveBeenCalledTimes(1);
   });
 
   it("should apply startTime only once via handleCanPlay", () => {
@@ -191,7 +192,7 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleCanPlay();
     });
 
-    expect(videoElement.currentTime).toBe(30);
+    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
 
     // Reset currentTime to 0 (simulating user seek to 0)
     videoElement.currentTime = 0;
@@ -201,7 +202,8 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleCanPlay();
     });
 
-    // currentTime should remain at 0, not reset to 30
+    // No second seek back to startTime
+    expect(videoElement.fastSeek).toHaveBeenCalledTimes(1);
     expect(videoElement.currentTime).toBe(0);
   });
 
@@ -217,12 +219,14 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    expect(videoElement.currentTime).toBe(30);
+    expect(videoElement.fastSeek).toHaveBeenCalledWith(30);
 
     // User seeks to 0
     act(() => {
       result.current.handleProgressChangeCommitted(0);
     });
+
+    expect(videoElement.fastSeek).toHaveBeenLastCalledWith(0);
 
     // Simulate canplay event after seek
     videoElement.currentTime = 0;
@@ -230,7 +234,8 @@ describe("useVideoPlayer startTime behavior", () => {
       result.current.handleCanPlay();
     });
 
-    // Should stay at 0, not reset to startTime
+    // Should stay at 0, not seek back to startTime
+    expect(videoElement.fastSeek).toHaveBeenCalledTimes(2);
     expect(videoElement.currentTime).toBe(0);
   });
 
@@ -275,7 +280,7 @@ describe("useVideoPlayer startTime behavior", () => {
       } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    expect(videoElement.currentTime).toBe(10);
+    expect(videoElement.fastSeek).toHaveBeenCalledWith(10);
 
     videoElement.fastSeek = vi.fn();
     videoElement.currentTime = 10.4;
@@ -283,7 +288,6 @@ describe("useVideoPlayer startTime behavior", () => {
     rerender({ src: "test.mp4", startTime: 45 });
 
     expect(videoElement.fastSeek).toHaveBeenCalledWith(45);
-    expect(videoElement.currentTime).toBe(45);
   });
 
   it("should not seek again when startTime changes during active playback", () => {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
@@ -312,6 +312,57 @@ describe("useVideoPlayer startTime behavior", () => {
     expect(videoElement.fastSeek).not.toHaveBeenCalled();
     expect(videoElement.currentTime).toBe(35);
   });
+
+  it("suppresses pre-restore timeupdates so they cannot clobber saved progress", () => {
+    const onTimeUpdate = vi.fn();
+    const { result } = renderHook(() =>
+      useVideoPlayer({ src: "test.mp4", startTime: 30, onTimeUpdate })
+    );
+
+    result.current.videoRef.current = videoElement;
+
+    // Safari emits a timeupdate at ~0 before the restore seek is issued
+    // at loadedmetadata; it must not reach the progress tracker.
+    videoElement.currentTime = 0.4;
+    act(() => {
+      result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).not.toHaveBeenCalled();
+    expect(result.current.currentTime).toBe(0);
+
+    // Restore applies at loadedmetadata...
+    act(() => {
+      result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+    expect(videoElement.currentTime).toBe(30);
+
+    // ...after which timeupdates flow again.
+    videoElement.currentTime = 30.2;
+    act(() => {
+      result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(30.2);
+  });
+
+  it("propagates timeupdates past the tolerance even if the restore never applied", () => {
+    const onTimeUpdate = vi.fn();
+    const { result } = renderHook(() =>
+      useVideoPlayer({ src: "test.mp4", startTime: 30, onTimeUpdate })
+    );
+
+    result.current.videoRef.current = videoElement;
+
+    // Escape valve: if playback somehow progresses without the restore
+    // being applied, progress saving must not stay suppressed.
+    videoElement.currentTime = 5;
+    act(() => {
+      result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(5);
+  });
 });
 
 describe("useVideoPlayer playbackRate behavior", () => {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoLoading.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoLoading.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useLanguage } from "../../../../contexts/LanguageContext";
+import { isSafari } from "../../../../utils/playerUtils";
 
 export const useVideoLoading = () => {
   const { t } = useLanguage();
@@ -55,10 +56,7 @@ export const useVideoLoading = () => {
       console.error("Video error code:", videoElement.error.code);
       console.error("Video error message:", videoElement.error.message);
 
-      // Detect Safari browser
-      const isSafari = /^((?!chrome|android).)*safari/i.test(
-        navigator.userAgent,
-      );
+      const safari = isSafari();
 
       let errorMessage = t("failedToLoadVideo");
       switch (videoElement.error.code) {
@@ -70,7 +68,7 @@ export const useVideoLoading = () => {
           break;
         case 3: // MEDIA_ERR_DECODE
           // Safari-specific message for decode errors (often codec-related)
-          if (isSafari) {
+          if (safari) {
             const src = videoElement.src || "";
             const isWebM = src.toLowerCase().includes(".webm");
             if (isWebM) {
@@ -83,7 +81,7 @@ export const useVideoLoading = () => {
           }
           break;
         case 4: // MEDIA_ERR_SRC_NOT_SUPPORTED
-          if (isSafari) {
+          if (safari) {
             errorMessage = t("safariVideoFormatNotSupported");
           } else {
             errorMessage = t("browserVideoFormatNotSupported");

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -58,16 +58,13 @@ export const useVideoPlayer = ({
   const seekTo = useCallback((videoElement: HTMLVideoElement, time: number) => {
     const safeTime = clampPlaybackTime(time, videoElement.duration);
 
-    // Issue exactly one seek. Calling fastSeek() and then assigning
-    // currentTime queues two seek operations; Safari's linear WebM loader
-    // restarts its full-file download for each one, doubling seek latency
-    // and bandwidth. fastSeek (keyframe-aligned, Safari/Firefox) is
-    // preferred for speed; precise seeking is the fallback elsewhere.
-    if (typeof videoElement.fastSeek === "function") {
-      videoElement.fastSeek(safeTime);
-    } else {
-      videoElement.currentTime = safeTime;
-    }
+    // Issue exactly one seek, via currentTime only. Pairing fastSeek()
+    // with a currentTime assignment queues two seek operations, and
+    // Safari's linear WebM loader restarts its full-file download for
+    // each one. fastSeek() alone is not an option either: Safari
+    // silently ignores it for the saved-progress seek issued right
+    // after loadedmetadata, so playback would start from the beginning.
+    videoElement.currentTime = safeTime;
     setCurrentTime(safeTime);
   }, [clampPlaybackTime]);
 

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -58,10 +58,16 @@ export const useVideoPlayer = ({
   const seekTo = useCallback((videoElement: HTMLVideoElement, time: number) => {
     const safeTime = clampPlaybackTime(time, videoElement.duration);
 
+    // Issue exactly one seek. Calling fastSeek() and then assigning
+    // currentTime queues two seek operations; Safari's linear WebM loader
+    // restarts its full-file download for each one, doubling seek latency
+    // and bandwidth. fastSeek (keyframe-aligned, Safari/Firefox) is
+    // preferred for speed; precise seeking is the fallback elsewhere.
     if (typeof videoElement.fastSeek === "function") {
       videoElement.fastSeek(safeTime);
+    } else {
+      videoElement.currentTime = safeTime;
     }
-    videoElement.currentTime = safeTime;
     setCurrentTime(safeTime);
   }, [clampPlaybackTime]);
 
@@ -112,7 +118,8 @@ export const useVideoPlayer = ({
     }
 
     if (src) {
-      videoElement.preload = "metadata";
+      // preload is governed by the <video preload> prop in VideoElement;
+      // overriding it here would defeat the adaptive preload strategy.
       videoElement.src = src;
       // Reset flag when setting new source (for initial load)
       if (!previousSrc) {
@@ -180,7 +187,6 @@ export const useVideoPlayer = ({
     setIsPlaying(!isPlaying);
   };
 
-  // Seek using fastSeek() on mobile for better audio sync, fallback to currentTime
   const handleSeek = useCallback((seconds: number) => {
     const videoElement = videoRef.current;
     if (!videoElement || !isFinite(videoElement.duration)) return;

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -239,6 +239,20 @@ export const useVideoPlayer = ({
       return;
     }
 
+    // Drop pre-restore ticks. Browsers (Safari in particular) emit a
+    // timeupdate at ~0 before the saved-progress seek is issued at
+    // loadedmetadata; propagating it lets the progress tracker
+    // overwrite the stored position with 0. The tolerance check is an
+    // escape valve: if the restore is ever skipped, ticks past 1s flow
+    // again so progress saving cannot stay suppressed for a session.
+    if (
+      startTime > 0 &&
+      !startTimeAppliedRef.current &&
+      time < START_TIME_APPLY_TOLERANCE_SECONDS
+    ) {
+      return;
+    }
+
     setCurrentTime(time);
 
     if (onTimeUpdate) {

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -141,13 +141,12 @@ const VideoControls: React.FC<VideoControlsProps> = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [src]);
 
-    // Handle video loading events
+    // Handle video loading events. preload is owned by VideoElement's
+    // adaptive strategy; forcing 'metadata' here disabled read-ahead
+    // buffering in every browser and made seeks outside the buffer stall
+    // (worst on Safari, whose WebM pipeline cannot byte-range seek).
     const handleLoadStart = () => {
         loading.startLoading();
-        const videoElement = videoPlayer.videoRef.current;
-        if (videoElement) {
-            videoElement.preload = 'metadata';
-        }
     };
 
     const handleCanPlay = () => {

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -14,6 +14,7 @@ import VideoElement from './VideoElement';
 
 interface VideoControlsProps {
     src: string;
+    mediaPath?: string | null;
     autoPlay?: boolean;
     autoLoop?: boolean;
     pauseOnFocusLoss?: boolean;
@@ -39,6 +40,7 @@ interface VideoControlsProps {
 
 const VideoControls: React.FC<VideoControlsProps> = ({
     src,
+    mediaPath,
     autoPlay = false,
     autoLoop = false,
     pauseOnFocusLoss = false,
@@ -222,6 +224,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 <VideoElement
                     videoRef={videoPlayer.videoRef}
                     src={src}
+                    mediaPath={mediaPath}
                     poster={poster}
                     isLoading={loading.isLoading}
                     loadError={loading.loadError}

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -116,6 +116,8 @@ describe("useVideoProgress", () => {
   });
 
   it("syncs progress writes into the cache before the view threshold is reached", async () => {
+    let now = 1000;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const video = {
       id: "video-2",
       duration: "120",
@@ -131,6 +133,7 @@ describe("useVideoProgress", () => {
       { wrapper },
     );
 
+    now = 7000;
     act(() => {
       result.current.handleTimeUpdate(5);
     });
@@ -189,6 +192,8 @@ describe("useVideoProgress", () => {
     act(() => {
       result.current.setIsDeleting(true);
     });
+
+    dateNowSpy.mockRestore();
   });
 
   it("sends progress on unmount and keeps the cache resume point fresh", () => {
@@ -249,6 +254,8 @@ describe("useVideoProgress", () => {
   });
 
   it("does not persist exact duration as the resume progress", () => {
+    let now = 1000;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const video = {
       id: "video-4",
       duration: "120",
@@ -264,6 +271,7 @@ describe("useVideoProgress", () => {
       { wrapper },
     );
 
+    now = 7000;
     act(() => {
       result.current.handleTimeUpdate(120);
     });
@@ -276,5 +284,50 @@ describe("useVideoProgress", () => {
         progress: 119,
       })
     );
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("does not clobber saved progress with an immediate save on the first timeupdate", () => {
+    let now = 1000;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const video = {
+      id: "video-5",
+      duration: "1776",
+      progress: 1222,
+      viewCount: 0,
+    } as any;
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-5"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-5", video }),
+      { wrapper },
+    );
+
+    // Pre-restore tick at ~0, right after mount: the old code saved
+    // instantly here (throttle clock started at 0), overwriting the
+    // stored resume position with 0.
+    act(() => {
+      result.current.handleTimeUpdate(0.3);
+    });
+
+    expect(mockApiPut).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(["video", "video-5"])).toEqual(
+      expect.objectContaining({ progress: 1222 })
+    );
+
+    // Once real playback has run past the throttle window, saves flow.
+    now = 7000;
+    act(() => {
+      result.current.handleTimeUpdate(1230);
+    });
+
+    expect(mockApiPut).toHaveBeenCalledWith("/videos/video-5/progress", {
+      progress: 1230,
+    });
+
+    dateNowSpy.mockRestore();
   });
 });

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -72,6 +72,10 @@ export function useVideoProgress({ videoId, video }: UseVideoProgressProps) {
   useEffect(() => {
     setHasViewed(false);
     currentTimeRef.current = 0;
+    // Start the periodic-save throttle now: with the initial 0 the very
+    // first timeupdate saved immediately, racing the saved-progress
+    // restore and overwriting the stored position with ~0.
+    lastProgressSave.current = Date.now();
   }, [videoId]);
 
   useEffect(() => {

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -388,6 +388,7 @@ const VideoPlayer: React.FC = () => {
                     >
                     <VideoControls
                         src={(videoUrl || video?.sourceUrl) || null}
+                        mediaPath={video.videoPath}
                         poster={posterUrl || localPosterUrl || video?.thumbnailUrl}
                         autoPlay={autoPlay}
                         autoLoop={autoLoop}

--- a/frontend/src/utils/__tests__/playerUtils.test.ts
+++ b/frontend/src/utils/__tests__/playerUtils.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { getAvailablePlayers, getPlayerUrl, isAndroid, isIOS, isMac, isWindows } from '../playerUtils';
+import { getAvailablePlayers, getPlayerUrl, isAndroid, isIOS, isMac, isSafari, isWindows } from '../playerUtils';
 
 describe('playerUtils', () => {
     const originalUserAgent = navigator.userAgent;
@@ -35,6 +35,21 @@ describe('playerUtils', () => {
          it('should detect Android', () => {
             mockUserAgent('Mozilla/5.0 (Linux; Android 10; SM-G960U)');
             expect(isAndroid()).toBe(true);
+        });
+
+        it('should detect desktop Safari', () => {
+            mockUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15');
+            expect(isSafari()).toBe(true);
+        });
+
+        it('should detect iOS Safari', () => {
+            mockUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1');
+            expect(isSafari()).toBe(true);
+        });
+
+        it('should not report Chrome as Safari despite its Safari UA token', () => {
+            mockUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36');
+            expect(isSafari()).toBe(false);
         });
     });
 

--- a/frontend/src/utils/__tests__/preloadStrategy.test.ts
+++ b/frontend/src/utils/__tests__/preloadStrategy.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { computePreloadStrategy } from "../preloadStrategy";
+
+const UA = {
+    safariMac:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.5.2 Safari/605.1.15",
+    firefoxMac:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:126.0) Gecko/20100101 Firefox/126.0",
+    safariIphone:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+    firefoxAndroid:
+        "Mozilla/5.0 (Android 14; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0",
+};
+
+describe("computePreloadStrategy", () => {
+    const originalUserAgent = navigator.userAgent;
+    const originalMaxTouchPoints = navigator.maxTouchPoints;
+
+    const mockUserAgent = (userAgent: string) => {
+        Object.defineProperty(navigator, "userAgent", {
+            value: userAgent,
+            writable: true,
+            configurable: true,
+        });
+    };
+
+    const mockMaxTouchPoints = (value: number) => {
+        Object.defineProperty(navigator, "maxTouchPoints", {
+            value,
+            writable: true,
+            configurable: true,
+        });
+    };
+
+    const mockConnection = (connection: {
+        effectiveType?: string;
+        saveData?: boolean;
+    }) => {
+        Object.defineProperty(navigator, "connection", {
+            value: connection,
+            writable: true,
+            configurable: true,
+        });
+    };
+
+    afterEach(() => {
+        mockUserAgent(originalUserAgent);
+        mockMaxTouchPoints(originalMaxTouchPoints);
+        delete (navigator as { connection?: unknown }).connection;
+    });
+
+    describe("with the Network Information API", () => {
+        it("returns 'none' when Save-Data is on", () => {
+            mockConnection({ effectiveType: "4g", saveData: true });
+            expect(computePreloadStrategy()).toBe("none");
+        });
+
+        it("returns 'auto' on a fast connection", () => {
+            mockConnection({ effectiveType: "4g", saveData: false });
+            expect(computePreloadStrategy()).toBe("auto");
+        });
+
+        it("returns 'metadata' on a slow connection", () => {
+            mockConnection({ effectiveType: "3g", saveData: false });
+            expect(computePreloadStrategy()).toBe("metadata");
+        });
+    });
+
+    describe("without the Network Information API", () => {
+        it("returns 'auto' for desktop Safari (linear WebM loader needs read-ahead)", () => {
+            mockUserAgent(UA.safariMac);
+            mockMaxTouchPoints(0);
+            expect(computePreloadStrategy()).toBe("auto");
+        });
+
+        it("returns 'metadata' for desktop Firefox (range-seeks fine)", () => {
+            mockUserAgent(UA.firefoxMac);
+            mockMaxTouchPoints(0);
+            expect(computePreloadStrategy()).toBe("metadata");
+        });
+
+        it("returns 'metadata' for iPhone Safari", () => {
+            mockUserAgent(UA.safariIphone);
+            expect(computePreloadStrategy()).toBe("metadata");
+        });
+
+        it("returns 'metadata' for iPadOS Safari despite its desktop Mac UA", () => {
+            mockUserAgent(UA.safariMac);
+            mockMaxTouchPoints(5);
+            expect(computePreloadStrategy()).toBe("metadata");
+        });
+
+        it("returns 'metadata' for Android Firefox", () => {
+            mockUserAgent(UA.firefoxAndroid);
+            expect(computePreloadStrategy()).toBe("metadata");
+        });
+    });
+});

--- a/frontend/src/utils/__tests__/preloadStrategy.test.ts
+++ b/frontend/src/utils/__tests__/preloadStrategy.test.ts
@@ -67,10 +67,33 @@ describe("computePreloadStrategy", () => {
     });
 
     describe("without the Network Information API", () => {
-        it("returns 'auto' for desktop Safari (linear WebM loader needs read-ahead)", () => {
+        it("returns 'auto' for desktop Safari WebM (linear WebM loader needs read-ahead)", () => {
             mockUserAgent(UA.safariMac);
             mockMaxTouchPoints(0);
-            expect(computePreloadStrategy()).toBe("auto");
+            expect(computePreloadStrategy({ src: "/videos/clip.webm" })).toBe("auto");
+        });
+
+        it("returns 'metadata' for desktop Safari MP4", () => {
+            mockUserAgent(UA.safariMac);
+            mockMaxTouchPoints(0);
+            expect(computePreloadStrategy({ src: "/videos/clip.mp4" })).toBe("metadata");
+        });
+
+        it("returns 'auto' for desktop Safari WebM when the playback URL has no extension", () => {
+            mockUserAgent(UA.safariMac);
+            mockMaxTouchPoints(0);
+            expect(
+                computePreloadStrategy({
+                    src: "/api/mount-video/v1",
+                    mediaPath: "mount:/library/videos/clip.webm",
+                })
+            ).toBe("auto");
+        });
+
+        it("returns 'metadata' for desktop Safari when neither URL nor media path identifies WebM", () => {
+            mockUserAgent(UA.safariMac);
+            mockMaxTouchPoints(0);
+            expect(computePreloadStrategy({ src: "/api/mount-video/v1" })).toBe("metadata");
         });
 
         it("returns 'metadata' for desktop Firefox (range-seeks fine)", () => {

--- a/frontend/src/utils/playerUtils.ts
+++ b/frontend/src/utils/playerUtils.ts
@@ -38,6 +38,12 @@ export const isIOS = () => {
 
 export const isAndroid = () => /Android/.test(navigator.userAgent);
 
+// True for Safari on any Apple platform. Chromium-based browsers also
+// advertise "Safari" in their UA, so anything carrying "Chrome"/"Android"
+// tokens is excluded.
+export const isSafari = () =>
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
 export const isLinux = () => {
   const userAgent = navigator.userAgent;
   return /Linux/.test(userAgent) && !isAndroid() && !/Android/.test(userAgent);

--- a/frontend/src/utils/preloadStrategy.ts
+++ b/frontend/src/utils/preloadStrategy.ts
@@ -1,0 +1,54 @@
+import { isAndroid, isIOS, isSafari } from "./playerUtils";
+
+/**
+ * Decides the `<video preload>` value for the player.
+ *
+ * Extracted from `VideoElement.tsx` so it can be unit-tested (and so the
+ * component file only exports components, keeping Fast Refresh working).
+ */
+
+type NetworkInformationLike = {
+  effectiveType?: string;
+  saveData?: boolean;
+};
+
+type NavigatorWithConnection = Navigator & {
+  connection?: NetworkInformationLike;
+  mozConnection?: NetworkInformationLike;
+  webkitConnection?: NetworkInformationLike;
+};
+
+export const computePreloadStrategy = (): "auto" | "metadata" | "none" => {
+  const navigatorWithConnection = navigator as NavigatorWithConnection;
+  const connection =
+    navigatorWithConnection.connection ||
+    navigatorWithConnection.mozConnection ||
+    navigatorWithConnection.webkitConnection;
+
+  if (connection) {
+    const type = connection.effectiveType; // 'slow-2g', '2g', '3g', '4g'
+    const saveData = connection.saveData;
+
+    if (saveData) {
+      return "none"; // Save data mode -> minimal loading
+    }
+    if (type === "4g") {
+      return "auto"; // Good connection -> auto preload
+    }
+    return "metadata"; // Slower connection -> metadata only
+  }
+
+  // Browsers without the Network Information API (Safari, Firefox).
+  // Mobile devices stay conservative to avoid burning cellular data;
+  // isIOS() also catches iPadOS, whose Safari reports a desktop Mac UA.
+  if (isIOS() || isAndroid()) {
+    return "metadata";
+  }
+
+  // Desktop Safari gets 'auto': read-ahead buffering is what makes
+  // timeline seeks land in already-buffered data, and Safari's native
+  // WebM pipeline downloads linearly and cannot byte-range seek. Other
+  // desktop browsers without the API (Firefox) range-seek fine and
+  // keep their long-standing 'metadata' behavior.
+  return isSafari() ? "auto" : "metadata";
+};

--- a/frontend/src/utils/preloadStrategy.ts
+++ b/frontend/src/utils/preloadStrategy.ts
@@ -18,7 +18,27 @@ type NavigatorWithConnection = Navigator & {
   webkitConnection?: NetworkInformationLike;
 };
 
-export const computePreloadStrategy = (): "auto" | "metadata" | "none" => {
+type PreloadStrategyInput = {
+  src?: string | null;
+  mediaPath?: string | null;
+};
+
+const hasWebMExtension = (value: string | null | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  const withoutQuery = value.trim().split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
+  return withoutQuery.endsWith(".webm");
+};
+
+const isWebMSource = ({ src, mediaPath }: PreloadStrategyInput): boolean =>
+  hasWebMExtension(mediaPath) || hasWebMExtension(src);
+
+export const computePreloadStrategy = ({
+  src = null,
+  mediaPath = null,
+}: PreloadStrategyInput = {}): "auto" | "metadata" | "none" => {
   const navigatorWithConnection = navigator as NavigatorWithConnection;
   const connection =
     navigatorWithConnection.connection ||
@@ -45,10 +65,9 @@ export const computePreloadStrategy = (): "auto" | "metadata" | "none" => {
     return "metadata";
   }
 
-  // Desktop Safari gets 'auto': read-ahead buffering is what makes
-  // timeline seeks land in already-buffered data, and Safari's native
-  // WebM pipeline downloads linearly and cannot byte-range seek. Other
-  // desktop browsers without the API (Firefox) range-seek fine and
-  // keep their long-standing 'metadata' behavior.
-  return isSafari() ? "auto" : "metadata";
+  // Desktop Safari gets 'auto' only for WebM: read-ahead buffering is
+  // what makes timeline seeks land in already-buffered data, and
+  // Safari's native WebM pipeline downloads linearly. Other formats and
+  // browsers keep their long-standing 'metadata' behavior.
+  return isSafari() && isWebMSource({ src, mediaPath }) ? "auto" : "metadata";
 };


### PR DESCRIPTION
## What changed
- Use direct `currentTime` seeking for progress restore and user seek paths so Safari's WebM behavior is handled consistently.
- Keep the video preload strategy adaptive, using desktop `auto` preload where browsers without Network Information API support benefit from read-ahead buffering.
- Avoid feeding playback-local time back into `startTime` on unrelated rerenders.
- Update player hook tests for the single-seek behavior.

## Why
Safari ignores or poorly handles `fastSeek()` for WebM in this flow, especially when restoring progress or seeking outside buffered ranges. The result is slower or unreliable seek behavior. Direct `currentTime` assignment gives Safari the compatible path while preserving the existing player controls.

## Impact
Video playback should restore progress and seek more reliably on Safari WebM files, without changing the visible player controls.

## Validation
- `npm run test -- useVideoPlayer.test.ts`
- `npm run typecheck`
- `npm run lint`
- `git diff --check origin/master...HEAD`