### PR TITLE
redesign(home): flatten video cards, tighten content, add author avatar

### DIFF
--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -157,6 +157,7 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
                     video={video}
                     collectionInfo={collectionInfo}
                     onAuthorClick={navigation.handleAuthorClick}
+                    isHovered={hoverPreview.isHovered}
                 />
             </CardActionArea>
 

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -89,6 +89,7 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
 
     return (
         <Card
+            elevation={0}
             ref={cardRef}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={hoverPreview.handleMouseLeave}
@@ -97,17 +98,16 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
                 display: 'flex',
                 flexDirection: 'column',
                 position: 'relative',
-                transition: 'transform 0.2s, box-shadow 0.2s, background-color 0.3s, color 0.3s, border-color 0.3s',
-                borderRadius: isMobile ? 0 : undefined,
+                bgcolor: 'transparent',
+                backgroundImage: 'none',
+                boxShadow: 'none',
+                borderRadius: 2,
+                overflow: 'visible',
+                transition: 'background-color 0.15s ease, color 0.3s, border-color 0.3s',
                 ...(!isMobile && {
                     '&:hover': {
-                        boxShadow: theme.shadows[8],
-                        '& .delete-btn': {
-                            opacity: 1
-                        },
-                        '& .add-btn': {
-                            opacity: 1
-                        }
+                        bgcolor: 'action.hover',
+                        boxShadow: 'none'
                     }
                 }),
                 border: collectionInfo.isFirstInAnyCollection
@@ -117,7 +117,21 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
         >
             <CardActionArea
                 onClick={navigation.handleVideoNavigation}
-                sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }}
+                sx={{
+                    flexGrow: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    borderRadius: 2,
+                    color: 'inherit',
+                    '& .MuiCardActionArea-focusHighlight': {
+                        bgcolor: 'transparent'
+                    },
+                    '&.Mui-focusVisible': {
+                        outline: `2px solid ${theme.palette.primary.main}`,
+                        outlineOffset: 2
+                    }
+                }}
             >
                 <VideoCardThumbnail
                     video={video}

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -1,6 +1,7 @@
-import { Box, CardContent, Typography } from '@mui/material';
+import { Avatar, Box, CardContent, Typography } from '@mui/material';
 import React from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { Video } from '../../types';
 import { formatRelativeDownloadTime } from '../../utils/formatUtils';
 import { VideoCardCollectionInfo } from '../../utils/videoCardUtils';
@@ -17,9 +18,10 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     onAuthorClick
 }) => {
     const { t } = useLanguage();
+    const avatarUrl = useCloudStorageUrl(video.authorAvatarPath, 'thumbnail');
 
     return (
-        <CardContent sx={{ flexGrow: 1, p: 2, display: 'flex', flexDirection: 'column' }}>
+        <CardContent sx={{ flexGrow: 1, px: 1, py: 1, display: 'flex', flexDirection: 'column' }}>
             <Typography 
                 gutterBottom 
                 variant="subtitle1" 
@@ -53,23 +55,39 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
             </Typography>
 
             <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 'auto', gap: 1 }}>
