### PR TITLE
fix(db): self-heal missing visitor users table on startup

### DIFF
--- a/backend/src/__tests__/db/migrate.test.ts
+++ b/backend/src/__tests__/db/migrate.test.ts
@@ -6,6 +6,7 @@ const migrateMock = vi.hoisted(() => vi.fn());
 const configureDatabaseMock = vi.hoisted(() => vi.fn());
 const runDataMigrationMock = vi.hoisted(() => vi.fn());
 const migrateLegacySharedVisitorPasswordMock = vi.hoisted(() => vi.fn());
+const ensureVisitorUsersTableMock = vi.hoisted(() => vi.fn());
 const securityMocks = vi.hoisted(() => ({
   accessTrustedSync: vi.fn(),
   pathExistsSafeSync: vi.fn(),
@@ -55,6 +56,10 @@ vi.mock("../../services/userService", () => ({
   migrateLegacySharedVisitorPassword: migrateLegacySharedVisitorPasswordMock,
 }));
 
+vi.mock("../../services/storageService/migrations/schemaMigrations", () => ({
+  ensureVisitorUsersTable: ensureVisitorUsersTableMock,
+}));
+
 describe("runMigrations", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,6 +77,7 @@ describe("runMigrations", () => {
     configureDatabaseMock.mockImplementation(() => undefined);
     runDataMigrationMock.mockResolvedValue(undefined);
     migrateLegacySharedVisitorPasswordMock.mockResolvedValue(undefined);
+    ensureVisitorUsersTableMock.mockImplementation(() => undefined);
   });
 
   it("runs drizzle, legacy data import, and visitor password migration in order", async () => {
@@ -80,12 +86,20 @@ describe("runMigrations", () => {
     expect(migrateMock).toHaveBeenCalledTimes(1);
     expect(configureDatabaseMock).toHaveBeenCalledTimes(1);
     expect(runDataMigrationMock).toHaveBeenCalledTimes(1);
+    expect(ensureVisitorUsersTableMock).toHaveBeenCalledTimes(1);
     expect(migrateLegacySharedVisitorPasswordMock).toHaveBeenCalledTimes(1);
     expect(
       migrateMock.mock.invocationCallOrder[0]
     ).toBeLessThan(runDataMigrationMock.mock.invocationCallOrder[0]);
     expect(
       runDataMigrationMock.mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      migrateLegacySharedVisitorPasswordMock.mock.invocationCallOrder[0]
+    );
+    // The users table must be self-healed before the legacy-password
+    // migration touches it, otherwise it fails with "no such table: users".
+    expect(
+      ensureVisitorUsersTableMock.mock.invocationCallOrder[0]
     ).toBeLessThan(
       migrateLegacySharedVisitorPasswordMock.mock.invocationCallOrder[0]
     );

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -232,6 +232,17 @@ export async function runMigrations() {
       logger.info("No legacy data files found. Skipping data migration.");
     }
 
+    // Guarantee the visitor `users` table exists before the legacy-password
+    // migration (and every subsequent request) touches it. Drizzle may have
+    // aborted its batch on a swallowed duplicate-column error above, never
+    // reaching the 0019 CREATE TABLE users; this idempotent self-heal covers
+    // that case so migrateLegacySharedVisitorPassword succeeds on first boot
+    // instead of failing with "no such table: users".
+    const { ensureVisitorUsersTable } = await import(
+      "../services/storageService/migrations/schemaMigrations"
+    );
+    ensureVisitorUsersTable();
+
     const { migrateLegacySharedVisitorPassword } = await import(
       "../services/userService"
     );

--- a/backend/src/services/storageService/__tests__/initialization.test.ts
+++ b/backend/src/services/storageService/__tests__/initialization.test.ts
@@ -171,6 +171,12 @@ describe("storageService initialization", () => {
     expect(sqlite.prepare).toHaveBeenCalledWith(
       "CREATE INDEX IF NOT EXISTS idx_rss_tokens_created_at ON rss_tokens (created_at)"
     );
+    expect(sqlite.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("CREATE TABLE IF NOT EXISTS users")
+    );
+    expect(sqlite.prepare).toHaveBeenCalledWith(
+      "CREATE UNIQUE INDEX IF NOT EXISTS users_username_lower_uidx ON users (lower(username))"
+    );
     expect(dedupeDeleteRun).toHaveBeenCalledWith("src-1", "youtube", "keep-1");
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("duplicated video_downloads groups")
@@ -235,7 +241,10 @@ describe("storageService initialization", () => {
           ]),
         } as any;
       }
-      if (sql.includes("CREATE UNIQUE INDEX")) {
+      if (
+        sql.includes("CREATE UNIQUE INDEX") &&
+        sql.includes("video_downloads")
+      ) {
         return { run: indexRun } as any;
       }
       if (

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -350,8 +350,58 @@ function migrateContinuousDownloadTaskColumns(): void {
   }
 }
 
+// Ensure the visitor `users` table (and its case-insensitive username index)
+// exists even if drizzle never applied the visitor-users migration (0019).
+//
+// On installs whose __drizzle_migrations journal is out of sync with the
+// migration files, drizzle-kit aborts the whole migration batch on the first
+// duplicate-column ALTER it encounters. runMigrations() swallows that error
+// ("verified by initialization.ts"), which means every migration ordered after
+// the failing one -- including the CREATE TABLE users in 0019 -- silently never
+// runs, leaving the app to throw "no such table: users" on every request.
+// CREATE TABLE / INDEX IF NOT EXISTS makes this idempotent and safe on every
+// boot, mirroring the rss_tokens / video_downloads self-heals below.
+export function ensureVisitorUsersTable(): void {
+  try {
+    sqlite
+      .prepare(
+        `
+      CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY NOT NULL,
+        username TEXT NOT NULL,
+        password_hash TEXT NOT NULL,
+        role TEXT DEFAULT 'visitor' NOT NULL,
+        enabled INTEGER DEFAULT 1 NOT NULL,
+        is_legacy_shared INTEGER DEFAULT 0 NOT NULL,
+        session_version INTEGER DEFAULT 1 NOT NULL,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        last_login_at INTEGER,
+        CONSTRAINT users_role_check CHECK(role IN ('visitor'))
+      )
+    `
+      )
+      .run();
+    sqlite
+      .prepare(
+        "CREATE UNIQUE INDEX IF NOT EXISTS users_username_lower_uidx ON users (lower(username))"
+      )
+      .run();
+  } catch (error) {
+    logger.error(
+      "Error ensuring visitor users table exists",
+      error instanceof Error ? error : new Error(String(error))
+    );
+    throw new MigrationError(
+      "Failed to ensure visitor users table",
+      "users_table",
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+}
+
 // Additive column/table self-heal for videos, downloads, collections,
-// subscriptions, continuous tasks, video_downloads, rss_tokens and
+// subscriptions, continuous tasks, video_downloads, rss_tokens, users and
 // download_history, plus the file-size/video_id data backfills.
 export function migrateColumnsAndTables(): void {
   try {
@@ -555,6 +605,10 @@ export function migrateColumnsAndTables(): void {
         "CREATE INDEX IF NOT EXISTS idx_rss_tokens_created_at ON rss_tokens (created_at)"
       )
       .run();
+
+    // Ensure the visitor users table exists even if drizzle stopped before the
+    // 0019 visitor-users migration was applied.
+    ensureVisitorUsersTable();
 
     // Check download_history table for video_id, downloaded_at, deleted_at columns
     const downloadHistoryTableInfo = sqlite


### PR DESCRIPTION
## Problem

After deploying v1.10.8, installs whose SQLite `__drizzle_migrations` journal is **out of sync** with the migration files fail hard at startup:

```
[WARN]  Migration encountered duplicate column (may have been applied manually). Columns will be verified by initialization.ts
[ERROR] Failed to migrate legacy shared visitor password to user account {"name":"SqliteError","message":"no such table: users"}
[ERROR] Unhandled error {"name":"SqliteError","message":"no such table: users"}   ← on every request
```

### Root cause

1. `runMigrations()` calls drizzle's `migrate()`, which replays pending migrations and hits an `ALTER TABLE … ADD COLUMN` on a column that already exists (added long ago by the `initialization.ts` self-heal, never recorded in drizzle's journal) → throws **`duplicate column name`**.
2. The catch in `migrate.ts` **swallows** that error — but drizzle has already **aborted the entire batch**, so `0019_visitor_users.sql`, the only place `users` is created, never runs.
3. The self-heal in `migrateColumnsAndTables()` re-creates `rss_tokens` and `video_downloads` for exactly this scenario — but **`users` was never added there**, so nothing ever creates it.

## Fix

- Add idempotent `ensureVisitorUsersTable()` (`CREATE TABLE` / `UNIQUE INDEX IF NOT EXISTS`) mirroring the existing `rss_tokens` self-heal, and wire it into `migrateColumnsAndTables()`.
- Call it in `runMigrations()` **before** `migrateLegacySharedVisitorPassword()` (which runs before `initializeStorage`) so the legacy shared-visitor-password migration succeeds on the **first** boot instead of failing.
- Extend the `migrate` and `initialization` test suites (call ordering + table-creation assertions).

## Verification

- `npx vitest run` on the affected suites: **21 passed**.
- `npx tsc --noEmit`: clean.

Once an image with this fix is deployed, the `users` table is created automatically on startup and the errors stop — no manual DB surgery required.

## Follow-up (not in this PR)

The deeper hazard is that `migrate.ts` swallowing `duplicate column name` silently drops **all** subsequent drizzle migrations. The self-heal is the intended safety net (which is why `rss_tokens`/`video_downloads` live there), so any *new* drizzle table must also get a self-heal entry. Hardening `migrate.ts` to not abort the batch on a benign duplicate-column error could be considered separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
