### PR TITLE
Polish favorites and responsive headers

### DIFF
--- a/backend/drizzle/0023_striped_ender_wiggin.sql
+++ b/backend/drizzle/0023_striped_ender_wiggin.sql
@@ -1,5 +1,5 @@
 /* tsqllint-disable */
-CREATE TABLE `favorite_collections` (
+CREATE TABLE IF NOT EXISTS `favorite_collections` (
 	`user_id` text NOT NULL,
 	`collection_id` text NOT NULL,
 	`created_at` integer NOT NULL,
@@ -7,9 +7,9 @@ CREATE TABLE `favorite_collections` (
 	FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE INDEX `idx_favorite_collections_user` ON `favorite_collections` (`user_id`);
+CREATE INDEX IF NOT EXISTS `idx_favorite_collections_user` ON `favorite_collections` (`user_id`);
 --> statement-breakpoint
-CREATE TABLE `favorite_authors` (
+CREATE TABLE IF NOT EXISTS `favorite_authors` (
 	`user_id` text NOT NULL,
 	`author` text NOT NULL,
 	`display_name` text,
@@ -19,6 +19,6 @@ CREATE TABLE `favorite_authors` (
 	PRIMARY KEY(`user_id`, `author`)
 );
 --> statement-breakpoint
-CREATE INDEX `idx_favorite_authors_user` ON `favorite_authors` (`user_id`);
+CREATE INDEX IF NOT EXISTS `idx_favorite_authors_user` ON `favorite_authors` (`user_id`);
 --> statement-breakpoint
-CREATE INDEX `idx_favorite_authors_author` ON `favorite_authors` (`author`);
+CREATE INDEX IF NOT EXISTS `idx_favorite_authors_author` ON `favorite_authors` (`author`);

--- a/backend/src/__tests__/db/favoriteMigration.test.ts
+++ b/backend/src/__tests__/db/favoriteMigration.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import os from "os";
+import path from "path";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { afterEach, describe, expect, it } from "vitest";
+
+const migrationSource = path.resolve(process.cwd(), "drizzle");
+const temporaryFolders: string[] = [];
+
+const createMigrationFolder = (): string => {
+  const folder = mkdtempSync(path.join(os.tmpdir(), "mytube-favorite-migration-"));
+  temporaryFolders.push(folder);
+  mkdirSync(path.join(folder, "meta"));
+
+  for (const tag of ["0021_audio_media_type", "0022_download_media_type", "0023_striped_ender_wiggin"]) {
+    writeFileSync(
+      path.join(folder, `${tag}.sql`),
+      readFileSync(path.join(migrationSource, `${tag}.sql`)),
+    );
+  }
+
+  writeFileSync(
+    path.join(folder, "meta", "_journal.json"),
+    JSON.stringify({
+      version: "7",
+      dialect: "sqlite",
+      entries: [
+        { idx: 0, version: "6", when: 1, tag: "0021_audio_media_type", breakpoints: true },
+        { idx: 1, version: "6", when: 2, tag: "0022_download_media_type", breakpoints: true },
+        { idx: 2, version: "6", when: 3, tag: "0023_striped_ender_wiggin", breakpoints: true },
+      ],
+    }),
+  );
+
+  return folder;
+};
+
+afterEach(() => {
+  temporaryFolders.splice(0).forEach((folder) => rmSync(folder, { recursive: true, force: true }));
+});
+
+describe("favorites migration", () => {
+  it("completes when the favorites self-heal has already created its tables", () => {
+    const sqlite = new Database(":memory:");
+    const db = drizzle(sqlite);
+
+    sqlite.exec(`
+      CREATE TABLE videos (id TEXT PRIMARY KEY);
+      CREATE TABLE collections (id TEXT PRIMARY KEY);
+      CREATE TABLE video_downloads (
+        source_video_id TEXT NOT NULL,
+        platform TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX video_downloads_source_video_id_platform_uidx
+        ON video_downloads (source_video_id, platform);
+      CREATE TABLE favorite_collections (
+        user_id TEXT NOT NULL,
+        collection_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (user_id, collection_id),
+        FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE
+      );
+      CREATE INDEX idx_favorite_collections_user ON favorite_collections (user_id);
+      CREATE TABLE favorite_authors (
+        user_id TEXT NOT NULL,
+        author TEXT NOT NULL,
+        display_name TEXT,
+        avatar_path TEXT,
+        channel_url TEXT,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (user_id, author)
+      );
+      CREATE INDEX idx_favorite_authors_user ON favorite_authors (user_id);
+      CREATE INDEX idx_favorite_authors_author ON favorite_authors (author);
+    `);
+
+    expect(() => migrate(db, { migrationsFolder: createMigrationFolder() })).not.toThrow();
+    expect(sqlite.prepare("PRAGMA table_info(videos)").all()).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "media_type" })]),
+    );
+    expect(sqlite.prepare("SELECT count(*) AS count FROM __drizzle_migrations").get()).toEqual({ count: 3 });
+
+    sqlite.close();
+  });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -148,7 +148,7 @@ function AppContent() {
                             )}
                         </Suspense>
 
-                        <Box component="main" sx={{ flexGrow: 1, p: 0, width: '100%', overflowX: 'hidden' }}>
+                        <Box component="main" sx={{ flexGrow: 1, p: 0, width: '100%', overflowX: 'clip' }}>
                             <Suspense fallback={
                                 <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
                                     <CircularProgress />

--- a/frontend/src/components/Header/SearchInput.tsx
+++ b/frontend/src/components/Header/SearchInput.tsx
@@ -235,13 +235,6 @@ const SearchInput: React.FC<SearchInputProps> = ({
                                         }),
                                     }}
                                 >