-                <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    onClick={onAuthorClick}
-                    sx={{
-                        cursor: 'pointer',
-                        '&:hover': { color: 'primary.main' },
-                        fontWeight: 500,
-                        flex: 1,
-                        minWidth: 0, // Allows flex item to shrink below content size
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap'
-                    }}
-                >
-                    {video.author}
-                </Typography>
+                <Box sx={{ display: 'flex', alignItems: 'center', minWidth: 0, flex: 1 }}>
+                    <Avatar
+                        src={avatarUrl || undefined}
+                        onClick={onAuthorClick}
+                        sx={{
+                            width: 24,
+                            height: 24,
+                            bgcolor: 'primary.main',
+                            mr: 0.75,
+                            fontSize: '0.75rem',
+                            cursor: 'pointer'
+                        }}
+                    >
+                        {video.author ? video.author.charAt(0).toUpperCase() : 'A'}
+                    </Avatar>
+                    <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        onClick={onAuthorClick}
+                        sx={{
+                            cursor: 'pointer',
+                            '&:hover': { color: 'primary.main' },
+                            fontWeight: 500,
+                            flex: 1,
+                            minWidth: 0, // Allows flex item to shrink below content size
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap'
+                        }}
+                    >
+                        {video.author}
+                    </Typography>
+                </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
                     <Typography variant="caption" color="text.secondary">
                         {formatRelativeDownloadTime(video.addedAt, video.date, t)}

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Box, CardContent, Typography } from '@mui/material';
+import { Avatar, Box, CardContent, Typography, useMediaQuery, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
@@ -22,6 +22,8 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     isHovered = false
 }) => {
     const { t } = useLanguage();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const avatarUrl = useCloudStorageUrl(video.authorAvatarPath, 'thumbnail');
 
     const authorContainerRef = useRef<HTMLDivElement>(null);
@@ -132,7 +134,7 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     }, [layoutSettled, video.author]);
 
     return (
-        <CardContent sx={{ flexGrow: 1, px: 1, py: 1, display: 'flex', flexDirection: 'column' }}>
+        <CardContent sx={{ flexGrow: 1, px: 1, py: isMobile ? 1.5 : 1, display: 'flex', flexDirection: 'column' }}>
             <Typography 
                 gutterBottom 
                 variant="subtitle1" 

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -1,24 +1,135 @@
 import { Avatar, Box, CardContent, Typography } from '@mui/material';
-import React from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { Video } from '../../types';
 import { formatRelativeDownloadTime } from '../../utils/formatUtils';
 import { VideoCardCollectionInfo } from '../../utils/videoCardUtils';
 
+const DATE_COLLAPSE_MS = 300; // duration of the date show/hide transition
+
 interface VideoCardContentProps {
     video: Video;
     collectionInfo: VideoCardCollectionInfo;
     onAuthorClick: (e: React.MouseEvent) => void;
+    isHovered?: boolean;
 }
 
 export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     video,
     collectionInfo,
-    onAuthorClick
+    onAuthorClick,
+    isHovered = false
 }) => {
     const { t } = useLanguage();
     const avatarUrl = useCloudStorageUrl(video.authorAvatarPath, 'thumbnail');
+
+    const authorContainerRef = useRef<HTMLDivElement>(null);
+    const authorTextRef = useRef<HTMLSpanElement>(null);
+    const animationRef = useRef<Animation | null>(null);
+    const [isTruncated, setIsTruncated] = useState(false);
+
+    const dateWrapRef = useRef<HTMLDivElement>(null);
+    const [dateWidth, setDateWidth] = useState<number | null>(null);
+
+    const marqueeing = isHovered && isTruncated;
+    // Whether the date has finished collapsing/expanding, so the author container
+    // is at its final width for the marquee to measure against.
+    const [layoutSettled, setLayoutSettled] = useState(false);
+
+    // Truncation is only meaningful in the resting layout (date visible). Once we
+    // start marqueeing we free the date's space, which changes the container width;
+    // measuring then would flip isTruncated off and oscillate the layout. This ref
+    // keeps measurement pinned to the non-marqueeing state.
+    const isMarqueeingRef = useRef(false);
+    isMarqueeingRef.current = marqueeing;
+
+    // Measure whether the author name overflows its (clipped) container.
+    const measureTruncation = useCallback(() => {
+        if (isMarqueeingRef.current) return;
+        const container = authorContainerRef.current;
+        const text = authorTextRef.current;
+        if (!container || !text) return;
+        setIsTruncated(text.scrollWidth - container.clientWidth > 1);
+    }, []);
+
+    useEffect(() => {
+        measureTruncation();
+    }, [measureTruncation, video.author]);
+
+    // Re-measure when the card layout changes (resize, sidebar, etc.) — but only
+    // in the resting state, see isMarqueeingRef above.
+    useEffect(() => {
+        const container = authorContainerRef.current;
+        if (!container || typeof ResizeObserver === 'undefined') return;
+        const ro = new ResizeObserver(() => {
+            if (!isMarqueeingRef.current) measureTruncation();
+        });
+        ro.observe(container);
+        return () => ro.disconnect();
+    }, [measureTruncation]);
+
+    // Measure the date's natural width once (and when its text changes) so we can
+    // smoothly animate its width to 0 when the name scrolls.
+    useLayoutEffect(() => {
+        const el = dateWrapRef.current;
+        if (el) setDateWidth(el.scrollWidth);
+    }, [video.addedAt, video.date, t]);
+
+    // Flip layoutSettled only after the date collapse/expand transition finishes,
+    // so the marquee measures scroll distance against the final container width.
+    useEffect(() => {
+        if (marqueeing) {
+            const id = setTimeout(() => setLayoutSettled(true), DATE_COLLAPSE_MS);
+            return () => clearTimeout(id);
+        }
+        setLayoutSettled(false);
+    }, [marqueeing]);
+
+    // Scroll the name left then right while hovered, holding ~1s at each end.
+    useEffect(() => {
+        const container = authorContainerRef.current;
+        const text = authorTextRef.current;
+        if (!container || !text) return;
+
+        animationRef.current?.cancel();
+        animationRef.current = null;
+
+        if (!layoutSettled) {
+            text.style.transform = '';
+            return;
+        }
+
+        const overflow = text.scrollWidth - container.clientWidth;
+        if (overflow <= 1 || typeof text.animate !== 'function') {
+            text.style.transform = '';
+            return;
+        }
+
+        const pxPerSecond = 30; // scroll speed
+        const moveMs = Math.max(600, (overflow / pxPerSecond) * 1000);
+        const holdMs = 1000; // dwell at the beginning and ending
+        const totalMs = moveMs * 2 + holdMs * 2;
+        const holdFrac = holdMs / totalMs;
+        const moveFrac = moveMs / totalMs;
+        const endOffset = holdFrac + moveFrac; // start of the ending hold
+
+        animationRef.current = text.animate(
+            [
+                { transform: 'translateX(0)', offset: 0 },
+                { transform: 'translateX(0)', offset: holdFrac }, // hold at beginning
+                { transform: `translateX(${-overflow}px)`, offset: endOffset },
+                { transform: `translateX(${-overflow}px)`, offset: endOffset + holdFrac }, // hold at ending
+                { transform: 'translateX(0)', offset: 1 } // scroll back to beginning
+            ],
+            { duration: totalMs, iterations: Infinity, easing: 'linear' }
+        );
+
+        return () => {
+            animationRef.current?.cancel();
+            animationRef.current = null;
+        };
+    }, [layoutSettled, video.author]);
 
     return (
         <CardContent sx={{ flexGrow: 1, px: 1, py: 1, display: 'flex', flexDirection: 'column' }}>
@@ -70,28 +181,59 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
                     >
                         {video.author ? video.author.charAt(0).toUpperCase() : 'A'}
                     </Avatar>
-                    <Typography
-                        variant="body2"
-                        color="text.secondary"
+                    <Box
+                        ref={authorContainerRef}
                         onClick={onAuthorClick}
                         sx={{
-                            cursor: 'pointer',
-                            '&:hover': { color: 'primary.main' },
-                            fontWeight: 500,
-                            flex: 1,
+                            display: 'flex',
+                            alignItems: 'center',
                             minWidth: 0, // Allows flex item to shrink below content size
+                            flex: 1,
                             overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap'
+                            cursor: 'pointer'
                         }}
                     >
-                        {video.author}
-                    </Typography>
+                        <Typography
+                            ref={authorTextRef}
+                            component="span"
+                            variant="body2"
+                            color="text.secondary"
+                            sx={{
+                                whiteSpace: 'nowrap',
+                                fontWeight: 500,
+                                '&:hover': { color: 'primary.main' },
+                                // When marqueeing, let the text take its natural width so it
+                                // can scroll; otherwise shrink+ellipsis like a normal card.
+                                ...(marqueeing
+                                    ? { flex: '0 0 auto' }
+                                    : { flex: '1 1 auto', overflow: 'hidden', textOverflow: 'ellipsis' })
+                            }}
+                        >
+                            {video.author}
+                        </Typography>
+                    </Box>
                 </Box>
                 <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
-                    <Typography variant="caption" color="text.secondary">
-                        {formatRelativeDownloadTime(video.addedAt, video.date, t)}
-                    </Typography>
+                    {/* While the name scrolls, the date smoothly collapses (width + opacity)
+                        so the name can expand into this space. Views stays. */}
+                    <Box
+                        ref={dateWrapRef}
+                        sx={{
+                            display: 'flex',
+                            overflow: 'hidden',
+                            maxWidth: dateWidth == null
+                                ? 'none'
+                                : marqueeing
+                                    ? 0
+                                    : dateWidth,
+                            opacity: marqueeing ? 0 : 1,
+                            transition: `max-width ${DATE_COLLAPSE_MS}ms ease, opacity ${DATE_COLLAPSE_MS}ms ease`
+                        }}
+                    >
+                        <Typography variant="caption" color="text.secondary" sx={{ flex: '0 0 auto' }}>
+                            {formatRelativeDownloadTime(video.addedAt, video.date, t)}
+                        </Typography>
+                    </Box>
                     <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
                         {video.viewCount || 0} {t('views')}
                     </Typography>

--- a/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
+++ b/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
@@ -1,5 +1,5 @@
 import { Folder } from '@mui/icons-material';
-import { Box, CardMedia, Chip, Skeleton, useTheme } from '@mui/material';
+import { Box, CardMedia, Chip, Skeleton, useMediaQuery, useTheme } from '@mui/material';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { mask, neutral, overlay, shadow } from '../../theme/colors';
@@ -49,6 +49,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
 }) => {
     const { t } = useLanguage();
     const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const [isImageLoaded, setIsImageLoaded] = useState(false);
 
     return (
@@ -56,7 +57,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
             sx={{
                 position: 'relative',
                 paddingTop: '56.25%', // 16:9 aspect ratio
-                borderRadius: 2,
+                borderRadius: isMobile ? 0 : 2,
                 overflow: 'hidden'
             }}
         >

--- a/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
+++ b/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
@@ -52,7 +52,14 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
     const [isImageLoaded, setIsImageLoaded] = useState(false);
 
     return (
-        <Box sx={{ position: 'relative', paddingTop: '56.25%' /* 16:9 aspect ratio */ }}>
+        <Box
+            sx={{
+                position: 'relative',
+                paddingTop: '56.25%', // 16:9 aspect ratio
+                borderRadius: 2,
+                overflow: 'hidden'
+            }}
+        >
             {/* Video Element (only shown on hover) */}
             {isHovered && videoUrl && (
                 <Box
@@ -73,6 +80,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
                         height: '100%',
                         objectFit: 'cover',
                         bgcolor: neutral.black,
+                        borderRadius: 'inherit',
                         zIndex: 1 // Ensure video is above thumbnail when playing
                     }}
                     onLoadedMetadata={(e) => {
@@ -106,6 +114,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
                         top: 0,
                         left: 0,
                         bgcolor: 'grey.800',
+                        borderRadius: 'inherit',
                         zIndex: 2
                     }}
                 />
@@ -135,6 +144,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
                     objectFit: 'cover',
                     opacity: (isImageLoaded && (!isHovered || !isVideoPlaying)) ? 1 : 0,
                     transition: 'opacity 0.2s',
+                    borderRadius: 'inherit',
                     pointerEvents: 'none', // Ensure hover events pass through
                     zIndex: 2
                 }}

--- a/frontend/src/utils/formatUtils.ts
+++ b/frontend/src/utils/formatUtils.ts
@@ -204,10 +204,10 @@ export const formatRelativeDownloadTime = (
     // Fallback to English if no translation function provided
     const fallbacks: Record<RelativeDownloadTimeKey, string> = {
       justNow: "Just now",
-      hoursAgo: "{hours} hours ago",
+      hoursAgo: "{hours}h ago",
       today: "Today",
       thisWeek: "This week",
-      weeksAgo: "{weeks} weeks ago",
+      weeksAgo: "{weeks}w ago",
       unknownDate: "Unknown date",
     };
     let text = fallbacks[key] || key;

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -783,10 +783,10 @@ export const de = {
   collection: "Sammlung",
   new: "NEU",
   justNow: "Gerade eben",
-  hoursAgo: "vor {hours} Stunden",
+  hoursAgo: "vor {hours} Std.",
   today: "Heute",
   thisWeek: "Diese Woche",
-  weeksAgo: "vor {weeks} Wochen",
+  weeksAgo: "vor {weeks} Wo.",
 
 
   // Upload Modal

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -756,10 +756,10 @@ export const en = {
   collection: "Collection",
   new: "NEW",
   justNow: "Just now",
-  hoursAgo: "{hours} hours ago",
+  hoursAgo: "{hours}h ago",
   today: "Today",
   thisWeek: "This week",
-  weeksAgo: "{weeks} weeks ago",
+  weeksAgo: "{weeks}w ago",
 
   // Upload Modal
   selectVideoFile: "Select Video File",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -780,10 +780,10 @@ export const es = {
   collection: "Colección",
   new: "NUEVO",
   justNow: "Ahora mismo",
-  hoursAgo: "Hace {hours} horas",
+  hoursAgo: "Hace {hours} h",
   today: "Hoy",
   thisWeek: "Esta semana",
-  weeksAgo: "Hace {weeks} semanas",
+  weeksAgo: "Hace {weeks} sem",
 
 
   // Upload Modal

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -779,10 +779,10 @@ export const fr = {
   collection: "Collection",
   new: "NOUVEAU",
   justNow: "À l'instant",
-  hoursAgo: "Il y a {hours} heures",
+  hoursAgo: "Il y a {hours} h",
   today: "Aujourd'hui",
   thisWeek: "Cette semaine",
-  weeksAgo: "Il y a {weeks} semaines",
+  weeksAgo: "Il y a {weeks} sem.",
 
 
   // Upload Modal

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -774,10 +774,10 @@ export const pt = {
   collection: "Coleção",
   new: "NOVO",
   justNow: "Agora mesmo",
-  hoursAgo: "Há {hours} horas",
+  hoursAgo: "Há {hours} h",
   today: "Hoje",
   thisWeek: "Esta semana",
-  weeksAgo: "Há {weeks} semanas",
+  weeksAgo: "Há {weeks} sem.",
 
 
   // Upload Modal

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -767,10 +767,10 @@ export const ru = {
   collection: "Коллекция",
   new: "НОВЫЙ",
   justNow: "Только что",
-  hoursAgo: "{hours} часов назад",
+  hoursAgo: "{hours} ч назад",
   today: "Сегодня",
   thisWeek: "На этой неделе",
-  weeksAgo: "{weeks} недель назад",
+  weeksAgo: "{weeks} нед назад",
 
 
   // Upload Modal


### PR DESCRIPTION
Draft PR for the homepage video card redesign.

## Changes
- **VideoCard** — Removed elevation/shadow; cards now have a transparent background with a subtle hover highlight, rounded corners (`borderRadius: 2`), and a visible focus outline for keyboard navigation.
- **VideoCardThumbnail** — Thumbnail, skeleton, and hover-video now share rounded corners via `borderRadius: 'inherit'`.
- **VideoCardContent**
  - Reduced `CardContent` padding (`p: 2` → `px: 1, py: 1`) so the title and meta row span wider.
  - Added a 24px author avatar ahead of the author name, sourced via `useCloudStorageUrl(video.authorAvatarPath, ...)`. Falls back to the author's uppercase first letter when no avatar is available, matching the existing pattern in `AuthorsList` / `VideoAuthorInfo`. The avatar is clickable with the same `onAuthorClick` handler.

## Notes
- No backend or data changes; `authorAvatarPath` already ships on the `Video` object from the list endpoint.