### PR TITLE
[codex] Redesign Up Next recommender

### DIFF
--- a/backend/scripts/replay-up-next.ts
+++ b/backend/scripts/replay-up-next.ts
@@ -1,0 +1,339 @@
+import Database from "better-sqlite3";
+
+interface VideoRow {
+  id: string;
+  title: string;
+  author: string | null;
+  source: string | null;
+  videoFilename: string | null;
+  addedAt: string | null;
+  date: string | null;
+  tags: string | null;
+  seriesTitle: string | null;
+  partNumber: number | null;
+  rating: number | null;
+  viewCount: number | null;
+  progress: number | null;
+  lastPlayedAt: number | null;
+}
+
+interface CollectionVideoRow {
+  collectionId: string;
+  videoId: string;
+  orderValue: number | null;
+}
+
+interface PlayEventRow {
+  sessionId: string | null;
+  videoId: string | null;
+  recordedAt: number;
+}
+
+interface VideoModel extends VideoRow {
+  parsedTags: string[];
+}
+
+interface Transition {
+  fromVideoId: string;
+  toVideoId: string;
+}
+
+interface Metrics {
+  total: number;
+  hit3: number;
+  hit10: number;
+  mrr: number;
+}
+
+const args = process.argv.slice(2);
+
+function getArg(name: string): string | null {
+  const index = args.indexOf(name);
+  if (index === -1 || index === args.length - 1) return null;
+  return args[index + 1];
+}
+
+function parseLimit(): number {
+  const raw = getArg("--limit");
+  if (!raw) return 5000;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 5000;
+}
+
+function parseTags(value: string | null): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed)
+      ? parsed
+          .filter((tag): tag is string => typeof tag === "string")
+          .map((tag) => tag.trim().toLowerCase())
+          .filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function tokenize(value: string | null): Set<string> {
+  return new Set(
+    (value ?? "")
+      .toLowerCase()
+      .replace(/\.[a-z0-9]{2,5}$/i, " ")
+      .split(/[^a-z0-9]+/i)
+      .filter((token) => token.length > 1)
+  );
+}
+
+function jaccard(a: readonly string[], b: readonly string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const aSet = new Set(a);
+  const bSet = new Set(b);
+  let overlap = 0;
+  for (const item of aSet) {
+    if (bSet.has(item)) overlap += 1;
+  }
+  return overlap / new Set([...aSet, ...bSet]).size;
+}
+
+function loadVideos(db: Database.Database): Map<string, VideoModel> {
+  const rows = db
+    .prepare(
+      `SELECT id,
+              title,
+              author,
+              source,
+              video_filename AS videoFilename,
+              added_at AS addedAt,
+              date,
+              tags,
+              series_title AS seriesTitle,
+              part_number AS partNumber,
+              rating,
+              view_count AS viewCount,
+              progress,
+              last_played_at AS lastPlayedAt
+       FROM videos`
+    )
+    .all() as VideoRow[];
+
+  return new Map(
+    rows.map((row) => [
+      row.id,
+      {
+        ...row,
+        parsedTags: parseTags(row.tags),
+      },
+    ])
+  );
+}
+
+function loadCollections(db: Database.Database): Map<string, string[]> {
+  const rows = db
+    .prepare(
+      `SELECT collection_id AS collectionId,
+              video_id AS videoId,
+              "order" AS orderValue
+       FROM collection_videos
+       ORDER BY collection_id ASC, COALESCE("order", 0) ASC`
+    )
+    .all() as CollectionVideoRow[];
+  const byCollection = new Map<string, string[]>();
+
+  for (const row of rows) {
+    const list = byCollection.get(row.collectionId) ?? [];
+    list.push(row.videoId);
+    byCollection.set(row.collectionId, list);
+  }
+
+  return byCollection;
+}
+
+function loadTransitions(
+  db: Database.Database,
+  videos: Map<string, VideoModel>,
+  limit: number
+): Transition[] {
+  const rows = db
+    .prepare(
+      `SELECT session_id AS sessionId,
+              video_id AS videoId,
+              recorded_at AS recordedAt
+       FROM usage_statistics_events
+       WHERE event_type = 'video_play_started'
+         AND session_id IS NOT NULL
+         AND video_id IS NOT NULL
+       ORDER BY session_id ASC, recorded_at ASC
+       LIMIT ?`
+    )
+    .all(limit) as PlayEventRow[];
+  const transitions: Transition[] = [];
+  let previous: PlayEventRow | null = null;
+
+  for (const row of rows) {
+    if (
+      previous &&
+      previous.sessionId === row.sessionId &&
+      previous.videoId &&
+      row.videoId &&
+      previous.videoId !== row.videoId &&
+      videos.has(previous.videoId) &&
+      videos.has(row.videoId)
+    ) {
+      transitions.push({
+        fromVideoId: previous.videoId,
+        toVideoId: row.videoId,
+      });
+    }
+    previous = row;
+  }
+
+  return transitions;
+}
+
+function getCollectionIds(
+  videoId: string,
+  collections: Map<string, string[]>
+): string[] {
+  const ids: string[] = [];
+  for (const [collectionId, videoIds] of collections.entries()) {
+    if (videoIds.includes(videoId)) ids.push(collectionId);
+  }
+  return ids;
+}
+
+function legacyScore(
+  current: VideoModel,
+  candidate: VideoModel,
+  videos: VideoModel[],
+  collections: Map<string, string[]>
+): number {
+  const currentCollections = getCollectionIds(current.id, collections);
+  const candidateCollections = getCollectionIds(candidate.id, collections);
+  const sameCollection = currentCollections.some((id) => candidateCollections.includes(id));
+  const sorted = [...videos].sort((a, b) =>
+    (a.videoFilename ?? a.title).localeCompare(b.videoFilename ?? b.title, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    })
+  );
+  const currentIndex = sorted.findIndex((video) => video.id === current.id);
+  const nextGlobalId = currentIndex >= 0 ? sorted[currentIndex + 1]?.id : null;
+
+  return (
+    (sameCollection || current.seriesTitle === candidate.seriesTitle ? 0.4 : 0) +
+    (current.author && current.author === candidate.author ? 0.3 : 0) +
+    jaccard(current.parsedTags, candidate.parsedTags) * 0.35 +
+    (current.source && current.source === candidate.source ? 0.08 : 0) +
+    (candidate.id === nextGlobalId ? 0.25 : 0)
+  );
+}
+
+function redesignedScore(
+  current: VideoModel,
+  candidate: VideoModel,
+  collections: Map<string, string[]>
+): number {
+  let score = 0;
+  if (
+    current.seriesTitle &&
+    current.seriesTitle === candidate.seriesTitle &&
+    current.partNumber !== null &&
+    candidate.partNumber === current.partNumber + 1
+  ) {
+    score += 1;
+  }
+
+  const currentCollections = getCollectionIds(current.id, collections);
+  for (const collectionId of currentCollections) {
+    const ids = collections.get(collectionId) ?? [];
+    const currentIndex = ids.indexOf(current.id);
+    const candidateIndex = ids.indexOf(candidate.id);
+    if (currentIndex >= 0 && candidateIndex > currentIndex) {
+      score += 0.5 / Math.max(1, candidateIndex - currentIndex);
+    }
+  }
+
+  score += current.author && current.author === candidate.author ? 0.25 : 0;
+  score += jaccard(current.parsedTags, candidate.parsedTags) * 0.2;
+  score += current.source && current.source === candidate.source ? 0.05 : 0;
+  score += ((candidate.rating ?? 3) - 3) * 0.05;
+  return score;
+}
+
+function rank(
+  current: VideoModel,
+  videos: VideoModel[],
+  collections: Map<string, string[]>,
+  mode: "legacy" | "redesigned"
+): string[] {
+  return videos
+    .filter((candidate) => candidate.id !== current.id)
+    .map((candidate) => ({
+      id: candidate.id,
+      score:
+        mode === "legacy"
+          ? legacyScore(current, candidate, videos, collections)
+          : redesignedScore(current, candidate, collections),
+      name: candidate.videoFilename ?? candidate.title,
+    }))
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name, undefined, {
+      numeric: true,
+      sensitivity: "base",
+    }))
+    .slice(0, 10)
+    .map((item) => item.id);
+}
+
+function evaluate(
+  transitions: Transition[],
+  videos: Map<string, VideoModel>,
+  collections: Map<string, string[]>,
+  mode: "legacy" | "redesigned"
+): Metrics {
+  const allVideos = Array.from(videos.values());
+  const metrics: Metrics = { total: 0, hit3: 0, hit10: 0, mrr: 0 };
+
+  for (const transition of transitions) {
+    const current = videos.get(transition.fromVideoId);
+    if (!current) continue;
+    const ranked = rank(current, allVideos, collections, mode);
+    const index = ranked.indexOf(transition.toVideoId);
+    metrics.total += 1;
+    if (index >= 0 && index < 3) metrics.hit3 += 1;
+    if (index >= 0 && index < 10) metrics.hit10 += 1;
+    if (index >= 0) metrics.mrr += 1 / (index + 1);
+  }
+
+  return metrics;
+}
+
+function formatMetrics(metrics: Metrics): string {
+  if (metrics.total === 0) return "no transitions";
+  return [
+    `n=${metrics.total}`,
+    `hit@3=${(metrics.hit3 / metrics.total).toFixed(3)}`,
+    `hit@10=${(metrics.hit10 / metrics.total).toFixed(3)}`,
+    `mrr=${(metrics.mrr / metrics.total).toFixed(3)}`,
+  ].join(" ");
+}
+
+const dbPath = getArg("--db");
+if (!dbPath) {
+  console.error("Usage: ts-node scripts/replay-up-next.ts --db /path/to/mytube.db [--limit 5000]");
+  process.exit(1);
+}
+
+const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+try {
+  const videos = loadVideos(db);
+  const collections = loadCollections(db);
+  const transitions = loadTransitions(db, videos, parseLimit());
+  const legacy = evaluate(transitions, videos, collections, "legacy");
+  const redesigned = evaluate(transitions, videos, collections, "redesigned");
+
+  console.log(`legacy     ${formatMetrics(legacy)}`);
+  console.log(`redesigned ${formatMetrics(redesigned)}`);
+} finally {
+  db.close();
+}

--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -18,6 +18,7 @@ import { rateVideo } from "../../controllers/videoMetadataController";
 import downloadManager from "../../services/downloadManager";
 import * as downloadService from "../../services/downloadService";
 import { isLoginRequired } from "../../services/passwordService";
+import { invalidateRecommendationSignalsCache } from "../../services/recommendationSignalsService";
 import * as storageService from "../../services/storageService";
 
 vi.mock("../../db", () => ({
@@ -35,6 +36,9 @@ vi.mock("../../db", () => ({
 
 vi.mock("../../services/downloadService");
 vi.mock("../../services/storageService");
+vi.mock("../../services/recommendationSignalsService", () => ({
+  invalidateRecommendationSignalsCache: vi.fn(),
+}));
 // isLoginRequired defaults to false (single-user mode) so existing tests are
 // unaffected; visitor-visibility tests opt into login-enabled per-case.
 vi.mock("../../services/passwordService", async (importOriginal) => {
@@ -583,6 +587,18 @@ describe("VideoController", () => {
 
       updateVideoDetails(req as Request, res as Response);
 
+      expect(status).toHaveBeenCalledWith(200);
+    });
+
+    it("invalidates recommendation signals when visibility changes", () => {
+      req.params = { id: "1" };
+      req.body = { visibility: 0 };
+      const mockVideo = { id: "1", visibility: 0 };
+      (storageService.updateVideo as any).mockReturnValue(mockVideo);
+
+      updateVideoDetails(req as Request, res as Response);
+
+      expect(invalidateRecommendationSignalsCache).toHaveBeenCalledTimes(1);
       expect(status).toHaveBeenCalledWith(200);
     });
 

--- a/backend/src/__tests__/services/recommendationSignalsService.test.ts
+++ b/backend/src/__tests__/services/recommendationSignalsService.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrepare = vi.fn();
+const mockIsStatisticsEnabled = vi.fn();
+
+vi.mock("../../db", () => ({
+  sqlite: {
+    prepare: (...args: unknown[]) => mockPrepare(...args),
+  },
+}));
+
+vi.mock("../../services/statistics/collector", () => ({
+  isStatisticsEnabled: () => mockIsStatisticsEnabled(),
+}));
+
+import {
+  getRecommendationSignals,
+  invalidateRecommendationSignalsCache,
+} from "../../services/recommendationSignalsService";
+
+interface MockRows {
+  videos?: unknown[];
+  events?: unknown[];
+  subscriptions?: unknown[];
+}
+
+const installRows = (rows: MockRows): void => {
+  mockPrepare.mockImplementation((sql: string) => {
+    const all = vi.fn(() => {
+      if (sql.includes("FROM videos")) return rows.videos ?? [];
+      if (sql.includes("FROM usage_statistics_events")) return rows.events ?? [];
+      if (sql.includes("FROM subscriptions")) return rows.subscriptions ?? [];
+      throw new Error(`Unexpected SQL: ${sql}`);
+    });
+
+    return { all };
+  });
+};
+
+describe("recommendationSignalsService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-04T12:00:00Z"));
+    mockIsStatisticsEnabled.mockReturnValue(true);
+    invalidateRecommendationSignalsCache();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null without querying when statistics are disabled", () => {
+    mockIsStatisticsEnabled.mockReturnValue(false);
+
+    expect(getRecommendationSignals()).toBeNull();
+    expect(mockPrepare).not.toHaveBeenCalled();
+  });
+
+  it("aggregates watch, affinity, and co-play signals", () => {
+    const now = Date.now();
+    installRows({
+      videos: [
+        {
+          id: "v1",
+          author: "Ada",
+          channelUrl: "https://example.com/ada",
+          tags: JSON.stringify(["React"]),
+          duration: "100",
+          rating: 5,
+          viewCount: 2,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+        {
+          id: "v2",
+          author: "Grace",
+          channelUrl: "https://example.com/grace",
+          tags: JSON.stringify(["React", "TypeScript"]),
+          duration: "100",
+          rating: 4,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+      ],
+      subscriptions: [
+        { author: "Ada", authorUrl: "https://example.com/ada" },
+      ],
+      events: [
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 10_000,
+          sessionId: "s1",
+          videoId: "v1",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 9_000,
+          sessionId: "s1",
+          videoId: "v1",
+          durationSeconds: 100,
+        },
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 8_000,
+          sessionId: "s1",
+          videoId: "v2",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 7_000,
+          sessionId: "s1",
+          videoId: "v2",
+          durationSeconds: 95,
+        },
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 6_000,
+          sessionId: "s2",
+          videoId: "v1",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 5_000,
+          sessionId: "s2",
+          videoId: "v1",
+          durationSeconds: 10,
+        },
+      ],
+    });
+
+    const signals = getRecommendationSignals();
+
+    expect(signals).not.toBeNull();
+    expect(signals?.perVideo.v1.ws).toBeGreaterThan(0);
+    expect(signals?.perVideo.v1.ar).toBe(0.5);
+    expect(signals?.perVideo.v1.rw).toBe(0.5);
+    expect(signals?.perVideo.v1.nb[0][0]).toBe("v2");
+    expect(signals?.authorAffinity["https://example.com/ada"]).toBeGreaterThan(0.15);
+    expect(signals?.tagAffinity.react).toBeGreaterThan(0);
+    expect(
+      (signals?.durationBands ?? []).reduce(
+        (sum: number, value: number) => sum + value,
+        0
+      )
+    ).toBeCloseTo(1);
+  });
+
+  it("filters hidden videos and neighbors for visitor signals", () => {
+    const now = Date.now();
+    installRows({
+      videos: [
+        {
+          id: "visible",
+          author: "Ada",
+          channelUrl: null,
+          tags: JSON.stringify(["public"]),
+          duration: "100",
+          rating: null,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+        {
+          id: "hidden",
+          author: "Hidden",
+          channelUrl: null,
+          tags: JSON.stringify(["private"]),
+          duration: "100",
+          rating: null,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 0,
+        },
+      ],
+      events: [
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 3_000,
+          sessionId: "s1",
+          videoId: "visible",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 2_000,
+          sessionId: "s1",
+          videoId: "visible",
+          durationSeconds: 100,
+        },
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 1_000,
+          sessionId: "s1",
+          videoId: "hidden",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 500,
+          sessionId: "s1",
+          videoId: "hidden",
+          durationSeconds: 100,
+        },
+      ],
+    });
+
+    const signals = getRecommendationSignals("visitor");
+
+    expect(signals?.perVideo.visible).toBeDefined();
+    expect(signals?.perVideo.hidden).toBeUndefined();
+    expect(signals?.perVideo.visible.nb).toEqual([]);
+    expect(signals?.tagAffinity.private).toBeUndefined();
+  });
+});

--- a/backend/src/__tests__/services/recommendationSignalsService.test.ts
+++ b/backend/src/__tests__/services/recommendationSignalsService.test.ts
@@ -220,4 +220,129 @@ describe("recommendationSignalsService", () => {
     expect(signals?.perVideo.visible.nb).toEqual([]);
     expect(signals?.tagAffinity.private).toBeUndefined();
   });
+
+  it("segments repeated watches of the same video by play instance", () => {
+    const now = Date.now();
+    installRows({
+      videos: [
+        {
+          id: "repeat",
+          author: "Ada",
+          channelUrl: null,
+          tags: "[]",
+          duration: "100",
+          rating: null,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+      ],
+      events: [
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 4_000,
+          sessionId: "s1",
+          videoId: "repeat",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 3_000,
+          sessionId: "s1",
+          videoId: "repeat",
+          durationSeconds: 20,
+        },
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 2_000,
+          sessionId: "s1",
+          videoId: "repeat",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 1_000,
+          sessionId: "s1",
+          videoId: "repeat",
+          durationSeconds: 20,
+        },
+      ],
+    });
+
+    const signals = getRecommendationSignals();
+
+    expect(signals?.perVideo.repeat.cr).toBe(0.2);
+    expect(signals?.perVideo.repeat.ar).toBe(1);
+    expect(signals?.perVideo.repeat.rw).toBe(0.5);
+    expect(signals?.perVideo.repeat.lf).toBeNull();
+  });
+
+  it("does not count fully watched short videos as abandoned", () => {
+    const now = Date.now();
+    installRows({
+      videos: [
+        {
+          id: "short",
+          author: "Ada",
+          channelUrl: null,
+          tags: "[]",
+          duration: "20",
+          rating: null,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+        {
+          id: "next",
+          author: "Ada",
+          channelUrl: null,
+          tags: "[]",
+          duration: "60",
+          rating: null,
+          viewCount: 1,
+          progress: 0,
+          lastPlayedAt: null,
+          visibility: 1,
+        },
+      ],
+      events: [
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 4_000,
+          sessionId: "s1",
+          videoId: "short",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 3_000,
+          sessionId: "s1",
+          videoId: "short",
+          durationSeconds: 20,
+        },
+        {
+          eventType: "video_play_started",
+          recordedAt: now - 2_000,
+          sessionId: "s1",
+          videoId: "next",
+          durationSeconds: null,
+        },
+        {
+          eventType: "video_watch_chunk_recorded",
+          recordedAt: now - 1_000,
+          sessionId: "s1",
+          videoId: "next",
+          durationSeconds: 60,
+        },
+      ],
+    });
+
+    const signals = getRecommendationSignals();
+
+    expect(signals?.perVideo.short.cr).toBe(1);
+    expect(signals?.perVideo.short.ar).toBe(0);
+    expect(signals?.perVideo.short.nb[0][0]).toBe("next");
+  });
 });

--- a/backend/src/__tests__/services/recommendationSignalsService.test.ts
+++ b/backend/src/__tests__/services/recommendationSignalsService.test.ts
@@ -57,6 +57,21 @@ describe("recommendationSignalsService", () => {
     expect(mockPrepare).not.toHaveBeenCalled();
   });
 