-                                    <Button
-                                        type="submit"
-                                        aria-label={t('download')}
-                                        sx={{ minWidth: 'auto', px: 2.5 }}
-                                    >
-                                        {isSubmitting ? <CircularProgress size={24} color="inherit" /> : <Search />}
-                                    </Button>
                                     {!isVisitor && showAudioDownloadButton && !isMissAVInput && (
                                         <Button
                                             type="button"
@@ -254,10 +247,24 @@ const SearchInput: React.FC<SearchInputProps> = ({
                                             <Audiotrack fontSize="small" />
                                         </Button>
                                     )}
+                                    <Button
+                                        type="submit"
+                                        aria-label={t('download')}
+                                        sx={{ minWidth: 'auto', px: 2.5 }}
+                                    >
+                                        {isSubmitting ? <CircularProgress size={24} color="inherit" /> : <Search />}
+                                    </Button>
                                 </ButtonGroup>
                             </InputAdornment>
                         ),
-                        sx: { pr: 0, borderRadius: 2 }
+                        sx: {
+                            pr: 0,
+                            borderRadius: 2,
+                            '& .MuiInputAdornment-positionEnd': {
+                                maxHeight: 'none',
+                                height: '100%',
+                            },
+                        }
                     }
                 }}
             />

--- a/frontend/src/components/HomeHeader.tsx
+++ b/frontend/src/components/HomeHeader.tsx
@@ -28,6 +28,14 @@ const getViewModeLabel = (
     }
 };
 
+// The active heading shares a row with five icon controls on mobile. The
+// shorter label keeps translated copy from wrapping into the controls while
+// the controls themselves still convey that this is the "all" view.
+const getMobileViewModeLabel = (
+    viewMode: ViewMode,
+    t: (key: TranslationKey) => string
+): string => viewMode === 'all-videos' ? t('videos') : getViewModeLabel(viewMode, t);
+
 interface HomeHeaderProps {
     viewMode: ViewMode;
     onViewModeChange: (mode: ViewMode) => void;
@@ -53,10 +61,16 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
 }) => {
     const { t } = useLanguage();
     const isFavorite = viewMode === 'favorite';
+    const viewModeLabel = getViewModeLabel(viewMode, t);
+    const mobileViewModeLabel = getMobileViewModeLabel(viewMode, t);
 
     return (
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3, px: { xs: 2, sm: 0 } }}>
-            <Typography variant="h5" fontWeight="bold" sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: { xs: 1, sm: 2 }, mb: 3, px: { xs: 2, sm: 0 } }}>
+            <Typography
+                variant="h5"
+                fontWeight="bold"
+                sx={{ display: 'flex', alignItems: 'center', gap: 2, flex: '1 1 auto', minWidth: 0 }}
+            >
                 <Button
                     onClick={onSidebarToggle}
                     variant="outlined"
@@ -82,36 +96,47 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
                         </IconButton>
                     </Tooltip>
                 )}
-                <Box component="span" sx={{ display: { xs: 'block', md: 'none' } }}>
-                    {getViewModeLabel(viewMode, t)}
+                <Box
+                    component="span"
+                    aria-label={viewModeLabel}
+                    title={viewModeLabel}
+                    sx={{
+                        display: { xs: 'block', md: 'none' },
+                        minWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                    }}
+                >
+                    {mobileViewModeLabel}
                 </Box>
             </Typography>
-            <Box sx={{ display: 'flex' }}>
+            <Box sx={{ display: 'flex', flexShrink: 0 }}>
                 <ToggleButtonGroup
                     value={viewMode}
                     exclusive
                     onChange={(_, newMode) => newMode && onViewModeChange(newMode)}
                     size="small"
                 >
-                    <ToggleButton value="all-videos" sx={{ px: { xs: 2, md: 2 } }}>
+                    <ToggleButton value="all-videos" aria-label={t('allVideos')} sx={{ width: { xs: 50, md: 'auto' }, minWidth: { xs: 50, md: 'auto' }, px: { xs: 1, md: 2 } }}>
                         <GridView fontSize="small" sx={{ mr: { xs: 0, md: 1 } }} />
                         <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }}>
                             {t('allVideos')}
                         </Box>
                     </ToggleButton>
-                    <ToggleButton value="collections" sx={{ px: { xs: 2, md: 2 } }}>
+                    <ToggleButton value="collections" aria-label={t('collections')} sx={{ width: { xs: 50, md: 'auto' }, minWidth: { xs: 50, md: 'auto' }, px: { xs: 1, md: 2 } }}>
                         <CollectionsIcon fontSize="small" sx={{ mr: { xs: 0, md: 1 } }} />
                         <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }}>
                             {t('collections')}
                         </Box>
                     </ToggleButton>
-                    <ToggleButton value="history" sx={{ px: { xs: 2, md: 2 } }}>
+                    <ToggleButton value="history" aria-label={t('history')} sx={{ width: { xs: 50, md: 'auto' }, minWidth: { xs: 50, md: 'auto' }, px: { xs: 1, md: 2 } }}>
                         <History fontSize="small" sx={{ mr: { xs: 0, md: 1 } }} />
                         <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }}>
                             {t('history')}
                         </Box>
                     </ToggleButton>
-                    <ToggleButton value="favorite" sx={{ px: { xs: 2, md: 2 } }}>
+                    <ToggleButton value="favorite" aria-label={t('favorite')} sx={{ width: { xs: 50, md: 'auto' }, minWidth: { xs: 50, md: 'auto' }, px: { xs: 1, md: 2 } }}>
                         <Star fontSize="small" sx={{ mr: { xs: 0, md: 1 } }} />
                         <Box component="span" sx={{ display: { xs: 'none', md: 'block' } }}>
                             {t('favorite')}

