### PR TITLE
[codex] Fix video progress flush and author avatars

### DIFF
--- a/backend/src/__tests__/controllers/videoMetadataController.test.ts
+++ b/backend/src/__tests__/controllers/videoMetadataController.test.ts
@@ -673,7 +673,7 @@ describe("videoMetadataController", () => {
       });
     });
 
-    it("does not let a near-zero progress update overwrite an existing resume point", async () => {
+    it("does not let a low progress update overwrite an existing resume point", async () => {
       const { res, json } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
@@ -683,7 +683,7 @@ describe("videoMetadataController", () => {
       await videoMetadataController.updateProgress(
         {
           params: { id: "v1" },
-          body: { progress: 0.4 },
+          body: { progress: 20.4 },
         } as unknown as Request,
         res
       );

--- a/backend/src/__tests__/controllers/videoMetadataController.test.ts
+++ b/backend/src/__tests__/controllers/videoMetadataController.test.ts
@@ -138,6 +138,10 @@ describe("videoMetadataController", () => {
     vi.mocked(getVideoDuration as any).mockResolvedValue(120);
     vi.mocked(execFileSafe as any).mockResolvedValue(undefined);
     vi.mocked(storageService.findVideoFile as any).mockReturnValue(null);
+    vi.mocked(storageService.getVideoById as any).mockReturnValue({
+      id: "v1",
+      progress: 0,
+    });
     vi.mocked(storageService.getCollections as any).mockReturnValue([]);
     vi.mocked(storageService.isThumbnailReferencedByOtherVideo as any).mockReturnValue(false);
     vi.mocked(storageService.getSettings as any).mockReturnValue({
@@ -625,7 +629,7 @@ describe("videoMetadataController", () => {
 
     it("throws when updating missing video", async () => {
       const { res } = createResponse();
-      vi.mocked(storageService.updateVideo as any).mockReturnValue(null);
+      vi.mocked(storageService.getVideoById as any).mockReturnValue(null);
 
       await expect(
         videoMetadataController.updateProgress(
@@ -640,6 +644,10 @@ describe("videoMetadataController", () => {
 
     it("updates progress and returns standardized success response", async () => {
       const { res, json } = createResponse();
+      vi.mocked(storageService.getVideoById as any).mockReturnValue({
+        id: "v1",
+        progress: 10,
+      });
       vi.mocked(storageService.updateVideo as any).mockReturnValue({
         id: "v1",
         progress: 75,
@@ -665,6 +673,30 @@ describe("videoMetadataController", () => {
       });
     });
 
+    it("does not let a near-zero progress update overwrite an existing resume point", async () => {
+      const { res, json } = createResponse();
+      vi.mocked(storageService.getVideoById as any).mockReturnValue({
+        id: "v1",
+        progress: 747,
+      });
+
+      await videoMetadataController.updateProgress(
+        {
+          params: { id: "v1" },
+          body: { progress: 0.4 },
+        } as unknown as Request,
+        res
+      );
+
+      expect(storageService.updateVideo).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          progress: 747,
+        },
+      });
+    });
+
     it("validates body video id for keepalive progress updates", async () => {
       const { res } = createResponse();
 
@@ -680,6 +712,10 @@ describe("videoMetadataController", () => {
 
     it("updates progress from a fixed keepalive route body", async () => {
       const { res, json } = createResponse();
+      vi.mocked(storageService.getVideoById as any).mockReturnValue({
+        id: "v2",
+        progress: 10,
+      });
       vi.mocked(storageService.updateVideo as any).mockReturnValue({
         id: "v2",
         progress: 45,

--- a/backend/src/__tests__/controllers/videoMetadataController.test.ts
+++ b/backend/src/__tests__/controllers/videoMetadataController.test.ts
@@ -673,11 +673,39 @@ describe("videoMetadataController", () => {
       });
     });
 
-    it("does not let a low progress update overwrite an existing resume point", async () => {
+    it("does not let a near-zero progress update overwrite an existing resume point", async () => {
       const { res, json } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
         progress: 747,
+      });
+
+      await videoMetadataController.updateProgress(
+        {
+          params: { id: "v1" },
+          body: { progress: 0.4 },
+        } as unknown as Request,
+        res
+      );
+
+      expect(storageService.updateVideo).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith({
+        success: true,
+        data: {
+          progress: 747,
+        },
+      });
+    });
+
+    it("allows an intentional rewind below thirty seconds", async () => {
+      const { res, json } = createResponse();
+      vi.mocked(storageService.getVideoById as any).mockReturnValue({
+        id: "v1",
+        progress: 747,
+      });
+      vi.mocked(storageService.updateVideo as any).mockReturnValue({
+        id: "v1",
+        progress: 20,
       });
 
       await videoMetadataController.updateProgress(
@@ -688,11 +716,13 @@ describe("videoMetadataController", () => {
         res
       );
 
-      expect(storageService.updateVideo).not.toHaveBeenCalled();
+      expect(storageService.updateVideo).toHaveBeenCalledWith("v1", {
+        progress: 20,
+      });
       expect(json).toHaveBeenCalledWith({
         success: true,
         data: {
-          progress: 747,
+          progress: 20,
         },
       });
     });

--- a/backend/src/__tests__/controllers/videoMetadataController.test.ts
+++ b/backend/src/__tests__/controllers/videoMetadataController.test.ts
@@ -643,6 +643,7 @@ describe("videoMetadataController", () => {
     });
 
     it("updates progress and returns standardized success response", async () => {
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(123_000);
       const { res, json } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
@@ -651,6 +652,7 @@ describe("videoMetadataController", () => {
       vi.mocked(storageService.updateVideo as any).mockReturnValue({
         id: "v1",
         progress: 75,
+        progressUpdatedAt: 123_000,
       });
 
       await videoMetadataController.updateProgress(
@@ -663,14 +665,16 @@ describe("videoMetadataController", () => {
 
       expect(storageService.updateVideo).toHaveBeenCalledWith(
         "v1",
-        expect.objectContaining({ progress: 75 })
+        expect.objectContaining({ progress: 75, progressUpdatedAt: 123_000 })
       );
       expect(json).toHaveBeenCalledWith({
         success: true,
         data: {
           progress: 75,
+          progressUpdatedAt: 123_000,
         },
       });
+      nowSpy.mockRestore();
     });
 
     it("does not let a near-zero progress update overwrite an existing resume point", async () => {
@@ -678,6 +682,7 @@ describe("videoMetadataController", () => {
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
         progress: 747,
+        progressUpdatedAt: 77_000,
       });
 
       await videoMetadataController.updateProgress(
@@ -693,11 +698,13 @@ describe("videoMetadataController", () => {
         success: true,
         data: {
           progress: 747,
+          progressUpdatedAt: 77_000,
         },
       });
     });
 
     it("allows an intentional rewind below thirty seconds", async () => {
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(124_000);
       const { res, json } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
@@ -706,6 +713,7 @@ describe("videoMetadataController", () => {
       vi.mocked(storageService.updateVideo as any).mockReturnValue({
         id: "v1",
         progress: 20,
+        progressUpdatedAt: 124_000,
       });
 
       await videoMetadataController.updateProgress(
@@ -718,13 +726,16 @@ describe("videoMetadataController", () => {
 
       expect(storageService.updateVideo).toHaveBeenCalledWith("v1", {
         progress: 20,
+        progressUpdatedAt: 124_000,
       });
       expect(json).toHaveBeenCalledWith({
         success: true,
         data: {
           progress: 20,
+          progressUpdatedAt: 124_000,
         },
       });
+      nowSpy.mockRestore();
     });
 
     it("validates body video id for keepalive progress updates", async () => {
@@ -741,6 +752,7 @@ describe("videoMetadataController", () => {
     });
 
     it("updates progress from a fixed keepalive route body", async () => {
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(125_000);
       const { res, json } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v2",
@@ -749,6 +761,7 @@ describe("videoMetadataController", () => {
       vi.mocked(storageService.updateVideo as any).mockReturnValue({
         id: "v2",
         progress: 45,
+        progressUpdatedAt: 125_000,
       });
 
       await videoMetadataController.updateProgressByBody(
@@ -760,14 +773,16 @@ describe("videoMetadataController", () => {
 
       expect(storageService.updateVideo).toHaveBeenCalledWith(
         "v2",
-        expect.objectContaining({ progress: 45 })
+        expect.objectContaining({ progress: 45, progressUpdatedAt: 125_000 })
       );
       expect(json).toHaveBeenCalledWith({
         success: true,
         data: {
           progress: 45,
+          progressUpdatedAt: 125_000,
         },
       });
+      nowSpy.mockRestore();
     });
   });
 

--- a/backend/src/controllers/videoMetadataController.ts
+++ b/backend/src/controllers/videoMetadataController.ts
@@ -576,7 +576,12 @@ export const incrementViewCount = async (
  * Update progress
  * Errors are automatically handled by asyncHandler middleware
  */
-function updateVideoProgress(id: string, progress: unknown): number | null | undefined {
+interface UpdatedVideoProgress {
+  progress: number | null | undefined;
+  progressUpdatedAt?: number | null;
+}
+
+function updateVideoProgress(id: string, progress: unknown): UpdatedVideoProgress {
   if (typeof progress !== "number") {
     throw new ValidationError("Progress must be a number", "progress");
   }
@@ -593,18 +598,32 @@ function updateVideoProgress(id: string, progress: unknown): number | null | und
       : 0;
 
   if (normalizedProgress <= 1 && existingProgress > 30) {
-    return existingProgress;
+    return {
+      progress: existingProgress,
+      progressUpdatedAt:
+        typeof existingVideo.progressUpdatedAt === "number"
+          ? existingVideo.progressUpdatedAt
+          : null,
+    };
   }
 
+  const progressUpdatedAt = Date.now();
   const updatedVideo = storageService.updateVideo(id, {
     progress: normalizedProgress,
+    progressUpdatedAt,
   });
 
   if (!updatedVideo) {
     throw new NotFoundError("Video", id);
   }
 
-  return updatedVideo.progress;
+  return {
+    progress: updatedVideo.progress,
+    progressUpdatedAt:
+      typeof updatedVideo.progressUpdatedAt === "number"
+        ? updatedVideo.progressUpdatedAt
+        : progressUpdatedAt,
+  };
 }
 
 export const updateProgress = async (
@@ -617,7 +636,8 @@ export const updateProgress = async (
 
   res.status(200).json(
     successResponse({
-      progress: updatedProgress,
+      progress: updatedProgress.progress,
+      progressUpdatedAt: updatedProgress.progressUpdatedAt,
     })
   );
 };
@@ -635,7 +655,8 @@ export const updateProgressByBody = async (
 
   res.status(200).json(
     successResponse({
-      progress: updatedProgress,
+      progress: updatedProgress.progress,
+      progressUpdatedAt: updatedProgress.progressUpdatedAt,
     })
   );
 };

--- a/backend/src/controllers/videoMetadataController.ts
+++ b/backend/src/controllers/videoMetadataController.ts
@@ -581,8 +581,23 @@ function updateVideoProgress(id: string, progress: unknown): number | null | und
     throw new ValidationError("Progress must be a number", "progress");
   }
 
+  const normalizedProgress = Math.max(0, Math.floor(progress));
+  const existingVideo = storageService.getVideoById(id);
+  if (!existingVideo) {
+    throw new NotFoundError("Video", id);
+  }
+
+  const existingProgress =
+    typeof existingVideo.progress === "number" && Number.isFinite(existingVideo.progress)
+      ? existingVideo.progress
+      : 0;
+
+  if (normalizedProgress <= 1 && existingProgress > 30) {
+    return existingProgress;
+  }
+
   const updatedVideo = storageService.updateVideo(id, {
-    progress,
+    progress: normalizedProgress,
   });
 
   if (!updatedVideo) {

--- a/backend/src/controllers/videoMetadataController.ts
+++ b/backend/src/controllers/videoMetadataController.ts
@@ -592,7 +592,7 @@ function updateVideoProgress(id: string, progress: unknown): number | null | und
       ? existingVideo.progress
       : 0;
 
-  if (normalizedProgress < 30 && existingProgress > 30) {
+  if (normalizedProgress <= 1 && existingProgress > 30) {
     return existingProgress;
   }
 

--- a/backend/src/controllers/videoMetadataController.ts
+++ b/backend/src/controllers/videoMetadataController.ts
@@ -592,7 +592,7 @@ function updateVideoProgress(id: string, progress: unknown): number | null | und
       ? existingVideo.progress
       : 0;
 
-  if (normalizedProgress <= 1 && existingProgress > 30) {
+  if (normalizedProgress < 30 && existingProgress > 30) {
     return existingProgress;
   }
 

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -37,6 +37,7 @@ export const videos = sqliteTable(
     duration: text("duration"),
     tags: text("tags"), // JSON stringified array of strings
     progress: integer("progress"), // Playback progress in seconds
+    progressUpdatedAt: integer("progress_updated_at"), // Timestamp when progress was last saved
     fileSize: text("file_size"),
     lastPlayedAt: integer("last_played_at"), // Timestamp when video was last played
     subtitles: text("subtitles"), // JSON stringified array of subtitle objects

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -78,12 +78,15 @@ const apiRouteDefinitions: ApiRouteDefinition[] = [
     handlers: [asyncHandler(videoController.serveMountVideo)],
   },
   {
-    method: "put",
+    // Current keepalive/beacon path for body-based progress updates.
+    method: "post",
     path: "/videos/progress",
     handlers: [asyncHandler(videoMetadataController.updateProgressByBody)],
   },
   {
-    method: "post",
+    // Back-compat: older cached clients issued this beacon as PUT before the
+    // switch to POST. Kept so their unload progress beacons still succeed.
+    method: "put",
     path: "/videos/progress",
     handlers: [asyncHandler(videoMetadataController.updateProgressByBody)],
   },

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -83,6 +83,11 @@ const apiRouteDefinitions: ApiRouteDefinition[] = [
     handlers: [asyncHandler(videoMetadataController.updateProgressByBody)],
   },
   {
+    method: "post",
+    path: "/videos/progress",
+    handlers: [asyncHandler(videoMetadataController.updateProgressByBody)],
+  },
+  {
     method: "put",
     path: "/videos/:id",
     handlers: [asyncHandler(videoController.updateVideoDetails)],

--- a/backend/src/services/storageService/__tests__/initialization.test.ts
+++ b/backend/src/services/storageService/__tests__/initialization.test.ts
@@ -210,6 +210,7 @@ describe("storageService initialization", () => {
           all: vi.fn(() => [
             { name: "view_count" },
             { name: "progress" },
+            { name: "progress_updated_at" },
             { name: "duration" },
             { name: "file_size" },
             { name: "last_played_at" },
@@ -389,6 +390,7 @@ describe("storageService initialization", () => {
             { name: "tags" },
             { name: "view_count" },
             { name: "progress" },
+            { name: "progress_updated_at" },
             { name: "duration" },
             { name: "file_size" },
             { name: "last_played_at" },

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -452,6 +452,16 @@ export function migrateColumnsAndTables(): void {
       logger.info("Migration successful: progress added.");
     }
 
+    if (!columns.includes("progress_updated_at")) {
+      logger.info(
+        "Migrating database: Adding progress_updated_at column to videos table..."
+      );
+      sqlite
+        .prepare("ALTER TABLE videos ADD COLUMN progress_updated_at INTEGER")
+        .run();
+      logger.info("Migration successful: progress_updated_at added.");
+    }
+
     if (!columns.includes("duration")) {
       logger.info(
         "Migrating database: Adding duration column to videos table..."

--- a/backend/src/services/storageService/types.ts
+++ b/backend/src/services/storageService/types.ts
@@ -9,6 +9,7 @@ export interface Video {
   tags?: string[];
   viewCount?: number;
   progress?: number;
+  progressUpdatedAt?: number;
   fileSize?: string;
   description?: string;
   [key: string]: any;

--- a/backend/src/services/storageService/videoQueries.ts
+++ b/backend/src/services/storageService/videoQueries.ts
@@ -75,6 +75,7 @@ const videoSummaryColumns = () => ({
   duration: videos.duration,
   tags: videos.tags,
   progress: videos.progress,
+  progressUpdatedAt: videos.progressUpdatedAt,
   fileSize: videos.fileSize,
   lastPlayedAt: videos.lastPlayedAt,
   channelUrl: videos.channelUrl,

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
@@ -405,6 +405,27 @@ describe("useVideoPlayer startTime behavior", () => {
     expect(onTimeUpdate).not.toHaveBeenCalled();
     expect(result.current.currentTime).toBe(30);
   });
+
+  it("tracks the clamped startTime as the pending restore target", () => {
+    const onTimeUpdate = vi.fn();
+    const { result } = renderHook(() =>
+      useVideoPlayer({ src: "test.mp4", startTime: 150, onTimeUpdate })
+    );
+
+    result.current.videoRef.current = videoElement;
+
+    act(() => {
+      result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(videoElement.currentTime).toBe(99.75);
+
+    act(() => {
+      result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(99.75);
+  });
 });
 
 describe("useVideoPlayer playbackRate behavior", () => {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useVideoPlayer.test.ts
@@ -34,10 +34,12 @@ describe("useVideoPlayer seek behavior", () => {
 
     // Mock other properties
     Object.defineProperty(videoElement, "duration", {
+      configurable: true,
       writable: true,
       value: 100,
     });
     Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
       writable: true,
       value: 0,
     });
@@ -158,10 +160,12 @@ describe("useVideoPlayer startTime behavior", () => {
     videoElement.fastSeek = vi.fn();
 
     Object.defineProperty(videoElement, "duration", {
+      configurable: true,
       writable: true,
       value: 100,
     });
     Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
       writable: true,
       value: 0,
     });
@@ -198,8 +202,10 @@ describe("useVideoPlayer startTime behavior", () => {
 
     expect(videoElement.currentTime).toBe(30);
 
-    // Reset currentTime to 0 (simulating user seek to 0)
-    videoElement.currentTime = 0;
+    // Reset currentTime to 0 through the real user seek path.
+    act(() => {
+      result.current.handleProgressChangeCommitted(0);
+    });
 
     // Second handleCanPlay should NOT reset to startTime
     act(() => {
@@ -346,7 +352,7 @@ describe("useVideoPlayer startTime behavior", () => {
     expect(onTimeUpdate).toHaveBeenCalledWith(30.2);
   });
 
-  it("propagates timeupdates past the tolerance even if the restore never applied", () => {
+  it("suppresses low timeupdates after restore assignment until the target time is observed", () => {
     const onTimeUpdate = vi.fn();
     const { result } = renderHook(() =>
       useVideoPlayer({ src: "test.mp4", startTime: 30, onTimeUpdate })
@@ -354,14 +360,50 @@ describe("useVideoPlayer startTime behavior", () => {
 
     result.current.videoRef.current = videoElement;
 
-    // Escape valve: if playback somehow progresses without the restore
-    // being applied, progress saving must not stay suppressed.
+    act(() => {
+      result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(videoElement.currentTime).toBe(30);
+
+    // Safari can report low playback after accepting the restore seek
+    // assignment for a large WebM. The hook must not publish that as real
+    // progress, because the progress saver would persist it.
     videoElement.currentTime = 5;
     act(() => {
       result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
     });
 
-    expect(onTimeUpdate).toHaveBeenCalledWith(5);
+    expect(onTimeUpdate).not.toHaveBeenCalled();
+    expect(result.current.currentTime).toBe(30);
+
+    videoElement.currentTime = 30.1;
+    act(() => {
+      result.current.handleTimeUpdate({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).toHaveBeenCalledWith(30.1);
+  });
+
+  it("suppresses low seeked events while a startTime restore is pending", () => {
+    const onTimeUpdate = vi.fn();
+    const { result } = renderHook(() =>
+      useVideoPlayer({ src: "test.mp4", startTime: 30, onTimeUpdate })
+    );
+
+    result.current.videoRef.current = videoElement;
+
+    act(() => {
+      result.current.handleLoadedMetadata({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    videoElement.currentTime = 4;
+    act(() => {
+      result.current.handleSeeked({ currentTarget: videoElement } as React.SyntheticEvent<HTMLVideoElement>);
+    });
+
+    expect(onTimeUpdate).not.toHaveBeenCalled();
+    expect(result.current.currentTime).toBe(30);
   });
 });
 

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -9,6 +9,10 @@ interface UseVideoPlayerProps {
   onLoadedMetadata?: (duration: number) => void;
 }
 
+const START_TIME_APPLY_TOLERANCE_SECONDS = 1;
+const START_TIME_RETRY_INTERVAL_MS = 1500;
+const END_SEEK_GUARD_SECONDS = 0.25;
+
 export const useVideoPlayer = ({
   src,
   autoPlay = false,
@@ -30,8 +34,8 @@ export const useVideoPlayer = ({
   const startTimeAppliedRef = useRef<boolean>(false);
   // Track last applied startTime so we apply again when it updates (e.g. progress loaded after initial render)
   const lastAppliedStartTimeRef = useRef<number>(-1);
-  const START_TIME_APPLY_TOLERANCE_SECONDS = 1;
-  const END_SEEK_GUARD_SECONDS = 0.25;
+  const pendingStartTimeRestoreRef = useRef<number | null>(null);
+  const lastStartTimeRetryAtRef = useRef<number>(0);
 
   const getMaxPlayableTime = useCallback((videoDuration: number): number => {
     if (!isFinite(videoDuration) || videoDuration <= 0) {
@@ -67,6 +71,79 @@ export const useVideoPlayer = ({
     videoElement.currentTime = safeTime;
     setCurrentTime(safeTime);
   }, [clampPlaybackTime]);
+
+  const markStartTimeRestorePending = useCallback((targetTime: number) => {
+    startTimeAppliedRef.current = true;
+    lastAppliedStartTimeRef.current = targetTime;
+    pendingStartTimeRestoreRef.current = targetTime;
+    lastStartTimeRetryAtRef.current = 0;
+  }, []);
+
+  const applyStartTime = useCallback(
+    (videoElement: HTMLVideoElement, targetTime: number) => {
+      seekTo(videoElement, targetTime);
+      markStartTimeRestorePending(targetTime);
+    },
+    [markStartTimeRestorePending, seekTo]
+  );
+
+  const clearPendingStartTimeRestore = useCallback(() => {
+    pendingStartTimeRestoreRef.current = null;
+    lastStartTimeRetryAtRef.current = 0;
+  }, []);
+
+  const isAtOrPastStartTimeRestore = useCallback((time: number, targetTime: number) => {
+    return time + START_TIME_APPLY_TOLERANCE_SECONDS >= targetTime;
+  }, []);
+
+  const retryPendingStartTimeRestore = useCallback(
+    (videoElement: HTMLVideoElement) => {
+      const targetTime = pendingStartTimeRestoreRef.current;
+      if (targetTime === null) {
+        return;
+      }
+
+      const currentTime = videoElement.currentTime;
+      if (isAtOrPastStartTimeRestore(currentTime, targetTime)) {
+        clearPendingStartTimeRestore();
+        return;
+      }
+
+      const now = Date.now();
+      if (
+        lastStartTimeRetryAtRef.current > 0 &&
+        now - lastStartTimeRetryAtRef.current < START_TIME_RETRY_INTERVAL_MS
+      ) {
+        return;
+      }
+
+      lastStartTimeRetryAtRef.current = now;
+      seekTo(videoElement, targetTime);
+    },
+    [clearPendingStartTimeRestore, isAtOrPastStartTimeRestore, seekTo]
+  );
+
+  const suppressUntilStartTimeRestored = useCallback(
+    (videoElement: HTMLVideoElement, time: number): boolean => {
+      const targetTime = pendingStartTimeRestoreRef.current;
+      if (targetTime === null) {
+        return false;
+      }
+
+      if (isAtOrPastStartTimeRestore(time, targetTime)) {
+        clearPendingStartTimeRestore();
+        return false;
+      }
+
+      retryPendingStartTimeRestore(videoElement);
+      return true;
+    },
+    [
+      clearPendingStartTimeRestore,
+      isAtOrPastStartTimeRestore,
+      retryPendingStartTimeRestore,
+    ]
+  );
 
   const shouldApplyStartTime = useCallback(
     (videoElement: HTMLVideoElement) => {
@@ -112,6 +189,7 @@ export const useVideoPlayer = ({
       // Reset startTime flag for new video
       startTimeAppliedRef.current = false;
       lastAppliedStartTimeRef.current = -1;
+      clearPendingStartTimeRestore();
     }
 
     if (src) {
@@ -122,6 +200,7 @@ export const useVideoPlayer = ({
       if (!previousSrc) {
         startTimeAppliedRef.current = false;
         lastAppliedStartTimeRef.current = -1;
+        clearPendingStartTimeRestore();
       }
     }
 
@@ -130,7 +209,7 @@ export const useVideoPlayer = ({
       videoElement.src = "";
       videoElement.load();
     };
-  }, [src]);
+  }, [clearPendingStartTimeRestore, src]);
 
   useEffect(() => {
     if (videoRef.current) {
@@ -166,11 +245,9 @@ export const useVideoPlayer = ({
     if (!videoElement || startTime <= 0) return;
 
     if (shouldApplyStartTime(videoElement)) {
-      seekTo(videoElement, startTime);
-      startTimeAppliedRef.current = true;
-      lastAppliedStartTimeRef.current = startTime;
+      applyStartTime(videoElement, startTime);
     }
-  }, [seekTo, shouldApplyStartTime, startTime]);
+  }, [applyStartTime, shouldApplyStartTime, startTime]);
 
   const handlePlayPause = () => {
     const videoElement = videoRef.current;
@@ -193,8 +270,9 @@ export const useVideoPlayer = ({
       Math.min(videoElement.duration, videoElement.currentTime + seconds)
     );
 
+    clearPendingStartTimeRestore();
     seekTo(videoElement, newTime);
-  }, [seekTo]);
+  }, [clearPendingStartTimeRestore, seekTo]);
 
   const handleProgressChange = (newTime: number) => {
     if (!videoRef.current || duration <= 0 || !isFinite(duration)) return;
@@ -205,6 +283,7 @@ export const useVideoPlayer = ({
     const videoElement = videoRef.current;
     if (!videoElement || duration <= 0 || !isFinite(duration)) return;
 
+    clearPendingStartTimeRestore();
     seekTo(videoElement, newTime);
     setIsDragging(false);
   };
@@ -239,17 +318,18 @@ export const useVideoPlayer = ({
       return;
     }
 
-    // Drop pre-restore ticks. Browsers (Safari in particular) emit a
-    // timeupdate at ~0 before the saved-progress seek is issued at
-    // loadedmetadata; propagating it lets the progress tracker
-    // overwrite the stored position with 0. The tolerance check is an
-    // escape valve: if the restore is ever skipped, ticks past 1s flow
-    // again so progress saving cannot stay suppressed for a session.
+    // Drop pre-restore ticks. Safari can accept a currentTime assignment for
+    // a large WebM and still keep reporting playback near zero until its
+    // linear loader catches up. Do not publish those low ticks as real
+    // progress; retry the restore seek instead.
     if (
       startTime > 0 &&
       !startTimeAppliedRef.current &&
       time < START_TIME_APPLY_TOLERANCE_SECONDS
     ) {
+      return;
+    }
+    if (suppressUntilStartTimeRestored(e.currentTarget, time)) {
       return;
     }
 
@@ -266,9 +346,7 @@ export const useVideoPlayer = ({
       setDuration(videoDuration);
     }
     if (shouldApplyStartTime(e.currentTarget)) {
-      seekTo(e.currentTarget, startTime);
-      startTimeAppliedRef.current = true;
-      lastAppliedStartTimeRef.current = startTime;
+      applyStartTime(e.currentTarget, startTime);
     }
     if (onLoadedMetadata) {
       onLoadedMetadata(videoDuration);
@@ -295,11 +373,17 @@ export const useVideoPlayer = ({
 
     // Apply startTime when not yet applied or when it updated (e.g. progress loaded after first paint)
     if (shouldApplyStartTime(videoElement)) {
-      seekTo(videoElement, startTime);
-      startTimeAppliedRef.current = true;
-      lastAppliedStartTimeRef.current = startTime;
+      applyStartTime(videoElement, startTime);
+    } else {
+      retryPendingStartTimeRestore(videoElement);
     }
-  }, [duration, seekTo, shouldApplyStartTime, startTime]);
+  }, [
+    applyStartTime,
+    duration,
+    retryPendingStartTimeRestore,
+    shouldApplyStartTime,
+    startTime,
+  ]);
 
   const handlePlay = () => {
     setIsPlaying(true);
@@ -317,13 +401,16 @@ export const useVideoPlayer = ({
     (e: React.SyntheticEvent<HTMLVideoElement>) => {
       const time = e.currentTarget.currentTime;
       setIsSeeking(false);
+      if (suppressUntilStartTimeRestored(e.currentTarget, time)) {
+        return;
+      }
       setCurrentTime(time);
 
       if (onTimeUpdate) {
         onTimeUpdate(time);
       }
     },
-    [onTimeUpdate]
+    [onTimeUpdate, suppressUntilStartTimeRestored]
   );
 
   return {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -70,6 +70,7 @@ export const useVideoPlayer = ({
     // after loadedmetadata, so playback would start from the beginning.
     videoElement.currentTime = safeTime;
     setCurrentTime(safeTime);
+    return safeTime;
   }, [clampPlaybackTime]);
 
   const markStartTimeRestorePending = useCallback((targetTime: number) => {
@@ -81,8 +82,8 @@ export const useVideoPlayer = ({
 
   const applyStartTime = useCallback(
     (videoElement: HTMLVideoElement, targetTime: number) => {
-      seekTo(videoElement, targetTime);
-      markStartTimeRestorePending(targetTime);
+      const appliedTime = seekTo(videoElement, targetTime);
+      markStartTimeRestorePending(appliedTime);
     },
     [markStartTimeRestorePending, seekTo]
   );

--- a/frontend/src/components/VideoPlayer/VideoInfo.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo.tsx
@@ -72,7 +72,6 @@ const VideoInfo: React.FC<VideoInfoProps> = ({
             {needsDetection && (videoUrl || video.sourceUrl) && (
                 <video
                     ref={videoRef}
-                    src={videoUrl || video.sourceUrl}
                     style={{
                         position: 'absolute',
                         width: '1px',

--- a/frontend/src/contexts/VideoContext.tsx
+++ b/frontend/src/contexts/VideoContext.tsx
@@ -3,6 +3,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import { Video, VideoSearchResult } from '../types';
 import { useStatisticsIngestion } from '../hooks/useStatisticsIngestion';
 import { api } from '../utils/apiClient';
+import { withCanonicalAuthorAvatars } from '../utils/authorAvatar';
 import { hasAxiosStatus } from '../utils/errors';
 import { settingsQueryOptions } from '../utils/settingsQueries';
 import { useAuth } from './AuthContext';
@@ -126,10 +127,11 @@ export const VideoProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
     // Filter invisible videos when in visitor mode
     const videos = useMemo(() => {
+        const normalizedVideos = withCanonicalAuthorAvatars(videosRaw);
         if (isVisitor) {
-            return videosRaw.filter(video => (video.visibility ?? 1) === 1);
+            return normalizedVideos.filter(video => (video.visibility ?? 1) === 1);
         }
-        return videosRaw;
+        return normalizedVideos;
     }, [videosRaw, isVisitor]);
 
     // Settings Query (tags and showYoutubeSearch)

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -253,6 +253,95 @@ describe("useVideoProgress", () => {
     dateNowSpy.mockRestore();
   });
 
+  it("samples the media element on unmount when no timeupdate fired", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    const video = {
+      id: "video-element-unmount",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      value: 37.8,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-element-unmount"], video);
+
+    const { unmount } = renderHook(
+      () => useVideoProgress({ videoId: "video-element-unmount", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-element-unmount",
+      37
+    );
+    expect(queryClient.getQueryData(["videos"])).toEqual([
+      expect.objectContaining({
+        id: "video-element-unmount",
+        progress: 37,
+      }),
+    ]);
+    expect(queryClient.getQueryData(["video", "video-element-unmount"])).toEqual(
+      expect.objectContaining({
+        id: "video-element-unmount",
+        progress: 37,
+      })
+    );
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("flushes sampled media element progress on pagehide", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    const video = {
+      id: "video-pagehide",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      value: 42.2,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-pagehide"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-pagehide", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-pagehide",
+      42
+    );
+    expect(queryClient.getQueryData(["video", "video-pagehide"])).toEqual(
+      expect.objectContaining({
+        progress: 42,
+      })
+    );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
   it("does not persist exact duration as the resume progress", () => {
     let now = 1000;
     const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -587,7 +587,8 @@ describe("useVideoProgress", () => {
       id: "video-server-rewind",
       duration: "1776",
       progress: 20,
-      lastPlayedAt: 70_000,
+      lastPlayedAt: 500,
+      progressUpdatedAt: 70_000,
       viewCount: 0,
     } as any;
     const videoElement = document.createElement("video");

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -578,6 +578,58 @@ describe("useVideoProgress", () => {
     dateNowSpy.mockRestore();
   });
 
+  it("uses a fresher lower server resume point instead of stale local progress", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    writeVideoResumeProgress("video-server-rewind", 120);
+    dateNowSpy.mockReturnValue(80_000);
+
+    const video = {
+      id: "video-server-rewind",
+      duration: "1776",
+      progress: 20,
+      lastPlayedAt: 70_000,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 20,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-server-rewind"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-server-rewind", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-server-rewind",
+      20
+    );
+    expect(mockSendVideoProgressWithKeepalive).not.toHaveBeenCalledWith(
+      "video-server-rewind",
+      120
+    );
+    expect(queryClient.getQueryData(["video", "video-server-rewind"])).toEqual(
+      expect.objectContaining({
+        progress: 20,
+      })
+    );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
   it("does not persist exact duration as the resume progress", () => {
     let now = 1000;
     const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -3,7 +3,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useVideoProgress } from "../useVideoProgress";
-import { readVideoResumeProgress } from "../../utils/videoResumeProgress";
+import {
+  readVideoResumeProgress,
+  writeVideoResumeProgress,
+} from "../../utils/videoResumeProgress";
 
 const mockApiPost = vi.fn();
 const mockApiPut = vi.fn();
@@ -365,13 +368,156 @@ describe("useVideoProgress", () => {
     );
 
     act(() => {
-      videoElement.dispatchEvent(new Event("timeupdate"));
+      videoElement.dispatchEvent(new Event("playing"));
     });
 
     expect(readVideoResumeProgress("video-native-event")).toEqual({
       progress: 58,
       updatedAt: 1000,
     });
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("does not clobber a higher resume point with low native Safari samples before restore is observed", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    const video = {
+      id: "video-safari-restore",
+      duration: "1776",
+      progress: 826,
+      lastPlayedAt: 900,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 5,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-safari-restore"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-safari-restore", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      videoElement.dispatchEvent(new Event("timeupdate"));
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-safari-restore",
+      826
+    );
+    expect(readVideoResumeProgress("video-safari-restore")).toEqual({
+      progress: 826,
+      updatedAt: 1000,
+    });
+    expect(queryClient.getQueryData(["video", "video-safari-restore"])).toEqual(
+      expect.objectContaining({
+        progress: 826,
+      })
+    );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("releases the resume guard once the player reports a trusted low time", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    const video = {
+      id: "video-guard-release",
+      duration: "1776",
+      progress: 826,
+      lastPlayedAt: 900,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 5,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-guard-release"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-guard-release", video, videoElement }),
+      { wrapper },
+    );
+
+    // The player only forwards a time once its saved-progress seek settles, so
+    // this simulates the user scrubbing back to 100s before the restore point is
+    // reached. That trusted value must release the guard so the real position is
+    // persisted instead of the stale 826s resume point.
+    videoElement.currentTime = 100;
+    act(() => {
+      result.current.handleTimeUpdate(100);
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-guard-release",
+      100
+    );
+    expect(mockSendVideoProgressWithKeepalive).not.toHaveBeenCalledWith(
+      "video-guard-release",
+      826
+    );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("uses the server resume point when local progress is a stale low Safari sample", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    writeVideoResumeProgress("video-low-local", 5);
+
+    const video = {
+      id: "video-low-local",
+      duration: "1776",
+      progress: 826,
+      lastPlayedAt: 900,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 5,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-low-local", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-low-local",
+      826
+    );
 
     act(() => {
       result.current.setIsDeleting(true);

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -526,6 +526,58 @@ describe("useVideoProgress", () => {
     dateNowSpy.mockRestore();
   });
 
+  it("uses the server resume point when stale local progress is within the guard window", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    writeVideoResumeProgress("video-near-local", 800);
+    dateNowSpy.mockReturnValue(80_000);
+
+    const video = {
+      id: "video-near-local",
+      duration: "1776",
+      progress: 826,
+      lastPlayedAt: 70_000,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      writable: true,
+      value: 800,
+    });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["videos"], [video]);
+    queryClient.setQueryData(["video", "video-near-local"], video);
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-near-local", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(mockSendVideoProgressWithKeepalive).toHaveBeenCalledWith(
+      "video-near-local",
+      826
+    );
+    expect(mockSendVideoProgressWithKeepalive).not.toHaveBeenCalledWith(
+      "video-near-local",
+      800
+    );
+    expect(queryClient.getQueryData(["video", "video-near-local"])).toEqual(
+      expect.objectContaining({
+        progress: 826,
+      })
+    );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
   it("does not persist exact duration as the resume progress", () => {
     let now = 1000;
     const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useVideoProgress } from "../useVideoProgress";
+import { readVideoResumeProgress } from "../../utils/videoResumeProgress";
 
 const mockApiPost = vi.fn();
 const mockApiPut = vi.fn();
@@ -45,6 +46,7 @@ const createWrapper = () => {
 describe("useVideoProgress", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     mockUserRole = "admin";
     mockApiPost.mockResolvedValue({ data: { success: true, viewCount: 1 } });
     mockApiPut.mockResolvedValue({ data: { success: true } });
@@ -334,6 +336,42 @@ describe("useVideoProgress", () => {
         progress: 42,
       })
     );
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+
+    dateNowSpy.mockRestore();
+  });
+
+  it("keeps local resume progress fresh from native media events", () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
+    const video = {
+      id: "video-native-event",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const videoElement = document.createElement("video");
+    Object.defineProperty(videoElement, "currentTime", {
+      configurable: true,
+      value: 58.6,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useVideoProgress({ videoId: "video-native-event", video, videoElement }),
+      { wrapper },
+    );
+
+    act(() => {
+      videoElement.dispatchEvent(new Event("timeupdate"));
+    });
+
+    expect(readVideoResumeProgress("video-native-event")).toEqual({
+      progress: 58,
+      updatedAt: 1000,
+    });
 
     act(() => {
       result.current.setIsDeleting(true);

--- a/frontend/src/hooks/__tests__/useVideoResolution.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoResolution.test.tsx
@@ -47,6 +47,7 @@ describe("formatResolution", () => {
 describe("useVideoResolution", () => {
   const originalRequestIdleCallback = (window as any).requestIdleCallback;
   const originalCancelIdleCallback = (window as any).cancelIdleCallback;
+  const originalUserAgent = window.navigator.userAgent;
   let loadSpy: ReturnType<typeof vi.spyOn>;
   let pauseSpy: ReturnType<typeof vi.spyOn>;
 
@@ -78,6 +79,10 @@ describe("useVideoResolution", () => {
     } else {
       delete (window as any).cancelIdleCallback;
     }
+    Object.defineProperty(window.navigator, "userAgent", {
+      value: originalUserAgent,
+      configurable: true,
+    });
   });
 
   it("skips detection when resolution exists on video object", () => {
@@ -92,6 +97,20 @@ describe("useVideoResolution", () => {
 
     expect(screen.getByTestId("probe-needs")).toHaveTextContent("true");
     expect(screen.getByTestId("probe-resolution")).toHaveTextContent("");
+  });
+
+  it("skips hidden video detection for Safari WebM sources", () => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+      configurable: true,
+    });
+
+    render(<Probe video={{ id: "safari-webm", videoPath: "/videos/file.webm", sourceUrl: "https://origin/video" }} />);
+
+    expect(screen.getByTestId("probe-needs")).toHaveTextContent("false");
+    expect(screen.getByTestId("probe-resolution")).toHaveTextContent("");
+    expect(loadSpy).not.toHaveBeenCalled();
   });
 
   it("detects resolution with delayed metadata loading fallback", async () => {

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -101,7 +101,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     const resumeProgress = getBestVideoResumeProgress(
       videoId,
       video?.progress,
-      video?.lastPlayedAt
+      video?.progressUpdatedAt ?? video?.lastPlayedAt
     );
 
     if (
@@ -117,7 +117,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
       resumeGuardObservedRef.current =
         resumeGuardTargetRef.current <= RESTORE_GUARD_MIN_PROGRESS_SECONDS;
     }
-  }, [video?.lastPlayedAt, video?.progress, videoId]);
+  }, [video?.lastPlayedAt, video?.progress, video?.progressUpdatedAt, videoId]);
 
   useEffect(() => {
     durationRef.current = videoDuration;
@@ -191,8 +191,10 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
       return;
     }
 
+    const progressUpdatedAt = Date.now();
     syncVideoPlaybackCache(queryClient, videoId, {
       progress,
+      progressUpdatedAt,
     });
 
     if (options.keepalive) {

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -105,8 +105,9 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     );
 
     if (
-      resumeProgress > 0 &&
-      (currentTimeRef.current <= 0 || currentTimeRef.current < resumeProgress)
+      currentTimeRef.current <= 0 ||
+      currentTimeRef.current < resumeProgress ||
+      !resumeGuardObservedRef.current
     ) {
       currentTimeRef.current = resumeProgress;
       resumeGuardTargetRef.current =

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -4,6 +4,10 @@ import { useAuth } from "../contexts/AuthContext";
 import { Video } from "../types";
 import { api, sendVideoProgressWithKeepalive } from "../utils/apiClient";
 import { parseDuration } from "../utils/formatUtils";
+import {
+  readVideoResumeProgress,
+  writeVideoResumeProgress,
+} from "../utils/videoResumeProgress";
 
 interface UseVideoProgressProps {
   videoId: string | undefined;
@@ -12,6 +16,7 @@ interface UseVideoProgressProps {
 }
 
 const PROGRESS_SAVE_INTERVAL_MS = 5000;
+const LOCAL_PROGRESS_SAMPLE_INTERVAL_MS = 1000;
 
 function getViewThreshold(duration: string | undefined): number {
   const durationSeconds = parseDuration(duration);
@@ -75,12 +80,19 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   // Reset hasViewed when video changes
   useEffect(() => {
     setHasViewed(false);
-    currentTimeRef.current = 0;
+    currentTimeRef.current = readVideoResumeProgress(videoId)?.progress ?? 0;
     // Start the periodic-save throttle now: with the initial 0 the very
     // first timeupdate saved immediately, racing the saved-progress
     // restore and overwriting the stored position with ~0.
     lastProgressSave.current = Date.now();
   }, [videoId]);
+
+  useEffect(() => {
+    if (currentTimeRef.current <= 0 && video?.progress) {
+      currentTimeRef.current =
+        readVideoResumeProgress(videoId)?.progress ?? video.progress;
+    }
+  }, [video?.progress, videoId]);
 
   useEffect(() => {
     durationRef.current = videoDuration;
@@ -106,6 +118,14 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     return currentTimeRef.current;
   }, []);
 
+  const cacheProgressLocally = useCallback((playbackTime: number) => {
+    const progress = getResumeProgress(playbackTime, durationRef.current);
+    if (progress > 0) {
+      writeVideoResumeProgress(videoId, progress);
+    }
+    return progress;
+  }, [videoId]);
+
   const saveProgress = useCallback((
     playbackTime: number,
     options: { keepalive?: boolean } = {}
@@ -114,7 +134,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
       return;
     }
 
-    const progress = getResumeProgress(playbackTime, durationRef.current);
+    const progress = cacheProgressLocally(playbackTime);
 
     if (progress <= 0) {
       return;
@@ -136,7 +156,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
       .catch((err) => {
         console.error("Error saving progress:", err);
       });
-  }, [isVisitor, queryClient, videoId]);
+  }, [cacheProgressLocally, isVisitor, queryClient, videoId]);
 
   const flushSampledProgress = useCallback((options: { keepalive?: boolean } = {}) => {
     const playbackTime = samplePlaybackTime();
@@ -149,17 +169,59 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     }
 
     const timer = window.setInterval(() => {
+      const playbackTime = samplePlaybackTime();
+      cacheProgressLocally(playbackTime);
+
       const now = Date.now();
       if (now - lastProgressSave.current <= PROGRESS_SAVE_INTERVAL_MS) {
         return;
       }
 
       lastProgressSave.current = now;
-      flushSampledProgress();
-    }, 1000);
+      saveProgress(playbackTime);
+    }, LOCAL_PROGRESS_SAMPLE_INTERVAL_MS);
 
     return () => window.clearInterval(timer);
-  }, [flushSampledProgress, isVisitor, videoElement, videoId]);
+  }, [
+    cacheProgressLocally,
+    isVisitor,
+    samplePlaybackTime,
+    saveProgress,
+    videoElement,
+    videoId,
+  ]);
+
+  useEffect(() => {
+    if (!videoId || isVisitor || !videoElement) {
+      return;
+    }
+
+    const sampleAndCache = () => {
+      cacheProgressLocally(samplePlaybackTime());
+    };
+    const sampleAndSave = () => {
+      flushSampledProgress();
+    };
+
+    videoElement.addEventListener("timeupdate", sampleAndCache);
+    videoElement.addEventListener("playing", sampleAndCache);
+    videoElement.addEventListener("seeked", sampleAndSave);
+    videoElement.addEventListener("pause", sampleAndSave);
+
+    return () => {
+      videoElement.removeEventListener("timeupdate", sampleAndCache);
+      videoElement.removeEventListener("playing", sampleAndCache);
+      videoElement.removeEventListener("seeked", sampleAndSave);
+      videoElement.removeEventListener("pause", sampleAndSave);
+    };
+  }, [
+    cacheProgressLocally,
+    flushSampledProgress,
+    isVisitor,
+    samplePlaybackTime,
+    videoElement,
+    videoId,
+  ]);
 
   // Save progress when the page is hidden or discarded. Safari can defer
   // timeupdate events for very large WebM files, so sample the media element.
@@ -195,6 +257,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
 
   const handleTimeUpdate = (currentTime: number) => {
     currentTimeRef.current = currentTime;
+    cacheProgressLocally(currentTime);
 
     // Increment views and refresh watch history at the same threshold.
     const viewThreshold = getViewThreshold(videoDuration);

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -5,6 +5,7 @@ import { Video } from "../types";
 import { api, sendVideoProgressWithKeepalive } from "../utils/apiClient";
 import { parseDuration } from "../utils/formatUtils";
 import {
+  getBestVideoResumeProgress,
   readVideoResumeProgress,
   writeVideoResumeProgress,
 } from "../utils/videoResumeProgress";
@@ -17,6 +18,8 @@ interface UseVideoProgressProps {
 
 const PROGRESS_SAVE_INTERVAL_MS = 5000;
 const LOCAL_PROGRESS_SAMPLE_INTERVAL_MS = 1000;
+const RESTORE_GUARD_MIN_PROGRESS_SECONDS = 30;
+const RESTORE_GUARD_TOLERANCE_SECONDS = 2;
 
 function getViewThreshold(duration: string | undefined): number {
   const durationSeconds = parseDuration(duration);
@@ -75,12 +78,19 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const isDeletingRef = useRef<boolean>(false);
   const durationRef = useRef<string | undefined>(undefined);
   const videoElementRef = useRef<HTMLVideoElement | null>(null);
+  const resumeGuardTargetRef = useRef<number>(0);
+  const resumeGuardObservedRef = useRef<boolean>(true);
   const videoDuration = video?.duration;
 
   // Reset hasViewed when video changes
   useEffect(() => {
     setHasViewed(false);
-    currentTimeRef.current = readVideoResumeProgress(videoId)?.progress ?? 0;
+    const storedProgress = readVideoResumeProgress(videoId)?.progress ?? 0;
+    currentTimeRef.current = storedProgress;
+    resumeGuardTargetRef.current =
+      storedProgress > RESTORE_GUARD_MIN_PROGRESS_SECONDS ? storedProgress : 0;
+    resumeGuardObservedRef.current =
+      resumeGuardTargetRef.current <= RESTORE_GUARD_MIN_PROGRESS_SECONDS;
     // Start the periodic-save throttle now: with the initial 0 the very
     // first timeupdate saved immediately, racing the saved-progress
     // restore and overwriting the stored position with ~0.
@@ -88,11 +98,27 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   }, [videoId]);
 
   useEffect(() => {
-    if (currentTimeRef.current <= 0 && video?.progress) {
-      currentTimeRef.current =
-        readVideoResumeProgress(videoId)?.progress ?? video.progress;
+    const resumeProgress = getBestVideoResumeProgress(
+      videoId,
+      video?.progress,
+      video?.lastPlayedAt
+    );
+
+    if (
+      resumeProgress > 0 &&
+      (currentTimeRef.current <= 0 ||
+        currentTimeRef.current + RESTORE_GUARD_MIN_PROGRESS_SECONDS <
+          resumeProgress)
+    ) {
+      currentTimeRef.current = resumeProgress;
+      resumeGuardTargetRef.current =
+        resumeProgress > RESTORE_GUARD_MIN_PROGRESS_SECONDS
+          ? resumeProgress
+          : 0;
+      resumeGuardObservedRef.current =
+        resumeGuardTargetRef.current <= RESTORE_GUARD_MIN_PROGRESS_SECONDS;
     }
-  }, [video?.progress, videoId]);
+  }, [video?.lastPlayedAt, video?.progress, videoId]);
 
   useEffect(() => {
     durationRef.current = videoDuration;
@@ -102,21 +128,47 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     videoElementRef.current = videoElement ?? null;
   }, [videoElement]);
 
+  const getTrustedPlaybackTime = useCallback((playbackTime: number) => {
+    if (typeof playbackTime !== "number" || !Number.isFinite(playbackTime)) {
+      return null;
+    }
+
+    const safeTime = Math.max(0, playbackTime);
+    const resumeTarget = resumeGuardTargetRef.current;
+
+    if (
+      resumeTarget > RESTORE_GUARD_MIN_PROGRESS_SECONDS &&
+      !resumeGuardObservedRef.current
+    ) {
+      if (safeTime + RESTORE_GUARD_TOLERANCE_SECONDS >= resumeTarget) {
+        resumeGuardObservedRef.current = true;
+      } else {
+        return null;
+      }
+    }
+
+    return safeTime;
+  }, []);
+
   const samplePlaybackTime = useCallback(() => {
     const mediaElement = videoElementRef.current;
     const sampledTime = mediaElement?.currentTime;
+    const trustedTime =
+      typeof sampledTime === "number" && Number.isFinite(sampledTime)
+        ? getTrustedPlaybackTime(sampledTime)
+        : null;
 
-    if (typeof sampledTime !== "number" || !Number.isFinite(sampledTime)) {
+    if (trustedTime === null) {
       return currentTimeRef.current;
     }
 
-    if (sampledTime <= 0 && currentTimeRef.current > 0) {
+    if (trustedTime <= 0 && currentTimeRef.current > 0) {
       return currentTimeRef.current;
     }
 
-    currentTimeRef.current = Math.max(0, sampledTime);
+    currentTimeRef.current = trustedTime;
     return currentTimeRef.current;
-  }, []);
+  }, [getTrustedPlaybackTime]);
 
   const cacheProgressLocally = useCallback((playbackTime: number) => {
     const progress = getResumeProgress(playbackTime, durationRef.current);
@@ -203,13 +255,15 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
       flushSampledProgress();
     };
 
-    videoElement.addEventListener("timeupdate", sampleAndCache);
+    // The React onTimeUpdate handler already caches on every "timeupdate", so we
+    // do not listen for it again here (doing so double-wrote localStorage on each
+    // tick). "playing" backfills the cache when playback resumes, and the 1s
+    // interval covers Safari's deferred-timeupdate case.
     videoElement.addEventListener("playing", sampleAndCache);
     videoElement.addEventListener("seeked", sampleAndSave);
     videoElement.addEventListener("pause", sampleAndSave);
 
     return () => {
-      videoElement.removeEventListener("timeupdate", sampleAndCache);
       videoElement.removeEventListener("playing", sampleAndCache);
       videoElement.removeEventListener("seeked", sampleAndSave);
       videoElement.removeEventListener("pause", sampleAndSave);
@@ -256,12 +310,24 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   }, [flushSampledProgress]);
 
   const handleTimeUpdate = (currentTime: number) => {
-    currentTimeRef.current = currentTime;
-    cacheProgressLocally(currentTime);
+    // The player suppresses onTimeUpdate while a saved-progress seek is still
+    // pending, so any value delivered here is authoritative: the restore has
+    // completed, or the user seeked/started somewhere else. Release the sampling
+    // guard so the deferred-sample paths (native events, interval, pagehide)
+    // track the live position instead of holding the previous resume point.
+    resumeGuardObservedRef.current = true;
+
+    const trustedCurrentTime = getTrustedPlaybackTime(currentTime);
+    if (trustedCurrentTime === null) {
+      return;
+    }
+
+    currentTimeRef.current = trustedCurrentTime;
+    cacheProgressLocally(trustedCurrentTime);
 
     // Increment views and refresh watch history at the same threshold.
     const viewThreshold = getViewThreshold(videoDuration);
-    if (currentTime >= viewThreshold && !hasViewed && videoId && !isVisitor) {
+    if (trustedCurrentTime >= viewThreshold && !hasViewed && videoId && !isVisitor) {
       setHasViewed(true);
       const lastPlayedAt = Date.now();
       api
@@ -283,7 +349,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     const now = Date.now();
     if (now - lastProgressSave.current > PROGRESS_SAVE_INTERVAL_MS && videoId && !isVisitor) {
       lastProgressSave.current = now;
-      saveProgress(currentTime);
+      saveProgress(trustedCurrentTime);
     }
   };
 

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -1,5 +1,5 @@
 import { QueryClient, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "../contexts/AuthContext";
 import { Video } from "../types";
 import { api, sendVideoProgressWithKeepalive } from "../utils/apiClient";
@@ -8,7 +8,10 @@ import { parseDuration } from "../utils/formatUtils";
 interface UseVideoProgressProps {
   videoId: string | undefined;
   video: Video | undefined;
+  videoElement?: HTMLVideoElement | null;
 }
+
+const PROGRESS_SAVE_INTERVAL_MS = 5000;
 
 function getViewThreshold(duration: string | undefined): number {
   const durationSeconds = parseDuration(duration);
@@ -57,7 +60,7 @@ function syncVideoPlaybackCache(
 /**
  * Custom hook to manage video progress tracking and view counting
  */
-export function useVideoProgress({ videoId, video }: UseVideoProgressProps) {
+export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgressProps) {
   const { userRole } = useAuth();
   const isVisitor = userRole === "visitor";
   const queryClient = useQueryClient();
@@ -66,6 +69,7 @@ export function useVideoProgress({ videoId, video }: UseVideoProgressProps) {
   const currentTimeRef = useRef<number>(0);
   const isDeletingRef = useRef<boolean>(false);
   const durationRef = useRef<string | undefined>(undefined);
+  const videoElementRef = useRef<HTMLVideoElement | null>(null);
   const videoDuration = video?.duration;
 
   // Reset hasViewed when video changes
@@ -82,25 +86,112 @@ export function useVideoProgress({ videoId, video }: UseVideoProgressProps) {
     durationRef.current = videoDuration;
   }, [videoDuration]);
 
+  useEffect(() => {
+    videoElementRef.current = videoElement ?? null;
+  }, [videoElement]);
+
+  const samplePlaybackTime = useCallback(() => {
+    const mediaElement = videoElementRef.current;
+    const sampledTime = mediaElement?.currentTime;
+
+    if (typeof sampledTime !== "number" || !Number.isFinite(sampledTime)) {
+      return currentTimeRef.current;
+    }
+
+    if (sampledTime <= 0 && currentTimeRef.current > 0) {
+      return currentTimeRef.current;
+    }
+
+    currentTimeRef.current = Math.max(0, sampledTime);
+    return currentTimeRef.current;
+  }, []);
+
+  const saveProgress = useCallback((
+    playbackTime: number,
+    options: { keepalive?: boolean } = {}
+  ) => {
+    if (!videoId || isDeletingRef.current || isVisitor) {
+      return;
+    }
+
+    const progress = getResumeProgress(playbackTime, durationRef.current);
+
+    if (progress <= 0) {
+      return;
+    }
+
+    syncVideoPlaybackCache(queryClient, videoId, {
+      progress,
+    });
+
+    if (options.keepalive) {
+      sendVideoProgressWithKeepalive(videoId, progress);
+      return;
+    }
+
+    api
+      .put(`/videos/${videoId}/progress`, {
+        progress,
+      })
+      .catch((err) => {
+        console.error("Error saving progress:", err);
+      });
+  }, [isVisitor, queryClient, videoId]);
+
+  const flushSampledProgress = useCallback((options: { keepalive?: boolean } = {}) => {
+    const playbackTime = samplePlaybackTime();
+    saveProgress(playbackTime, options);
+  }, [samplePlaybackTime, saveProgress]);
+
+  useEffect(() => {
+    if (!videoId || isVisitor || !videoElement) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      const now = Date.now();
+      if (now - lastProgressSave.current <= PROGRESS_SAVE_INTERVAL_MS) {
+        return;
+      }
+
+      lastProgressSave.current = now;
+      flushSampledProgress();
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [flushSampledProgress, isVisitor, videoElement, videoId]);
+
+  // Save progress when the page is hidden or discarded. Safari can defer
+  // timeupdate events for very large WebM files, so sample the media element.
+  useEffect(() => {
+    if (!videoId || isVisitor) {
+      return;
+    }
+
+    const flushWithKeepalive = () => {
+      flushSampledProgress({ keepalive: true });
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        flushWithKeepalive();
+      }
+    };
+
+    window.addEventListener("pagehide", flushWithKeepalive);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("pagehide", flushWithKeepalive);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [flushSampledProgress, isVisitor, videoId]);
+
   // Save progress on unmount
   useEffect(() => {
     return () => {
-      if (
-        videoId &&
-        currentTimeRef.current > 0 &&
-        !isDeletingRef.current &&
-        !isVisitor
-      ) {
-        const progress = getResumeProgress(currentTimeRef.current, durationRef.current);
-
-        syncVideoPlaybackCache(queryClient, videoId, {
-          progress,
-        });
-
-        sendVideoProgressWithKeepalive(videoId, progress);
-      }
+      flushSampledProgress({ keepalive: true });
     };
-  }, [queryClient, videoId, isVisitor]);
+  }, [flushSampledProgress]);
 
   const handleTimeUpdate = (currentTime: number) => {
     currentTimeRef.current = currentTime;
@@ -127,21 +218,9 @@ export function useVideoProgress({ videoId, video }: UseVideoProgressProps) {
 
     // Save progress every 5 seconds
     const now = Date.now();
-    if (now - lastProgressSave.current > 5000 && videoId && !isVisitor) {
+    if (now - lastProgressSave.current > PROGRESS_SAVE_INTERVAL_MS && videoId && !isVisitor) {
       lastProgressSave.current = now;
-      const progress = getResumeProgress(currentTime, videoDuration);
-
-      syncVideoPlaybackCache(queryClient, videoId, {
-        progress,
-      });
-
-      api
-        .put(`/videos/${videoId}/progress`, {
-          progress,
-        })
-        .catch((err) => {
-          console.error("Error saving progress:", err);
-        });
+      saveProgress(currentTime);
     }
   };
 

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -106,9 +106,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
 
     if (
       resumeProgress > 0 &&
-      (currentTimeRef.current <= 0 ||
-        currentTimeRef.current + RESTORE_GUARD_MIN_PROGRESS_SECONDS <
-          resumeProgress)
+      (currentTimeRef.current <= 0 || currentTimeRef.current < resumeProgress)
     ) {
       currentTimeRef.current = resumeProgress;
       resumeGuardTargetRef.current =

--- a/frontend/src/hooks/useVideoQueries.ts
+++ b/frontend/src/hooks/useVideoQueries.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { api } from '../utils/apiClient';
 import { Video } from '../types';
+import { buildAuthorAvatarPathMap, withCanonicalAuthorAvatar } from '../utils/authorAvatar';
 
 interface UseVideoQueriesProps {
     videoId: string | undefined;
@@ -12,12 +14,17 @@ interface UseVideoQueriesProps {
  * Custom hook to manage all video-related data fetching
  */
 export function useVideoQueries({ videoId, videos, showComments }: UseVideoQueriesProps) {
+    const avatarPathByKey = useMemo(
+        () => buildAuthorAvatarPathMap(videos),
+        [videos]
+    );
+
     // Fetch video details. The list row from VideoContext renders instantly as
     // placeholder, but the full row must still be fetched: the list endpoint
     // omits description/subtitles (heavy columns), so seeding it as
     // initialData would let the global staleTime suppress the fetch and leave
     // the player without them.
-    const { data: video, isLoading: loading, error } = useQuery({
+    const { data: rawVideo, isLoading: loading, error } = useQuery({
         queryKey: ['video', videoId],
         queryFn: async () => {
             const response = await api.get(`/videos/${videoId}`);
@@ -29,6 +36,10 @@ export function useVideoQueries({ videoId, videos, showComments }: UseVideoQueri
         enabled: !!videoId,
         retry: false
     });
+    const video = useMemo(
+        () => rawVideo ? withCanonicalAuthorAvatar(rawVideo, avatarPathByKey) : rawVideo,
+        [avatarPathByKey, rawVideo]
+    );
 
     // Fetch comments
     const { data: comments = [], isLoading: loadingComments } = useQuery({

--- a/frontend/src/hooks/useVideoResolution.ts
+++ b/frontend/src/hooks/useVideoResolution.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Video } from "../types";
 import { useCloudStorageUrl } from "./useCloudStorageUrl";
+import { isSafari } from "../utils/playerUtils";
 
 // Format video resolution from video object
 export const formatResolution = (video: Video): string | null => {
@@ -47,6 +48,15 @@ export const formatResolution = (video: Video): string | null => {
   return null;
 };
 
+const hasWebMExtension = (value: string | null | undefined): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  const withoutQuery = value.trim().split(/[?#]/, 1)[0]?.toLowerCase() ?? "";
+  return withoutQuery.endsWith(".webm");
+};
+
 export const useVideoResolution = (video: Video) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [detectedResolution, setDetectedResolution] = useState<string | null>(
@@ -56,9 +66,14 @@ export const useVideoResolution = (video: Video) => {
 
   // First check if resolution is already available in video object
   const resolutionFromObject = formatResolution(video);
+  const skipSafariWebMDetection =
+    isSafari() &&
+    (hasWebMExtension(video.videoPath) || hasWebMExtension(videoUrl));
 
-  // Only create video element if resolution is not available in video object
-  const needsDetection = !resolutionFromObject;
+  // Only create a probe video when resolution is unknown and probing will not
+  // compete with the main player. Safari's WebM loader is linear, so a hidden
+  // probe of a large WebM can interfere with the visible player's resume seek.
+  const needsDetection = !resolutionFromObject && !skipSafariWebMDetection;
 
   useEffect(() => {
     // Skip video element creation if resolution is already available

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -198,7 +198,7 @@ const VideoPlayer: React.FC = () => {
         onDeleteSuccess: () => navigate('/', { replace: true })
     });
 
-    const { handleTimeUpdate, setIsDeleting } = useVideoProgress({ videoId: id, video });
+    const { handleTimeUpdate, setIsDeleting } = useVideoProgress({ videoId: id, video, videoElement });
 
     const { relatedVideos } = useVideoRecommendations({
         video,

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -33,6 +33,7 @@ import { useVideoQueries } from '../hooks/useVideoQueries';
 import { useVideoRecommendations } from '../hooks/useVideoRecommendations';
 import { useVideoSubscriptions } from '../hooks/useVideoSubscriptions';
 import { getBackendUrl } from '../utils/apiUrl';
+import { getBestVideoResumeProgress } from '../utils/videoResumeProgress';
 
 const VideoPlayer: React.FC = () => {
     const { id } = useParams<{ id: string }>();
@@ -437,7 +438,9 @@ const VideoPlayer: React.FC = () => {
 
     // Determine start time based on saved progress only.
     // Playback-local time should not be fed back into startTime on unrelated rerenders.
-    const startTimeResult = playFromBeginning ? 0 : (video.progress ?? 0);
+    const startTimeResult = playFromBeginning
+        ? 0
+        : getBestVideoResumeProgress(id, video.progress, video.lastPlayedAt);
 
     return (
         <Container maxWidth={false} disableGutters sx={{ py: { xs: 2, md: 4 }, px: { xs: 0, md: 2 } }}>

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -440,7 +440,11 @@ const VideoPlayer: React.FC = () => {
     // Playback-local time should not be fed back into startTime on unrelated rerenders.
     const startTimeResult = playFromBeginning
         ? 0
-        : getBestVideoResumeProgress(id, video.progress, video.lastPlayedAt);
+        : getBestVideoResumeProgress(
+            id,
+            video.progress,
+            video.progressUpdatedAt ?? video.lastPlayedAt
+        );
 
     return (
         <Container maxWidth={false} disableGutters sx={{ py: { xs: 2, md: 4 }, px: { xs: 0, md: 2 } }}>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,48 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+const createMemoryStorage = (): Storage => {
+  let store: Record<string, string> = {};
+
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    key: vi.fn((index: number) => Object.keys(store)[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = String(value);
+    }),
+  };
+};
+
+try {
+  void window.localStorage;
+} catch {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: createMemoryStorage(),
+  });
+}
+
+if (!window.localStorage) {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: createMemoryStorage(),
+  });
+}
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: window.localStorage,
+});
+
 // Mock matchMedia for MUI
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,7 @@ export interface Video {
   tags?: string[];
   viewCount?: number;
   progress?: number;
+  progressUpdatedAt?: number;
   duration?: string;
   fileSize?: string; // Size in bytes as string
   lastPlayedAt?: number;

--- a/frontend/src/utils/__tests__/apiClient.test.ts
+++ b/frontend/src/utils/__tests__/apiClient.test.ts
@@ -204,14 +204,14 @@ describe("api wrappers", () => {
     expect(sendVideoProgressWithKeepalive("video/with slash", 42)).toBe(true);
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    const [request] = fetchSpy.mock.calls[0] as [Request];
-    expect(request).toBeInstanceOf(Request);
-    expect(new URL(request.url).pathname).toBe("/api/videos/progress");
-    expect(request.method).toBe("PUT");
-    expect(request.credentials).toBe("include");
-    expect(request.keepalive).toBe(true);
-    expect(request.headers.get("X-CSRF-Token")).toBe("csrf-progress-123");
-    await expect(request.json()).resolves.toEqual({
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = new Headers(init.headers);
+    expect(new URL(url).pathname).toBe("/api/videos/progress");
+    expect(init.method).toBe("POST");
+    expect(init.credentials).toBe("include");
+    expect(init.keepalive).toBe(true);
+    expect(headers.get("X-CSRF-Token")).toBe("csrf-progress-123");
+    expect(JSON.parse(String(init.body))).toEqual({
       videoId: "video/with slash",
       progress: 42,
     });

--- a/frontend/src/utils/__tests__/authorAvatar.test.ts
+++ b/frontend/src/utils/__tests__/authorAvatar.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { Video } from "../../types";
+import {
+  buildAuthorAvatarPathMap,
+  withCanonicalAuthorAvatar,
+  withCanonicalAuthorAvatars,
+} from "../authorAvatar";
+
+const createVideo = (overrides: Partial<Video>): Video =>
+  ({
+    id: "base",
+    title: "Video",
+    author: "Author",
+    date: "20260101",
+    source: "youtube",
+    sourceUrl: "https://example.com/watch",
+    addedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }) as Video;
+
+describe("authorAvatar", () => {
+  it("shares the first available avatar across same-source author rows", () => {
+    const videos = [
+      createVideo({ id: "missing", author: "王志安" }),
+      createVideo({
+        id: "avatar",
+        author: " 王志安 ",
+        authorAvatarPath: "/avatars/youtube-wang.jpg",
+      }),
+    ];
+
+    expect(withCanonicalAuthorAvatars(videos)).toEqual([
+      expect.objectContaining({
+        id: "missing",
+        authorAvatarPath: "/avatars/youtube-wang.jpg",
+        authorAvatarFilename: "youtube-wang.jpg",
+      }),
+      expect.objectContaining({
+        id: "avatar",
+        authorAvatarPath: "/avatars/youtube-wang.jpg",
+      }),
+    ]);
+  });
+
+  it("does not share avatars across different sources with the same author name", () => {
+    const videos = [
+      createVideo({
+        id: "youtube",
+        author: "Same Name",
+        source: "youtube",
+        authorAvatarPath: "/avatars/youtube-same.jpg",
+      }),
+      createVideo({
+        id: "bilibili",
+        author: "Same Name",
+        source: "bilibili",
+      }),
+    ];
+
+    expect(withCanonicalAuthorAvatars(videos)[1]).not.toHaveProperty(
+      "authorAvatarPath"
+    );
+  });
+
+  it("normalizes a fetched detail row using the list avatar map", () => {
+    const listVideos = [
+      createVideo({
+        id: "list",
+        author: "Author",
+        channelUrl: "https://www.youtube.com/channel/abc/",
+        authorAvatarPath: "/avatars/channel-avatar.jpg",
+      }),
+    ];
+    const detailVideo = createVideo({
+      id: "detail",
+      author: "Author",
+      channelUrl: "https://www.youtube.com/channel/abc?view=videos",
+    });
+
+    const avatarPathByKey = buildAuthorAvatarPathMap(listVideos);
+
+    expect(withCanonicalAuthorAvatar(detailVideo, avatarPathByKey)).toEqual(
+      expect.objectContaining({
+        authorAvatarPath: "/avatars/channel-avatar.jpg",
+        authorAvatarFilename: "channel-avatar.jpg",
+      })
+    );
+  });
+});

--- a/frontend/src/utils/__tests__/authorAvatar.test.ts
+++ b/frontend/src/utils/__tests__/authorAvatar.test.ts
@@ -86,4 +86,24 @@ describe("authorAvatar", () => {
       })
     );
   });
+
+  it("does not fall back to author-name avatars for a different channel URL", () => {
+    const videos = [
+      createVideo({
+        id: "channel-with-avatar",
+        author: "Same Name",
+        channelUrl: "https://www.youtube.com/channel/one",
+        authorAvatarPath: "/avatars/channel-one.jpg",
+      }),
+      createVideo({
+        id: "different-channel",
+        author: "Same Name",
+        channelUrl: "https://www.youtube.com/channel/two",
+      }),
+    ];
+
+    expect(withCanonicalAuthorAvatars(videos)[1]).not.toHaveProperty(
+      "authorAvatarPath"
+    );
+  });
 });

--- a/frontend/src/utils/__tests__/videoResumeProgress.test.ts
+++ b/frontend/src/utils/__tests__/videoResumeProgress.test.ts
@@ -36,6 +36,15 @@ describe("videoResumeProgress", () => {
     expect(getBestVideoResumeProgress("video-3", 20, 100_000)).toBe(20);
   });
 
+  it("falls back to a fresher lower server progress save", () => {
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+    writeVideoResumeProgress("video-progress-save", 120);
+
+    expect(
+      getBestVideoResumeProgress("video-progress-save", 5, 100_000)
+    ).toBe(5);
+  });
+
   it("does not let a fresh low local value override a much later server resume point", () => {
     vi.spyOn(Date, "now").mockReturnValue(10_000);
     writeVideoResumeProgress("video-4", 5);

--- a/frontend/src/utils/__tests__/videoResumeProgress.test.ts
+++ b/frontend/src/utils/__tests__/videoResumeProgress.test.ts
@@ -35,4 +35,11 @@ describe("videoResumeProgress", () => {
 
     expect(getBestVideoResumeProgress("video-3", 20, 100_000)).toBe(20);
   });
+
+  it("does not let a fresh low local value override a much later server resume point", () => {
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+    writeVideoResumeProgress("video-4", 5);
+
+    expect(getBestVideoResumeProgress("video-4", 826, 9_000)).toBe(826);
+  });
 });

--- a/frontend/src/utils/__tests__/videoResumeProgress.test.ts
+++ b/frontend/src/utils/__tests__/videoResumeProgress.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getBestVideoResumeProgress,
+  readVideoResumeProgress,
+  writeVideoResumeProgress,
+} from "../videoResumeProgress";
+
+describe("videoResumeProgress", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("stores and reads a floored positive resume point", () => {
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+
+    writeVideoResumeProgress("video-1", 42.9);
+
+    expect(readVideoResumeProgress("video-1")).toEqual({
+      progress: 42,
+      updatedAt: 1000,
+    });
+  });
+
+  it("prefers fresh local progress over stale server progress", () => {
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+    writeVideoResumeProgress("video-2", 120);
+
+    expect(getBestVideoResumeProgress("video-2", 0, 9_000)).toBe(120);
+  });
+
+  it("falls back to server progress when local progress is older than the last play", () => {
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+    writeVideoResumeProgress("video-3", 120);
+
+    expect(getBestVideoResumeProgress("video-3", 20, 100_000)).toBe(20);
+  });
+});

--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -216,14 +216,13 @@ export const sendVideoProgressWithKeepalive = (
     });
     // Fixed internal endpoint; videoId stays in the JSON payload.
     // nosemgrep
-    const request = new Request(buildVideoProgressRequestUrl(), {
-      method: "PUT",
+    void fetch(buildVideoProgressRequestUrl(), {
+      method: "POST",
       credentials: "include",
       keepalive: true,
       headers,
       body: JSON.stringify({ videoId, progress }),
     });
-    void fetch(request);
     return true;
   } catch {
     return false;

--- a/frontend/src/utils/authorAvatar.ts
+++ b/frontend/src/utils/authorAvatar.ts
@@ -22,6 +22,10 @@ const getSourceKey = (video: Video): string =>
   typeof video.source === "string" ? video.source.toLocaleLowerCase() : "";
 
 const getAuthorFallbackKey = (video: Video): string => {
+  if (normalizeChannelUrl(video.channelUrl)) {
+    return "";
+  }
+
   const author = normalizeAuthorName(video.author);
   if (!author) {
     return "";

--- a/frontend/src/utils/authorAvatar.ts
+++ b/frontend/src/utils/authorAvatar.ts
@@ -1,0 +1,113 @@
+import { Video } from "../types";
+
+const normalizeAuthorName = (author: string | undefined): string =>
+  (author || "").trim().replace(/\s+/g, " ").toLocaleLowerCase();
+
+const normalizeChannelUrl = (channelUrl: unknown): string => {
+  if (typeof channelUrl !== "string" || channelUrl.trim() === "") {
+    return "";
+  }
+
+  try {
+    const url = new URL(channelUrl.trim());
+    url.hash = "";
+    url.search = "";
+    return `${url.hostname.toLocaleLowerCase()}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return channelUrl.trim().replace(/\/+$/, "").toLocaleLowerCase();
+  }
+};
+
+const getSourceKey = (video: Video): string =>
+  typeof video.source === "string" ? video.source.toLocaleLowerCase() : "";
+
+const getAuthorFallbackKey = (video: Video): string => {
+  const author = normalizeAuthorName(video.author);
+  if (!author) {
+    return "";
+  }
+
+  return `${getSourceKey(video)}:author:${author}`;
+};
+
+const getAuthorPrimaryKey = (video: Video): string => {
+  const channelUrl = normalizeChannelUrl(video.channelUrl);
+  if (channelUrl) {
+    return `${getSourceKey(video)}:channel:${channelUrl}`;
+  }
+
+  return getAuthorFallbackKey(video);
+};
+
+const getAuthorAvatarFilename = (avatarPath: string): string | undefined => {
+  const pathWithoutQuery = avatarPath.split(/[?#]/, 1)[0];
+  const filename = pathWithoutQuery.split("/").filter(Boolean).pop();
+  return filename || undefined;
+};
+
+export function buildAuthorAvatarPathMap(videos: Video[]): Map<string, string> {
+  const avatarPathByKey = new Map<string, string>();
+
+  for (const video of videos) {
+    if (!video.authorAvatarPath) {
+      continue;
+    }
+
+    const primaryKey = getAuthorPrimaryKey(video);
+    const fallbackKey = getAuthorFallbackKey(video);
+
+    if (primaryKey && !avatarPathByKey.has(primaryKey)) {
+      avatarPathByKey.set(primaryKey, video.authorAvatarPath);
+    }
+    if (fallbackKey && !avatarPathByKey.has(fallbackKey)) {
+      avatarPathByKey.set(fallbackKey, video.authorAvatarPath);
+    }
+  }
+
+  return avatarPathByKey;
+}
+
+export function getCanonicalAuthorAvatarPath(
+  video: Video,
+  avatarPathByKey: Map<string, string>
+): string | undefined {
+  const primaryKey = getAuthorPrimaryKey(video);
+  const fallbackKey = getAuthorFallbackKey(video);
+
+  return (
+    (primaryKey ? avatarPathByKey.get(primaryKey) : undefined) ||
+    (fallbackKey ? avatarPathByKey.get(fallbackKey) : undefined) ||
+    video.authorAvatarPath
+  );
+}
+
+export function withCanonicalAuthorAvatar(
+  video: Video,
+  avatarPathByKey: Map<string, string>
+): Video {
+  const canonicalAvatarPath = getCanonicalAuthorAvatarPath(video, avatarPathByKey);
+
+  if (!canonicalAvatarPath || canonicalAvatarPath === video.authorAvatarPath) {
+    return video;
+  }
+
+  return {
+    ...video,
+    authorAvatarPath: canonicalAvatarPath,
+    authorAvatarFilename:
+      getAuthorAvatarFilename(canonicalAvatarPath) || video.authorAvatarFilename,
+  };
+}
+
+export function withCanonicalAuthorAvatars(videos: Video[]): Video[] {
+  const avatarPathByKey = buildAuthorAvatarPathMap(videos);
+  let changed = false;
+
+  const normalizedVideos = videos.map((video) => {
+    const normalizedVideo = withCanonicalAuthorAvatar(video, avatarPathByKey);
+    changed = changed || normalizedVideo !== video;
+    return normalizedVideo;
+  });
+
+  return changed ? normalizedVideos : videos;
+}

--- a/frontend/src/utils/videoResumeProgress.ts
+++ b/frontend/src/utils/videoResumeProgress.ts
@@ -1,6 +1,7 @@
 const VIDEO_RESUME_PROGRESS_PREFIX = "mytube:video-resume-progress:";
 const LOCAL_PROGRESS_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const LOCAL_PROGRESS_FRESHNESS_SLOP_MS = 60 * 1000;
+const LOCAL_PROGRESS_REGRESSION_GUARD_SECONDS = 30;
 
 interface StoredVideoResumeProgress {
   progress: number;
@@ -112,6 +113,14 @@ export function getBestVideoResumeProgress(
   const stored = readVideoResumeProgress(videoId);
 
   if (!stored || !isStoredProgressFresh(stored, lastPlayedAt)) {
+    return normalizedServerProgress;
+  }
+
+  if (
+    normalizedServerProgress > LOCAL_PROGRESS_REGRESSION_GUARD_SECONDS &&
+    stored.progress + LOCAL_PROGRESS_REGRESSION_GUARD_SECONDS <
+      normalizedServerProgress
+  ) {
     return normalizedServerProgress;
   }
 

--- a/frontend/src/utils/videoResumeProgress.ts
+++ b/frontend/src/utils/videoResumeProgress.ts
@@ -21,18 +21,21 @@ const getKey = (videoId: string): string =>
 
 const isStoredProgressFresh = (
   stored: StoredVideoResumeProgress,
-  lastPlayedAt?: number | null
+  serverProgressUpdatedAt?: number | null
 ): boolean => {
   const now = Date.now();
   if (now - stored.updatedAt > LOCAL_PROGRESS_MAX_AGE_MS) {
     return false;
   }
 
-  if (!lastPlayedAt || !Number.isFinite(lastPlayedAt)) {
+  if (!serverProgressUpdatedAt || !Number.isFinite(serverProgressUpdatedAt)) {
     return true;
   }
 
-  return stored.updatedAt + LOCAL_PROGRESS_FRESHNESS_SLOP_MS >= lastPlayedAt;
+  return (
+    stored.updatedAt + LOCAL_PROGRESS_FRESHNESS_SLOP_MS >=
+    serverProgressUpdatedAt
+  );
 };
 
 export function readVideoResumeProgress(
@@ -104,7 +107,7 @@ export function writeVideoResumeProgress(
 export function getBestVideoResumeProgress(
   videoId: string | undefined,
   serverProgress: number | null | undefined,
-  lastPlayedAt?: number | null
+  serverProgressUpdatedAt?: number | null
 ): number {
   const normalizedServerProgress =
     typeof serverProgress === "number" && Number.isFinite(serverProgress)
@@ -112,7 +115,7 @@ export function getBestVideoResumeProgress(
       : 0;
   const stored = readVideoResumeProgress(videoId);
 
-  if (!stored || !isStoredProgressFresh(stored, lastPlayedAt)) {
+  if (!stored || !isStoredProgressFresh(stored, serverProgressUpdatedAt)) {
     return normalizedServerProgress;
   }
 

--- a/frontend/src/utils/videoResumeProgress.ts
+++ b/frontend/src/utils/videoResumeProgress.ts
@@ -1,0 +1,119 @@
+const VIDEO_RESUME_PROGRESS_PREFIX = "mytube:video-resume-progress:";
+const LOCAL_PROGRESS_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const LOCAL_PROGRESS_FRESHNESS_SLOP_MS = 60 * 1000;
+
+interface StoredVideoResumeProgress {
+  progress: number;
+  updatedAt: number;
+}
+
+const getStorage = (): Storage | null => {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+};
+
+const getKey = (videoId: string): string =>
+  `${VIDEO_RESUME_PROGRESS_PREFIX}${videoId}`;
+
+const isStoredProgressFresh = (
+  stored: StoredVideoResumeProgress,
+  lastPlayedAt?: number | null
+): boolean => {
+  const now = Date.now();
+  if (now - stored.updatedAt > LOCAL_PROGRESS_MAX_AGE_MS) {
+    return false;
+  }
+
+  if (!lastPlayedAt || !Number.isFinite(lastPlayedAt)) {
+    return true;
+  }
+
+  return stored.updatedAt + LOCAL_PROGRESS_FRESHNESS_SLOP_MS >= lastPlayedAt;
+};
+
+export function readVideoResumeProgress(
+  videoId: string | undefined
+): StoredVideoResumeProgress | null {
+  if (!videoId) {
+    return null;
+  }
+
+  const storage = getStorage();
+  if (!storage) {
+    return null;
+  }
+
+  try {
+    const rawValue = storage.getItem(getKey(videoId));
+    if (!rawValue) {
+      return null;
+    }
+
+    const parsed = JSON.parse(rawValue) as Partial<StoredVideoResumeProgress>;
+    const progress =
+      typeof parsed.progress === "number" && Number.isFinite(parsed.progress)
+        ? Math.max(0, Math.floor(parsed.progress))
+        : 0;
+    const updatedAt =
+      typeof parsed.updatedAt === "number" && Number.isFinite(parsed.updatedAt)
+        ? parsed.updatedAt
+        : 0;
+
+    if (progress <= 0 || updatedAt <= 0) {
+      storage.removeItem(getKey(videoId));
+      return null;
+    }
+
+    return { progress, updatedAt };
+  } catch {
+    storage.removeItem(getKey(videoId));
+    return null;
+  }
+}
+
+export function writeVideoResumeProgress(
+  videoId: string | undefined,
+  progress: number
+): void {
+  if (!videoId || !Number.isFinite(progress) || progress <= 0) {
+    return;
+  }
+
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      getKey(videoId),
+      JSON.stringify({
+        progress: Math.floor(progress),
+        updatedAt: Date.now(),
+      } satisfies StoredVideoResumeProgress)
+    );
+  } catch {
+    // localStorage can be unavailable or full; backend progress remains primary.
+  }
+}
+
+export function getBestVideoResumeProgress(
+  videoId: string | undefined,
+  serverProgress: number | null | undefined,
+  lastPlayedAt?: number | null
+): number {
+  const normalizedServerProgress =
+    typeof serverProgress === "number" && Number.isFinite(serverProgress)
+      ? Math.max(0, Math.floor(serverProgress))
+      : 0;
+  const stored = readVideoResumeProgress(videoId);
+
+  if (!stored || !isStoredProgressFresh(stored, lastPlayedAt)) {
+    return normalizedServerProgress;
+  }
+
+  return stored.progress;
+}


### PR DESCRIPTION
## Summary

Fixes two playback/library regressions:

- Samples the actual `<video>` element and flushes progress on interval, `pagehide`, tab hiding, and unmount so large WebM/Safari playback is not dependent on timely `timeupdate` events.
- Normalizes author avatar display by stable source/channel-or-author keys so rows for the same author reuse the same available avatar path in list and detail views.

## Root Cause

Playback progress was only updated from `timeupdate`/seek events plus an unmount ref. Large 4K WebM playback can defer or skip useful `timeupdate` events before route navigation, leaving the unmount save with a stale `0` value.

Video cards rendered each row's `authorAvatarPath` directly. When one row for an author had an avatar and another row had a missing path or slightly different author formatting, the UI showed mixed avatars/fallback initials for the same author.

## Validation

- `npm test -- src/hooks/__tests__/useVideoProgress.test.tsx`
- `npm test -- src/utils/__tests__/authorAvatar.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Browser smoke test: `http://localhost:5556/video/1783194324634` mounts the video at saved progress `820s` with no new console errors after fresh load.