+  it("orders session events by client occurrence with stable tie-breakers", () => {
+    // Batch ingest stamps recorded_at in a tight loop, so ties within a session
+    // are common; without a deterministic order a chunk can precede its
+    // video_play_started row and get dropped from play accounting.
+    installRows({ videos: [], events: [] });
+
+    getRecommendationSignals();
+
+    const eventsSql = mockPrepare.mock.calls
+      .map(([sql]) => sql as string)
+      .find(sql => sql.includes("FROM usage_statistics_events"));
+    expect(eventsSql).toContain("COALESCE(client_occurred_at, recorded_at)");
+    expect(eventsSql).toContain("rowid ASC");
+  });
+
   it("aggregates watch, affinity, and co-play signals", () => {
     const now = Date.now();
     installRows({

--- a/backend/src/__tests__/services/statistics/collector.test.ts
+++ b/backend/src/__tests__/services/statistics/collector.test.ts
@@ -436,6 +436,106 @@ describe("statistics collector", () => {
         externalResultCount: 10_000,
       });
     });
+
+    it("preserves bounded visitor up next click lane, position, and value", () => {
+      const runMock = vi.fn();
+      vi.mocked(sqlite.prepare)
+        .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
+        .mockReturnValueOnce(makeStmt({ get: undefined }) as any)     // isDaySealed
+        .mockReturnValueOnce(makeStmt() as any)                       // markDayDirty
+        .mockReturnValueOnce(makeStmt() as any);                      // bumpIngestionMinute
+
+      const result = ingestBatch(
+        [
+          {
+            eventType: "up_next_clicked",
+            videoId: "video-2",
+            value: 999,
+            payload: {
+              lane: "continue",
+              position: 3,
+              fromVideoId: "video-1",
+              toVideoId: "video-2",
+            },
+          },
+        ],
+        {
+          actorRole: "visitor",
+          surface: "web",
+          serverSessionId: "web:server-derived-session",
+        }
+      );
+
+      expect(result.acceptedCount).toBe(1);
+      const insertedArgs = runMock.mock.calls[0];
+      expect(insertedArgs[16]).toBeNull();
+      expect(insertedArgs[17]).toBe(100);
+      expect(JSON.parse(insertedArgs[18])).toEqual({
+        lane: "continue",
+        position: 3,
+      });
+    });
+
+    it("defaults forged visitor up next lanes to unknown", () => {
+      const runMock = vi.fn();
+      vi.mocked(sqlite.prepare)
+        .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
+        .mockReturnValueOnce(makeStmt({ get: undefined }) as any)     // isDaySealed
+        .mockReturnValueOnce(makeStmt() as any)                       // markDayDirty
+        .mockReturnValueOnce(makeStmt() as any);                      // bumpIngestionMinute
+
+      const result = ingestBatch(
+        [
+          {
+            eventType: "up_next_clicked",
+            videoId: "video-2",
+            payload: { lane: "forged", position: 99_999 },
+          },
+        ],
+        {
+          actorRole: "visitor",
+          surface: "web",
+          serverSessionId: "web:server-derived-session",
+        }
+      );
+
+      expect(result.acceptedCount).toBe(1);
+      const insertedArgs = runMock.mock.calls[0];
+      expect(JSON.parse(insertedArgs[18])).toEqual({
+        lane: "unknown",
+        position: 100,
+      });
+    });
+
+    it("bounds visitor autoplay abandonment duration", () => {
+      const runMock = vi.fn();
+      vi.mocked(sqlite.prepare)
+        .mockReturnValueOnce({ run: runMock } as any)                 // insertStatement
+        .mockReturnValueOnce(makeStmt({ get: undefined }) as any)     // isDaySealed
+        .mockReturnValueOnce(makeStmt() as any)                       // markDayDirty
+        .mockReturnValueOnce(makeStmt() as any);                      // bumpIngestionMinute
+
+      const result = ingestBatch(
+        [
+          {
+            eventType: "autoplay_abandoned",
+            videoId: "video-2",
+            durationSeconds: 86_400,
+            payload: { fromVideoId: "video-1", toVideoId: "video-2" },
+          },
+        ],
+        {
+          actorRole: "visitor",
+          surface: "web",
+          serverSessionId: "web:server-derived-session",
+        }
+      );
+
+      expect(result.acceptedCount).toBe(1);
+      const insertedArgs = runMock.mock.calls[0];
+      expect(insertedArgs[16]).toBe(30);
+      expect(insertedArgs[18]).toBe("{}");
+    });
   });
 
   describe("invalidateStatisticsSettingsCache", () => {

--- a/backend/src/__tests__/services/statistics/collector.test.ts
+++ b/backend/src/__tests__/services/statistics/collector.test.ts
@@ -250,6 +250,23 @@ describe("statistics collector", () => {
       expect(result.droppedCount).toBe(0);
     });
 
+    it("accepts the up-next feedback event types", () => {
+      vi.mocked(sqlite.prepare).mockReturnValue(makeStmt() as any);
+
+      const result = ingestBatch(
+        [
+          { eventType: "up_next_impression", sessionId: "sess-1" },
+          { eventType: "up_next_clicked", sessionId: "sess-1", value: 2 },
+          { eventType: "autoplay_advanced", sessionId: "sess-1" },
+          { eventType: "autoplay_abandoned", sessionId: "sess-1", durationSeconds: 12 },
+        ],
+        { actorRole: "admin", surface: "web" }
+      );
+
+      expect(result.acceptedCount).toBe(4);
+      expect(result.droppedCount).toBe(0);
+    });
+
     it("drops the batch without throwing when the transaction fails to commit", () => {
       vi.mocked(sqlite.prepare).mockReturnValue(makeStmt() as any);
       // Simulate a commit-time failure (e.g. SQLITE_BUSY / disk full): the

--- a/backend/src/__tests__/services/statistics/rollups.test.ts
+++ b/backend/src/__tests__/services/statistics/rollups.test.ts
@@ -301,6 +301,34 @@ describe("statistics rollups", () => {
             }),
             makeEvent({
               id: "evt-19",
+              eventType: "up_next_impression",
+              recordedAt: 975_000,
+            }),
+            makeEvent({
+              id: "evt-20",
+              eventType: "up_next_clicked",
+              payload: JSON.stringify({ lane: "related", position: 2 }),
+              value: 2,
+              recordedAt: 976_000,
+            }),
+            makeEvent({
+              id: "evt-21",
+              eventType: "autoplay_advanced",
+              recordedAt: 977_000,
+            }),
+            makeEvent({
+              id: "evt-22",
+              eventType: "autoplay_advanced",
+              recordedAt: 978_000,
+            }),
+            makeEvent({
+              id: "evt-23",
+              eventType: "autoplay_abandoned",
+              durationSeconds: 12,
+              recordedAt: 979_000,
+            }),
+            makeEvent({
+              id: "evt-24",
               eventType: "unknown_event",
               recordedAt: 980_000,
             }),
@@ -338,6 +366,25 @@ describe("statistics rollups", () => {
     );
     expect(findRollupRow(rows, "search_zero_result", { actor_role: "admin" })).toEqual(
       expect.objectContaining({ count: 1, sum: 1 })
+    );
+    expect(findRollupRow(rows, "up_next_impression", { actor_role: "admin" })).toEqual(
+      expect.objectContaining({ count: 1 })
+    );
+    expect(findRollupRow(rows, "up_next_clicked", {
+      actor_role: "admin",
+      lane: "related",
+    })).toEqual(expect.objectContaining({ count: 1, sum: 2 }));
+    expect(findRollupRow(rows, "up_next_ctr", { actor_role: "admin" })).toEqual(
+      expect.objectContaining({ count: 1, sum: 1 })
+    );
+    expect(findRollupRow(rows, "autoplay_advanced", { actor_role: "admin" })).toEqual(
+      expect.objectContaining({ count: 2 })
+    );
+    expect(findRollupRow(rows, "autoplay_abandoned", { actor_role: "admin" })).toEqual(
+      expect.objectContaining({ count: 1, sum: 12 })
+    );
+    expect(findRollupRow(rows, "autoplay_survival", { actor_role: "admin" })).toEqual(
+      expect.objectContaining({ count: 2, sum: 1 })
     );
     expect(
       findRollupRow(rows, "download_enqueued", {

--- a/backend/src/controllers/recommendationController.ts
+++ b/backend/src/controllers/recommendationController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from "express";
+import { getRecommendationSignals } from "../services/recommendationSignalsService";
+import { getVisibilityScopedRole } from "./video/visibility";
+
+export const getRecommendationSignalsEndpoint = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const signals = getRecommendationSignals(getVisibilityScopedRole(req));
+
+  if (!signals) {
+    res.status(204).end();
+    return;
+  }
+
+  res.set("Cache-Control", "private, max-age=300");
+  res.json(signals);
+};

--- a/backend/src/controllers/videoController.ts
+++ b/backend/src/controllers/videoController.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { SUBTITLES_DIR, VIDEOS_DIR } from "../config/paths";
 import { NotFoundError, ValidationError } from "../errors/DownloadErrors";
 import { syncMediaServerArtifactsForRecord } from "../services/mediaServerExport";
+import { invalidateRecommendationSignalsCache } from "../services/recommendationSignalsService";
 import * as storageService from "../services/storageService";
 import { addTagsToGlobalSettings } from "../services/tagService";
 import { logger } from "../utils/logger";
@@ -362,6 +363,10 @@ export const updateVideoDetails = async (
   // tagging a video also appear in Tags Management and as suggestions.
   if (Array.isArray(allowedUpdates.tags) && allowedUpdates.tags.length > 0) {
     addTagsToGlobalSettings(allowedUpdates.tags);
+  }
+
+  if (allowedUpdates.visibility !== undefined) {
+    invalidateRecommendationSignalsCache();
   }
 
   syncMediaServerArtifactsForRecord(updatedVideo);

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -3,6 +3,7 @@ import * as cleanupController from "../controllers/cleanupController";
 import * as cloudStorageController from "../controllers/cloudStorageController";
 import * as collectionController from "../controllers/collectionController";
 import * as downloadController from "../controllers/downloadController";
+import * as recommendationController from "../controllers/recommendationController";
 import * as rssController from "../controllers/rssController";
 import * as scanController from "../controllers/scanController";
 import * as statisticsController from "../controllers/statisticsController";
@@ -240,6 +241,13 @@ const apiRouteDefinitions: ApiRouteDefinition[] = [
     method: "delete",
     path: "/collections/:id",
     handlers: [asyncHandler(collectionController.deleteCollection)],
+  },
+
+  // Recommendation routes
+  {
+    method: "get",
+    path: "/recommendations/signals",
+    handlers: [asyncHandler(recommendationController.getRecommendationSignalsEndpoint)],
   },
 
   // Subscription routes

--- a/backend/src/services/recommendationSignalsService.ts
+++ b/backend/src/services/recommendationSignalsService.ts
@@ -54,9 +54,6 @@ interface StatisticsSignalEventRow {
 interface SessionPlay {
   videoId: string;
   recordedAt: number;
-}
-
-interface SessionVideoWatch {
   rawSeconds: number;
   lastRecordedAt: number;
 }
@@ -173,8 +170,10 @@ const createStats = (): MutableVideoStats => ({
   lastFinishedAt: null,
 });
 
-const getAbandonThreshold = (durationSeconds: number | null): number =>
-  Math.max(30, (durationSeconds ?? 0) * 0.05);
+const getAbandonThreshold = (durationSeconds: number | null): number => {
+  if (!durationSeconds || durationSeconds <= 0) return 30;
+  return Math.min(durationSeconds, Math.max(30, durationSeconds * 0.05));
+};
 
 const addToRecord = (
   record: Record<string, number>,
@@ -205,7 +204,7 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
 
   const statsByVideoId = new Map<string, MutableVideoStats>();
   const sessionPlays = new Map<string, SessionPlay[]>();
-  const watchBySessionVideo = new Map<string, SessionVideoWatch>();
+  const latestPlayBySessionVideo = new Map<string, SessionPlay>();
   const decayedWatchByVideoId = new Map<string, number>();
   const durationBands = [0, 0, 0, 0];
 
@@ -217,8 +216,15 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
     if (row.eventType === "video_play_started") {
       const sessionId = row.sessionId || `play:${row.videoId}:${row.recordedAt}`;
       const plays = sessionPlays.get(sessionId) ?? [];
-      plays.push({ videoId: row.videoId, recordedAt: row.recordedAt });
+      const play = {
+        videoId: row.videoId,
+        recordedAt: row.recordedAt,
+        rawSeconds: 0,
+        lastRecordedAt: row.recordedAt,
+      };
+      plays.push(play);
       sessionPlays.set(sessionId, plays);
+      latestPlayBySessionVideo.set(getSessionVideoKey(sessionId, row.videoId), play);
       const stats = statsByVideoId.get(row.videoId) ?? createStats();
       stats.sessions += 1;
       statsByVideoId.set(row.videoId, stats);
@@ -237,10 +243,10 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
 
     if (!row.sessionId) continue;
     const key = getSessionVideoKey(row.sessionId, row.videoId);
-    const watch = watchBySessionVideo.get(key) ?? { rawSeconds: 0, lastRecordedAt: row.recordedAt };
-    watch.rawSeconds += durationSecondsWatched;
-    watch.lastRecordedAt = Math.max(watch.lastRecordedAt, row.recordedAt);
-    watchBySessionVideo.set(key, watch);
+    const play = latestPlayBySessionVideo.get(key);
+    if (!play) continue;
+    play.rawSeconds += durationSecondsWatched;
+    play.lastRecordedAt = Math.max(play.lastRecordedAt, row.recordedAt);
   }
 
   for (const [videoId, watchSeconds] of decayedWatchByVideoId.entries()) {
@@ -249,14 +255,13 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
     statsByVideoId.set(videoId, stats);
   }
 
-  for (const [sessionId, plays] of sessionPlays.entries()) {
+  for (const plays of sessionPlays.values()) {
     for (const play of plays) {
       const video = videoById.get(play.videoId);
       if (!video) continue;
 
       const durationSeconds = parseDurationSeconds(video.duration);
-      const watch = watchBySessionVideo.get(getSessionVideoKey(sessionId, play.videoId));
-      const rawSeconds = watch?.rawSeconds ?? 0;
+      const rawSeconds = play.rawSeconds;
       const stats = statsByVideoId.get(play.videoId) ?? createStats();
       stats.rawWatchSeconds += rawSeconds;
 
@@ -267,7 +272,7 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
       if (durationSeconds && rawSeconds / durationSeconds >= 0.9) {
         stats.lastFinishedAt = Math.max(
           stats.lastFinishedAt ?? 0,
-          watch?.lastRecordedAt ?? play.recordedAt
+          play.lastRecordedAt
         );
       }
 
@@ -278,12 +283,11 @@ const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals 
   const edgeWeights = new Map<string, Map<string, number>>();
   const edgeTotals = new Map<string, number>();
 
-  for (const [sessionId, plays] of sessionPlays.entries()) {
+  for (const plays of sessionPlays.values()) {
     const qualifiedPlays = plays.filter(play => {
       const video = videoById.get(play.videoId);
       if (!video) return false;
-      const watch = watchBySessionVideo.get(getSessionVideoKey(sessionId, play.videoId));
-      return (watch?.rawSeconds ?? 0) >= getAbandonThreshold(parseDurationSeconds(video.duration));
+      return play.rawSeconds >= getAbandonThreshold(parseDurationSeconds(video.duration));
     });
 
     for (let sourceIndex = 0; sourceIndex < qualifiedPlays.length; sourceIndex += 1) {

--- a/backend/src/services/recommendationSignalsService.ts
+++ b/backend/src/services/recommendationSignalsService.ts
@@ -158,7 +158,10 @@ const queryStatisticsEvents = (): StatisticsSignalEventRow[] =>
        FROM usage_statistics_events
        WHERE event_type IN ('video_play_started', 'video_watch_chunk_recorded')
          AND video_id IS NOT NULL
-       ORDER BY COALESCE(session_id, ''), recorded_at ASC`
+       ORDER BY COALESCE(session_id, ''),
+                COALESCE(client_occurred_at, recorded_at) ASC,
+                recorded_at ASC,
+                rowid ASC`
     )
     .all() as StatisticsSignalEventRow[];
 

--- a/backend/src/services/recommendationSignalsService.ts
+++ b/backend/src/services/recommendationSignalsService.ts
@@ -1,0 +1,415 @@
+import { sqlite } from "../db";
+import { parseDurationSeconds } from "./statistics/normalizers";
+import { isStatisticsEnabled } from "./statistics/collector";
+
+const SIGNAL_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const WATCH_HALF_LIFE_MS = 90 * 24 * 60 * 60 * 1000;
+const COPLAY_HALF_LIFE_MS = 120 * 24 * 60 * 60 * 1000;
+const COPLAY_SHRINK_K = 3;
+const TOP_NEIGHBOR_LIMIT = 20;
+
+export interface RecommendationSignals {
+  computedAt: number;
+  perVideo: Record<string, {
+    ws: number;
+    cr: number;
+    ar: number;
+    lf: number | null;
+    rw: number;
+    nb: [string, number][];
+  }>;
+  authorAffinity: Record<string, number>;
+  tagAffinity: Record<string, number>;
+  durationBands: number[];
+}
+
+type VisibilityRole = "admin" | "visitor";
+
+interface VideoSignalRow {
+  id: string;
+  author: string | null;
+  channelUrl: string | null;
+  tags: string | null;
+  duration: string | null;
+  rating: number | null;
+  viewCount: number | null;
+  progress: number | null;
+  lastPlayedAt: number | null;
+  visibility: number | null;
+}
+
+interface SubscriptionSignalRow {
+  author: string | null;
+  authorUrl: string | null;
+}
+
+interface StatisticsSignalEventRow {
+  eventType: "video_play_started" | "video_watch_chunk_recorded";
+  recordedAt: number;
+  sessionId: string | null;
+  videoId: string;
+  durationSeconds: number | null;
+}
+
+interface SessionPlay {
+  videoId: string;
+  recordedAt: number;
+}
+
+interface SessionVideoWatch {
+  rawSeconds: number;
+  lastRecordedAt: number;
+}
+
+interface MutableVideoStats {
+  watchSeconds: number;
+  rawWatchSeconds: number;
+  sessions: number;
+  abandonedSessions: number;
+  lastFinishedAt: number | null;
+}
+
+interface CachedSignals {
+  expiresAt: number;
+  value: RecommendationSignals | null;
+}
+
+const cacheByRole = new Map<VisibilityRole, CachedSignals>();
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const normalizeKey = (value: string | null | undefined): string =>
+  (value ?? "").trim().toLowerCase();
+
+const getAuthorKey = (video: VideoSignalRow): string =>
+  normalizeKey(video.channelUrl || video.author);
+
+const getSubscriptionKeys = (subscription: SubscriptionSignalRow): string[] =>
+  [subscription.authorUrl, subscription.author]
+    .map(normalizeKey)
+    .filter(Boolean);
+
+const parseTags = (value: string | null): string[] => {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return Array.from(new Set(
+      parsed
+        .filter((tag): tag is string => typeof tag === "string")
+        .map(normalizeKey)
+        .filter(Boolean)
+    ));
+  } catch {
+    return [];
+  }
+};
+
+const decay = (recordedAt: number, now: number, halfLifeMs: number): number => {
+  const age = Math.max(0, now - recordedAt);
+  return Math.pow(2, -age / halfLifeMs);
+};
+
+const getDurationBand = (durationSeconds: number | null): number => {
+  if (!durationSeconds || durationSeconds < 5 * 60) return 0;
+  if (durationSeconds < 15 * 60) return 1;
+  if (durationSeconds < 45 * 60) return 2;
+  return 3;
+};
+
+const getSessionVideoKey = (sessionId: string, videoId: string): string =>
+  `${sessionId}\u0000${videoId}`;
+
+const isVisibleForRole = (video: VideoSignalRow, role: VisibilityRole): boolean =>
+  role !== "visitor" || video.visibility !== 0;
+
+const queryVideos = (): VideoSignalRow[] =>
+  sqlite
+    .prepare(
+      `SELECT id,
+              author,
+              channel_url AS channelUrl,
+              tags,
+              duration,
+              rating,
+              view_count AS viewCount,
+              progress,
+              last_played_at AS lastPlayedAt,
+              visibility
+       FROM videos`
+    )
+    .all() as VideoSignalRow[];
+
+const querySubscriptions = (): SubscriptionSignalRow[] =>
+  sqlite
+    .prepare(
+      `SELECT author, author_url AS authorUrl
+       FROM subscriptions
+       WHERE COALESCE(paused, 0) = 0`
+    )
+    .all() as SubscriptionSignalRow[];
+
+const queryStatisticsEvents = (): StatisticsSignalEventRow[] =>
+  sqlite
+    .prepare(
+      `SELECT event_type AS eventType,
+              recorded_at AS recordedAt,
+              session_id AS sessionId,
+              video_id AS videoId,
+              duration_seconds AS durationSeconds
+       FROM usage_statistics_events
+       WHERE event_type IN ('video_play_started', 'video_watch_chunk_recorded')
+         AND video_id IS NOT NULL
+       ORDER BY COALESCE(session_id, ''), recorded_at ASC`
+    )
+    .all() as StatisticsSignalEventRow[];
+
+const createStats = (): MutableVideoStats => ({
+  watchSeconds: 0,
+  rawWatchSeconds: 0,
+  sessions: 0,
+  abandonedSessions: 0,
+  lastFinishedAt: null,
+});
+
+const getAbandonThreshold = (durationSeconds: number | null): number =>
+  Math.max(30, (durationSeconds ?? 0) * 0.05);
+
+const addToRecord = (
+  record: Record<string, number>,
+  key: string,
+  value: number
+): void => {
+  if (!key || value <= 0) return;
+  record[key] = (record[key] ?? 0) + value;
+};
+
+const normalizeRecord = (record: Record<string, number>): Record<string, number> => {
+  const total = Object.values(record).reduce((sum, value) => sum + value, 0);
+  if (total <= 0) return {};
+
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [key, clamp(value / total, 0, 1)])
+  );
+};
+
+const buildSignals = (role: VisibilityRole, now: number): RecommendationSignals | null => {
+  const allVideos = queryVideos();
+  const videos = allVideos.filter(video => isVisibleForRole(video, role));
+  const videoById = new Map(videos.map(video => [video.id, video]));
+  const visibleVideoIds = new Set(videoById.keys());
+  const events = queryStatisticsEvents().filter(row => visibleVideoIds.has(row.videoId));
+
+  if (events.length === 0) return null;
+
+  const statsByVideoId = new Map<string, MutableVideoStats>();
+  const sessionPlays = new Map<string, SessionPlay[]>();
+  const watchBySessionVideo = new Map<string, SessionVideoWatch>();
+  const decayedWatchByVideoId = new Map<string, number>();
+  const durationBands = [0, 0, 0, 0];
+
+  for (const row of events) {
+    const video = videoById.get(row.videoId);
+    if (!video) continue;
+    const durationSeconds = parseDurationSeconds(video.duration);
+
+    if (row.eventType === "video_play_started") {
+      const sessionId = row.sessionId || `play:${row.videoId}:${row.recordedAt}`;
+      const plays = sessionPlays.get(sessionId) ?? [];
+      plays.push({ videoId: row.videoId, recordedAt: row.recordedAt });
+      sessionPlays.set(sessionId, plays);
+      const stats = statsByVideoId.get(row.videoId) ?? createStats();
+      stats.sessions += 1;
+      statsByVideoId.set(row.videoId, stats);
+      continue;
+    }
+
+    const durationSecondsWatched = row.durationSeconds ?? 0;
+    if (durationSecondsWatched <= 0) continue;
+
+    const decayedSeconds = durationSecondsWatched * decay(row.recordedAt, now, WATCH_HALF_LIFE_MS);
+    decayedWatchByVideoId.set(
+      row.videoId,
+      (decayedWatchByVideoId.get(row.videoId) ?? 0) + decayedSeconds
+    );
+    durationBands[getDurationBand(durationSeconds)] += decayedSeconds;
+
+    if (!row.sessionId) continue;
+    const key = getSessionVideoKey(row.sessionId, row.videoId);
+    const watch = watchBySessionVideo.get(key) ?? { rawSeconds: 0, lastRecordedAt: row.recordedAt };
+    watch.rawSeconds += durationSecondsWatched;
+    watch.lastRecordedAt = Math.max(watch.lastRecordedAt, row.recordedAt);
+    watchBySessionVideo.set(key, watch);
+  }
+
+  for (const [videoId, watchSeconds] of decayedWatchByVideoId.entries()) {
+    const stats = statsByVideoId.get(videoId) ?? createStats();
+    stats.watchSeconds = watchSeconds;
+    statsByVideoId.set(videoId, stats);
+  }
+
+  for (const [sessionId, plays] of sessionPlays.entries()) {
+    for (const play of plays) {
+      const video = videoById.get(play.videoId);
+      if (!video) continue;
+
+      const durationSeconds = parseDurationSeconds(video.duration);
+      const watch = watchBySessionVideo.get(getSessionVideoKey(sessionId, play.videoId));
+      const rawSeconds = watch?.rawSeconds ?? 0;
+      const stats = statsByVideoId.get(play.videoId) ?? createStats();
+      stats.rawWatchSeconds += rawSeconds;
+
+      if (rawSeconds < getAbandonThreshold(durationSeconds)) {
+        stats.abandonedSessions += 1;
+      }
+
+      if (durationSeconds && rawSeconds / durationSeconds >= 0.9) {
+        stats.lastFinishedAt = Math.max(
+          stats.lastFinishedAt ?? 0,
+          watch?.lastRecordedAt ?? play.recordedAt
+        );
+      }
+
+      statsByVideoId.set(play.videoId, stats);
+    }
+  }
+
+  const edgeWeights = new Map<string, Map<string, number>>();
+  const edgeTotals = new Map<string, number>();
+
+  for (const [sessionId, plays] of sessionPlays.entries()) {
+    const qualifiedPlays = plays.filter(play => {
+      const video = videoById.get(play.videoId);
+      if (!video) return false;
+      const watch = watchBySessionVideo.get(getSessionVideoKey(sessionId, play.videoId));
+      return (watch?.rawSeconds ?? 0) >= getAbandonThreshold(parseDurationSeconds(video.duration));
+    });
+
+    for (let sourceIndex = 0; sourceIndex < qualifiedPlays.length; sourceIndex += 1) {
+      for (let targetIndex = sourceIndex + 1; targetIndex < qualifiedPlays.length; targetIndex += 1) {
+        const source = qualifiedPlays[sourceIndex];
+        const target = qualifiedPlays[targetIndex];
+        if (source.videoId === target.videoId) continue;
+
+        const playsBetween = targetIndex - sourceIndex - 1;
+        const weight = Math.pow(2, -playsBetween) *
+          decay(target.recordedAt, now, COPLAY_HALF_LIFE_MS);
+        const neighbors = edgeWeights.get(source.videoId) ?? new Map<string, number>();
+        neighbors.set(target.videoId, (neighbors.get(target.videoId) ?? 0) + weight);
+        edgeWeights.set(source.videoId, neighbors);
+        edgeTotals.set(source.videoId, (edgeTotals.get(source.videoId) ?? 0) + weight);
+      }
+    }
+  }
+
+  const authorWatch: Record<string, number> = {};
+  const tagWatch: Record<string, number> = {};
+  const ratingByAuthor = new Map<string, { total: number; count: number }>();
+
+  for (const video of videos) {
+    const authorKey = getAuthorKey(video);
+    if (authorKey && typeof video.rating === "number") {
+      const current = ratingByAuthor.get(authorKey) ?? { total: 0, count: 0 };
+      current.total += video.rating;
+      current.count += 1;
+      ratingByAuthor.set(authorKey, current);
+    }
+
+    const watchSeconds = decayedWatchByVideoId.get(video.id) ?? 0;
+    if (watchSeconds <= 0) continue;
+
+    addToRecord(authorWatch, authorKey, watchSeconds);
+    for (const tag of parseTags(video.tags)) {
+      addToRecord(tagWatch, tag, watchSeconds);
+    }
+  }
+
+  const authorAffinity = normalizeRecord(authorWatch);
+  for (const subscription of querySubscriptions()) {
+    for (const key of getSubscriptionKeys(subscription)) {
+      authorAffinity[key] = clamp((authorAffinity[key] ?? 0) + 0.15, 0, 1);
+    }
+  }
+
+  for (const [authorKey, rating] of ratingByAuthor.entries()) {
+    if (rating.count === 0) continue;
+    const meanRating = rating.total / rating.count;
+    authorAffinity[authorKey] = clamp(
+      (authorAffinity[authorKey] ?? 0) + Math.max(0, (meanRating - 3) / 2) * 0.05,
+      0,
+      1
+    );
+  }
+
+  const tagAffinity = normalizeRecord(tagWatch);
+  const durationTotal = durationBands.reduce((sum, value) => sum + value, 0);
+  const normalizedDurationBands = durationTotal > 0
+    ? durationBands.map(value => clamp(value / durationTotal, 0, 1))
+    : durationBands;
+
+  const perVideo: RecommendationSignals["perVideo"] = {};
+  for (const [videoId, stats] of statsByVideoId.entries()) {
+    if (stats.sessions <= 0 && stats.watchSeconds <= 0) continue;
+    const video = videoById.get(videoId);
+    const durationSeconds = parseDurationSeconds(video?.duration ?? null);
+    const completionRatio = durationSeconds && stats.sessions > 0
+      ? clamp(stats.rawWatchSeconds / (durationSeconds * stats.sessions), 0, 1)
+      : 0;
+    const abandonRate = stats.sessions > 0
+      ? clamp(stats.abandonedSessions / stats.sessions, 0, 1)
+      : 0;
+    const rewatchRate = stats.sessions > 0
+      ? clamp(Math.max(0, stats.sessions - 1) / stats.sessions, 0, 1)
+      : 0;
+    const outTotal = edgeTotals.get(videoId) ?? 0;
+    const neighbors = Array.from(edgeWeights.get(videoId)?.entries() ?? [])
+      .map(([neighborId, weight]) => [
+        neighborId,
+        clamp(weight / (outTotal + COPLAY_SHRINK_K), 0, 1),
+      ] as [string, number])
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, TOP_NEIGHBOR_LIMIT);
+
+    perVideo[videoId] = {
+      ws: Math.round(stats.watchSeconds),
+      cr: Number(completionRatio.toFixed(4)),
+      ar: Number(abandonRate.toFixed(4)),
+      lf: stats.lastFinishedAt,
+      rw: Number(rewatchRate.toFixed(4)),
+      nb: neighbors.map(([neighborId, score]) => [
+        neighborId,
+        Number(score.toFixed(4)),
+      ]),
+    };
+  }
+
+  return {
+    computedAt: now,
+    perVideo,
+    authorAffinity,
+    tagAffinity,
+    durationBands: normalizedDurationBands.map(value => Number(value.toFixed(4))),
+  };
+};
+
+export const invalidateRecommendationSignalsCache = (): void => {
+  cacheByRole.clear();
+};
+
+export const getRecommendationSignals = (
+  role: "admin" | "visitor" | undefined = "admin"
+): RecommendationSignals | null => {
+  if (!isStatisticsEnabled()) return null;
+
+  const cacheKey: VisibilityRole = role === "visitor" ? "visitor" : "admin";
+  const now = Date.now();
+  const cached = cacheByRole.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    return cached.value;
+  }
+
+  const value = buildSignals(cacheKey, now);
+  cacheByRole.set(cacheKey, { value, expiresAt: now + SIGNAL_CACHE_TTL_MS });
+  return value;
+};

--- a/backend/src/services/statistics/collector.ts
+++ b/backend/src/services/statistics/collector.ts
@@ -8,6 +8,7 @@ import { logger } from "../../utils/logger";
 import * as storageService from "../storageService";
 import { Settings } from "../../types/settings";
 import {
+  FRONTEND_EVENT_TYPES,
   StatisticsEventInput,
   StatisticsEventType,
 } from "./eventTypes";
@@ -383,12 +384,6 @@ interface BatchIngestOptions {
   serverSessionId?: string;
 }
 
-const FRONTEND_ALLOWED_TYPES: ReadonlySet<StatisticsEventType> = new Set<StatisticsEventType>([
-  "search_submitted",
-  "video_play_started",
-  "video_watch_chunk_recorded",
-]);
-
 const MAX_VISITOR_WATCH_CHUNK_SECONDS = 120;
 const MAX_VISITOR_SEARCH_RESULT_COUNT = 10_000;
 
@@ -477,7 +472,7 @@ export function ingestBatch(
   // failures are caught inside the loop, so one bad event never rolls back the rest.
   const ingestAll = sqlite.transaction((batch: BatchIngestEvent[]) => {
     for (const evt of batch) {
-      if (!FRONTEND_ALLOWED_TYPES.has(evt.eventType)) {
+      if (!FRONTEND_EVENT_TYPES.has(evt.eventType)) {
         result.droppedCount += 1;
         continue;
       }

--- a/backend/src/services/statistics/collector.ts
+++ b/backend/src/services/statistics/collector.ts
@@ -386,6 +386,15 @@ interface BatchIngestOptions {
 
 const MAX_VISITOR_WATCH_CHUNK_SECONDS = 120;
 const MAX_VISITOR_SEARCH_RESULT_COUNT = 10_000;
+// autoplay_abandoned only fires below 30 qualified seconds, so anything larger
+// is forged; up_next_clicked positions are 1-based slate indexes.
+const MAX_VISITOR_AUTOPLAY_ABANDONED_SECONDS = 30;
+const MAX_VISITOR_UP_NEXT_POSITION = 100;
+const VISITOR_UP_NEXT_LANES: ReadonlySet<string> = new Set([
+  "continue",
+  "related",
+  "discover",
+]);
 
 function sanitizeBoundedInteger(
   value: unknown,
@@ -398,16 +407,44 @@ function sanitizeBoundedInteger(
 }
 
 function sanitizeVisitorDurationSeconds(event: BatchIngestEvent): number | undefined {
-  if (event.eventType !== "video_watch_chunk_recorded") {
+  if (event.eventType === "video_watch_chunk_recorded") {
+    return sanitizeBoundedInteger(
+      event.durationSeconds,
+      MAX_VISITOR_WATCH_CHUNK_SECONDS
+    );
+  }
+  if (event.eventType === "autoplay_abandoned") {
+    return sanitizeBoundedInteger(
+      event.durationSeconds,
+      MAX_VISITOR_AUTOPLAY_ABANDONED_SECONDS
+    );
+  }
+  return undefined;
+}
+
+function sanitizeVisitorValue(event: BatchIngestEvent): number | undefined {
+  if (event.eventType !== "up_next_clicked") {
     return undefined;
   }
-  return sanitizeBoundedInteger(
-    event.durationSeconds,
-    MAX_VISITOR_WATCH_CHUNK_SECONDS
-  );
+  return sanitizeBoundedInteger(event.value, MAX_VISITOR_UP_NEXT_POSITION);
 }
 
 function sanitizeVisitorPayload(event: BatchIngestEvent): Record<string, unknown> | undefined {
+  if (event.eventType === "up_next_clicked") {
+    const payload = event.payload ?? {};
+    return {
+      lane:
+        typeof payload.lane === "string" && VISITOR_UP_NEXT_LANES.has(payload.lane)
+          ? payload.lane
+          : "unknown",
+      position:
+        sanitizeBoundedInteger(
+          payload.position,
+          MAX_VISITOR_UP_NEXT_POSITION
+        ) ?? 0,
+    };
+  }
+
   if (event.eventType !== "search_submitted") {
     return undefined;
   }
@@ -442,7 +479,7 @@ function sanitizeBatchEventForActor(
     sourceKind: "unknown",
     surface: normalizeSurface(options.surface),
     durationSeconds: sanitizeVisitorDurationSeconds(event),
-    value: undefined,
+    value: sanitizeVisitorValue(event),
     payload: sanitizeVisitorPayload(event),
   };
 }

--- a/backend/src/services/statistics/eventTypes.ts
+++ b/backend/src/services/statistics/eventTypes.ts
@@ -37,6 +37,10 @@ export type StatisticsEventType =
   | "search_submitted"
   | "video_play_started"
   | "video_watch_chunk_recorded"
+  | "up_next_impression"
+  | "up_next_clicked"
+  | "autoplay_advanced"
+  | "autoplay_abandoned"
   // Backend
   | "download_enqueued"
   | "download_started"
@@ -50,6 +54,10 @@ export const FRONTEND_EVENT_TYPES: ReadonlySet<StatisticsEventType> = new Set([
   "search_submitted",
   "video_play_started",
   "video_watch_chunk_recorded",
+  "up_next_impression",
+  "up_next_clicked",
+  "autoplay_advanced",
+  "autoplay_abandoned",
 ]);
 
 export const BACKEND_EVENT_TYPES: ReadonlySet<StatisticsEventType> = new Set([

--- a/backend/src/services/statistics/rollups.ts
+++ b/backend/src/services/statistics/rollups.ts
@@ -89,6 +89,20 @@ class DailyAggregator {
     bump(entry.acc, value);
   }
 
+  addSummary(key: UpsertKey, count: number, sum: number): void {
+    if (count <= 0) return;
+    const stringKey = makeKey(key);
+    let entry = this.map.get(stringKey);
+    if (!entry) {
+      entry = { key, acc: emptyAccumulator() };
+      this.map.set(stringKey, entry);
+    }
+    entry.acc.count += count;
+    entry.acc.sum += sum;
+    entry.acc.min = entry.acc.min === null ? sum : Math.min(entry.acc.min, sum);
+    entry.acc.max = entry.acc.max === null ? sum : Math.max(entry.acc.max, sum);
+  }
+
   entries(): Array<{ key: UpsertKey; acc: DailyAccumulator }> {
     return Array.from(this.map.values());
   }
@@ -169,6 +183,14 @@ function getCompletionBucket(completionRatio: number): string {
   return "90-100";
 }
 
+function incrementCounter(
+  map: Map<string, number>,
+  key: string,
+  amount = 1
+): void {
+  map.set(key, (map.get(key) ?? 0) + amount);
+}
+
 function recomputeDay(day: string): void {
   const events = getEventsForDay(day);
 
@@ -177,6 +199,10 @@ function recomputeDay(day: string): void {
   // Track watch-chunk runs per (sessionId, videoId) to merge contiguous segments
   // for completion math. "Adjacent" = next chunk's start within 90s of prev end.
   const sessionRuns = new Map<string, WatchSessionRun[]>();
+  const upNextImpressionsByRole = new Map<string, number>();
+  const upNextClicksByRole = new Map<string, number>();
+  const autoplayAdvancedByRole = new Map<string, number>();
+  const autoplayAbandonedByRole = new Map<string, number>();
 
   for (const e of events) {
     const platform = e.platform ?? "unknown";
@@ -241,6 +267,40 @@ function recomputeDay(day: string): void {
             sessionRuns.set(key, list);
           }
         }
+        break;
+      }
+      case "up_next_impression": {
+        aggregator.add({
+          metricKey: "up_next_impression",
+          dimensions: { actor_role: role },
+        });
+        incrementCounter(upNextImpressionsByRole, role);
+        break;
+      }
+      case "up_next_clicked": {
+        const lane = typeof payload.lane === "string" ? payload.lane : "unknown";
+        const position = Number(payload.position ?? e.value ?? 0);
+        aggregator.add({
+          metricKey: "up_next_clicked",
+          dimensions: { actor_role: role, lane },
+        }, Number.isFinite(position) ? position : 0);
+        incrementCounter(upNextClicksByRole, role);
+        break;
+      }
+      case "autoplay_advanced": {
+        aggregator.add({
+          metricKey: "autoplay_advanced",
+          dimensions: { actor_role: role },
+        });
+        incrementCounter(autoplayAdvancedByRole, role);
+        break;
+      }
+      case "autoplay_abandoned": {
+        aggregator.add({
+          metricKey: "autoplay_abandoned",
+          dimensions: { actor_role: role },
+        }, Math.max(0, Number(e.durationSeconds ?? 0)));
+        incrementCounter(autoplayAbandonedByRole, role);
         break;
       }
       case "download_enqueued": {
@@ -322,6 +382,23 @@ function recomputeDay(day: string): void {
       default:
         break;
     }
+  }
+
+  for (const [role, impressionCount] of upNextImpressionsByRole.entries()) {
+    aggregator.addSummary(
+      { metricKey: "up_next_ctr", dimensions: { actor_role: role } },
+      impressionCount,
+      upNextClicksByRole.get(role) ?? 0
+    );
+  }
+
+  for (const [role, advancedCount] of autoplayAdvancedByRole.entries()) {
+    const abandonedCount = autoplayAbandonedByRole.get(role) ?? 0;
+    aggregator.addSummary(
+      { metricKey: "autoplay_survival", dimensions: { actor_role: role } },
+      advancedCount,
+      Math.max(0, advancedCount - abandonedCount)
+    );
   }
 
   const durationByVideoId = getVideoDurations(

--- a/backend/src/services/storageService/videoDeletion.ts
+++ b/backend/src/services/storageService/videoDeletion.ts
@@ -63,6 +63,14 @@ export function deleteVideo(
     // Delete from DB
     db.delete(videos).where(eq(videos.id, id)).run();
     bumpVideosListRevision();
+    try {
+      const { invalidateRecommendationSignalsCache } = require("../recommendationSignalsService") as {
+        invalidateRecommendationSignalsCache: () => void;
+      };
+      invalidateRecommendationSignalsCache();
+    } catch {
+      // recommendation signals are best-effort
+    }
     removeMediaServerArtifactsForVideo(videoToDelete, {
       libraryVideos: getVideos(),
     });

--- a/frontend/src/components/VideoPlayer/UpNextSidebar.tsx
+++ b/frontend/src/components/VideoPlayer/UpNextSidebar.tsx
@@ -33,7 +33,7 @@ interface UpNextSidebarProps {
     relatedVideos: Video[];
     autoPlayNext: boolean;
     onAutoPlayNextChange: (checked: boolean) => void;
-    onVideoClick: (videoId: string) => void;
+    onVideoClick: (videoId: string, position: number) => void;
     onAddToCollection: (videoId: string) => void;
 }
 
@@ -144,7 +144,7 @@ const UpNextSidebar: React.FC<UpNextSidebarProps> = ({
                 />
             </Stack>
             <Grid container spacing={1.5}>
-                {relatedVideos.map(relatedVideo => (
+                {relatedVideos.map((relatedVideo, index) => (
                     <Grid key={relatedVideo.id} size={{ xs: 12, md: 6, lg: 12 }}>
                         <Card
                             elevation={0}
@@ -161,7 +161,7 @@ const UpNextSidebar: React.FC<UpNextSidebarProps> = ({
                                 transition: 'background-color 0.15s ease',
                                 '&:hover': { bgcolor: 'action.hover' }
                             }}
-                            onClick={() => onVideoClick(relatedVideo.id)}
+                            onClick={() => onVideoClick(relatedVideo.id, index)}
                             onMouseEnter={() => setHoveredVideoId(relatedVideo.id)}
                             onMouseLeave={() => setHoveredVideoId(null)}
                         >

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -34,6 +34,7 @@ interface VideoControlsProps {
     statisticsVideoId?: string | null;
     statisticsPlatform?: string | null;
     statisticsRelatedEventId?: string | null;
+    statisticsAutoplayFromVideoId?: string | null;
     onVideoElementReady?: (videoElement: HTMLVideoElement | null) => void;
     liveSubtitle?: { available: boolean; label: string; track: TextTrack | null };
 }
@@ -60,6 +61,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
     statisticsVideoId = null,
     statisticsPlatform = null,
     statisticsRelatedEventId = null,
+    statisticsAutoplayFromVideoId = null,
     onVideoElementReady,
     liveSubtitle,
 }) => {
@@ -94,6 +96,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
         videoId: statisticsVideoId,
         platform: statisticsPlatform,
         relatedEventId: statisticsRelatedEventId,
+        autoplayFromVideoId: statisticsAutoplayFromVideoId,
     });
 
     // Fullscreen management

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -33,6 +33,7 @@ interface VideoControlsProps {
     statisticsVideoId?: string | null;
     statisticsPlatform?: string | null;
     statisticsRelatedEventId?: string | null;
+    statisticsAutoplayFromVideoId?: string | null;
     onVideoElementReady?: (videoElement: HTMLVideoElement | null) => void;
     liveSubtitle?: { available: boolean; label: string; track: TextTrack | null };
 }
@@ -58,6 +59,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
     statisticsVideoId = null,
     statisticsPlatform = null,
     statisticsRelatedEventId = null,
+    statisticsAutoplayFromVideoId = null,
     onVideoElementReady,
     liveSubtitle,
 }) => {
@@ -92,6 +94,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
         videoId: statisticsVideoId,
         platform: statisticsPlatform,
         relatedEventId: statisticsRelatedEventId,
+        autoplayFromVideoId: statisticsAutoplayFromVideoId,
     });
 
     // Fullscreen management

--- a/frontend/src/components/VideoPlayer/__tests__/UpNextSidebar.test.tsx
+++ b/frontend/src/components/VideoPlayer/__tests__/UpNextSidebar.test.tsx
@@ -77,6 +77,6 @@ describe('UpNextSidebar', () => {
         // UpNextSidebar implements its own item rendering.
 
         await user.click(screen.getByText('Video 1'));
-        expect(mockOnVideoClick).toHaveBeenCalledWith('1');
+        expect(mockOnVideoClick).toHaveBeenCalledWith('1', 0);
     });
 });

--- a/frontend/src/hooks/__tests__/useRecommendationSignals.test.tsx
+++ b/frontend/src/hooks/__tests__/useRecommendationSignals.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  auth: {
+    isAuthenticated: true,
+    userRole: 'visitor' as 'admin' | 'visitor' | null,
+    loginRequired: true,
+  },
+}));
+
+vi.mock('../../utils/apiClient', () => ({
+  api: { get: (...args: unknown[]) => mocks.get(...args) },
+}));
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mocks.auth,
+}));
+
+import { useRecommendationSignals } from '../useRecommendationSignals';
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const makeSignals = (computedAt: number) => ({
+  computedAt,
+  perVideo: {},
+  authorAffinity: {},
+  tagAffinity: {},
+  durationBands: [],
+});
+
+describe('useRecommendationSignals', () => {
+  beforeEach(() => {
+    mocks.get.mockReset();
+    mocks.auth.isAuthenticated = true;
+    mocks.auth.userRole = 'visitor';
+    mocks.auth.loginRequired = true;
+  });
+
+  it('refetches rather than reusing cached signals when the requester role changes', async () => {
+    const wrapper = createWrapper();
+
+    mocks.get.mockResolvedValueOnce({ status: 200, data: makeSignals(1) });
+    const visitor = renderHook(() => useRecommendationSignals(), { wrapper });
+    await waitFor(() => expect(visitor.result.current.data?.computedAt).toBe(1));
+    expect(mocks.get).toHaveBeenCalledTimes(1);
+
+    mocks.auth.userRole = 'admin';
+    mocks.get.mockResolvedValueOnce({ status: 200, data: makeSignals(2) });
+    const admin = renderHook(() => useRecommendationSignals(), { wrapper });
+    await waitFor(() => expect(admin.result.current.data?.computedAt).toBe(2));
+    expect(mocks.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/__tests__/useStatisticsWatchTracker.test.tsx
+++ b/frontend/src/hooks/__tests__/useStatisticsWatchTracker.test.tsx
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  recordEvent: vi.fn(),
+  flushNow: vi.fn(),
+  flushKeepalive: vi.fn(),
+}));
+
+vi.mock('../useStatisticsIngestion', () => ({
+  useStatisticsIngestion: () => ({
+    enabled: true,
+    recordEvent: mocks.recordEvent,
+    flushNow: mocks.flushNow,
+    flushKeepalive: mocks.flushKeepalive,
+  }),
+}));
+
+import { useStatisticsWatchTracker } from '../useStatisticsWatchTracker';
+
+const createVideoRef = (): React.RefObject<HTMLVideoElement | null> => ({
+  current: document.createElement('video'),
+});
+
+describe('useStatisticsWatchTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not mark a naturally ended short autoplay as abandoned', () => {
+    const videoRef = createVideoRef();
+    const { unmount } = renderHook(() =>
+      useStatisticsWatchTracker({
+        videoRef,
+        videoId: 'next-video',
+        autoplayFromVideoId: 'current-video',
+      })
+    );
+
+    act(() => {
+      videoRef.current?.dispatchEvent(new Event('play'));
+      videoRef.current?.dispatchEvent(new Event('ended'));
+    });
+
+    unmount();
+
+    const eventTypes = mocks.recordEvent.mock.calls.map(([event]) => event.eventType);
+    expect(eventTypes).toContain('video_play_started');
+    expect(eventTypes).not.toContain('autoplay_abandoned');
+  });
+});

--- a/frontend/src/hooks/__tests__/useVideoRecommendations.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoRecommendations.test.ts
@@ -40,11 +40,18 @@ describe('useVideoRecommendations', () => {
             author: 'Ada',
             tags: ['react'],
             seriesTitle: 'React',
+            partNumber: 2,
+            totalParts: 8,
+            rating: 5,
             videoFilename: 'react-router-advanced.mp4',
             source: 'youtube',
             date: '20240115',
             addedAt: '2024-01-16T00:00:00Z',
             duration: '900',
+            progress: 120,
+            viewCount: 3,
+            lastPlayedAt: 1705449600000,
+            channelUrl: 'https://example.com/ada',
             sourceUrl: 'https://example.com/v1'
         } as Video;
         const otherVideo = {
@@ -68,7 +75,14 @@ describe('useVideoRecommendations', () => {
                     source: 'youtube',
                     date: '20240115',
                     addedAt: '2024-01-16T00:00:00Z',
-                    duration: '900'
+                    duration: '900',
+                    partNumber: 2,
+                    totalParts: 8,
+                    rating: 5,
+                    progress: 120,
+                    viewCount: 3,
+                    lastPlayedAt: 1705449600000,
+                    channelUrl: 'https://example.com/ada'
                 }),
                 allVideos: [video, otherVideo],
                 collections: []

--- a/frontend/src/hooks/__tests__/useVideoRecommendations.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoRecommendations.test.ts
@@ -6,6 +6,8 @@ import { useVideoRecommendations } from '../useVideoRecommendations';
 const mocks = vi.hoisted(() => ({
     videos: [] as Video[],
     collections: [] as any[],
+    settings: { statisticsEnabled: false },
+    signals: null as any,
     getRecommendations: vi.fn()
 }));
 
@@ -25,10 +27,24 @@ vi.mock('../../utils/recommendations', () => ({
     getRecommendations: mocks.getRecommendations
 }));
 
+vi.mock('../useSettings', () => ({
+    useSettings: () => ({
+        data: mocks.settings
+    })
+}));
+
+vi.mock('../useRecommendationSignals', () => ({
+    useRecommendationSignals: () => ({
+        data: mocks.signals
+    })
+}));
+
 describe('useVideoRecommendations', () => {
     beforeEach(() => {
         mocks.videos = [];
         mocks.collections = [];
+        mocks.settings = { statisticsEnabled: false };
+        mocks.signals = null;
         mocks.getRecommendations.mockReset();
         mocks.getRecommendations.mockReturnValue([]);
     });

--- a/frontend/src/hooks/useRecommendationSignals.ts
+++ b/frontend/src/hooks/useRecommendationSignals.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../contexts/AuthContext';
 import { api } from '../utils/apiClient';
 import { RecommendationSignals } from '../utils/recommendations';
 
@@ -8,9 +9,11 @@ interface UseRecommendationSignalsOptions {
 
 export const useRecommendationSignals = (
     options: UseRecommendationSignalsOptions = {}
-) =>
-    useQuery({
-        queryKey: ['recommendations', 'signals'],
+) => {
+    const { isAuthenticated, loginRequired, userRole } = useAuth();
+
+    return useQuery({
+        queryKey: ['recommendations', 'signals', userRole, loginRequired],
         queryFn: async (): Promise<RecommendationSignals | null> => {
             try {
                 const response = await api.get('/recommendations/signals', {
@@ -26,9 +29,10 @@ export const useRecommendationSignals = (
                 return null;
             }
         },
-        enabled: options.enabled ?? true,
+        enabled: (options.enabled ?? true) && isAuthenticated,
         staleTime: 6 * 60 * 60 * 1000,
         gcTime: 6 * 60 * 60 * 1000,
         refetchOnWindowFocus: false,
         retry: false,
     });
+};

--- a/frontend/src/hooks/useRecommendationSignals.ts
+++ b/frontend/src/hooks/useRecommendationSignals.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../utils/apiClient';
+import { RecommendationSignals } from '../utils/recommendations';
+
+interface UseRecommendationSignalsOptions {
+    enabled?: boolean;
+}
+
+export const useRecommendationSignals = (
+    options: UseRecommendationSignalsOptions = {}
+) =>
+    useQuery({
+        queryKey: ['recommendations', 'signals'],
+        queryFn: async (): Promise<RecommendationSignals | null> => {
+            try {
+                const response = await api.get('/recommendations/signals', {
+                    validateStatus: (status) =>
+                        (status >= 200 && status < 300) || status === 404,
+                });
+                if (response.status === 204 || response.status === 404) {
+                    return null;
+                }
+
+                return response.data as RecommendationSignals;
+            } catch {
+                return null;
+            }
+        },
+        enabled: options.enabled ?? true,
+        staleTime: 6 * 60 * 60 * 1000,
+        gcTime: 6 * 60 * 60 * 1000,
+        refetchOnWindowFocus: false,
+        retry: false,
+    });

--- a/frontend/src/hooks/useStatisticsIngestion.ts
+++ b/frontend/src/hooks/useStatisticsIngestion.ts
@@ -11,7 +11,11 @@ const MAX_BATCH_SIZE = 50;
 export type FrontendEventType =
   | 'search_submitted'
   | 'video_play_started'
-  | 'video_watch_chunk_recorded';
+  | 'video_watch_chunk_recorded'
+  | 'up_next_impression'
+  | 'up_next_clicked'
+  | 'autoplay_advanced'
+  | 'autoplay_abandoned';
 
 export interface StatisticsEventInput {
   eventType: FrontendEventType;

--- a/frontend/src/hooks/useStatisticsWatchTracker.ts
+++ b/frontend/src/hooks/useStatisticsWatchTracker.ts
@@ -109,9 +109,11 @@ export function useStatisticsWatchTracker(options: Options): void {
       });
     };
 
-    const endSession = () => {
+    const endSession = (recordAbandonment = true) => {
       flushChunk();
-      recordAutoplayAbandonedIfNeeded();
+      if (recordAbandonment) {
+        recordAutoplayAbandonedIfNeeded();
+      }
       playSessionRef.current = null;
     };
 
@@ -151,7 +153,7 @@ export function useStatisticsWatchTracker(options: Options): void {
       flushChunk();
     };
     const handleEnded = () => {
-      endSession();
+      endSession(false);
     };
     const handleSeeking = () => {
       flushChunk();

--- a/frontend/src/hooks/useStatisticsWatchTracker.ts
+++ b/frontend/src/hooks/useStatisticsWatchTracker.ts
@@ -10,6 +10,7 @@ interface Options {
   platform?: string | null;
   // optional related event id — use VideoContext.lastSearchEventId for search-origin plays
   relatedEventId?: string | null;
+  autoplayFromVideoId?: string | null;
 }
 
 // Tracks qualified playback time and emits:
@@ -25,7 +26,7 @@ interface Options {
 // Buffering, seeking, and rate changes do not contribute time. Only wall-clock
 // playback advances qualified time.
 export function useStatisticsWatchTracker(options: Options): void {
-  const { videoRef, videoId, platform, relatedEventId } = options;
+  const { videoRef, videoId, platform, relatedEventId, autoplayFromVideoId } = options;
   const {
     enabled,
     recordEvent,
@@ -43,12 +44,37 @@ export function useStatisticsWatchTracker(options: Options): void {
   );
   const isPiPRef = useRef<boolean>(false);
   const tickTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const qualifiedSessionSecondsRef = useRef<number>(0);
+  const autoplayAbandonedRecordedRef = useRef<boolean>(false);
 
   useEffect(() => {
     if (!enabled) return;
     if (!videoId) return;
     const videoEl = videoRef.current;
     if (!videoEl) return;
+
+    const recordAutoplayAbandonedIfNeeded = () => {
+      if (!autoplayFromVideoId || autoplayAbandonedRecordedRef.current) return;
+      if (!playSessionRef.current?.active) return;
+
+      const qualifiedSeconds = Math.round(qualifiedSessionSecondsRef.current);
+      if (qualifiedSeconds >= 30) return;
+
+      autoplayAbandonedRecordedRef.current = true;
+      recordEvent({
+        eventType: 'autoplay_abandoned',
+        surface: 'web',
+        videoId,
+        platform: (platform ?? null) as any,
+        durationSeconds: qualifiedSeconds,
+        relatedEventId,
+        payload: {
+          fromVideoId: autoplayFromVideoId,
+          toVideoId: videoId,
+          qualifiedSeconds,
+        },
+      });
+    };
 
     const flushChunk = () => {
       if (accumulatedRef.current >= 1) {
@@ -71,6 +97,8 @@ export function useStatisticsWatchTracker(options: Options): void {
     const startSessionIfNeeded = () => {
       if (playSessionRef.current?.active) return;
       playSessionRef.current = { active: true, startedAt: Date.now() };
+      qualifiedSessionSecondsRef.current = 0;
+      autoplayAbandonedRecordedRef.current = false;
       recordEvent({
         eventType: 'video_play_started',
         surface: 'web',
@@ -83,6 +111,7 @@ export function useStatisticsWatchTracker(options: Options): void {
 
     const endSession = () => {
       flushChunk();
+      recordAutoplayAbandonedIfNeeded();
       playSessionRef.current = null;
     };
 
@@ -102,6 +131,7 @@ export function useStatisticsWatchTracker(options: Options): void {
           const elapsed = (now - lastTickRef.current) / 1000;
           if (elapsed > 0 && elapsed < 5) {
             accumulatedRef.current += elapsed * (videoEl.playbackRate > 0 ? 1 : 1);
+            qualifiedSessionSecondsRef.current += elapsed;
           }
         }
         lastTickRef.current = now;
@@ -169,7 +199,18 @@ export function useStatisticsWatchTracker(options: Options): void {
         tickTimerRef.current = null;
       }
       flushChunk();
+      recordAutoplayAbandonedIfNeeded();
       flushNow();
     };
-  }, [enabled, flushKeepalive, flushNow, platform, recordEvent, relatedEventId, videoId, videoRef]);
+  }, [
+    autoplayFromVideoId,
+    enabled,
+    flushKeepalive,
+    flushNow,
+    platform,
+    recordEvent,
+    relatedEventId,
+    videoId,
+    videoRef
+  ]);
 }

--- a/frontend/src/hooks/useVideoRecommendations.ts
+++ b/frontend/src/hooks/useVideoRecommendations.ts
@@ -30,12 +30,20 @@ export function useVideoRecommendations({
             author: video.author,
             tags: video.tags,
             seriesTitle: video.seriesTitle,
+            partNumber: video.partNumber,
+            totalParts: video.totalParts,
+            rating: video.rating,
             title: video.title,
             videoFilename: video.videoFilename,
             source: video.source,
+            sourceUrl: video.sourceUrl,
             date: video.date,
             addedAt: video.addedAt,
-            duration: video.duration
+            duration: video.duration,
+            progress: video.progress,
+            viewCount: video.viewCount,
+            lastPlayedAt: video.lastPlayedAt,
+            channelUrl: video.channelUrl
         } as Video;
     }, [video]);
     const deferredRecommendationVideo = useDeferredValue(recommendationVideo);

--- a/frontend/src/hooks/useVideoRecommendations.ts
+++ b/frontend/src/hooks/useVideoRecommendations.ts
@@ -3,6 +3,8 @@ import { useCollection } from '../contexts/CollectionContext';
 import { useVideo } from '../contexts/VideoContext';
 import { Video } from '../types';
 import { getRecommendations } from '../utils/recommendations';
+import { useRecommendationSignals } from './useRecommendationSignals';
+import { useSettings } from './useSettings';
 
 interface UseVideoRecommendationsProps {
     video: Video | undefined;
@@ -20,8 +22,13 @@ export function useVideoRecommendations({
 }: UseVideoRecommendationsProps) {
     const { videos } = useVideo();
     const { collections } = useCollection();
+    const { data: settings } = useSettings();
+    const { data: signals } = useRecommendationSignals({
+        enabled: settings?.statisticsEnabled === true
+    });
     const deferredVideos = useDeferredValue(videos);
     const deferredCollections = useDeferredValue(collections);
+    const deferredSignals = useDeferredValue(signals);
     const recommendationVideo = useMemo(() => {
         if (!video) return undefined;
 
@@ -56,12 +63,14 @@ export function useVideoRecommendations({
             allVideos: deferredVideos,
             collections: deferredCollections,
             sourceCollectionId,
-            playbackQueueVideoIds
+            playbackQueueVideoIds,
+            signals: deferredSignals
         }).slice(0, 10);
     }, [
         deferredRecommendationVideo,
         deferredVideos,
         deferredCollections,
+        deferredSignals,
         sourceCollectionId,
         playbackQueueVideoIds
     ]);

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -5,7 +5,7 @@ import {
     Container,
     Typography
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import CollectionModal from '../components/CollectionModal';
 import ConfirmationModal from '../components/ConfirmationModal';
@@ -24,6 +24,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { useVideo } from '../contexts/VideoContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { useSettings } from '../hooks/useSettings';
+import { useStatisticsIngestion } from '../hooks/useStatisticsIngestion';
 import { useVideoCollections } from '../hooks/useVideoCollections';
 import { useVideoMutations } from '../hooks/useVideoMutations';
 import { useVideoPlayerSettings } from '../hooks/useVideoPlayerSettings';
@@ -47,12 +48,14 @@ const VideoPlayer: React.FC = () => {
             statisticsRelatedEventId?: string | null;
             sourceCollectionId?: string | null;
             playbackQueueVideoIds?: string[];
+            autoplayFromVideoId?: string | null;
         }
         | null;
     const statisticsRelatedEventId =
         navigationState?.statisticsRelatedEventId ?? null;
     const sourceCollectionId = navigationState?.sourceCollectionId ?? null;
     const playbackQueueVideoIds = navigationState?.playbackQueueVideoIds;
+    const autoplayFromVideoId = navigationState?.autoplayFromVideoId ?? null;
 
     const [showComments, setShowComments] = useState<boolean>(false);
     const [autoPlayNext, setAutoPlayNext] = useState<boolean>(() => {
@@ -63,6 +66,9 @@ const VideoPlayer: React.FC = () => {
     // Underlying <video> element, exposed by VideoControls for live translation capture.
     const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null);
     const { data: liveTranslationAvailability } = useLiveTranslationAvailability();
+    const statisticsIngestion = useStatisticsIngestion();
+    const upNextImpressionEventIdRef = useRef<string | null>(null);
+    const upNextImpressionKeyRef = useRef<string | null>(null);
     const liveTargetLanguage = liveTranslationAvailability?.targetLanguage || 'en';
     const liveSubtitleLabel = `${t('liveTranslation') || 'Live translation'} (${getLiveTranslationLanguageLabel(liveTargetLanguage)})`;
     const liveSubtitleTrack = useLiveTranslationSubtitleTrack(
@@ -200,6 +206,64 @@ const VideoPlayer: React.FC = () => {
         playbackQueueVideoIds
     });
 
+    const upNextSlate = useMemo(() => {
+        if (!video) return [];
+
+        const queueIds = playbackQueueVideoIds?.includes(video.id)
+            ? playbackQueueVideoIds
+            : sourceCollectionId
+                ? collections.find(collection =>
+                    collection.id === sourceCollectionId &&
+                    collection.videos.includes(video.id)
+                )?.videos
+                : undefined;
+        const currentQueueIndex = queueIds?.indexOf(video.id) ?? -1;
+
+        return relatedVideos.map((relatedVideo, index) => {
+            let lane: 'continue' | 'related' | 'discover' = 'related';
+            if (
+                currentQueueIndex !== -1 &&
+                queueIds?.slice(currentQueueIndex + 1, currentQueueIndex + 4).includes(relatedVideo.id)
+            ) {
+                lane = 'continue';
+            } else if (
+                index < 3 &&
+                video.seriesTitle &&
+                relatedVideo.seriesTitle === video.seriesTitle &&
+                typeof video.partNumber === 'number' &&
+                relatedVideo.partNumber === video.partNumber + 1
+            ) {
+                lane = 'continue';
+            } else if (index >= Math.max(relatedVideos.length - 2, 3)) {
+                lane = 'discover';
+            }
+
+            return {
+                videoId: relatedVideo.id,
+                lane,
+                position: index + 1
+            };
+        });
+    }, [collections, playbackQueueVideoIds, relatedVideos, sourceCollectionId, video]);
+
+    useEffect(() => {
+        if (!statisticsIngestion.enabled || !video || upNextSlate.length === 0) return;
+
+        const slateKey = `${video.id}:${upNextSlate.map(item => `${item.videoId}:${item.lane}`).join(',')}`;
+        if (upNextImpressionKeyRef.current === slateKey) return;
+
+        upNextImpressionKeyRef.current = slateKey;
+        upNextImpressionEventIdRef.current = statisticsIngestion.recordEvent({
+            eventType: 'up_next_impression',
+            surface: 'web',
+            videoId: video.id,
+            payload: {
+                fromVideoId: video.id,
+                slate: upNextSlate
+            }
+        });
+    }, [statisticsIngestion, upNextSlate, video]);
+
     const handleToggleComments = () => {
         setShowComments(!showComments);
     };
@@ -332,20 +396,42 @@ const VideoPlayer: React.FC = () => {
 
 
 
+    const buildPlaybackState = (
+        relatedEventId: string | null = statisticsRelatedEventId,
+        extras: Record<string, unknown> = {}
+    ) => ({
+        ...(relatedEventId ? { statisticsRelatedEventId: relatedEventId } : {}),
+        ...(sourceCollectionId ? { sourceCollectionId } : {}),
+        ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {}),
+        ...extras
+    });
+
     const handleVideoEnded = () => {
         if (autoPlayNext && relatedVideos.length > 0) {
-            const state = {
-                ...(statisticsRelatedEventId ? { statisticsRelatedEventId } : {}),
-                ...(sourceCollectionId ? { sourceCollectionId } : {}),
-                ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {})
-            };
+            const nextVideo = relatedVideos[0];
+            const autoplayEventId = statisticsIngestion.enabled && video
+                ? statisticsIngestion.recordEvent({
+                    eventType: 'autoplay_advanced',
+                    surface: 'web',
+                    videoId: nextVideo.id,
+                    relatedEventId: upNextImpressionEventIdRef.current,
+                    payload: {
+                        fromVideoId: video.id,
+                        toVideoId: nextVideo.id
+                    }
+                })
+                : null;
+            const state = buildPlaybackState(
+                autoplayEventId ?? statisticsRelatedEventId,
+                statisticsIngestion.enabled && video ? { autoplayFromVideoId: video.id } : {}
+            );
 
             if (Object.keys(state).length > 0) {
-                navigate(`/video/${relatedVideos[0].id}`, { state });
+                navigate(`/video/${nextVideo.id}`, { state });
                 return;
             }
 
-            navigate(`/video/${relatedVideos[0].id}`);
+            navigate(`/video/${nextVideo.id}`);
         }
     };
 
@@ -406,6 +492,7 @@ const VideoPlayer: React.FC = () => {
                             typeof video.source === 'string' ? video.source.toLowerCase() : null
                         }
                         statisticsRelatedEventId={statisticsRelatedEventId}
+                        statisticsAutoplayFromVideoId={autoplayFromVideoId}
                         onUploadSubtitle={async (file: File) => {
                             if (!id) return;
                             await uploadSubtitleMutation.mutateAsync({ file });
@@ -476,12 +563,28 @@ const VideoPlayer: React.FC = () => {
                         relatedVideos={relatedVideos}
                         autoPlayNext={autoPlayNext}
                         onAutoPlayNextChange={setAutoPlayNext}
-                        onVideoClick={(videoId) => {
-                            const state = {
-                                ...(statisticsRelatedEventId ? { statisticsRelatedEventId } : {}),
-                                ...(sourceCollectionId ? { sourceCollectionId } : {}),
-                                ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {})
+                        onVideoClick={(videoId, index) => {
+                            const slateItem = upNextSlate[index] ?? {
+                                videoId,
+                                lane: 'related',
+                                position: index + 1
                             };
+                            const clickEventId = statisticsIngestion.enabled && video
+                                ? statisticsIngestion.recordEvent({
+                                    eventType: 'up_next_clicked',
+                                    surface: 'web',
+                                    videoId,
+                                    relatedEventId: upNextImpressionEventIdRef.current,
+                                    value: slateItem.position,
+                                    payload: {
+                                        fromVideoId: video.id,
+                                        toVideoId: videoId,
+                                        position: slateItem.position,
+                                        lane: slateItem.lane
+                                    }
+                                })
+                                : null;
+                            const state = buildPlaybackState(clickEventId ?? statisticsRelatedEventId);
 
                             if (Object.keys(state).length > 0) {
                                 navigate(`/video/${videoId}`, { state });

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -5,7 +5,7 @@ import {
     Container,
     Typography
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import CollectionModal from '../components/CollectionModal';
 import ConfirmationModal from '../components/ConfirmationModal';
@@ -24,6 +24,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { useVideo } from '../contexts/VideoContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { useSettings } from '../hooks/useSettings';
+import { useStatisticsIngestion } from '../hooks/useStatisticsIngestion';
 import { useVideoCollections } from '../hooks/useVideoCollections';
 import { useVideoMutations } from '../hooks/useVideoMutations';
 import { useVideoPlayerSettings } from '../hooks/useVideoPlayerSettings';
@@ -47,12 +48,14 @@ const VideoPlayer: React.FC = () => {
             statisticsRelatedEventId?: string | null;
             sourceCollectionId?: string | null;
             playbackQueueVideoIds?: string[];
+            autoplayFromVideoId?: string | null;
         }
         | null;
     const statisticsRelatedEventId =
         navigationState?.statisticsRelatedEventId ?? null;
     const sourceCollectionId = navigationState?.sourceCollectionId ?? null;
     const playbackQueueVideoIds = navigationState?.playbackQueueVideoIds;
+    const autoplayFromVideoId = navigationState?.autoplayFromVideoId ?? null;
 
     const [showComments, setShowComments] = useState<boolean>(false);
     const [autoPlayNext, setAutoPlayNext] = useState<boolean>(() => {
@@ -63,6 +66,9 @@ const VideoPlayer: React.FC = () => {
     // Underlying <video> element, exposed by VideoControls for live translation capture.
     const [videoElement, setVideoElement] = useState<HTMLVideoElement | null>(null);
     const { data: liveTranslationAvailability } = useLiveTranslationAvailability();
+    const statisticsIngestion = useStatisticsIngestion();
+    const upNextImpressionEventIdRef = useRef<string | null>(null);
+    const upNextImpressionKeyRef = useRef<string | null>(null);
     const liveTargetLanguage = liveTranslationAvailability?.targetLanguage || 'en';
     const liveSubtitleLabel = `${t('liveTranslation') || 'Live translation'} (${getLiveTranslationLanguageLabel(liveTargetLanguage)})`;
     const liveSubtitleTrack = useLiveTranslationSubtitleTrack(
@@ -200,6 +206,64 @@ const VideoPlayer: React.FC = () => {
         playbackQueueVideoIds
     });
 
+    const upNextSlate = useMemo(() => {
+        if (!video) return [];
+
+        const queueIds = playbackQueueVideoIds?.includes(video.id)
+            ? playbackQueueVideoIds
+            : sourceCollectionId
+                ? collections.find(collection =>
+                    collection.id === sourceCollectionId &&
+                    collection.videos.includes(video.id)
+                )?.videos
+                : undefined;
+        const currentQueueIndex = queueIds?.indexOf(video.id) ?? -1;
+
+        return relatedVideos.map((relatedVideo, index) => {
+            let lane: 'continue' | 'related' | 'discover' = 'related';
+            if (
+                currentQueueIndex !== -1 &&
+                queueIds?.slice(currentQueueIndex + 1, currentQueueIndex + 4).includes(relatedVideo.id)
+            ) {
+                lane = 'continue';
+            } else if (
+                index < 3 &&
+                video.seriesTitle &&
+                relatedVideo.seriesTitle === video.seriesTitle &&
+                typeof video.partNumber === 'number' &&
+                relatedVideo.partNumber === video.partNumber + 1
+            ) {
+                lane = 'continue';
+            } else if (index >= Math.max(relatedVideos.length - 2, 3)) {
+                lane = 'discover';
+            }
+
+            return {
+                videoId: relatedVideo.id,
+                lane,
+                position: index + 1
+            };
+        });
+    }, [collections, playbackQueueVideoIds, relatedVideos, sourceCollectionId, video]);
+
+    useEffect(() => {
+        if (!statisticsIngestion.enabled || !video || upNextSlate.length === 0) return;
+
+        const slateKey = `${video.id}:${upNextSlate.map(item => `${item.videoId}:${item.lane}`).join(',')}`;
+        if (upNextImpressionKeyRef.current === slateKey) return;
+
+        upNextImpressionKeyRef.current = slateKey;
+        upNextImpressionEventIdRef.current = statisticsIngestion.recordEvent({
+            eventType: 'up_next_impression',
+            surface: 'web',
+            videoId: video.id,
+            payload: {
+                fromVideoId: video.id,
+                slate: upNextSlate
+            }
+        });
+    }, [statisticsIngestion, upNextSlate, video]);
+
     const handleToggleComments = () => {
         setShowComments(!showComments);
     };
@@ -332,20 +396,42 @@ const VideoPlayer: React.FC = () => {
 
 
 
+    const buildPlaybackState = (
+        relatedEventId: string | null = statisticsRelatedEventId,
+        extras: Record<string, unknown> = {}
+    ) => ({
+        ...(relatedEventId ? { statisticsRelatedEventId: relatedEventId } : {}),
+        ...(sourceCollectionId ? { sourceCollectionId } : {}),
+        ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {}),
+        ...extras
+    });
+
     const handleVideoEnded = () => {
         if (autoPlayNext && relatedVideos.length > 0) {
-            const state = {
-                ...(statisticsRelatedEventId ? { statisticsRelatedEventId } : {}),
-                ...(sourceCollectionId ? { sourceCollectionId } : {}),
-                ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {})
-            };
+            const nextVideo = relatedVideos[0];
+            const autoplayEventId = statisticsIngestion.enabled && video
+                ? statisticsIngestion.recordEvent({
+                    eventType: 'autoplay_advanced',
+                    surface: 'web',
+                    videoId: nextVideo.id,
+                    relatedEventId: upNextImpressionEventIdRef.current,
+                    payload: {
+                        fromVideoId: video.id,
+                        toVideoId: nextVideo.id
+                    }
+                })
+                : null;
+            const state = buildPlaybackState(
+                autoplayEventId ?? statisticsRelatedEventId,
+                statisticsIngestion.enabled && video ? { autoplayFromVideoId: video.id } : {}
+            );
 
             if (Object.keys(state).length > 0) {
-                navigate(`/video/${relatedVideos[0].id}`, { state });
+                navigate(`/video/${nextVideo.id}`, { state });
                 return;
             }
 
-            navigate(`/video/${relatedVideos[0].id}`);
+            navigate(`/video/${nextVideo.id}`);
         }
     };
 
@@ -407,6 +493,7 @@ const VideoPlayer: React.FC = () => {
                             typeof video.source === 'string' ? video.source.toLowerCase() : null
                         }
                         statisticsRelatedEventId={statisticsRelatedEventId}
+                        statisticsAutoplayFromVideoId={autoplayFromVideoId}
                         onUploadSubtitle={async (file: File) => {
                             if (!id) return;
                             await uploadSubtitleMutation.mutateAsync({ file });
@@ -477,12 +564,28 @@ const VideoPlayer: React.FC = () => {
                         relatedVideos={relatedVideos}
                         autoPlayNext={autoPlayNext}
                         onAutoPlayNextChange={setAutoPlayNext}
-                        onVideoClick={(videoId) => {
-                            const state = {
-                                ...(statisticsRelatedEventId ? { statisticsRelatedEventId } : {}),
-                                ...(sourceCollectionId ? { sourceCollectionId } : {}),
-                                ...(playbackQueueVideoIds ? { playbackQueueVideoIds } : {})
+                        onVideoClick={(videoId, index) => {
+                            const slateItem = upNextSlate[index] ?? {
+                                videoId,
+                                lane: 'related',
+                                position: index + 1
                             };
+                            const clickEventId = statisticsIngestion.enabled && video
+                                ? statisticsIngestion.recordEvent({
+                                    eventType: 'up_next_clicked',
+                                    surface: 'web',
+                                    videoId,
+                                    relatedEventId: upNextImpressionEventIdRef.current,
+                                    value: slateItem.position,
+                                    payload: {
+                                        fromVideoId: video.id,
+                                        toVideoId: videoId,
+                                        position: slateItem.position,
+                                        lane: slateItem.lane
+                                    }
+                                })
+                                : null;
+                            const state = buildPlaybackState(clickEventId ?? statisticsRelatedEventId);
 
                             if (Object.keys(state).length > 0) {
                                 navigate(`/video/${videoId}`, { state });

--- a/frontend/src/pages/__tests__/VideoPlayer.test.tsx
+++ b/frontend/src/pages/__tests__/VideoPlayer.test.tsx
@@ -44,6 +44,7 @@ const mockDeleteSubtitleMutateAsync = vi.fn();
 const mockHandleTimeUpdate = vi.fn();
 const mockSetIsDeleting = vi.fn();
 const mockHandleSubtitlesToggle = vi.fn(), mockHandleLoopToggle = vi.fn(), mockScrollTo = vi.fn();
+const mockStatisticsRecordEvent = vi.fn();
 
 // ---- Mutable mock state (overridable per test) ----
 
@@ -54,6 +55,7 @@ let mockVideoSubscriptionsReturn: Record<string, unknown>;
 let mockVideoCollectionsReturn: Record<string, unknown>;
 let mockVideoRecommendationsReturn: unknown;
 let mockVideoPlayerSettingsReturn: Record<string, unknown>;
+let mockStatisticsIngestionReturn: Record<string, unknown>;
 
 // ---- Mock hooks ----
 
@@ -115,6 +117,10 @@ vi.mock('../../hooks/useVideoProgress', () => ({
 
 vi.mock('../../hooks/useVideoRecommendations', () => ({
     useVideoRecommendations: () => mockVideoRecommendationsReturn,
+}));
+
+vi.mock('../../hooks/useStatisticsIngestion', () => ({
+    useStatisticsIngestion: () => mockStatisticsIngestionReturn,
 }));
 
 vi.mock('../../utils/apiUrl', () => ({
@@ -268,6 +274,14 @@ function resetDefaults() {
     };
 
     mockVideoRecommendationsReturn = { relatedVideos: [] };
+
+    mockStatisticsIngestionReturn = {
+        enabled: false,
+        recordEvent: mockStatisticsRecordEvent,
+        flushNow: vi.fn(),
+        flushKeepalive: vi.fn(),
+        sessionId: 'stats-session',
+    };
 
     mockVideoPlayerSettingsReturn = {
         autoPlay: false,
@@ -557,6 +571,39 @@ describe('VideoPlayer', () => {
             expect(mockNavigate).toHaveBeenCalledWith('/video/v2');
         });
 
+        it('records autoplay advancement when statistics are enabled', () => {
+            localStorageMock.setItem('autoPlayNext', 'true');
+            mockVideoRecommendationsReturn = { relatedVideos: [{ id: 'v2' }] };
+            mockStatisticsIngestionReturn = {
+                ...mockStatisticsIngestionReturn,
+                enabled: true,
+            };
+            mockStatisticsRecordEvent
+                .mockReturnValueOnce('impression-1')
+                .mockReturnValueOnce('autoplay-1');
+            render(<VideoPlayer />);
+
+            act(() => { capturedVideoControlsProps.onEnded(); });
+
+            expect(mockStatisticsRecordEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    eventType: 'autoplay_advanced',
+                    videoId: 'v2',
+                    relatedEventId: 'impression-1',
+                    payload: expect.objectContaining({
+                        fromVideoId: 'v1',
+                        toVideoId: 'v2',
+                    }),
+                })
+            );
+            expect(mockNavigate).toHaveBeenCalledWith('/video/v2', {
+                state: {
+                    statisticsRelatedEventId: 'autoplay-1',
+                    autoplayFromVideoId: 'v1',
+                },
+            });
+        });
+
         it('does not navigate when autoPlayNext is off', () => {
             mockVideoRecommendationsReturn = { relatedVideos: [{ id: 'v2' }] };
             render(<VideoPlayer />);
@@ -741,8 +788,52 @@ describe('VideoPlayer', () => {
     describe('UpNextSidebar onVideoClick', () => {
         it('navigates to video page when a related video is clicked', () => {
             render(<VideoPlayer />);
-            act(() => { capturedUpNextSidebarProps.onVideoClick('v5'); });
+            act(() => { capturedUpNextSidebarProps.onVideoClick('v5', 0); });
             expect(mockNavigate).toHaveBeenCalledWith('/video/v5');
+        });
+
+        it('records Up Next impression and click events when statistics are enabled', () => {
+            mockVideoRecommendationsReturn = { relatedVideos: [{ id: 'v5', title: 'Next' }] };
+            mockStatisticsIngestionReturn = {
+                ...mockStatisticsIngestionReturn,
+                enabled: true,
+            };
+            mockStatisticsRecordEvent
+                .mockReturnValueOnce('impression-1')
+                .mockReturnValueOnce('click-1');
+
+            render(<VideoPlayer />);
+
+            expect(mockStatisticsRecordEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    eventType: 'up_next_impression',
+                    videoId: 'v1',
+                    payload: expect.objectContaining({
+                        fromVideoId: 'v1',
+                        slate: [{ videoId: 'v5', lane: 'related', position: 1 }],
+                    }),
+                })
+            );
+
+            act(() => { capturedUpNextSidebarProps.onVideoClick('v5', 0); });
+
+            expect(mockStatisticsRecordEvent).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    eventType: 'up_next_clicked',
+                    videoId: 'v5',
+                    relatedEventId: 'impression-1',
+                    value: 1,
+                    payload: expect.objectContaining({
+                        fromVideoId: 'v1',
+                        toVideoId: 'v5',
+                        position: 1,
+                        lane: 'related',
+                    }),
+                })
+            );
+            expect(mockNavigate).toHaveBeenCalledWith('/video/v5', {
+                state: { statisticsRelatedEventId: 'click-1' },
+            });
         });
     });
 

--- a/frontend/src/pages/__tests__/videoPlayerTestTypes.d.ts
+++ b/frontend/src/pages/__tests__/videoPlayerTestTypes.d.ts
@@ -42,7 +42,7 @@ export interface CapturedCommentsSectionProps extends Record<string, unknown> {
 
 export interface CapturedUpNextSidebarProps extends Record<string, unknown> {
     onAutoPlayNextChange: (value: boolean) => void;
-    onVideoClick: (id: string) => void;
+    onVideoClick: (id: string, position: number) => void;
     autoPlayNext: boolean;
 }
 

--- a/frontend/src/utils/__tests__/recommendations.test.ts
+++ b/frontend/src/utils/__tests__/recommendations.test.ts
@@ -471,6 +471,45 @@ describe("recommendations", () => {
       ).toBeLessThanOrEqual(3);
     });
 
+    it("should boost co-play neighbors when recommendation signals are available", () => {
+      const currentVideo = createMockVideo("1", {
+        title: "Current Topic",
+        source: "youtube",
+      });
+      const coPlayVideo = createMockVideo("2", {
+        title: "Related Topic",
+        source: "youtube",
+      });
+      const comparableVideo = createMockVideo("3", {
+        title: "Related Topic",
+        source: "youtube",
+      });
+
+      const recommendations = getRecommendations({
+        currentVideo,
+        allVideos: [currentVideo, comparableVideo, coPlayVideo],
+        collections: [],
+        signals: {
+          computedAt: Date.now(),
+          perVideo: {
+            "1": {
+              ws: 120,
+              cr: 1,
+              ar: 0,
+              lf: null,
+              rw: 0,
+              nb: [["2", 0.8]],
+            },
+          },
+          authorAffinity: {},
+          tagAffinity: {},
+          durationBands: [0, 1, 0, 0],
+        },
+      });
+
+      expect(recommendations[0]).toEqual(coPlayVideo);
+    });
+
     it("should return all candidates when no specific criteria match", () => {
       const currentVideo = createMockVideo("1");
       const videos = [

--- a/frontend/src/utils/__tests__/recommendations.test.ts
+++ b/frontend/src/utils/__tests__/recommendations.test.ts
@@ -219,13 +219,22 @@ describe("recommendations", () => {
       expect(recommendations[0]).toEqual(inProgressVideo);
     });
 
-    it("should prioritize recently played videos", () => {
+    it("should not reward recently completed videos during the re-watch cooldown", () => {
       const now = Date.now();
       const currentVideo = createMockVideo("1");
       const recentlyPlayed = createMockVideo("2", {
+        title: "Video Topic",
+        duration: "10:00",
+        progress: 600,
+        viewCount: 5,
         lastPlayedAt: now - 1000 * 60 * 60, // 1 hour ago
       });
-      const neverPlayed = createMockVideo("3");
+      const neverPlayed = createMockVideo("3", {
+        title: "Video Topic",
+        duration: "10:00",
+        progress: 0,
+        viewCount: 0,
+      });
 
       const recommendations = getRecommendations({
         currentVideo,
@@ -233,48 +242,84 @@ describe("recommendations", () => {
         collections: [],
       });
 
-      // Recently played should be ranked higher
       const recentIndex = recommendations.findIndex((v) => v.id === "2");
       const neverPlayedIndex = recommendations.findIndex((v) => v.id === "3");
-      expect(recentIndex).toBeLessThan(neverPlayedIndex);
+      expect(neverPlayedIndex).toBeLessThan(recentIndex);
     });
 
-    it("should prioritize videos with higher view count", () => {
+    it("should use rating affinity when relevance is comparable", () => {
       const currentVideo = createMockVideo("1");
-      const highViews = createMockVideo("2", { viewCount: 1000 });
-      const lowViews = createMockVideo("3", { viewCount: 10 });
+      const highRated = createMockVideo("2", {
+        title: "Comparable Topic",
+        rating: 5,
+        viewCount: 0,
+      });
+      const lowRated = createMockVideo("3", {
+        title: "Comparable Topic",
+        rating: 2,
+        viewCount: 0,
+      });
 
       const recommendations = getRecommendations({
         currentVideo,
-        allVideos: [currentVideo, highViews, lowViews],
+        allVideos: [currentVideo, lowRated, highRated],
         collections: [],
       });
 
-      // Higher view count should be ranked higher
-      const highViewsIndex = recommendations.findIndex((v) => v.id === "2");
-      const lowViewsIndex = recommendations.findIndex((v) => v.id === "3");
-      expect(highViewsIndex).toBeLessThan(lowViewsIndex);
+      expect(recommendations[0]).toEqual(highRated);
     });
 
-    it("should prioritize next video in sequence", () => {
+    it("should prioritize exact next episodes using part numbers", () => {
       const currentVideo = createMockVideo("1", {
-        videoFilename: "video_001.mp4",
+        seriesTitle: "Course",
+        partNumber: 1,
+        totalParts: 3,
       });
-      const nextInSequence = createMockVideo("2", {
-        videoFilename: "video_002.mp4",
+      const nextEpisode = createMockVideo("2", {
+        seriesTitle: "Course",
+        partNumber: 2,
+        totalParts: 3,
       });
       const otherVideo = createMockVideo("3", {
-        videoFilename: "video_010.mp4",
+        seriesTitle: "Course",
+        partNumber: 3,
+        totalParts: 3,
       });
 
       const recommendations = getRecommendations({
         currentVideo,
-        allVideos: [currentVideo, nextInSequence, otherVideo],
+        allVideos: [currentVideo, otherVideo, nextEpisode],
         collections: [],
       });
 
-      // Next in sequence should be ranked higher
-      expect(recommendations[0]).toEqual(nextInSequence);
+      expect(recommendations[0]).toEqual(nextEpisode);
+    });
+
+    it("should scope filename-adjacent sequence recommendations to the same author and title stem", () => {
+      const currentVideo = createMockVideo("1", {
+        author: "Author A",
+        title: "Course 001",
+        videoFilename: "course_001.mp4",
+      });
+      const sameAuthorNext = createMockVideo("2", {
+        author: "Author A",
+        title: "Course 002",
+        videoFilename: "course_002.mp4",
+      });
+      const globalAlphabeticNext = createMockVideo("3", {
+        author: "Author B",
+        title: "Course 001b",
+        videoFilename: "course_001b.mp4",
+      });
+
+      const recommendations = getRecommendations({
+        currentVideo,
+        allVideos: [currentVideo, globalAlphabeticNext, sameAuthorNext],
+        collections: [],
+      });
+
+      expect(recommendations[0]).toEqual(sameAuthorNext);
+      expect(recommendations[0]).not.toEqual(globalAlphabeticNext);
     });
 
     it("should prioritize remaining videos from the source collection queue", () => {
@@ -376,6 +421,56 @@ describe("recommendations", () => {
       expect(recommendations[0]).toEqual(sameSeriesVideo);
     });
 
+    it("should prefer the next unwatched video by shared collection order", () => {
+      const currentVideo = createMockVideo("1");
+      const nextCollectionVideo = createMockVideo("2", { viewCount: 0 });
+      const laterCollectionVideo = createMockVideo("3", { viewCount: 0 });
+      const outsideVideo = createMockVideo("4", { rating: 5 });
+
+      const recommendations = getRecommendations({
+        currentVideo,
+        allVideos: [
+          currentVideo,
+          laterCollectionVideo,
+          outsideVideo,
+          nextCollectionVideo,
+        ],
+        collections: [createMockCollection("col1", ["1", "2", "3"])],
+      });
+
+      expect(recommendations[0]).toEqual(nextCollectionVideo);
+    });
+
+    it("should apply author diversity caps across the slate", () => {
+      const currentVideo = createMockVideo("1", {
+        author: "Author A",
+        title: "Current Topic",
+      });
+      const sameAuthorVideos = Array.from({ length: 5 }, (_, index) =>
+        createMockVideo(`${index + 2}`, {
+          author: "Author A",
+          title: `Same Author ${index}`,
+          addedAt: `2023-01-0${index + 2}`,
+        })
+      );
+      const differentAuthorVideo = createMockVideo("7", {
+        author: "Author B",
+        title: "Different Author",
+        addedAt: "2023-01-08",
+      });
+
+      const recommendations = getRecommendations({
+        currentVideo,
+        allVideos: [currentVideo, ...sameAuthorVideos, differentAuthorVideo],
+        collections: [],
+      });
+
+      expect(recommendations.slice(0, 4)).toContain(differentAuthorVideo);
+      expect(
+        recommendations.filter(video => video.author === "Author A").length
+      ).toBeLessThanOrEqual(3);
+    });
+
     it("should return all candidates when no specific criteria match", () => {
       const currentVideo = createMockVideo("1");
       const videos = [
@@ -405,6 +500,7 @@ describe("recommendations", () => {
       expect(DEFAULT_WEIGHTS).toHaveProperty("author");
       expect(DEFAULT_WEIGHTS).toHaveProperty("filename");
       expect(DEFAULT_WEIGHTS).toHaveProperty("sequence");
+      expect(DEFAULT_WEIGHTS).toHaveProperty("rating");
     });
 
     it("should have numeric weight values", () => {

--- a/frontend/src/utils/__tests__/recommendations.test.ts
+++ b/frontend/src/utils/__tests__/recommendations.test.ts
@@ -453,22 +453,60 @@ describe("recommendations", () => {
           addedAt: `2023-01-0${index + 2}`,
         })
       );
-      const differentAuthorVideo = createMockVideo("7", {
-        author: "Author B",
-        title: "Different Author",
-        addedAt: "2023-01-08",
-      });
+      const differentAuthorVideos = Array.from({ length: 8 }, (_, index) =>
+        createMockVideo(`${index + 7}`, {
+          author: `Author B${index}`,
+          title: `Different Author ${index}`,
+          addedAt: "2023-01-08",
+        })
+      );
 
       const recommendations = getRecommendations({
         currentVideo,
-        allVideos: [currentVideo, ...sameAuthorVideos, differentAuthorVideo],
+        allVideos: [currentVideo, ...sameAuthorVideos, ...differentAuthorVideos],
         collections: [],
       });
 
-      expect(recommendations.slice(0, 4)).toContain(differentAuthorVideo);
+      expect(recommendations).toHaveLength(10);
+      expect(
+        recommendations.slice(0, 4).some(video => video.author !== "Author A")
+      ).toBe(true);
       expect(
         recommendations.filter(video => video.author === "Author A").length
       ).toBeLessThanOrEqual(3);
+    });
+
+    it("should relax author caps instead of truncating single-author libraries", () => {
+      const videos = Array.from({ length: 12 }, (_, index) =>
+        createMockVideo(`${index + 1}`, {
+          author: "Solo Author",
+          title: `Solo Video ${index + 1}`,
+        })
+      );
+
+      const recommendations = getRecommendations({
+        currentVideo: videos[0],
+        allVideos: videos,
+        collections: [],
+      });
+
+      expect(recommendations).toHaveLength(10);
+    });
+
+    it("should relax collection caps instead of truncating single-collection libraries", () => {
+      const videos = Array.from({ length: 12 }, (_, index) =>
+        createMockVideo(`${index + 1}`)
+      );
+
+      const recommendations = getRecommendations({
+        currentVideo: videos[0],
+        allVideos: videos,
+        collections: [
+          createMockCollection("col1", videos.map(video => video.id)),
+        ],
+      });
+
+      expect(recommendations).toHaveLength(10);
     });
 
     it("should boost co-play neighbors when recommendation signals are available", () => {

--- a/frontend/src/utils/recommendations.ts
+++ b/frontend/src/utils/recommendations.ts
@@ -13,21 +13,25 @@ export interface RecommendationWeights {
     dateProximity: number;
     duration: number;
     watchState: number;
+    rating: number;
 }
 
 export const DEFAULT_WEIGHTS: RecommendationWeights = {
-    recency: 0.08,
-    frequency: 0.04,
-    collection: 0.4,
-    tags: 0.35,
-    author: 0.3,
-    filename: 0.0, // Used as tie-breaker mostly
-    sequence: 0.25, // Boost for the immediate next file
-    source: 0.08,
-    title: 0.25,
-    dateProximity: 0.08,
+    // Deprecated Phase 1 inputs kept for callers that pass partial custom weights.
+    // Recency/watch-state are now represented by the re-watch cooldown multiplier.
+    recency: 0,
+    frequency: 0,
+    collection: 0.3,
+    tags: 0.2,
+    author: 0.25,
+    filename: 0,
+    sequence: 0.35,
+    source: 0.05,
+    title: 0.1,
+    dateProximity: 0.05,
     duration: 0.05,
-    watchState: 0.2,
+    watchState: 0,
+    rating: 0.15,
 };
 
 const STOP_WORDS = new Set([
@@ -38,6 +42,8 @@ const STOP_WORDS = new Set([
     'as',
     'at',
     'by',
+    'episode',
+    'ep',
     'for',
     'from',
     'in',
@@ -47,6 +53,7 @@ const STOP_WORDS = new Set([
     'on',
     'or',
     'part',
+    'pt',
     'the',
     'to',
     'video',
@@ -54,7 +61,11 @@ const STOP_WORDS = new Set([
 ]);
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const ONE_YEAR_MS = 365 * DAY_MS;
+const REWATCH_HALF_LIFE_MS = 45 * DAY_MS;
+const RESUME_WINDOW_MS = 30 * DAY_MS;
+const MAX_RECOMMENDATIONS = 10;
+const RELATED_AUTHOR_CAP = 3;
+const RELATED_COLLECTION_CAP = 3;
 
 const normalizeText = (value: string | undefined | null): string =>
     (value ?? '').trim().toLowerCase();
@@ -87,6 +98,9 @@ const jaccardScore = (a: string[], b: string[]): number => {
     const union = new Set([...aSet, ...bSet]);
     return intersection / union.size;
 };
+
+const clamp = (value: number, min: number, max: number): number =>
+    Math.min(max, Math.max(min, value));
 
 const parseDateValue = (value: string | undefined): number | null => {
     if (!value) return null;
@@ -138,21 +152,393 @@ const getDurationSimilarityScore = (currentVideo: Video, candidate: Video): numb
     return shorterDuration / longerDuration;
 };
 
-const getWatchStateScore = (video: Video): number => {
-    const viewCount = video.viewCount || 0;
+const getProgressRatio = (video: Video): number => {
     const duration = parseDurationSeconds(video.duration);
     const progress = typeof video.progress === 'number' ? video.progress : 0;
 
-    if (duration && progress > 0) {
-        const progressRatio = Math.min(progress / duration, 1);
-        if (progressRatio >= 0.9) return -0.8;
-        return 0.7;
+    if (!duration || progress <= 0) return 0;
+    return clamp(progress / duration, 0, 1);
+};
+
+const isInProgress = (video: Video): boolean => {
+    const progressRatio = getProgressRatio(video);
+    return progressRatio > 0.05 && progressRatio < 0.9;
+};
+
+const isCompleted = (video: Video): boolean => getProgressRatio(video) >= 0.9;
+
+const isUnwatched = (video: Video): boolean =>
+    (video.viewCount || 0) === 0 && getProgressRatio(video) === 0;
+
+const getRewatchMultiplier = (video: Video, now: number): number => {
+    if (isInProgress(video)) return 1.15;
+    if (!isCompleted(video)) return 1;
+
+    const lastFinishedAt = typeof video.lastPlayedAt === 'number' ? video.lastPlayedAt : null;
+    if (!lastFinishedAt) return 1;
+
+    const age = Math.max(0, now - lastFinishedAt);
+    const base = 1 - Math.pow(2, -age / REWATCH_HALF_LIFE_MS);
+    const rating = typeof video.rating === 'number' ? clamp(video.rating, 1, 5) : 3;
+    const ratingBoost = 1 + 0.3 * ((rating - 3) / 2);
+    const viewCount = video.viewCount || 0;
+    const rewatchRate = viewCount > 0 ? Math.max(0, viewCount - 1) / viewCount : 0;
+
+    return clamp(base * (ratingBoost + 0.5 * rewatchRate), 0, 1);
+};
+
+const getRatingAffinity = (video: Video, weight: number): number => {
+    if (typeof video.rating !== 'number') return 0;
+    return clamp((video.rating - 3) / 2, -1, 1) * weight;
+};
+
+const getAuthorKey = (video: Video): string =>
+    normalizeText(typeof video.channelUrl === 'string' ? video.channelUrl : video.author);
+
+const sortByNaturalName = (a: Video, b: Video): number =>
+    getName(a).localeCompare(getName(b), undefined, { numeric: true, sensitivity: 'base' });
+
+const getAddedAtTimestamp = (video: Video): number =>
+    parseDateValue(video.addedAt) ?? parseDateValue(video.date) ?? 0;
+
+const sortByNewest = (a: Video, b: Video): number =>
+    getAddedAtTimestamp(b) - getAddedAtTimestamp(a) || sortByNaturalName(a, b);
+
+type CollectionMembership = Map<string, Array<{ id: string; index: number }>>;
+
+const buildCollectionMembership = (collections: Collection[]): CollectionMembership => {
+    const membership: CollectionMembership = new Map();
+
+    collections.forEach(collection => {
+        collection.videos.forEach((videoId, index) => {
+            const existing = membership.get(videoId) ?? [];
+            existing.push({ id: collection.id, index });
+            membership.set(videoId, existing);
+        });
+    });
+
+    return membership;
+};
+
+const getCollectionPositionScore = (
+    currentVideo: Video,
+    candidate: Video,
+    membership: CollectionMembership
+): number => {
+    const currentMembership = membership.get(currentVideo.id) ?? [];
+    const candidateMembership = membership.get(candidate.id) ?? [];
+    let bestScore = 0;
+
+    currentMembership.forEach(currentItem => {
+        const candidateItem = candidateMembership.find(item => item.id === currentItem.id);
+        if (!candidateItem) return;
+
+        const distance = Math.abs(candidateItem.index - currentItem.index);
+        if (distance === 0) return;
+
+        bestScore = Math.max(bestScore, 1 / distance);
+    });
+
+    return clamp(bestScore, 0, 1);
+};
+
+const hasSameSeries = (currentVideo: Video, candidate: Video): boolean =>
+    Boolean(
+        currentVideo.seriesTitle &&
+        candidate.seriesTitle &&
+        normalizeText(currentVideo.seriesTitle) === normalizeText(candidate.seriesTitle)
+    );
+
+const getSeriesStem = (video: Video): string =>
+    tokenize(getName(video))
+        .filter(token => !/^\d+$/.test(token))
+        .join(' ');
+
+const findNextEpisode = (currentVideo: Video, candidates: Video[]): Video | undefined => {
+    if (!currentVideo.seriesTitle || typeof currentVideo.partNumber !== 'number') return undefined;
+
+    const nextPartNumber = currentVideo.partNumber + 1;
+    return candidates
+        .filter(candidate =>
+            hasSameSeries(currentVideo, candidate) &&
+            candidate.partNumber === nextPartNumber
+        )
+        .sort((a, b) => {
+            const totalA = typeof a.totalParts === 'number' ? a.totalParts : Number.MAX_SAFE_INTEGER;
+            const totalB = typeof b.totalParts === 'number' ? b.totalParts : Number.MAX_SAFE_INTEGER;
+            return totalA - totalB || sortByNaturalName(a, b);
+        })[0];
+};
+
+const findNextSharedCollectionVideo = (
+    currentVideo: Video,
+    candidatesById: Map<string, Video>,
+    collections: Collection[]
+): Video | undefined => {
+    const options: Array<{ video: Video; distance: number; collectionIndex: number }> = [];
+
+    collections.forEach((collection, collectionIndex) => {
+        const currentIndex = collection.videos.indexOf(currentVideo.id);
+        if (currentIndex === -1) return;
+
+        for (let index = currentIndex + 1; index < collection.videos.length; index += 1) {
+            const candidate = candidatesById.get(collection.videos[index]);
+            if (!candidate || isCompleted(candidate)) continue;
+
+            options.push({
+                video: candidate,
+                distance: index - currentIndex,
+                collectionIndex
+            });
+            break;
+        }
+    });
+
+    return options.sort((a, b) =>
+        a.distance - b.distance ||
+        a.collectionIndex - b.collectionIndex ||
+        sortByNaturalName(a.video, b.video)
+    )[0]?.video;
+};
+
+const findFilenameAdjacentVideo = (currentVideo: Video, candidates: Video[]): Video | undefined => {
+    const currentAuthor = getAuthorKey(currentVideo);
+    const currentStem = getSeriesStem(currentVideo);
+    if (!currentAuthor || !currentStem) return undefined;
+
+    const scopedVideos = [currentVideo, ...candidates]
+        .filter(video => getAuthorKey(video) === currentAuthor && getSeriesStem(video) === currentStem)
+        .sort(sortByNaturalName);
+    const currentIndex = scopedVideos.findIndex(video => video.id === currentVideo.id);
+
+    if (currentIndex === -1 || currentIndex >= scopedVideos.length - 1) return undefined;
+    return scopedVideos[currentIndex + 1];
+};
+
+interface ScoredCandidate {
+    video: Video;
+    score: number;
+    collectionScore: number;
+}
+
+const scoreCandidate = (
+    currentVideo: Video,
+    candidate: Video,
+    allVideos: Video[],
+    membership: CollectionMembership,
+    weights: RecommendationWeights,
+    now: number,
+    currentTags: string[],
+    currentTitleTokens: string[],
+    nextScopedSequenceId: string | null
+): ScoredCandidate => {
+    const candidateTags = normalizeTags(candidate.tags);
+    const candidateTitleTokens = tokenize(`${candidate.title} ${candidate.videoFilename ?? ''}`);
+    const collectionScore = Math.max(
+        getCollectionPositionScore(currentVideo, candidate, membership),
+        hasSameSeries(currentVideo, candidate) ? 1 : 0
+    );
+    const authorScore = getAuthorKey(currentVideo) && getAuthorKey(currentVideo) === getAuthorKey(candidate) ? 1 : 0;
+    const sourceScore = currentVideo.source && candidate.source && currentVideo.source === candidate.source ? 1 : 0;
+    const maxViewCount = Math.max(...allVideos.map(video => video.viewCount || 0), 1);
+    const frequencyScore = (candidate.viewCount || 0) / maxViewCount;
+    const sequenceScore = candidate.id === nextScopedSequenceId ? 1 : 0;
+
+    const similarity =
+        collectionScore * weights.collection +
+        authorScore * weights.author +
+        jaccardScore(currentTags, candidateTags) * weights.tags +
+        jaccardScore(currentTitleTokens, candidateTitleTokens) * weights.title +
+        getDateProximityScore(currentVideo, candidate) * weights.dateProximity +
+        getDurationSimilarityScore(currentVideo, candidate) * weights.duration +
+        sourceScore * weights.source +
+        sequenceScore * weights.sequence +
+        frequencyScore * weights.frequency;
+
+    const score = similarity *
+        (1 + getRatingAffinity(candidate, weights.rating)) *
+        getRewatchMultiplier(candidate, now);
+
+    return {
+        video: candidate,
+        score,
+        collectionScore
+    };
+};
+
+const sortScoredCandidates = (a: ScoredCandidate, b: ScoredCandidate): number => {
+    if (Math.abs(a.score - b.score) > 0.001) return b.score - a.score;
+    if (Math.abs(a.collectionScore - b.collectionScore) > 0.001) {
+        return b.collectionScore - a.collectionScore;
     }
 
-    if (viewCount === 0) return 1;
-    if (viewCount <= 2) return 0.25;
+    return sortByNaturalName(a.video, b.video);
+};
 
-    return -0.1;
+const addCandidate = (candidateIds: Set<string>, video: Video | undefined, currentVideoId: string) => {
+    if (video && video.id !== currentVideoId) candidateIds.add(video.id);
+};
+
+const buildCandidatePool = (
+    currentVideo: Video,
+    allCandidates: Video[],
+    collections: Collection[],
+    membership: CollectionMembership
+): Video[] => {
+    const candidateIds = new Set<string>();
+    const allCandidatesById = new Map(allCandidates.map(video => [video.id, video]));
+    const currentTags = new Set(normalizeTags(currentVideo.tags));
+    const currentAuthor = getAuthorKey(currentVideo);
+
+    (membership.get(currentVideo.id) ?? []).forEach(item => {
+        const collection = collections.find(collectionItem => collectionItem.id === item.id);
+        collection?.videos.forEach(videoId => {
+            addCandidate(candidateIds, allCandidatesById.get(videoId), currentVideo.id);
+        });
+    });
+
+    allCandidates
+        .filter(video => getAuthorKey(video) === currentAuthor)
+        .sort(sortByNewest)
+        .slice(0, 50)
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    allCandidates
+        .filter(video => normalizeTags(video.tags).some(tag => currentTags.has(tag)))
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    allCandidates
+        .filter(video => hasSameSeries(currentVideo, video))
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    allCandidates
+        .filter(video => isInProgress(video))
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    allCandidates
+        .filter(video => typeof video.rating === 'number' && video.rating >= 4)
+        .sort((a, b) => (b.rating || 0) - (a.rating || 0) || sortByNewest(a, b))
+        .slice(0, 30)
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    allCandidates
+        .sort(sortByNewest)
+        .slice(0, 30)
+        .forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+
+    if (candidateIds.size < Math.min(MAX_RECOMMENDATIONS, allCandidates.length)) {
+        allCandidates.forEach(video => addCandidate(candidateIds, video, currentVideo.id));
+    }
+
+    return Array.from(candidateIds)
+        .map(videoId => allCandidatesById.get(videoId))
+        .filter((video): video is Video => Boolean(video));
+};
+
+interface DiversityState {
+    authorCounts: Map<string, number>;
+    collectionCounts: Map<string, number>;
+}
+
+const createDiversityState = (): DiversityState => ({
+    authorCounts: new Map(),
+    collectionCounts: new Map(),
+});
+
+const recordDiversity = (
+    video: Video,
+    membership: CollectionMembership,
+    state: DiversityState
+) => {
+    const authorKey = getAuthorKey(video);
+    if (authorKey) {
+        state.authorCounts.set(authorKey, (state.authorCounts.get(authorKey) || 0) + 1);
+    }
+
+    (membership.get(video.id) ?? []).forEach(item => {
+        state.collectionCounts.set(item.id, (state.collectionCounts.get(item.id) || 0) + 1);
+    });
+};
+
+const canSelectByDiversity = (
+    video: Video,
+    membership: CollectionMembership,
+    state: DiversityState
+): boolean => {
+    const authorKey = getAuthorKey(video);
+    if (authorKey && (state.authorCounts.get(authorKey) || 0) >= RELATED_AUTHOR_CAP) return false;
+
+    return (membership.get(video.id) ?? []).every(item =>
+        (state.collectionCounts.get(item.id) || 0) < RELATED_COLLECTION_CAP
+    );
+};
+
+const pickRelatedVideos = (
+    scoredCandidates: ScoredCandidate[],
+    selectedIds: Set<string>,
+    membership: CollectionMembership,
+    diversityState: DiversityState,
+    limit: number
+): Video[] => {
+    const selected: Video[] = [];
+
+    for (const item of scoredCandidates) {
+        if (selected.length >= limit) break;
+        if (selectedIds.has(item.video.id)) continue;
+        if (!canSelectByDiversity(item.video, membership, diversityState)) continue;
+
+        selected.push(item.video);
+        selectedIds.add(item.video.id);
+        recordDiversity(item.video, membership, diversityState);
+    }
+
+    return selected;
+};
+
+const pickDiscoverVideos = (
+    scoredCandidates: ScoredCandidate[],
+    selectedIds: Set<string>,
+    membership: CollectionMembership,
+    diversityState: DiversityState,
+    now: number,
+    limit: number
+): Video[] => {
+    const selected: Video[] = [];
+    const candidateVideos = scoredCandidates.map(item => item.video);
+    const freshestUnwatched = candidateVideos
+        .filter(video => !selectedIds.has(video.id) && isUnwatched(video))
+        .sort((a, b) => (b.rating || 0) - (a.rating || 0) || sortByNewest(a, b))[0];
+
+    if (
+        freshestUnwatched &&
+        canSelectByDiversity(freshestUnwatched, membership, diversityState)
+    ) {
+        selected.push(freshestUnwatched);
+        selectedIds.add(freshestUnwatched.id);
+        recordDiversity(freshestUnwatched, membership, diversityState);
+    }
+
+    if (selected.length >= limit) return selected;
+
+    const rewatchPick = candidateVideos
+        .filter(video => {
+            if (selectedIds.has(video.id) || !isCompleted(video)) return false;
+            return getRewatchMultiplier(video, now) >= 0.5 &&
+                ((video.rating || 0) >= 4 || (video.viewCount || 0) > 1);
+        })
+        .sort((a, b) =>
+            (getRewatchMultiplier(b, now) * (1 + getRatingAffinity(b, DEFAULT_WEIGHTS.rating))) -
+            (getRewatchMultiplier(a, now) * (1 + getRatingAffinity(a, DEFAULT_WEIGHTS.rating))) ||
+            sortByNewest(a, b)
+        )[0];
+
+    if (rewatchPick && canSelectByDiversity(rewatchPick, membership, diversityState)) {
+        selected.push(rewatchPick);
+        selectedIds.add(rewatchPick.id);
+        recordDiversity(rewatchPick, membership, diversityState);
+    }
+
+    return selected;
 };
 
 export interface RecommendationContext {
@@ -168,8 +554,7 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
     const { currentVideo, allVideos, collections, weights, sourceCollectionId, playbackQueueVideoIds } = context;
     const finalWeights = { ...DEFAULT_WEIGHTS, ...weights };
 
-    // Filter out current video
-    const candidates = allVideos.filter(v => v.id !== currentVideo.id);
+    const candidates = allVideos.filter(video => video.id !== currentVideo.id);
     const candidateById = new Map(candidates.map(video => [video.id, video]));
 
     const sourceCollection = sourceCollectionId
@@ -207,115 +592,76 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
         }
     }
 
-    // Pre-calculate collection membership for current video
-    const currentVideoCollections = collections.filter(c => c.videos.includes(currentVideo.id)).map(c => c.id);
+    if (candidates.length === 0) return [];
 
-    // Calculate max values for normalization
-    const maxViewCount = Math.max(...allVideos.map(v => v.viewCount || 0), 1);
     const now = Date.now();
+    const membership = buildCollectionMembership(collections);
+    const candidatePool = buildCandidatePool(currentVideo, candidates, collections, membership);
     const currentTags = normalizeTags(currentVideo.tags);
     const currentTitleTokens = tokenize(`${currentVideo.title} ${currentVideo.videoFilename ?? ''}`);
+    const nextEpisode = findNextEpisode(currentVideo, candidatePool);
+    const nextSharedCollectionVideo = findNextSharedCollectionVideo(currentVideo, candidateById, collections);
+    const filenameAdjacentVideo = findFilenameAdjacentVideo(currentVideo, candidatePool);
+    const nextScopedSequenceId =
+        nextEpisode?.id ??
+        nextSharedCollectionVideo?.id ??
+        filenameAdjacentVideo?.id ??
+        null;
+    const scoredCandidates = candidatePool
+        .map(candidate => scoreCandidate(
+            currentVideo,
+            candidate,
+            allVideos,
+            membership,
+            finalWeights,
+            now,
+            currentTags,
+            currentTitleTokens,
+            nextScopedSequenceId
+        ))
+        .sort(sortScoredCandidates);
 
-    // Determine natural sequence
-    // Sort all videos by filename/title to find the "next" one naturally
-    const sortedAllVideos = [...allVideos].sort((a, b) => {
-        const nameA = getName(a);
-        const nameB = getName(b);
-        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
-    });
-    const currentIndex = sortedAllVideos.findIndex(v => v.id === currentVideo.id);
-    const nextInSequenceId = currentIndex !== -1 && currentIndex < sortedAllVideos.length - 1 
-        ? sortedAllVideos[currentIndex + 1].id 
-        : null;
+    const selectedIds = new Set<string>();
+    const diversityState = createDiversityState();
+    const slate: Video[] = [];
 
-    const scoredCandidates = candidates.map(video => {
-        let score = 0;
+    [nextEpisode, nextSharedCollectionVideo, filenameAdjacentVideo].forEach(video => {
+        if (!video || selectedIds.has(video.id) || slate.length >= 3) return;
 
-        // 1. Recency (lastPlayedAt)
-        // Higher score for more recently played.
-        // If never played, score is 0.
-        if (video.lastPlayedAt) {
-            const age = Math.max(0, now - video.lastPlayedAt);
-            const recencyScore = Math.max(0, 1 - (age / ONE_YEAR_MS));
-            score += recencyScore * finalWeights.recency;
-        }
-
-        // 2. Frequency (viewCount). Kept intentionally weak so watched videos
-        // do not dominate topic relevance.
-        const frequencyScore = (video.viewCount || 0) / maxViewCount;
-        score += frequencyScore * finalWeights.frequency;
-
-        // 3. Collection/Series
-        // Check if video is in the same collection as current video
-        const videoCollections = collections.filter(c => c.videos.includes(video.id)).map(c => c.id);
-        const inSameCollection = currentVideoCollections.some(id => videoCollections.includes(id));
-        
-        // Also check seriesTitle if available
-        const sameSeriesTitle = currentVideo.seriesTitle && video.seriesTitle && currentVideo.seriesTitle === video.seriesTitle;
-
-        if (inSameCollection || sameSeriesTitle) {
-            score += 1.0 * finalWeights.collection;
-        }
-
-        // 4. Tags
-        // Jaccard index or simple overlap
-        const videoTags = normalizeTags(video.tags);
-        score += jaccardScore(currentTags, videoTags) * finalWeights.tags;
-
-        // 5. Author
-        if (currentVideo.author && video.author && currentVideo.author === video.author) {
-            score += 1.0 * finalWeights.author;
-        }
-
-        // 6. Platform/source
-        if (currentVideo.source && video.source && currentVideo.source === video.source) {
-            score += 1.0 * finalWeights.source;
-        }
-
-        // 7. Title/filename similarity
-        const videoTitleTokens = tokenize(`${video.title} ${video.videoFilename ?? ''}`);
-        score += jaccardScore(currentTitleTokens, videoTitleTokens) * finalWeights.title;
-
-        // 8. Video/add date proximity
-        score += getDateProximityScore(currentVideo, video) * finalWeights.dateProximity;
-
-        // 9. Duration similarity
-        score += getDurationSimilarityScore(currentVideo, video) * finalWeights.duration;
-
-        // 10. Watch state: prefer discovery and resumable videos.
-        score += getWatchStateScore(video) * finalWeights.watchState;
-        
-        // 11. Sequence (Natural Order)
-        if (video.id === nextInSequenceId) {
-            score += 1.0 * finalWeights.sequence;
-        }
-        
-        return {
-            video,
-            score,
-            inSameCollection
-        };
+        slate.push(video);
+        selectedIds.add(video.id);
+        recordDiversity(video, membership, diversityState);
     });
 
-    // Sort by score descending
-    scoredCandidates.sort((a, b) => {
-        if (Math.abs(a.score - b.score) > 0.001) {
-            return b.score - a.score;
-        }
+    const resumeVideo = scoredCandidates
+        .map(item => item.video)
+        .filter(video =>
+            !selectedIds.has(video.id) &&
+            isInProgress(video) &&
+            typeof video.lastPlayedAt === 'number' &&
+            now - video.lastPlayedAt <= RESUME_WINDOW_MS
+        )[0];
 
-        // Tie-breakers
-        
-        // 1. Same collection
-        if (a.inSameCollection !== b.inSameCollection) {
-            return a.inSameCollection ? -1 : 1;
-        }
+    if (resumeVideo && slate.length < 3) {
+        slate.push(resumeVideo);
+        selectedIds.add(resumeVideo.id);
+        recordDiversity(resumeVideo, membership, diversityState);
+    }
 
-        // 2. Filename natural order
-        const nameA = getName(a.video);
-        const nameB = getName(b.video);
-        
-        return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
-    });
+    const discoverSlots = Math.min(2, Math.max(0, MAX_RECOMMENDATIONS - slate.length));
+    const relatedSlots = Math.max(0, MAX_RECOMMENDATIONS - slate.length - discoverSlots);
+    slate.push(...pickRelatedVideos(scoredCandidates, selectedIds, membership, diversityState, relatedSlots));
+    slate.push(...pickDiscoverVideos(scoredCandidates, selectedIds, membership, diversityState, now, discoverSlots));
 
-    return scoredCandidates.map(item => item.video);
+    if (slate.length < Math.min(MAX_RECOMMENDATIONS, candidates.length)) {
+        slate.push(...pickRelatedVideos(
+            scoredCandidates,
+            selectedIds,
+            membership,
+            diversityState,
+            Math.min(MAX_RECOMMENDATIONS, candidates.length) - slate.length
+        ));
+    }
+
+    return slate;
 };

--- a/frontend/src/utils/recommendations.ts
+++ b/frontend/src/utils/recommendations.ts
@@ -16,6 +16,21 @@ export interface RecommendationWeights {
     rating: number;
 }
 
+export interface RecommendationSignals {
+    computedAt: number;
+    perVideo: Record<string, {
+        ws: number;
+        cr: number;
+        ar: number;
+        lf: number | null;
+        rw: number;
+        nb: [string, number][];
+    }>;
+    authorAffinity: Record<string, number>;
+    tagAffinity: Record<string, number>;
+    durationBands: number[];
+}
+
 export const DEFAULT_WEIGHTS: RecommendationWeights = {
     // Deprecated Phase 1 inputs kept for callers that pass partial custom weights.
     // Recency/watch-state are now represented by the re-watch cooldown multiplier.
@@ -170,11 +185,18 @@ const isCompleted = (video: Video): boolean => getProgressRatio(video) >= 0.9;
 const isUnwatched = (video: Video): boolean =>
     (video.viewCount || 0) === 0 && getProgressRatio(video) === 0;
 
-const getRewatchMultiplier = (video: Video, now: number): number => {
+const getRewatchMultiplier = (
+    video: Video,
+    now: number,
+    signal?: RecommendationSignals['perVideo'][string]
+): number => {
     if (isInProgress(video)) return 1.15;
-    if (!isCompleted(video)) return 1;
 
-    const lastFinishedAt = typeof video.lastPlayedAt === 'number' ? video.lastPlayedAt : null;
+    const signalFinishedAt = signal?.lf ?? null;
+    if (!signalFinishedAt && !isCompleted(video)) return 1;
+
+    const lastFinishedAt = signalFinishedAt ??
+        (typeof video.lastPlayedAt === 'number' ? video.lastPlayedAt : null);
     if (!lastFinishedAt) return 1;
 
     const age = Math.max(0, now - lastFinishedAt);
@@ -182,7 +204,8 @@ const getRewatchMultiplier = (video: Video, now: number): number => {
     const rating = typeof video.rating === 'number' ? clamp(video.rating, 1, 5) : 3;
     const ratingBoost = 1 + 0.3 * ((rating - 3) / 2);
     const viewCount = video.viewCount || 0;
-    const rewatchRate = viewCount > 0 ? Math.max(0, viewCount - 1) / viewCount : 0;
+    const rewatchRate = signal?.rw ??
+        (viewCount > 0 ? Math.max(0, viewCount - 1) / viewCount : 0);
 
     return clamp(base * (ratingBoost + 0.5 * rewatchRate), 0, 1);
 };
@@ -203,6 +226,72 @@ const getAddedAtTimestamp = (video: Video): number =>
 
 const sortByNewest = (a: Video, b: Video): number =>
     getAddedAtTimestamp(b) - getAddedAtTimestamp(a) || sortByNaturalName(a, b);
+
+const getDurationBand = (durationSeconds: number | null): number => {
+    if (!durationSeconds || durationSeconds < 5 * 60) return 0;
+    if (durationSeconds < 15 * 60) return 1;
+    if (durationSeconds < 45 * 60) return 2;
+    return 3;
+};
+
+const getDurationFit = (video: Video, signals?: RecommendationSignals): number => {
+    if (!signals || signals.durationBands.length === 0) return 0;
+    const duration = parseDurationSeconds(video.duration);
+    return signals.durationBands[getDurationBand(duration)] ?? 0;
+};
+
+const getTagAffinity = (video: Video, signals?: RecommendationSignals): number => {
+    if (!signals) return 0;
+    const tags = normalizeTags(video.tags);
+    if (tags.length === 0) return 0;
+
+    return clamp(
+        tags.reduce((sum, tag) => sum + (signals.tagAffinity[tag] ?? 0), 0) / tags.length,
+        0,
+        1
+    );
+};
+
+const getCoPlayScore = (
+    currentVideo: Video,
+    candidate: Video,
+    signals?: RecommendationSignals
+): number => {
+    const currentSignals = signals?.perVideo[currentVideo.id];
+    if (!currentSignals) return 0;
+
+    return currentSignals.nb.find(([videoId]) => videoId === candidate.id)?.[1] ?? 0;
+};
+
+const getBehavioralAffinity = (
+    currentVideo: Video,
+    candidate: Video,
+    signals: RecommendationSignals | undefined,
+    ratingWeight: number
+): number => {
+    const ratingAffinity = getRatingAffinity(candidate, ratingWeight);
+    if (!signals) return ratingAffinity;
+
+    const authorAffinity = signals.authorAffinity[getAuthorKey(candidate)] ?? 0;
+
+    return clamp(
+        getCoPlayScore(currentVideo, candidate, signals) * 0.4 +
+        authorAffinity * 0.3 +
+        getTagAffinity(candidate, signals) * 0.15 +
+        ratingAffinity +
+        getDurationFit(candidate, signals) * 0.1,
+        -1,
+        1
+    );
+};
+
+const getAvailabilityMultiplier = (
+    candidate: Video,
+    signals?: RecommendationSignals
+): number => {
+    const abandonRate = signals?.perVideo[candidate.id]?.ar ?? 0;
+    return clamp(1 - 0.5 * abandonRate, 0.5, 1);
+};
 
 type CollectionMembership = Map<string, Array<{ id: string; index: number }>>;
 
@@ -330,7 +419,8 @@ const scoreCandidate = (
     now: number,
     currentTags: string[],
     currentTitleTokens: string[],
-    nextScopedSequenceId: string | null
+    nextScopedSequenceId: string | null,
+    signals?: RecommendationSignals
 ): ScoredCandidate => {
     const candidateTags = normalizeTags(candidate.tags);
     const candidateTitleTokens = tokenize(`${candidate.title} ${candidate.videoFilename ?? ''}`);
@@ -356,8 +446,9 @@ const scoreCandidate = (
         frequencyScore * weights.frequency;
 
     const score = similarity *
-        (1 + getRatingAffinity(candidate, weights.rating)) *
-        getRewatchMultiplier(candidate, now);
+        (1 + getBehavioralAffinity(currentVideo, candidate, signals, weights.rating)) *
+        getRewatchMultiplier(candidate, now, signals?.perVideo[candidate.id]) *
+        getAvailabilityMultiplier(candidate, signals);
 
     return {
         video: candidate,
@@ -383,7 +474,8 @@ const buildCandidatePool = (
     currentVideo: Video,
     allCandidates: Video[],
     collections: Collection[],
-    membership: CollectionMembership
+    membership: CollectionMembership,
+    signals?: RecommendationSignals
 ): Video[] => {
     const candidateIds = new Set<string>();
     const allCandidatesById = new Map(allCandidates.map(video => [video.id, video]));
@@ -395,6 +487,10 @@ const buildCandidatePool = (
         collection?.videos.forEach(videoId => {
             addCandidate(candidateIds, allCandidatesById.get(videoId), currentVideo.id);
         });
+    });
+
+    signals?.perVideo[currentVideo.id]?.nb.forEach(([videoId]) => {
+        addCandidate(candidateIds, allCandidatesById.get(videoId), currentVideo.id);
     });
 
     allCandidates
@@ -501,7 +597,8 @@ const pickDiscoverVideos = (
     membership: CollectionMembership,
     diversityState: DiversityState,
     now: number,
-    limit: number
+    limit: number,
+    signals?: RecommendationSignals
 ): Video[] => {
     const selected: Video[] = [];
     const candidateVideos = scoredCandidates.map(item => item.video);
@@ -523,12 +620,20 @@ const pickDiscoverVideos = (
     const rewatchPick = candidateVideos
         .filter(video => {
             if (selectedIds.has(video.id) || !isCompleted(video)) return false;
-            return getRewatchMultiplier(video, now) >= 0.5 &&
+            return getRewatchMultiplier(video, now, signals?.perVideo[video.id]) >= 0.5 &&
                 ((video.rating || 0) >= 4 || (video.viewCount || 0) > 1);
         })
         .sort((a, b) =>
-            (getRewatchMultiplier(b, now) * (1 + getRatingAffinity(b, DEFAULT_WEIGHTS.rating))) -
-            (getRewatchMultiplier(a, now) * (1 + getRatingAffinity(a, DEFAULT_WEIGHTS.rating))) ||
+            (getRewatchMultiplier(b, now, signals?.perVideo[b.id]) *
+                (1 + getRatingAffinity(b, DEFAULT_WEIGHTS.rating) +
+                    (signals?.authorAffinity[getAuthorKey(b)] ?? 0) +
+                    getTagAffinity(b, signals) +
+                    getDurationFit(b, signals))) -
+            (getRewatchMultiplier(a, now, signals?.perVideo[a.id]) *
+                (1 + getRatingAffinity(a, DEFAULT_WEIGHTS.rating) +
+                    (signals?.authorAffinity[getAuthorKey(a)] ?? 0) +
+                    getTagAffinity(a, signals) +
+                    getDurationFit(a, signals))) ||
             sortByNewest(a, b)
         )[0];
 
@@ -548,10 +653,11 @@ export interface RecommendationContext {
     weights?: Partial<RecommendationWeights>;
     sourceCollectionId?: string | null;
     playbackQueueVideoIds?: string[];
+    signals?: RecommendationSignals | null;
 }
 
 export const getRecommendations = (context: RecommendationContext): Video[] => {
-    const { currentVideo, allVideos, collections, weights, sourceCollectionId, playbackQueueVideoIds } = context;
+    const { currentVideo, allVideos, collections, weights, sourceCollectionId, playbackQueueVideoIds, signals } = context;
     const finalWeights = { ...DEFAULT_WEIGHTS, ...weights };
 
     const candidates = allVideos.filter(video => video.id !== currentVideo.id);
@@ -585,7 +691,8 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
                     video.id === currentVideo.id || !queuedVideoIds.has(video.id)
                 ),
                 collections,
-                weights
+                weights,
+                signals
             });
 
             return [...queuedRecommendations, ...fallbackRecommendations];
@@ -596,7 +703,13 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
 
     const now = Date.now();
     const membership = buildCollectionMembership(collections);
-    const candidatePool = buildCandidatePool(currentVideo, candidates, collections, membership);
+    const candidatePool = buildCandidatePool(
+        currentVideo,
+        candidates,
+        collections,
+        membership,
+        signals ?? undefined
+    );
     const currentTags = normalizeTags(currentVideo.tags);
     const currentTitleTokens = tokenize(`${currentVideo.title} ${currentVideo.videoFilename ?? ''}`);
     const nextEpisode = findNextEpisode(currentVideo, candidatePool);
@@ -617,7 +730,8 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
             now,
             currentTags,
             currentTitleTokens,
-            nextScopedSequenceId
+            nextScopedSequenceId,
+            signals ?? undefined
         ))
         .sort(sortScoredCandidates);
 
@@ -651,7 +765,15 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
     const discoverSlots = Math.min(2, Math.max(0, MAX_RECOMMENDATIONS - slate.length));
     const relatedSlots = Math.max(0, MAX_RECOMMENDATIONS - slate.length - discoverSlots);
     slate.push(...pickRelatedVideos(scoredCandidates, selectedIds, membership, diversityState, relatedSlots));
-    slate.push(...pickDiscoverVideos(scoredCandidates, selectedIds, membership, diversityState, now, discoverSlots));
+    slate.push(...pickDiscoverVideos(
+        scoredCandidates,
+        selectedIds,
+        membership,
+        diversityState,
+        now,
+        discoverSlots,
+        signals ?? undefined
+    ));
 
     if (slate.length < Math.min(MAX_RECOMMENDATIONS, candidates.length)) {
         slate.push(...pickRelatedVideos(

--- a/frontend/src/utils/recommendations.ts
+++ b/frontend/src/utils/recommendations.ts
@@ -574,14 +574,15 @@ const pickRelatedVideos = (
     selectedIds: Set<string>,
     membership: CollectionMembership,
     diversityState: DiversityState,
-    limit: number
+    limit: number,
+    enforceDiversityCaps = true
 ): Video[] => {
     const selected: Video[] = [];
 
     for (const item of scoredCandidates) {
         if (selected.length >= limit) break;
         if (selectedIds.has(item.video.id)) continue;
-        if (!canSelectByDiversity(item.video, membership, diversityState)) continue;
+        if (enforceDiversityCaps && !canSelectByDiversity(item.video, membership, diversityState)) continue;
 
         selected.push(item.video);
         selectedIds.add(item.video.id);
@@ -775,13 +776,28 @@ export const getRecommendations = (context: RecommendationContext): Video[] => {
         signals ?? undefined
     ));
 
-    if (slate.length < Math.min(MAX_RECOMMENDATIONS, candidates.length)) {
+    const targetSlateSize = Math.min(MAX_RECOMMENDATIONS, candidates.length);
+    if (slate.length < targetSlateSize) {
         slate.push(...pickRelatedVideos(
             scoredCandidates,
             selectedIds,
             membership,
             diversityState,
-            Math.min(MAX_RECOMMENDATIONS, candidates.length) - slate.length
+            targetSlateSize - slate.length
+        ));
+    }
+
+    if (slate.length < targetSlateSize) {
+        // Diversity caps yield to fullness: in a homogeneous library (one author or
+        // one collection) the capped passes cannot fill the slate, so backfill by
+        // score instead of returning a truncated list.
+        slate.push(...pickRelatedVideos(
+            scoredCandidates,
+            selectedIds,
+            membership,
+            diversityState,
+            targetSlateSize - slate.length,
+            false
         ));
     }
 

--- a/reports/up-next-recommender-redesign-2026-07-03.md
+++ b/reports/up-next-recommender-redesign-2026-07-03.md
@@ -9,7 +9,7 @@
 
 - [x] Phase 1 — frontend heuristic ranker redesign completed on 2026-07-04.
 - [x] Phase 2 — backend recommendation signals and client integration completed on 2026-07-04.
-- [ ] Phase 3 — Up Next feedback events, rollups, and replay evaluation.
+- [x] Phase 3 — Up Next feedback events, rollups, and replay evaluation completed on 2026-07-04.
 
 ---
 

--- a/reports/up-next-recommender-redesign-2026-07-03.md
+++ b/reports/up-next-recommender-redesign-2026-07-03.md
@@ -1,0 +1,481 @@
+# Up Next Recommender — Review & Redesign
+
+- **Date:** 2026-07-03
+- **Status:** Proposal (no code changed)
+- **Scope:** The "Up Next" sidebar and autoplay-next selection on the video player page
+- **Author:** Claude (requested by Frank)
+
+## Implementation status
+
+- [x] Phase 1 — frontend heuristic ranker redesign completed on 2026-07-04.
+- [ ] Phase 2 — backend recommendation signals and client integration.
+- [ ] Phase 3 — Up Next feedback events, rollups, and replay evaluation.
+
+---
+
+## 1. Executive summary
+
+Today's Up Next list is produced entirely in the frontend by a single linear scorer
+([recommendations.ts](../frontend/src/utils/recommendations.ts)) that compares every video in the
+library against the *currently playing* video using metadata similarity (collection, author, tags,
+title tokens, dates, duration). It has no notion of the **user**: what they actually watch, finish,
+abandon, re-watch, or rate. Meanwhile the app already collects exactly the behavioral data a good
+recommender needs — per-session play events and 60-second watch chunks in
+`usage_statistics_events` — and stores explicit signals (`rating`, `partNumber`/`totalParts`,
+collection order, subscriptions) that the scorer ignores.
+
+This document proposes a redesign in three phases:
+
+1. **Phase 1 — fix the heuristics (frontend-only, no schema change).** Correct the broken
+   sequence signal, use `rating` and `partNumber`, stop rewarding just-watched videos, add
+   diversity, and cut wasted computation.
+2. **Phase 2 — behavioral signals (backend aggregates + client ranker).** A small backend
+   endpoint serves pre-aggregated taste and co-play signals mined from `usage_statistics_events`;
+   the client blends them with metadata similarity in a three-lane layout: **Continue → Related →
+   Discover**.
+3. **Phase 3 — feedback loop & evaluation.** Record Up Next impressions/clicks and autoplay
+   survival as statistics events, so recommendation quality becomes measurable and the weights
+   stop being guesses.
+
+The end state: the top of Up Next reliably continues what the user is doing (queue, series,
+resume), the middle reflects both similarity *and* demonstrated taste, the tail surfaces fresh
+downloads and worthy re-watches — and every change is measurable.
+
+---
+
+## 2. Current system review
+
+### 2.1 Data flow
+
+```mermaid
+flowchart LR
+    A["GET /api/videos<br/>(entire library)"] --> B[VideoContext<br/>React Query cache]
+    C["GET /api/collections"] --> D[CollectionContext]
+    B --> E[useVideoRecommendations]
+    D --> E
+    E -->|"getRecommendations()<br/>scores ALL videos, slice(0,10)"| F[UpNextSidebar<br/>10 cards]
+    F -->|"relatedVideos[0]"| G[Autoplay next<br/>VideoPlayer.tsx handleVideoEnded]
+```
+
+- The whole library is already client-side ([VideoContext.tsx:98](../frontend/src/contexts/VideoContext.tsx:98)),
+  so the recommender runs locally with zero API latency.
+- [useVideoRecommendations.ts](../frontend/src/hooks/useVideoRecommendations.ts) memoizes on a
+  stripped-down copy of the current video and defers recomputation (`useDeferredValue`).
+- The #1 ranked item is what autoplay navigates to
+  ([VideoPlayer.tsx:335-350](../frontend/src/pages/VideoPlayer.tsx:335)), so ranking quality
+  directly controls the lean-back experience.
+
+### 2.2 Scoring model
+
+`getRecommendations()` computes, for every other video in the library, a weighted sum:
+
+| # | Signal | Weight | Computation | Assessment |
+|---|--------|-------:|-------------|------------|
+| 1 | recency | 0.08 | linear decay of `lastPlayedAt` over 1 year | **Backwards** — rewards videos you just finished (§3.5) |
+| 2 | frequency | 0.04 | `viewCount / maxViewCount` | global popularity, near-noise at this weight |
+| 3 | collection | 0.40 | binary: shares a collection or `seriesTitle` | good signal, but binary (no position awareness) |
+| 4 | tags | 0.35 | Jaccard overlap of normalized tags | good when tags exist |
+| 5 | author | 0.30 | binary exact `author` match | good; keyed on display name, not `channelUrl` |
+| 6 | filename | 0.00 | unused | dead weight |
+| 7 | sequence | 0.25 | next item in **whole-library** filename sort | **Broken by design** (§3.4) |
+| 8 | source | 0.08 | same platform | weak proxy |
+| 9 | title | 0.25 | Jaccard of title+filename tokens | decent lexical fallback |
+| 10 | dateProximity | 0.08 | within 90 days (upload or added) | reasonable |
+| 11 | duration | 0.05 | short/long ratio | reasonable |
+| 12 | watchState | 0.20 | unwatched +1.0 · in-progress +0.7 · ≥90% watched −0.8 · viewCount≤2 +0.25 · else −0.1 | right idea, no time dimension (§3.5) |
+
+Special paths that run **before** scoring:
+
+- **Queue continuation:** if playing from a collection (`sourceCollectionId`) or an explicit
+  playback queue, the remaining queue items are returned first, in order, followed by scored
+  fallbacks. This is the strongest part of the current design and must be preserved.
+- **Tie-breakers:** same-collection first, then natural filename order.
+
+### 2.3 What already works well
+
+- Queue/collection continuation is deterministic and correct.
+- The scorer is pure, synchronous, unit-tested (417-line test file), and cheap to iterate on.
+- `useDeferredValue` keeps ranking off the critical render path.
+- Watch-state already tries to prefer discovery and resumable videos.
+
+Any redesign should keep these properties: **pure ranking core, deterministic continuation,
+client-side responsiveness.**
+
+---
+
+## 3. Problems with the current design
+
+### 3.1 No user taste model
+
+Scoring is purely *item-to-current-item* similarity. Two users (or the same user in different
+months) with wildly different habits get identical rankings. The library knows which authors and
+tags the user pours hours into — none of that shapes the list.
+
+### 3.2 Behavioral data is collected but unused
+
+The statistics subsystem ([eventTypes.ts](../backend/src/services/statistics/eventTypes.ts))
+records, with a per-tab `sessionId`:
+
+- `video_play_started` — every play session start, per video
+- `video_watch_chunk_recorded` — qualified watch time in ≤60s chunks (`durationSeconds`),
+  visibility/PiP-aware ([useStatisticsWatchTracker.ts](../frontend/src/hooks/useStatisticsWatchTracker.ts))
+
+From these you can derive per-video completion rates, abandon rates, true watch-time per
+author/tag, and **which videos are watched together or in sequence within a session** — the raw
+material for co-play recommendations. The recommender uses none of it; it only sees the three
+coarse columns on `videos` (`viewCount`, `progress`, `lastPlayedAt`).
+
+### 3.3 Explicit signals ignored
+
+- **`videos.rating`** — the user's own star rating. The single clearest "I like this" signal in
+  the database. Unused.
+- **`subscriptions.author`** — the user explicitly subscribed to these channels. Unused.
+- **`collection_videos.order`** — curated ordering, honored by the queue path but invisible to
+  scoring (membership is binary).
+
+### 3.4 The sequence signal is broken by design
+
+"Natural sequence" sorts the **entire library** by filename/title and boosts the single next
+item ([recommendations.ts:221-229](../frontend/src/utils/recommendations.ts:221)). In a
+multi-author library, alphabetic adjacency is meaningless: after "Zelda Part 3" from author A,
+the "next" video might be "Zoo Vlog" from author Z. Meanwhile `partNumber`/`totalParts`/
+`seriesTitle` — written by the downloader exactly for this purpose — are never consulted for
+ordering (seriesTitle is only used as a binary same-series flag).
+
+### 3.5 Re-watch bias and a missing time dimension
+
+`recency` gives up to +0.08 to *recently played* videos and `frequency` up to +0.04 to
+often-played ones — partially cancelling the −0.16 fully-watched penalty. Net effect: a video
+you finished an hour ago can outrank an unwatched video from the same author. For a personal
+media library the right model is a **re-watch cooldown curve**, not a static penalty: a finished
+video is a terrible recommendation today, a mediocre one next week, and a fine one in three
+months — especially if it's rated 5 stars or its author shows a high historical re-watch rate.
+
+### 3.6 No diversity control
+
+Same-collection (+0.40) and same-author (+0.30) are binary cliffs, so one author/collection can
+flood all 10 slots. There is no cap, no interleaving, and no exploration — the list for a given
+video is identical every single time, which trains the user to ignore it.
+
+### 3.7 No feedback loop, so weights are unfalsifiable
+
+Nothing records whether the user ever clicks Up Next items, at which position, or whether an
+autoplayed video survives 30 seconds. `DEFAULT_WEIGHTS` were hand-tuned once and can never be
+validated or improved with evidence.
+
+### 3.8 Minor: wasted computation
+
+Every recompute scores **all** videos: an O(N·C) collection-membership scan per candidate
+(`collections.filter(c => c.videos.includes(...))` inside the map), a full O(N log N) library
+sort for the (broken) sequence check, then sorts everything to keep 10. Fine at 500 videos,
+noticeable at 5,000 — and all of it thrown away except the top ten.
+
+---
+
+## 4. Data inventory — what the database offers
+
+From [schema.ts](../backend/src/db/schema.ts). ✅ = used today, ❌ = unused.
+
+| Source | Attribute | Used? | Recommender value |
+|--------|-----------|:-----:|-------------------|
+| `videos` | `author` | ✅ | identity for taste profile; prefer `channelUrl` as stable key |
+| `videos` | `tags` | ✅ | topic similarity + taste profile dimension |
+| `videos` | `seriesTitle` | ✅ (binary) | series grouping — should drive *ordering* too |
+| `videos` | `partNumber`, `totalParts` | ❌ | **exact next-episode ordering** |
+| `videos` | `rating` | ❌ | explicit preference; re-watch candidate quality |
+| `videos` | `description` | ❌ | lexical similarity fallback (TF-IDF tokens) when tags are sparse |
+| `videos` | `channelUrl` | ❌ | stable author identity across display-name changes |
+| `videos` | `viewCount`, `lastPlayedAt`, `progress` | ✅ | coarse watch state (kept as fallback) |
+| `videos` | `addedAt` / `createdAt` | ✅ (weak) | freshness for the Discover lane |
+| `videos` | `duration` | ✅ | session-fit; duration-band preference |
+| `videos` | `visibility` | ✅ (upstream) | must stay filtered for visitors |
+| `collection_videos` | `order` | ❌ (scoring) | position-aware continuation within curated lists |
+| `usage_statistics_events` | `video_play_started` (videoId, sessionId, recordedAt) | ❌ | session sequences → co-play graph |
+| `usage_statistics_events` | `video_watch_chunk_recorded` (durationSeconds) | ❌ | true watch time, completion & abandon rates |
+| `usage_statistics_daily` | `watch_seconds`, `play_sessions`, `completion_bucket` | ❌ | cheap long-horizon aggregates (raw events prune after `statisticsRetentionDays`, default 365) |
+| `subscriptions` | `author`, `paused` | ❌ | declared interest → taste prior |
+| `download_history` | `sourceKind`, `subscriptionId` | ❌ | "manually downloaded" ≈ stronger intent than subscription backfill |
+
+---
+
+## 5. Proposed design
+
+### 5.1 Design principles
+
+A personal library is **not** YouTube, and the differences drive the design:
+
+1. **Finite, known catalog** — every candidate can be scored; no retrieval problem.
+2. **Single taste profile** (admin + visitor share one household profile; visitors just see a
+   visibility-filtered view).
+3. **Continuation dominates** — most sessions are "next episode / next in queue"; getting slot 1
+   right matters more than anything else because autoplay consumes it.
+4. **Re-watching is legitimate** — favorites, music videos, comfort content. Model *when* to
+   resurface, not whether.
+5. **Degrade gracefully** — statistics can be disabled or empty (fresh install); metadata-only
+   ranking must remain a complete fallback.
+
+### 5.2 Three-lane slate instead of one scalar ranking
+
+Replace "sort everything by one score" with a slate of 10 slots filled from three lanes.
+Unfilled lanes cede slots to the next lane, so the list is always full when the library allows.
+
+```text
+┌─ Lane A · CONTINUE (up to 3 slots, deterministic, in this priority) ─────┐
+│ A1 explicit playback queue remainder (existing behavior, unchanged)     │
+│ A2 source-collection remainder in collection_videos.order (unchanged)   │
+│ A3 next episode: same seriesTitle, partNumber = current + 1;            │
+│    else next unwatched by order within a shared collection;             │
+│    else filename-adjacent WITHIN same author + series-like title stem   │
+│ A4 resume: in-progress video (5% < progress < 90%) with the highest     │
+│    behavioral affinity, if watched within the last 30 days              │
+├─ Lane B · RELATED (5–7 slots, scored, diversity-constrained) ────────────┤
+│ score = similarity(current, v) × affinity(user, v) × availability(v)    │
+├─ Lane C · DISCOVER (up to 2 slots) ──────────────────────────────────────┤
+│ C1 freshest unwatched video from a subscribed/high-affinity author      │
+│ C2 re-watch pick: high rating or high rewatch-rate, past cooldown,      │
+│    ε-greedy sampled from the top 20 so the slot varies between visits   │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Autoplay** consumes slot 1, which is Lane A whenever any continuation exists — this alone
+fixes the worst current failure (autoplay jumping to an alphabetic neighbor from another
+author). When only Lane B/C items exist, autoplay follows the top Related item, preserving
+today's behavior.
+
+### 5.3 Signals and formulas
+
+All decayed quantities use exponential decay `d(t) = 2^(−age/half-life)`.
+
+**Per-video behavioral aggregates** (from `usage_statistics_events`, fallback in parentheses):
+
+| Signal | Definition | Fallback without stats |
+|--------|-----------|------------------------|
+| `watchSeconds` | Σ `durationSeconds` of chunks, half-life 90 days | `viewCount × duration` |
+| `completionRatio` | watchSeconds per play session ÷ duration, clamped [0,1] | `progress / duration` |
+| `abandonRate` | share of play sessions with < max(30s, 5% duration) qualified time | — (0) |
+| `lastFinishedAt` | last session reaching ≥90% | `progress ≥ 90% ? lastPlayedAt : null` |
+| `rewatchRate` | sessions beyond the first ÷ total sessions | `max(0, viewCount − 1)/viewCount` |
+
+**Taste profile** (the "user" the current system lacks):
+
+- `authorAffinity[a]` = decayed watch-seconds share of author `a` (key: `channelUrl ?? author`),
+  +0.15 bonus if an active subscription exists, +small bonus scaled by mean rating of `a`'s videos.
+- `tagAffinity[g]` = decayed watch-seconds share of tag `g`.
+- `durationFit(v)` = closeness of `v.duration` to the watch-time-weighted duration distribution.
+
+**Co-play graph** (session association mining — single-user item-to-item CF):
+
+- For each statistics session, order `video_play_started` events by `recordedAt`; abandoned plays
+  (see `abandonRate` threshold) are dropped.
+- Directed edge `A→B` with weight `2^(−gap/2)` where `gap` = #plays between A and B in-session
+  (adjacent = 1.0, one apart = 0.5, …), decayed by event age (half-life 120 days).
+- `coPlay(A,B)` = shrunk score `w(A→B) / (w(A→*) + k)` with `k = 3` so two accidental
+  co-occurrences don't dominate; keep top-20 neighbors per video.
+
+**Re-watch cooldown** (replaces the static watched-penalty *and* the recency reward):
+
+```text
+rewatchMultiplier(v) =
+  unwatched или never finished → 1.0
+  finished, age = now − lastFinishedAt:
+    base = 1 − 2^(−age / H)          // H = 45 days default
+    boost = 1 + 0.3·(rating−3)/2     // 5★ recovers ~30% faster, 1★ slower
+            + 0.5·rewatchRate         // proven re-watch favorites recover faster
+    → clamp(base × boost, 0, 1)
+in-progress (5–90%) → 1.15            // resumable beats everything comparable
+```
+
+**Lane B final score** (initial weights; Phase 3 makes them tunable with evidence):
+
+```text
+similarity =  0.30·sameCollection(position-aware: closer order = higher)
+            + 0.25·authorMatch
+            + 0.20·tagJaccard
+            + 0.10·titleTokenJaccard        // + description tokens when tags absent
+            + 0.05·dateProximity
+            + 0.05·durationSimilarity
+            + 0.05·sourceMatch
+
+affinity   =  0.40·coPlay(current, v)                  // 0 without stats
+            + 0.30·authorAffinity[v.author]            // 0 without stats
+            + 0.15·tagAffinityDot(v.tags)              // 0 without stats
+            + 0.15·(rating(v) − 3)/2                   // −1..+1, 0 if unrated
+
+scoreB(v)  = similarity × (1 + affinity) × rewatchMultiplier(v)
+             × (1 − 0.5·abandonRate(v))
+```
+
+The multiplicative form is deliberate: affinity *amplifies* relevant items rather than letting a
+beloved-but-unrelated video outrank on-topic ones, and everything degrades to plain
+`similarity` when behavioral data is absent.
+
+**Diversity re-rank:** greedy fill of Lane B slots with a hard cap of 3 per author and 3 per
+collection across the whole slate, skipping to the next-best candidate on violation
+(MMR-lite; no pairwise similarity matrix needed).
+
+### 5.4 Architecture: backend signal aggregates + client ranker (hybrid)
+
+Full-backend ranking was considered and rejected (§9): the playback queue lives in client
+navigation state, the library is already in the client, and a per-video-page API call adds
+latency and a failure mode to a page that currently ranks instantly. Instead:
+
+```mermaid
+flowchart TD
+    subgraph backend [Backend — new recommendationSignalsService]
+        E[usage_statistics_events] --> AGG["aggregate on demand,<br/>cache 6h in memory,<br/>invalidate on video delete"]
+        V[videos: rating, viewCount…] --> AGG
+        S[subscriptions] --> AGG
+        AGG --> EP["GET /api/recommendations/signals"]
+    end
+    subgraph frontend [Frontend]
+        EP -->|"React Query, staleTime 6h,<br/>graceful 404/error → null"| RANK["recommendations.ts v2<br/>candidate gen → lanes → diversity"]
+        LIB[VideoContext videos] --> RANK
+        COL[CollectionContext] --> RANK
+        RANK --> UI[UpNextSidebar + autoplay]
+    end
+```
+
+**Endpoint payload** (compact, size-bounded; ~100–300 KB for a 2,000-video library):
+
+```ts
+interface RecommendationSignals {
+  computedAt: number;
+  perVideo: Record<string, {           // only videos with ≥1 play session
+    ws: number;                        // decayed watch seconds
+    cr: number;                        // completion ratio 0..1
+    ar: number;                        // abandon rate 0..1
+    lf: number | null;                 // lastFinishedAt epoch ms
+    rw: number;                        // rewatch rate 0..1
+    nb: [string, number][];            // top-20 co-play neighbors [videoId, score]
+  }>;
+  authorAffinity: Record<string, number>;   // normalized 0..1
+  tagAffinity: Record<string, number>;      // normalized 0..1
+  durationBands: number[];                   // watch-time histogram for durationFit
+}
+```
+
+Implementation notes:
+
+- One SQL pass over `video_play_started` + `video_watch_chunk_recorded` grouped by
+  `sessionId`/`videoId`; the existing index `idx_usage_statistics_events_video`
+  (videoId, eventType, recordedAt) covers it. At the default 365-day retention a heavy user
+  produces low hundreds of thousands of chunk rows — well within better-sqlite3 territory for a
+  6-hourly cached computation.
+- Visitor requests get the same payload minus entries for `visibility = 0` videos (compute once,
+  filter per role), mirroring the existing visitor filter in VideoContext.
+- If statistics are disabled or empty → `204 No Content`; the client ranker runs metadata-only.
+
+### 5.5 Frontend changes
+
+- `recommendations.ts` v2 keeps a pure, testable core with the same call sites but gains a
+  `signals?: RecommendationSignals` parameter (as it already anticipates with the unused
+  `weights` param).
+- **Candidate generation replaces score-everything:** union of buckets — same collections,
+  same author (top 50 by addedAt), tag-overlap matches, co-play neighbors, 30 most recent
+  additions, in-progress videos — typically 100–300 candidates instead of N. Removes the
+  per-candidate collection scan (build `videoId → collectionIds` map once) and the
+  global-library sort entirely.
+- New `useRecommendationSignals()` hook (React Query, 6 h staleTime, `enabled: statisticsEnabled`).
+- `UpNextSidebar` optionally renders a subtle lane hint on the first Continue card
+  ("Next episode" / "Resume") — small UX win, zero layout change.
+
+### 5.6 Feedback loop (Phase 3)
+
+New frontend event types (add to `FRONTEND_EVENT_TYPES` in
+[eventTypes.ts](../backend/src/services/statistics/eventTypes.ts) and the collector allowlist):
+
+| Event | Fields (payload) | Purpose |
+|-------|------------------|---------|
+| `up_next_impression` | slate videoIds + lanes, one event per slate render | denominator for CTR |
+| `up_next_clicked` | videoId, position, lane | slot/lane CTR |
+| `autoplay_advanced` | fromVideoId, toVideoId | autoplay volume |
+| `autoplay_abandoned` | toVideoId, qualifiedSeconds < 30 | bad-handoff rate (the key quality metric) |
+
+Rollup metric keys (`up_next_ctr`, `autoplay_survival`) join the existing daily rollups and can
+surface on the statistics dashboard. Impressions are one event per page view (not per card), so
+volume stays negligible next to watch chunks.
+
+### 5.7 Settings
+
+None initially. The system self-tunes to taste via signals; a "Prefer unwatched" toggle can be
+added later **if** feedback data shows bimodal behavior. Respecting the existing
+statistics-enabled setting is the only switch that matters (off → metadata-only mode).
+
+---
+
+## 6. Evaluation plan
+
+**Offline replay (build in Phase 3, before touching weights):** for each historical qualified
+transition A→B inside a session (excluding queue-driven plays, which are deterministic), rank
+A's slate with candidate ranker vs. current ranker and report `hit@10`, `hit@3`, and MRR of B.
+A ~200-line script in `backend/scripts/` against a copy of the production DB. This turns weight
+tuning from vibes into a number.
+
+**Online:** watch `autoplay_abandoned` rate and slot-1–3 CTR week-over-week after each phase
+ships. Success criteria for the project: autoplay-abandon rate down ≥30%, Up Next CTR up
+measurably, zero added latency on the player page.
+
+**Unit tests:** the existing 417-line test suite carries over; new cases cover episode ordering
+(`partNumber`), cooldown resurfacing, diversity caps, and signals-absent degradation.
+
+---
+
+## 7. Rollout phases
+
+| Phase | Contents | Touches | Est. effort | Risk |
+|-------|----------|---------|-------------|------|
+| **1** | Sequence fix (partNumber/series/author-scoped), rating signal, re-watch cooldown replacing recency+watchState, diversity caps, candidate generation perf, position-aware collection scoring | frontend only | 1–2 days | low — pure function + existing tests |
+| **2** | `recommendationSignalsService` + endpoint, `useRecommendationSignals`, affinity/co-play integration, three-lane slate, visitor filtering, graceful degradation | backend + frontend | 3–4 days | medium — new endpoint, cache lifecycle |
+| **3** | 4 new event types + rollups, replay evaluation script, weight tuning pass, optional dashboard tiles | backend + frontend | 2–3 days | low — additive |
+
+Each phase ships independently and improves the experience on its own; Phase 1 needs no
+migration, API, or settings work at all.
+
+---
+
+## 8. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Statistics disabled / fresh install → empty signals | Multiplicative design degrades to metadata similarity; `204` handled as null |
+| Feedback loop reinforces re-watch bubbles | Co-play capped at 0.40 of affinity; Discover lane reserved; cooldown gates finished content |
+| Signals payload growth on huge libraries | Only videos with play history included; top-20 neighbor cap; gzip; hard cap with watch-seconds cutoff |
+| Visitor leakage of hidden-video behavior | Signals filtered by `visibility` per role at the endpoint, same rule as VideoContext |
+| SQLite load from aggregation | 6 h in-memory cache, computed off request path (kick on first request, serve stale meanwhile); covered by existing indexes |
+| Ranking regressions vs. muscle memory | Phase-gated rollout; replay eval before weight changes; queue/collection continuation behavior intentionally unchanged |
+
+---
+
+## 9. Alternatives considered
+
+1. **Full backend ranking endpoint** (`GET /api/videos/:id/recommendations`) — rejected: the
+   playback queue is client navigation state, the library already lives in the client, and it
+   adds per-page latency plus an offline failure mode for little gain at this scale.
+2. **Embedding-based semantic similarity** (local sentence-encoder over titles/descriptions) —
+   deferred: a heavyweight dependency for a self-hosted app; token-level TF-IDF over
+   title+description captures most of the value at zero cost. Revisit if replay eval shows
+   lexical similarity is the bottleneck.
+3. **Learned ranker (logistic regression / GBDT on click feedback)** — premature: single-user
+   click volume is too small to beat well-tuned heuristics; the Phase 3 eval harness is the
+   prerequisite either way. The lane/score architecture leaves a clean slot for it later.
+4. **Keep single-score ranking, just add signals** — rejected: a scalar blend keeps
+   continuation, relevance, and discovery fighting over the same number; slot allocation is what
+   guarantees the autoplay slot is always the *right kind* of recommendation.
+
+---
+
+## Appendix A — current vs. proposed signal usage
+
+| Signal | Today | Proposed |
+|--------|-------|----------|
+| Collection membership | binary +0.40 | position-aware continuation (Lane A) + graded similarity (Lane B) |
+| `seriesTitle` / `partNumber` | binary / unused | exact next-episode ordering (Lane A3) |
+| Author | binary +0.30 | match (similarity) × watch-time affinity (taste) keyed on channelUrl |
+| Tags | Jaccard +0.35 | Jaccard (similarity) × tag affinity (taste) |
+| `rating` | unused | affinity term + cooldown boost |
+| `viewCount`/`lastPlayedAt` | popularity + recency reward | fallback inputs to rewatch model only |
+| `progress` | static watch-state buckets | resume lane + completion fallback |
+| Watch chunks / sessions | unused | watch time, completion, abandon, co-play graph |
+| Subscriptions | unused | author affinity prior |
+| `addedAt` | date proximity only | freshness for Discover lane |
+| Feedback (clicks/autoplay survival) | not collected | Phase 3 events → CTR/survival metrics → weight tuning |

--- a/reports/up-next-recommender-redesign-2026-07-03.md
+++ b/reports/up-next-recommender-redesign-2026-07-03.md
@@ -311,7 +311,9 @@ beloved-but-unrelated video outrank on-topic ones, and everything degrades to pl
 
 **Diversity re-rank:** greedy fill of Lane B slots with a hard cap of 3 per author and 3 per
 collection across the whole slate, skipping to the next-best candidate on violation
-(MMR-lite; no pairwise similarity matrix needed).
+(MMR-lite; no pairwise similarity matrix needed). The caps order candidates, they don't
+truncate: if the capped passes cannot fill the slate (single-author or single-collection
+libraries), the final backfill relaxes them — fullness (§5.2) wins over diversity.
 
 ### 5.4 Architecture: backend signal aggregates + client ranker (hybrid)
 

--- a/reports/up-next-recommender-redesign-2026-07-03.md
+++ b/reports/up-next-recommender-redesign-2026-07-03.md
@@ -8,7 +8,7 @@
 ## Implementation status
 
 - [x] Phase 1 — frontend heuristic ranker redesign completed on 2026-07-04.
-- [ ] Phase 2 — backend recommendation signals and client integration.
+- [x] Phase 2 — backend recommendation signals and client integration completed on 2026-07-04.
 - [ ] Phase 3 — Up Next feedback events, rollups, and replay evaluation.
 
 ---


### PR DESCRIPTION
## Summary

Implements the Up Next recommender redesign from `reports/up-next-recommender-redesign-2026-07-03.md` in three committed phases:

- Phase 1: frontend-only ranker redesign with deterministic continuation, part-number/series ordering, cooldown-based rewatch handling, rating affinity, bounded candidate generation, position-aware collection scoring, and diversity caps.
- Phase 2: backend recommendation signal aggregation endpoint plus frontend signal query and ranker blending for watch behavior, co-play, author/tag affinity, duration fit, abandon rate, and visitor-safe filtering.
- Phase 3: Up Next feedback events, daily rollup metrics for CTR/survival, autoplay abandonment tracking, and an offline replay evaluation script.

## Validation

- `frontend`: `npm run lint`
- `frontend`: `npm run typecheck`
- `frontend`: `npm test` (155 files, 1474 tests)
- `backend`: `npm run build`
- `backend`: `npm test` (176 files, 2265 tests)

## Notes

- No database schema migration is required; Phase 2 and Phase 3 use existing statistics/event tables.
- The design document is now tracked in the repo because the request required marking each completed phase in the document.