--- a/frontend/src/components/HomeSidebar.tsx
+++ b/frontend/src/components/HomeSidebar.tsx
@@ -39,8 +39,8 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
                     <Box sx={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
                         <Box sx={{
                             position: 'sticky',
-                            maxHeight: 'calc(100% - 80px)',
-                            minHeight: 'calc(100vh - 80px)',
+                            top: 0,
+                            maxHeight: 'calc(100vh - 80px)',
                             overflowY: 'auto',
                             '&::-webkit-scrollbar': {
                                 width: '6px',

--- a/frontend/src/components/__tests__/HomeHeader.test.tsx
+++ b/frontend/src/components/__tests__/HomeHeader.test.tsx
@@ -35,6 +35,13 @@ describe('HomeHeader', () => {
         expect(screen.getByText('favorite')).toBeInTheDocument();
     });
 
+    it('uses a compact mobile title while preserving the full view name', () => {
+        render(<HomeHeader {...defaultProps} />);
+
+        expect(screen.getByTitle('allVideos')).toHaveTextContent('videos');
+        expect(screen.getByRole('button', { name: 'allVideos' })).toBeInTheDocument();
+    });
+
     it('should call onViewModeChange when toggle button is clicked', () => {
         render(<HomeHeader {...defaultProps} />);
 

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -233,8 +233,8 @@ const CollectionPage: React.FC = () => {
                 />
 
                 <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-                        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: { xs: 'flex-start', md: 'center' }, mb: 3 }}>
+                        <Box sx={{ display: 'flex', alignItems: { xs: 'flex-start', md: 'center' }, flex: '1 1 auto', minWidth: 0 }}>
                             <Button
                                 onClick={() => setIsSidebarOpen(prev => !prev)}
                                 variant="outlined"
@@ -251,34 +251,47 @@ const CollectionPage: React.FC = () => {
                             >
                                 <ViewSidebar sx={{ transform: 'rotate(180deg)' }} />
                             </Button>
-                            <Avatar sx={{ width: 56, height: 56, bgcolor: 'secondary.main', mr: 2 }}>
+                            <Avatar
+                                sx={{
+                                    display: { xs: 'none', md: 'flex' },
+                                    width: 56,
+                                    height: 56,
+                                    bgcolor: 'secondary.main',
+                                    mr: 2,
+                                    flexShrink: 0,
+                                }}
+                            >
                                 <Folder fontSize="large" />
                             </Avatar>
-                            <Box>
-                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                                    <Typography variant="h4" component="h1" fontWeight="bold">
+                            <Box sx={{ minWidth: 0 }}>
+                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 0, md: 1 } }}>
+                                    <Typography
+                                        variant="h4"
+                                        component="h1"
+                                        fontWeight="bold"
+                                        sx={{
+                                            fontSize: { xs: '1.5rem', md: '2.125rem' },
+                                            lineHeight: { xs: 1.25, md: 1.235 },
+                                            overflowWrap: 'anywhere',
+                                            minWidth: 0,
+                                        }}
+                                    >
+                                        <Avatar
+                                            component="span"
+                                            aria-hidden
+                                            sx={{
+                                                display: { xs: 'inline-flex', md: 'none' },
+                                                width: 40,
+                                                height: 40,
+                                                mr: 1,
+                                                verticalAlign: 'middle',
+                                                bgcolor: 'secondary.main',
+                                            }}
+                                        >
+                                            <Folder sx={{ fontSize: 24 }} />
+                                        </Avatar>
                                         {collection.name}
                                     </Typography>
-                                    <Tooltip title={t('addTags')}>
-                                        <IconButton
-                                            color="primary"
-                                            onClick={() => setIsTagsModalOpen(true)}
-                                            aria-label="add tags to collection"
-                                        >
-                                            <LocalOffer />
-                                        </IconButton>
-                                    </Tooltip>
-                                    <FavoriteToggle
-                                        active={isFavoriteCollection(collection.id)}
-                                        onToggle={() => toggleFavoriteCollection(collection.id, {
-                                            name: collection.name,
-                                            title: collection.title,
-                                            videoCount: collectionVideos.length,
-                                        })}
-                                        label={t('favoriteCollection')}
-                                        activeLabel={t('unfavorite')}
-                                        disabled={isFavoriteToggling}
-                                    />
                                 </Box>
                                 <Typography variant="subtitle1" color="text.secondary">
                                     {collectionVideos.length === 0
@@ -290,15 +303,39 @@ const CollectionPage: React.FC = () => {
                             </Box>
                         </Box>
 
-                        {collectionVideos.length > 0 && (
-                            <SortControl
-                                sortOption={sortOption}
-                                sortAnchorEl={sortAnchorEl}
-                                onSortClick={handleSortClick}
-                                onSortClose={handleSortClose}
-                                sx={{ height: 38 }}
-                            />
-                        )}
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                                <Tooltip title={t('addTags')}>
+                                    <IconButton
+                                        color="primary"
+                                        onClick={() => setIsTagsModalOpen(true)}
+                                        aria-label="add tags to collection"
+                                    >
+                                        <LocalOffer />
+                                    </IconButton>
+                                </Tooltip>
+                                <FavoriteToggle
+                                    active={isFavoriteCollection(collection.id)}
+                                    onToggle={() => toggleFavoriteCollection(collection.id, {
+                                        name: collection.name,
+                                        title: collection.title,
+                                        videoCount: collectionVideos.length,
+                                    })}
+                                    label={t('favoriteCollection')}
+                                    activeLabel={t('unfavorite')}
+                                    disabled={isFavoriteToggling}
+                                />
+                            </Box>
+                            {collectionVideos.length > 0 && (
+                                <SortControl
+                                    sortOption={sortOption}
+                                    sortAnchorEl={sortAnchorEl}
+                                    onSortClick={handleSortClick}
+                                    onSortClose={handleSortClose}
+                                    sx={{ height: 38 }}
+                                />
+                            )}
+                        </Box>
                     </Box>
 
                     {collectionVideos.length === 0 ? (

--- a/frontend/src/pages/FavoritePage.tsx
+++ b/frontend/src/pages/FavoritePage.tsx
@@ -91,7 +91,6 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
                                 favorites={favoriteCollectionItems}
                                 videos={videos}
                                 loading={favoriteCollections.isLoading}
-                                onUnfavorite={(favorite) => favoriteCollections.toggle(favorite.collectionId)}
                             />
                         </Box>
                     </Fade>
@@ -100,7 +99,6 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
                             <FavoriteAuthorRail
                                 favorites={favoriteAuthorItems}
                                 loading={favoriteAuthors.isLoading}
-                                onUnfavorite={(favorite) => favoriteAuthors.toggle({ author: favorite.author })}
                             />
                         </Box>
                     </Fade>

--- a/frontend/src/pages/FavoritePage.tsx
+++ b/frontend/src/pages/FavoritePage.tsx
@@ -99,6 +99,7 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
                             <FavoriteAuthorRail
                                 favorites={favoriteAuthorItems}
                                 loading={favoriteAuthors.isLoading}
+                                onUnfavorite={(favorite) => favoriteAuthors.toggle({ author: favorite.author })}
                             />
                         </Box>
                     </Fade>

--- a/frontend/src/pages/authorVideos/AuthorVideosHeader.tsx
+++ b/frontend/src/pages/authorVideos/AuthorVideosHeader.tsx
@@ -57,8 +57,8 @@ const AuthorVideosHeader: React.FC<AuthorVideosHeaderProps> = ({
     const displayName = authorDisplayName || unknownAuthorLabel;
 
     return (
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: { xs: 'flex-start', md: 'center' }, mb: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: { xs: 'flex-start', md: 'center' }, flex: '1 1 auto', minWidth: 0 }}>
                 <Button
                     onClick={onToggleSidebar}
                     variant="outlined"
@@ -78,57 +78,50 @@ const AuthorVideosHeader: React.FC<AuthorVideosHeaderProps> = ({
 
                 <Avatar
                     src={avatarUrl || undefined}
-                    sx={{ width: 56, height: 56, bgcolor: 'primary.main', mr: 2, fontSize: '1.5rem' }}
+                    sx={{
+                        display: { xs: 'none', md: 'flex' },
+                        width: 56,
+                        height: 56,
+                        bgcolor: 'primary.main',
+                        mr: 2,
+                        fontSize: '1.5rem',
+                        flexShrink: 0,
+                    }}
                 >
                     {initial}
                 </Avatar>
 
-                <Box>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-                        <Typography variant="h4" component="h1" fontWeight="bold">
+                <Box sx={{ minWidth: 0 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: { xs: 0, md: 2 } }}>
+                        <Typography
+                            variant="h4"
+                            component="h1"
+                            fontWeight="bold"
+                            sx={{
+                                fontSize: { xs: '1.5rem', md: '2.125rem' },
+                                lineHeight: { xs: 1.25, md: 1.235 },
+                                overflowWrap: 'anywhere',
+                                minWidth: 0,
+                            }}
+                        >
+                            <Avatar
+                                component="span"
+                                src={avatarUrl || undefined}
+                                aria-hidden
+                                sx={{
+                                    display: { xs: 'inline-flex', md: 'none' },
+                                    width: 40,
+                                    height: 40,
+                                    mr: 1,
+                                    verticalAlign: 'middle',
+                                    bgcolor: 'primary.main',
+                                    fontSize: '1.1rem',
+                                }}
+                            >
+                                {initial}
+                            </Avatar>
                             {displayName}
                         </Typography>
-                        <Tooltip title={addTagsLabel}>
-                            <IconButton
-                                color="primary"
-                                onClick={onOpenTagsModal}
-                                disabled={isBusy}
-                                aria-label="add tags to author"
-                            >
-                                <LocalOffer />
-                            </IconButton>
-                        </Tooltip>
-                        <FavoriteToggle
-                            active={isFavorite}
-                            onToggle={onToggleFavorite}
-                            label={favoriteLabel}
-                            activeLabel={unfavoriteLabel}
-                            disabled={favoriteDisabled}
-                        />
-                        {hasVideos && (
-                            <>
-                                <Tooltip title={createCollectionTooltip}>
-                                    <IconButton
-                                        color="primary"
-                                        onClick={onOpenCreateCollectionModal}
-                                        disabled={isBusy}
-                                        aria-label="create collection from author"
-                                    >
-                                        <CreateNewFolder />
-                                    </IconButton>
-                                </Tooltip>
-                                <Tooltip title={deleteAuthorLabel}>
-                                    <IconButton
-                                        color="error"
-                                        onClick={onOpenDeleteModal}
-                                        disabled={isBusy}
-                                        aria-label="delete author"
-                                    >
-                                        <Delete />
-                                    </IconButton>
-                                </Tooltip>
-                            </>
-                        )}
                     </Box>
 
                     <Typography variant="subtitle1" color="text.secondary">
@@ -137,15 +130,60 @@ const AuthorVideosHeader: React.FC<AuthorVideosHeaderProps> = ({
                 </Box>
             </Box>
 
-            {hasVideos && (
-                <SortControl
-                    sortOption={sortOption}
-                    sortAnchorEl={sortAnchorEl}
-                    onSortClick={onSortClick}
-                    onSortClose={onSortClose}
-                    sx={{ height: 38 }}
-                />
-            )}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexShrink: 0 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+                    <Tooltip title={addTagsLabel}>
+                        <IconButton
+                            color="primary"
+                            onClick={onOpenTagsModal}
+                            disabled={isBusy}
+                            aria-label="add tags to author"
+                        >
+                            <LocalOffer />
+                        </IconButton>
+                    </Tooltip>
+                    <FavoriteToggle
+                        active={isFavorite}
+                        onToggle={onToggleFavorite}
+                        label={favoriteLabel}
+                        activeLabel={unfavoriteLabel}
+                        disabled={favoriteDisabled}
+                    />
+                    {hasVideos && (
+                        <>
+                            <Tooltip title={createCollectionTooltip}>
+                                <IconButton
+                                    color="primary"
+                                    onClick={onOpenCreateCollectionModal}
+                                    disabled={isBusy}
+                                    aria-label="create collection from author"
+                                >
+                                    <CreateNewFolder />
+                                </IconButton>
+                            </Tooltip>
+                            <Tooltip title={deleteAuthorLabel}>
+                                <IconButton
+                                    color="error"
+                                    onClick={onOpenDeleteModal}
+                                    disabled={isBusy}
+                                    aria-label="delete author"
+                                >
+                                    <Delete />
+                                </IconButton>
+                            </Tooltip>
+                        </>
+                    )}
+                </Box>
+                {hasVideos && (
+                    <SortControl
+                        sortOption={sortOption}
+                        sortAnchorEl={sortAnchorEl}
+                        onSortClick={onSortClick}
+                        onSortClose={onSortClose}
+                        sx={{ height: 38 }}
+                    />
+                )}
+            </Box>
         </Box>
     );
 };

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -5,17 +5,20 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { brand } from '../../theme/colors';
 import type { FavoriteAuthorItem } from '../../types';
+import FavoriteToggle from '../../components/FavoriteToggle';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
 import FavoriteSectionHeader from './FavoriteSectionHeader';
 
 interface FavoriteAuthorRailProps {
     favorites: FavoriteAuthorItem[];
     loading?: boolean;
+    onUnfavorite: (favorite: FavoriteAuthorItem) => void;
 }
 
 const FavoriteAuthorCard: React.FC<{
     favorite: FavoriteAuthorItem;
-}> = ({ favorite }) => {
+    onUnfavorite: () => void;
+}> = ({ favorite, onUnfavorite }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const avatarUrl = useCloudStorageUrl(
@@ -86,11 +89,22 @@ const FavoriteAuthorCard: React.FC<{
                     </Typography>
                 )}
             </CardActionArea>
+            {/* Overlay remove control so favorites (including unavailable
+                authors whose card is disabled) can be removed from the rail. */}
+            <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
+                <FavoriteToggle
+                    active
+                    onToggle={onUnfavorite}
+                    label={t('favoriteAuthor')}
+                    activeLabel={t('unfavorite')}
+                    color="warning"
+                />
+            </Box>
         </Card>
     );
 };
 
-const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false }) => {
+const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false, onUnfavorite }) => {
     const { t } = useLanguage();
 
     if (!loading && favorites.length === 0) return null;
@@ -111,6 +125,7 @@ const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, load
                         <FavoriteAuthorCard
                             key={favorite.author}
                             favorite={favorite}
+                            onUnfavorite={() => onUnfavorite(favorite)}
                         />
                     ))}
             </FavoriteRailCarousel>

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -1,7 +1,6 @@
 import { Person, WarningAmber } from '@mui/icons-material';
 import { Avatar, Box, Card, CardActionArea, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import FavoriteToggle from '../../components/FavoriteToggle';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { brand } from '../../theme/colors';
@@ -12,13 +11,11 @@ import FavoriteSectionHeader from './FavoriteSectionHeader';
 interface FavoriteAuthorRailProps {
     favorites: FavoriteAuthorItem[];
     loading?: boolean;
-    onUnfavorite: (favorite: FavoriteAuthorItem) => void;
 }
 
 const FavoriteAuthorCard: React.FC<{
     favorite: FavoriteAuthorItem;
-    onUnfavorite: () => void;
-}> = ({ favorite, onUnfavorite }) => {
+}> = ({ favorite }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const avatarUrl = useCloudStorageUrl(
@@ -89,20 +86,11 @@ const FavoriteAuthorCard: React.FC<{
                     </Typography>
                 )}
             </CardActionArea>
-            <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
-                <FavoriteToggle
-                    active
-                    onToggle={onUnfavorite}
-                    label={t('favoriteAuthor')}
-                    activeLabel={t('unfavorite')}
-                    color="warning"
-                />
-            </Box>
         </Card>
     );
 };
 
-const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false, onUnfavorite }) => {
+const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false }) => {
     const { t } = useLanguage();
 
     if (!loading && favorites.length === 0) return null;
@@ -123,7 +111,6 @@ const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, load
                         <FavoriteAuthorCard
                             key={favorite.author}
                             favorite={favorite}
-                            onUnfavorite={() => onUnfavorite(favorite)}
                         />
                     ))}
             </FavoriteRailCarousel>

--- a/frontend/src/pages/favorite/FavoriteCollectionRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteCollectionRail.tsx
@@ -1,7 +1,6 @@
 import { VideoLibrary } from '@mui/icons-material';
 import { Box, Card, CardActionArea, CardMedia, Chip, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import FavoriteToggle from '../../components/FavoriteToggle';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { neutral, overlay } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
@@ -13,7 +12,6 @@ interface FavoriteCollectionRailProps {
     favorites: FavoriteCollectionItem[];
     videos: Video[];
     loading?: boolean;
-    onUnfavorite: (favorite: FavoriteCollectionItem) => void;
 }
 
 /** Deterministic branded gradient so cover-less collections still look intentional. */
@@ -35,8 +33,7 @@ const gradientForName = (name: string): string => {
 const FavoriteCollectionCard: React.FC<{
     favorite: FavoriteCollectionItem;
     video?: Video;
-    onUnfavorite: () => void;
-}> = ({ favorite, video, onUnfavorite }) => {
+}> = ({ favorite, video }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const thumbnail = useFavoriteThumbnail(video);
@@ -141,15 +138,6 @@ const FavoriteCollectionCard: React.FC<{
                     </Box>
                 </Box>
             </CardActionArea>
-            <Box sx={{ position: 'absolute', top: 4, right: 4 }}>
-                <FavoriteToggle
-                    active
-                    onToggle={onUnfavorite}
-                    label={t('favoriteCollection')}
-                    activeLabel={t('unfavorite')}
-                    color="warning"
-                />
-            </Box>
         </Card>
     );
 };
@@ -158,7 +146,6 @@ const FavoriteCollectionRail: React.FC<FavoriteCollectionRailProps> = ({
     favorites,
     videos,
     loading = false,
-    onUnfavorite,
 }) => {
     const { t } = useLanguage();
 
@@ -181,7 +168,6 @@ const FavoriteCollectionRail: React.FC<FavoriteCollectionRailProps> = ({
                             key={favorite.collectionId}
                             favorite={favorite}
                             video={videos.find((video) => video.id === favorite.thumbnailVideoId)}
-                            onUnfavorite={() => onUnfavorite(favorite)}
                         />
                     ))}
             </FavoriteRailCarousel>

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -27,9 +27,10 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                 sx={{
                     position: 'relative',
                     overflow: 'hidden',
-                    // Keep the carousel from shifting surrounding content when
-                    // the featured title changes between one and two lines.
-                    height: { xs: 432, sm: 448, md: 'clamp(340px, 30vw, 440px)' },
+                    // Mobile keeps a fixed card height; desktop follows the
+                    // natural 16:9 media height so the card stays compact
+                    // without cropping the featured thumbnail.
+                    height: { xs: 432, sm: 448, md: 'auto' },
                     // Full-bleed edge-to-edge card on mobile; rounded on desktop.
                     borderRadius: { xs: 0, md: 2 },
                     bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'grey.100',
@@ -106,7 +107,12 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                             className="hero-img"
                             image={thumbnail}
                             alt={video.title}
-                            sx={{ width: '100%', aspectRatio: '16 / 9', objectFit: 'cover', display: 'block' }}
+                            sx={{
+                                width: '100%',
+                                aspectRatio: '16 / 9',
+                                objectFit: 'cover',
+                                display: 'block',
+                            }}
                         />
                         {video.duration && (
                             <Chip

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -27,10 +27,12 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                 sx={{
                     position: 'relative',
                     overflow: 'hidden',
-                    // Mobile keeps a fixed card height; desktop follows the
-                    // natural 16:9 media height so the card stays compact
-                    // without cropping the featured thumbnail.
-                    height: { xs: 432, sm: 448, md: 'auto' },
+                    // Compact floor on mobile that can still grow: below md the
+                    // layout stacks vertically with a full-width 16:9 thumbnail,
+                    // so a fixed height would clip the title/metadata/button at
+                    // tablet/landscape widths. minHeight keeps the card compact
+                    // while letting it expand to fit its content.
+                    minHeight: { xs: 432, sm: 448 },
                     // Full-bleed edge-to-edge card on mobile; rounded on desktop.
                     borderRadius: { xs: 0, md: 2 },
                     bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'background.paper',

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -27,6 +27,9 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                 sx={{
                     position: 'relative',
                     overflow: 'hidden',
+                    // Keep the carousel from shifting surrounding content when
+                    // the featured title changes between one and two lines.
+                    height: { xs: 432, sm: 448, md: 'clamp(340px, 30vw, 440px)' },
                     // Full-bleed edge-to-edge card on mobile; rounded on desktop.
                     borderRadius: { xs: 0, md: 2 },
                     bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'grey.100',
@@ -136,6 +139,9 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                             fontWeight={800}
                             sx={{
                                 lineHeight: 1.2,
+                                // Reserve both clamped title lines even when a
+                                // featured video has a shorter title.
+                                minHeight: '2.4em',
                                 display: '-webkit-box',
                                 overflow: 'hidden',
                                 WebkitBoxOrient: 'vertical',

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -33,7 +33,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                     height: { xs: 432, sm: 448, md: 'auto' },
                     // Full-bleed edge-to-edge card on mobile; rounded on desktop.
                     borderRadius: { xs: 0, md: 2 },
-                    bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'grey.100',
+                    bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'background.paper',
                     border: 'none',
                     transition: isReducedMotion ? 'none' : 'box-shadow 0.3s ease',
                     boxShadow: theme.palette.mode === 'dark'
@@ -51,7 +51,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                         backgroundSize: 'cover',
                         backgroundPosition: 'center',
                         filter: 'blur(28px)',
-                        opacity: 0.5,
+                        opacity: theme.palette.mode === 'dark' ? 0.5 : 0,
                         transform: 'scale(1.1)',
                     }}
                 />
@@ -60,11 +60,16 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                     sx={{
                         position: 'absolute',
                         inset: 0,
-                        // Vertical scrim on mobile (text sits below the image),
-                        // horizontal on desktop (text sits beside it).
+                        // Dark mode keeps the cinematic thumbnail wash. Light
+                        // mode uses a clean paper surface instead of a muddy
+                        // dark backdrop against the surrounding page.
                         background: {
-                            xs: `linear-gradient(to top, ${overlay.black90} 0%, ${overlay.black70} 46%, ${overlay.black35} 74%, transparent 100%)`,
-                            md: `linear-gradient(105deg, ${overlay.black90} 0%, ${overlay.black70} 42%, ${overlay.black35} 72%, transparent 100%)`,
+                            xs: theme.palette.mode === 'dark'
+                                ? `linear-gradient(to top, ${overlay.black90} 0%, ${overlay.black70} 46%, ${overlay.black35} 74%, transparent 100%)`
+                                : 'linear-gradient(to bottom, rgba(255,255,255,0.96), rgba(255,255,255,0.9))',
+                            md: theme.palette.mode === 'dark'
+                                ? `linear-gradient(105deg, ${overlay.black90} 0%, ${overlay.black70} 42%, ${overlay.black35} 72%, transparent 100%)`
+                                : 'linear-gradient(105deg, rgba(255,255,255,0.98), rgba(255,255,255,0.92))',
                         },
                     }}
                 />
@@ -123,7 +128,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                         )}
                     </Box>
 
-                    <Box sx={{ color: neutral.white, maxWidth: 620, width: { xs: '100%', md: 'auto' } }}>
+                    <Box sx={{ color: theme.palette.mode === 'dark' ? neutral.white : 'text.primary', maxWidth: 620, width: { xs: '100%', md: 'auto' } }}>
                         <Chip
                             icon={<Star sx={{ fontSize: 15 }} />}
                             label={t('featured')}
@@ -157,7 +162,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                             {video.title}
                         </Typography>
                         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1, flexWrap: 'wrap' }}>
-                            <Typography sx={{ opacity: 0.9, fontWeight: 500 }}>
+                            <Typography sx={{ color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary', fontWeight: 500 }}>
                                 {video.author || t('unknownAuthor')}
                                 {video.duration ? ` · ${formatDuration(video.duration)}` : ''}
                             </Typography>
@@ -169,7 +174,9 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                             <Box sx={{ display: 'flex', gap: 1.5, mt: 2.5, flexWrap: 'wrap' }}>
                                 <Button
                                     variant="outlined"
-                                    sx={{ color: neutral.white, borderColor: overlay.white70, '&:hover': { borderColor: neutral.white, bgcolor: overlay.white10 } }}
+                                    sx={theme.palette.mode === 'dark'
+                                        ? { color: neutral.white, borderColor: overlay.white70, '&:hover': { borderColor: neutral.white, bgcolor: overlay.white10 } }
+                                        : undefined}
                                     onClick={() => navigate(`/collection/${encodeURIComponent(collection.collectionId)}`)}
                                 >
                                     {t('openCollection')}

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -34,7 +34,13 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
     const [slideDirection, setSlideDirection] = useState(1);
     const touchStart = useRef<{ x: number; y: number } | null>(null);
     const suppressClick = useRef(false);
+    const suppressClickTimer = useRef<number | null>(null);
     const count = items.length;
+
+    // Clear the pending suppress-click reset on unmount.
+    useEffect(() => () => {
+        if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
+    }, []);
 
     // Keep the index valid if the favorites list shrinks under us.
     useEffect(() => {
@@ -59,7 +65,15 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         // change slides.
         if (Math.abs(horizontalDistance) < 48 || Math.abs(horizontalDistance) <= Math.abs(verticalDistance)) return;
 
+        // Suppress the synthetic click that some browsers dispatch after the
+        // swipe, but auto-clear shortly after so the flag never lingers to
+        // swallow the user's next genuine tap when no such click fires.
         suppressClick.current = true;
+        if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
+        suppressClickTimer.current = window.setTimeout(() => {
+            suppressClick.current = false;
+            suppressClickTimer.current = null;
+        }, 400);
         if (horizontalDistance < 0) {
             go(index + 1, 1);
         } else {
@@ -108,6 +122,10 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                 event.preventDefault();
                 event.stopPropagation();
                 suppressClick.current = false;
+                if (suppressClickTimer.current) {
+                    window.clearTimeout(suppressClickTimer.current);
+                    suppressClickTimer.current = null;
+                }
             }}
         >
             <motion.div

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
-import { Box, Fade, IconButton, useMediaQuery } from '@mui/material';
-import { useCallback, useEffect, useState } from 'react';
+import { Box, IconButton, useMediaQuery, useTheme } from '@mui/material';
+import { motion } from 'framer-motion';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { neutral, overlay } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
@@ -25,9 +26,14 @@ const AUTO_ADVANCE_MS = 7000;
  */
 const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) => {
     const { t } = useLanguage();
+    const theme = useTheme();
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+    const isMobile = useMediaQuery(theme.breakpoints.down('md'));
     const [index, setIndex] = useState(0);
     const [paused, setPaused] = useState(false);
+    const [slideDirection, setSlideDirection] = useState(1);
+    const touchStart = useRef<{ x: number; y: number } | null>(null);
+    const suppressClick = useRef(false);
     const count = items.length;
 
     // Keep the index valid if the favorites list shrinks under us.
@@ -35,9 +41,31 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         if (index >= count && count > 0) setIndex(0);
     }, [count, index]);
 
-    const go = useCallback((next: number) => {
+    const go = useCallback((next: number, direction = 1) => {
+        setSlideDirection(direction);
         setIndex(((next % count) + count) % count);
     }, [count]);
+
+    const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
+        const start = touchStart.current;
+        touchStart.current = null;
+        if (!start || !isMobile || count <= 1) return;
+
+        const touch = event.changedTouches[0];
+        const horizontalDistance = touch.clientX - start.x;
+        const verticalDistance = touch.clientY - start.y;
+
+        // Keep natural page scrolling intact; only deliberate horizontal swipes
+        // change slides.
+        if (Math.abs(horizontalDistance) < 48 || Math.abs(horizontalDistance) <= Math.abs(verticalDistance)) return;
+
+        suppressClick.current = true;
+        if (horizontalDistance < 0) {
+            go(index + 1, 1);
+        } else {
+            go(index - 1, -1);
+        }
+    };
 
     useEffect(() => {
         if (isReducedMotion || paused || count <= 1) return undefined;
@@ -56,17 +84,40 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         <Box
             // On mobile, break out of FavoritePage's `px: 2` so the hero spans
             // the full screen width edge-to-edge; unchanged on desktop.
-            sx={{ position: 'relative', mx: { xs: -2, md: 0 } }}
+            data-testid="favorite-hero-carousel"
+            sx={{
+                position: 'relative',
+                mx: { xs: -2, md: 0 },
+                // Allows vertical page scrolling while keeping horizontal
+                // gestures available for the mobile carousel.
+                touchAction: isMobile && count > 1 ? 'pan-y' : 'auto',
+            }}
             onMouseEnter={() => setPaused(true)}
             onMouseLeave={() => setPaused(false)}
             onFocusCapture={() => setPaused(true)}
             onBlurCapture={() => setPaused(false)}
+            onTouchStart={(event) => {
+                if (!isMobile || count <= 1) return;
+                const touch = event.touches[0];
+                touchStart.current = { x: touch.clientX, y: touch.clientY };
+            }}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={() => { touchStart.current = null; }}
+            onClickCapture={(event) => {
+                if (!suppressClick.current) return;
+                event.preventDefault();
+                event.stopPropagation();
+                suppressClick.current = false;
+            }}
         >
-            <Fade in key={current.video.id} timeout={isReducedMotion ? 0 : 450} appear>
-                <Box>
-                    <FavoriteHero video={current.video} collection={current.collection} />
-                </Box>
-            </Fade>
+            <motion.div
+                key={current.video.id}
+                initial={isReducedMotion ? false : { opacity: 0, x: slideDirection * 24 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={isReducedMotion ? { duration: 0 } : { duration: 0.3, ease: 'easeOut' }}
+            >
+                <FavoriteHero video={current.video} collection={current.collection} />
+            </motion.div>
 
             {count > 1 && (
                 <Box
@@ -88,7 +139,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                     <IconButton
                         size="small"
                         aria-label={t('previous')}
-                        onClick={() => go(safeIndex - 1)}
+                        onClick={() => go(safeIndex - 1, -1)}
                         sx={{ color: neutral.white, p: 0.5 }}
                     >
                         <ChevronLeft fontSize="small" />
@@ -101,7 +152,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                                 type="button"
                                 aria-label={`${t('featured')} ${dotIndex + 1}`}
                                 aria-current={dotIndex === safeIndex}
-                                onClick={() => setIndex(dotIndex)}
+                                onClick={() => go(dotIndex, dotIndex >= safeIndex ? 1 : -1)}
                                 sx={{
                                     p: 0,
                                     border: 'none',
@@ -118,7 +169,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                     <IconButton
                         size="small"
                         aria-label={t('next')}
-                        onClick={() => go(safeIndex + 1)}
+                        onClick={() => go(safeIndex + 1, 1)}
                         sx={{ color: neutral.white, p: 0.5 }}
                     >
                         <ChevronRight fontSize="small" />

--- a/frontend/src/pages/favorite/FavoriteTopRatedRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteTopRatedRail.tsx
@@ -1,4 +1,3 @@
-import { Star } from '@mui/icons-material';
 import { Box, Card, CardActionArea, CardMedia, Chip, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -47,9 +46,6 @@ const MiniVideoCard: React.FC<{ video: Video }> = ({ video }) => {
                     <Typography variant="caption" color="text.secondary" noWrap display="block">
                         {video.author || t('unknownAuthor')}
                     </Typography>
-                    <Box aria-label={`${video.rating ?? 5} ${t('stars')}`} sx={{ display: 'flex', mt: 0.5 }}>
-                        {[1, 2, 3, 4, 5].map((star) => <Star key={star} sx={{ fontSize: 15, color: neutral.grey400 }} />)}
-                    </Box>
                 </Box>
             </CardActionArea>
         </Card>

--- a/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
+++ b/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
@@ -70,6 +70,25 @@ describe('FavoriteHeroCarousel', () => {
         expect(screen.getByTestId('hero-slide')).toHaveTextContent('C');
     });
 
+    it('changes slides after a horizontal swipe on mobile', () => {
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: query.includes('max-width'),
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })) as never;
+        renderCarousel(makeItems(['A', 'B', 'C']));
+        const carousel = screen.getByTestId('favorite-hero-carousel');
+
+        fireEvent.touchStart(carousel, { touches: [{ clientX: 240, clientY: 80 }] });
+        fireEvent.touchEnd(carousel, { changedTouches: [{ clientX: 140, clientY: 84 }] });
+
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('B');
+    });
+
     it('jumps to a slide when its dot is clicked', () => {
         renderCarousel(makeItems(['A', 'B', 'C']));
         fireEvent.click(screen.getByRole('button', { name: 'featured 3' }));


### PR DESCRIPTION
## Summary
- add mobile swipe and transition behavior to the Favorites hero
- stabilize the hero layout, refine responsive collection and author headers, and tighten mobile navigation tabs
- recover safely when favorites tables were created before their Drizzle migration

## Why
The Favorites experience needed better mobile ergonomics and a migration journal mismatch could prevent the backend from starting.

## Validation
- `npm test` (frontend and backend)
- `npm run typecheck`
- `npm run lint`
- backend startup verified against the local database