### PR TITLE
Rework favorites hero and fix cross-page scroll

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './App.css';
 import Footer from './components/Footer';
 import Header from './components/Header';
+import ScrollToTop from './components/ScrollToTop';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { CollectionProvider, useCollection } from './contexts/CollectionContext';
 import { DownloadProvider, useDownload } from './contexts/DownloadContext';
@@ -117,6 +118,7 @@ function AppContent() {
                 )
             ) : (
                 <Router>
+                    <ScrollToTop />
                     <PageTagFilterProvider>
                         <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
                             <Header

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Resets the window scroll position to the top whenever the route changes.
+ * Without this, navigating from a scrolled page (e.g. the favorites rail) to
+ * an author or collection page lands the user in the middle of the new page.
+ */
+const ScrollToTop: React.FC = () => {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+};
+
+export default ScrollToTop;

--- a/frontend/src/components/ScrollToTop.tsx
+++ b/frontend/src/components/ScrollToTop.tsx
@@ -7,11 +7,11 @@ import { useLocation } from 'react-router-dom';
  * an author or collection page lands the user in the middle of the new page.
  */
 const ScrollToTop: React.FC = () => {
-    const { pathname } = useLocation();
+    const { pathname, search } = useLocation();
 
     useEffect(() => {
         window.scrollTo(0, 0);
-    }, [pathname]);
+    }, [pathname, search]);
 
     return null;
 };

--- a/frontend/src/pages/FavoritePage.tsx
+++ b/frontend/src/pages/FavoritePage.tsx
@@ -47,6 +47,17 @@ const isUnfinished = (video: Video): boolean => {
     return true;
 };
 
+const getSecureRandomIndex = (upperBound: number): number => {
+    // Avoid modulo bias by discarding values above the largest multiple of the
+    // upper bound. This keeps the Fisher–Yates shuffle uniform.
+    const limit = Math.floor(0x1_0000_0000 / upperBound) * upperBound;
+    const value = new Uint32Array(1);
+    do {
+        crypto.getRandomValues(value);
+    } while (value[0] >= limit);
+    return value[0] % upperBound;
+};
+
 const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFindAuthors }) => {
     const { t } = useLanguage();
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
@@ -78,7 +89,7 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
         const continueIds = new Set(continueWatchingVideos.map((video) => video.id));
         const pool = topRatedVideos.filter((video) => !continueIds.has(video.id));
         for (let i = pool.length - 1; i > 0; i -= 1) {
-            const j = Math.floor(Math.random() * (i + 1));
+            const j = getSecureRandomIndex(i + 1);
             [pool[i], pool[j]] = [pool[j], pool[i]];
         }
         return pool.slice(0, RANDOM_FEATURED_LIMIT);
@@ -150,6 +161,7 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
                             <FavoriteAuthorRail
                                 favorites={favoriteAuthorItems}
                                 loading={favoriteAuthors.isLoading}
+                                onUnfavorite={(favorite) => favoriteAuthors.toggle({ author: favorite.author })}
                             />
                         </Box>
                     </Fade>

--- a/frontend/src/pages/FavoritePage.tsx
+++ b/frontend/src/pages/FavoritePage.tsx
@@ -6,14 +6,20 @@ import { useVideo } from '../contexts/VideoContext';
 import { useFavoriteAuthors } from '../hooks/useFavoriteAuthors';
 import { useFavoriteCollections } from '../hooks/useFavoriteCollections';
 import type { Video } from '../types';
+import { parseDuration } from '../utils/formatUtils';
 import FavoriteAuthorRail from './favorite/FavoriteAuthorRail';
 import FavoriteCollectionRail from './favorite/FavoriteCollectionRail';
 import FavoriteEmptyState from './favorite/FavoriteEmptyState';
 import FavoriteHeroCarousel, { type FavoriteHeroItem } from './favorite/FavoriteHeroCarousel';
 import FavoriteTopRatedRail from './favorite/FavoriteTopRatedRail';
 
-// How many top-rated videos the Featured hero rotates through.
-const FEATURED_LIMIT = 5;
+// The hero carousel leads with up to two "continue watching" videos, then
+// rotates through a few random top-rated videos.
+const CONTINUE_LIMIT = 2;
+const RANDOM_FEATURED_LIMIT = 3;
+// A video within this fraction of the end counts as finished, so it never
+// resurfaces as "continue watching".
+const FINISHED_RATIO = 0.95;
 
 interface FavoritePageProps {
     onBrowseCollections: () => void;
@@ -25,6 +31,20 @@ const getActivityTimestamp = (video: Video): number => {
     if (typeof value === 'number') return value;
     const numericValue = Number(value);
     return Number.isFinite(numericValue) ? numericValue : Date.parse(String(value)) || 0;
+};
+
+// Most recent playback activity, used to order the continue-watching videos.
+const getProgressTimestamp = (video: Video): number =>
+    video.progressUpdatedAt ?? video.lastPlayedAt ?? 0;
+
+// A video is resumable when it has meaningful progress that hasn't reached the
+// (near) end. Finished videos already have their progress reset to 0 upstream.
+const isUnfinished = (video: Video): boolean => {
+    const progress = typeof video.progress === 'number' ? video.progress : 0;
+    if (progress <= 0) return false;
+    const duration = parseDuration(video.duration);
+    if (duration > 0 && progress / duration >= FINISHED_RATIO) return false;
+    return true;
 };
 
 const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFindAuthors }) => {
@@ -41,20 +61,51 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
             .sort((a, b) => getActivityTimestamp(b) - getActivityTimestamp(a)),
         [videos],
     );
-    const featuredVideo = topRatedVideos[0];
+
+    // Lead the hero with the user's most recently watched, still-unfinished
+    // videos so they can pick up where they left off.
+    const continueWatchingVideos = useMemo(
+        () => (Array.isArray(videos) ? videos : [])
+            .filter(isUnfinished)
+            .sort((a, b) => getProgressTimestamp(b) - getProgressTimestamp(a))
+            .slice(0, CONTINUE_LIMIT),
+        [videos],
+    );
+
+    // Follow the continue-watching videos with a random handful of top-rated
+    // videos (excluding any already shown, to avoid duplicate carousel slides).
+    const randomFeaturedVideos = useMemo(() => {
+        const continueIds = new Set(continueWatchingVideos.map((video) => video.id));
+        const pool = topRatedVideos.filter((video) => !continueIds.has(video.id));
+        for (let i = pool.length - 1; i > 0; i -= 1) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [pool[i], pool[j]] = [pool[j], pool[i]];
+        }
+        return pool.slice(0, RANDOM_FEATURED_LIMIT);
+    }, [topRatedVideos, continueWatchingVideos]);
+
     const featuredItems = useMemo<FavoriteHeroItem[]>(() => {
         const findCollection = (video: Video) => favoriteCollections.data?.find((favorite) => {
             const collection = collections.find((candidate) => candidate.id === favorite.collectionId);
             return collection?.videos.includes(video.id);
         });
-        return topRatedVideos
-            .slice(0, FEATURED_LIMIT)
-            .map((video) => ({ video, collection: findCollection(video) }));
-    }, [collections, favoriteCollections.data, topRatedVideos]);
+        return [
+            ...continueWatchingVideos.map((video) => ({
+                video,
+                collection: findCollection(video),
+                variant: 'continue' as const,
+            })),
+            ...randomFeaturedVideos.map((video) => ({
+                video,
+                collection: findCollection(video),
+                variant: 'featured' as const,
+            })),
+        ];
+    }, [collections, favoriteCollections.data, continueWatchingVideos, randomFeaturedVideos]);
 
     const favoriteCollectionItems = favoriteCollections.data ?? [];
     const favoriteAuthorItems = favoriteAuthors.data ?? [];
-    const hasContent = Boolean(featuredVideo || favoriteCollectionItems.length || favoriteAuthorItems.length);
+    const hasContent = Boolean(featuredItems.length || favoriteCollectionItems.length || favoriteAuthorItems.length);
     const isLoading = favoriteCollections.isLoading || favoriteAuthors.isLoading;
 
     if (isLoading && !hasContent) {
@@ -99,7 +150,6 @@ const FavoritePage: React.FC<FavoritePageProps> = ({ onBrowseCollections, onFind
                             <FavoriteAuthorRail
                                 favorites={favoriteAuthorItems}
                                 loading={favoriteAuthors.isLoading}
-                                onUnfavorite={(favorite) => favoriteAuthors.toggle({ author: favorite.author })}
                             />
                         </Box>
                     </Fade>

--- a/frontend/src/pages/FavoritePage.tsx
+++ b/frontend/src/pages/FavoritePage.tsx
@@ -7,6 +7,7 @@ import { useFavoriteAuthors } from '../hooks/useFavoriteAuthors';
 import { useFavoriteCollections } from '../hooks/useFavoriteCollections';
 import type { Video } from '../types';
 import { parseDuration } from '../utils/formatUtils';
+import { getBestVideoResumeProgress, readVideoResumeProgress } from '../utils/videoResumeProgress';
 import FavoriteAuthorRail from './favorite/FavoriteAuthorRail';
 import FavoriteCollectionRail from './favorite/FavoriteCollectionRail';
 import FavoriteEmptyState from './favorite/FavoriteEmptyState';
@@ -33,14 +34,24 @@ const getActivityTimestamp = (video: Video): number => {
     return Number.isFinite(numericValue) ? numericValue : Date.parse(String(value)) || 0;
 };
 
+// Playback progress the player would actually resume from. Visitor accounts (and
+// any failed/offline server save) only have progress in the local resume store,
+// so relying on video.progress alone would drop those videos from the hero.
+const getEffectiveProgress = (video: Video): number =>
+    getBestVideoResumeProgress(video.id, video.progress, video.progressUpdatedAt);
+
 // Most recent playback activity, used to order the continue-watching videos.
-const getProgressTimestamp = (video: Video): number =>
-    video.progressUpdatedAt ?? video.lastPlayedAt ?? 0;
+// Prefer whichever of the server or local resume timestamps is newer.
+const getProgressTimestamp = (video: Video): number => {
+    const serverTimestamp = video.progressUpdatedAt ?? video.lastPlayedAt ?? 0;
+    const localTimestamp = readVideoResumeProgress(video.id)?.updatedAt ?? 0;
+    return Math.max(serverTimestamp, localTimestamp);
+};
 
 // A video is resumable when it has meaningful progress that hasn't reached the
 // (near) end. Finished videos already have their progress reset to 0 upstream.
 const isUnfinished = (video: Video): boolean => {
-    const progress = typeof video.progress === 'number' ? video.progress : 0;
+    const progress = getEffectiveProgress(video);
     if (progress <= 0) return false;
     const duration = parseDuration(video.duration);
     if (duration > 0 && progress / duration >= FINISHED_RATIO) return false;

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -89,17 +89,19 @@ const FavoriteAuthorCard: React.FC<{
                     </Typography>
                 )}
             </CardActionArea>
-            {/* Keep stale/unavailable authors removable even though their card
-                navigation is disabled. */}
-            <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
-                <FavoriteToggle
-                    active
-                    onToggle={onUnfavorite}
-                    label={t('favoriteAuthor')}
-                    activeLabel={t('unfavorite')}
-                    color="warning"
-                />
-            </Box>
+            {/* Stale/unavailable authors can no longer be opened, so keep a
+                remove control on those cards as the only way to prune them. */}
+            {isUnavailable && (
+                <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
+                    <FavoriteToggle
+                        active
+                        onToggle={onUnfavorite}
+                        label={t('favoriteAuthor')}
+                        activeLabel={t('unfavorite')}
+                        color="warning"
+                    />
+                </Box>
+            )}
         </Card>
     );
 };

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -5,17 +5,20 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { brand } from '../../theme/colors';
 import type { FavoriteAuthorItem } from '../../types';
+import FavoriteToggle from '../../components/FavoriteToggle';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
 import FavoriteSectionHeader from './FavoriteSectionHeader';
 
 interface FavoriteAuthorRailProps {
     favorites: FavoriteAuthorItem[];
     loading?: boolean;
+    onUnfavorite: (favorite: FavoriteAuthorItem) => void;
 }
 
 const FavoriteAuthorCard: React.FC<{
     favorite: FavoriteAuthorItem;
-}> = ({ favorite }) => {
+    onUnfavorite: () => void;
+}> = ({ favorite, onUnfavorite }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const avatarUrl = useCloudStorageUrl(
@@ -86,11 +89,22 @@ const FavoriteAuthorCard: React.FC<{
                     </Typography>
                 )}
             </CardActionArea>
+            {/* Keep stale/unavailable authors removable even though their card
+                navigation is disabled. */}
+            <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
+                <FavoriteToggle
+                    active
+                    onToggle={onUnfavorite}
+                    label={t('favoriteAuthor')}
+                    activeLabel={t('unfavorite')}
+                    color="warning"
+                />
+            </Box>
         </Card>
     );
 };
 
-const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false }) => {
+const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false, onUnfavorite }) => {
     const { t } = useLanguage();
 
     if (!loading && favorites.length === 0) return null;
@@ -111,6 +125,7 @@ const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, load
                         <FavoriteAuthorCard
                             key={favorite.author}
                             favorite={favorite}
+                            onUnfavorite={() => onUnfavorite(favorite)}
                         />
                     ))}
             </FavoriteRailCarousel>

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -5,20 +5,17 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { brand } from '../../theme/colors';
 import type { FavoriteAuthorItem } from '../../types';
-import FavoriteToggle from '../../components/FavoriteToggle';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
 import FavoriteSectionHeader from './FavoriteSectionHeader';
 
 interface FavoriteAuthorRailProps {
     favorites: FavoriteAuthorItem[];
     loading?: boolean;
-    onUnfavorite: (favorite: FavoriteAuthorItem) => void;
 }
 
 const FavoriteAuthorCard: React.FC<{
     favorite: FavoriteAuthorItem;
-    onUnfavorite: () => void;
-}> = ({ favorite, onUnfavorite }) => {
+}> = ({ favorite }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const avatarUrl = useCloudStorageUrl(
@@ -89,22 +86,11 @@ const FavoriteAuthorCard: React.FC<{
                     </Typography>
                 )}
             </CardActionArea>
-            {/* Overlay remove control so favorites (including unavailable
-                authors whose card is disabled) can be removed from the rail. */}
-            <Box sx={{ position: 'absolute', top: 0, right: 0 }}>
-                <FavoriteToggle
-                    active
-                    onToggle={onUnfavorite}
-                    label={t('favoriteAuthor')}
-                    activeLabel={t('unfavorite')}
-                    color="warning"
-                />
-            </Box>
         </Card>
     );
 };
 
-const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false, onUnfavorite }) => {
+const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, loading = false }) => {
     const { t } = useLanguage();
 
     if (!loading && favorites.length === 0) return null;
@@ -125,7 +111,6 @@ const FavoriteAuthorRail: React.FC<FavoriteAuthorRailProps> = ({ favorites, load
                         <FavoriteAuthorCard
                             key={favorite.author}
                             favorite={favorite}
-                            onUnfavorite={() => onUnfavorite(favorite)}
                         />
                     ))}
             </FavoriteRailCarousel>

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -1,23 +1,48 @@
 import { Star } from '@mui/icons-material';
 import { Box, Button, Card, CardMedia, Chip, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { brand, neutral, overlay } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
-import { formatDuration } from '../../utils/formatUtils';
+import { api } from '../../utils/apiClient';
+import { formatDuration, parseDuration } from '../../utils/formatUtils';
 import { useFavoriteThumbnail } from './useFavoriteThumbnail';
 
 interface FavoriteHeroProps {
     video: Video;
     collection?: FavoriteCollectionItem;
+    variant?: 'continue' | 'featured';
 }
 
-const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
+const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant = 'featured' }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const theme = useTheme();
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
     const thumbnail = useFavoriteThumbnail(video);
+
+    const isContinue = variant === 'continue';
+    // Playback progress as a 0–1 fraction, for the resume line on the thumbnail.
+    const durationSeconds = parseDuration(video.duration);
+    const progressSeconds = typeof video.progress === 'number' ? video.progress : 0;
+    const progressRatio = durationSeconds > 0
+        ? Math.min(1, Math.max(0, progressSeconds / durationSeconds))
+        : 0;
+    const showProgressLine = isContinue && progressRatio > 0;
+
+    // The favorites list projection omits `description` (a heavy free-text
+    // column), so fetch the full video record for the featured item to show
+    // its description. Shares the ['video', id] cache key with the player and
+    // uses the list row as a placeholder for an instant first paint.
+    const { data: fullVideo } = useQuery<Video>({
+        queryKey: ['video', video.id],
+        queryFn: async () => (await api.get(`/videos/${video.id}`)).data,
+        placeholderData: video,
+        enabled: !!video.id,
+        retry: false,
+    });
+    const description = fullVideo?.description;
 
     const openVideo = () => navigate(`/video/${encodeURIComponent(video.id)}`);
 
@@ -27,12 +52,9 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                 sx={{
                     position: 'relative',
                     overflow: 'hidden',
-                    // Compact floor on mobile that can still grow: below md the
-                    // layout stacks vertically with a full-width 16:9 thumbnail,
-                    // so a fixed height would clip the title/metadata/button at
-                    // tablet/landscape widths. minHeight keeps the card compact
-                    // while letting it expand to fit its content.
-                    minHeight: { xs: 432, sm: 448 },
+                    // The card is sized entirely by its content — thumbnail, the
+                    // two reserved title lines and an optional button — so it has
+                    // no empty band under short featured videos on any viewport.
                     // Full-bleed edge-to-edge card on mobile; rounded on desktop.
                     borderRadius: { xs: 0, md: 2 },
                     bgcolor: theme.palette.mode === 'dark' ? 'grey.900' : 'background.paper',
@@ -128,50 +150,91 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection }) => {
                                 sx={{ position: 'absolute', bottom: 8, right: 8, height: 22, bgcolor: overlay.black75, color: neutral.white, fontWeight: 600 }}
                             />
                         )}
+                        {/* Resume progress line pinned to the bottom edge */}
+                        {showProgressLine && (
+                            <Box
+                                aria-hidden
+                                sx={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: '2px', bgcolor: overlay.black55 }}
+                            >
+                                <Box
+                                    sx={{
+                                        height: '100%',
+                                        width: `${progressRatio * 100}%`,
+                                        background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                                    }}
+                                />
+                            </Box>
+                        )}
                     </Box>
 
                     <Box sx={{ color: theme.palette.mode === 'dark' ? neutral.white : 'text.primary', maxWidth: 620, width: { xs: '100%', md: 'auto' } }}>
-                        <Chip
-                            icon={<Star sx={{ fontSize: 15 }} />}
-                            label={t('featured')}
-                            size="small"
-                            id="favorite-featured-heading"
-                            sx={{
-                                mb: 1.25,
-                                fontWeight: 700,
-                                letterSpacing: 0.6,
-                                textTransform: 'uppercase',
-                                color: neutral.white,
-                                background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
-                                '& .MuiChip-icon': { color: neutral.white },
-                            }}
-                        />
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.25, flexWrap: 'wrap' }}>
+                            <Chip
+                                icon={<Star sx={{ fontSize: 15 }} />}
+                                label={isContinue ? t('continueWatching') : t('featured')}
+                                size="small"
+                                id="favorite-featured-heading"
+                                sx={{
+                                    fontWeight: 700,
+                                    letterSpacing: 0.6,
+                                    textTransform: 'uppercase',
+                                    color: neutral.white,
+                                    background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                                    '& .MuiChip-icon': { color: neutral.white },
+                                }}
+                            />
+                            <Typography
+                                sx={{
+                                    color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary',
+                                    fontWeight: 500,
+                                }}
+                            >
+                                {video.author || t('unknownAuthor')}
+                            </Typography>
+                        </Box>
                         <Typography
                             variant="h5"
                             component="h2"
                             fontWeight={800}
                             sx={{
                                 lineHeight: 1.2,
-                                // Reserve both clamped title lines even when a
-                                // featured video has a shorter title.
+                                // Reserve two title lines even for a shorter
+                                // title; allow up to three lines on desktop.
                                 minHeight: '2.4em',
                                 display: '-webkit-box',
                                 overflow: 'hidden',
                                 WebkitBoxOrient: 'vertical',
-                                WebkitLineClamp: 2,
+                                WebkitLineClamp: { xs: 2, md: 3 },
+                                // Break long unbreakable runs (URLs, hashtag
+                                // strings) so the clamp wraps instead of
+                                // overflowing the card horizontally.
+                                overflowWrap: 'anywhere',
+                                wordBreak: 'break-word',
                             }}
                         >
                             {video.title}
                         </Typography>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mt: 1, flexWrap: 'wrap' }}>
-                            <Typography sx={{ color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary', fontWeight: 500 }}>
-                                {video.author || t('unknownAuthor')}
-                                {video.duration ? ` · ${formatDuration(video.duration)}` : ''}
+                        {/* Short description, desktop only, clamped to three lines */}
+                        {description && (
+                            <Typography
+                                variant="body2"
+                                sx={{
+                                    display: { xs: 'none', md: '-webkit-box' },
+                                    mt: 1,
+                                    color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary',
+                                    lineHeight: 1.4,
+                                    overflow: 'hidden',
+                                    WebkitBoxOrient: 'vertical',
+                                    WebkitLineClamp: 3,
+                                    // Break long unbreakable runs so the clamp
+                                    // wraps instead of overflowing horizontally.
+                                    overflowWrap: 'anywhere',
+                                    wordBreak: 'break-word',
+                                }}
+                            >
+                                {description}
                             </Typography>
-                            <Box sx={{ display: 'flex' }} aria-label={`5 ${t('stars')}`}>
-                                {[1, 2, 3, 4, 5].map((star) => <Star key={star} sx={{ fontSize: 16, color: neutral.grey400 }} />)}
-                            </Box>
-                        </Box>
+                        )}
                         {collection && (
                             <Box sx={{ display: 'flex', gap: 1.5, mt: 2.5, flexWrap: 'wrap' }}>
                                 <Button

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -10,6 +10,9 @@ import FavoriteHero from './FavoriteHero';
 export interface FavoriteHeroItem {
     video: Video;
     collection?: FavoriteCollectionItem;
+    // 'continue' renders a "Continue watching" chip and a playback progress
+    // line; 'featured' is the default top-rated presentation.
+    variant?: 'continue' | 'featured';
 }
 
 interface FavoriteHeroCarouselProps {
@@ -134,7 +137,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                 animate={{ opacity: 1, x: 0 }}
                 transition={isReducedMotion ? { duration: 0 } : { duration: 0.3, ease: 'easeOut' }}
             >
-                <FavoriteHero video={current.video} collection={current.collection} />
+                <FavoriteHero video={current.video} collection={current.collection} variant={current.variant} />
             </motion.div>
 
             {count > 1 && (

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1542,6 +1542,7 @@ export const ar = {
   topRated: "الأعلى تقييمًا",
   topRatedSubtitle: "الفيديوهات الأعلى تقييمًا في المكتبة",
   featured: "مميز",
+  continueWatching: "متابعة المشاهدة",
   browseCollections: "تصفح المجموعات",
   findAuthors: "البحث عن مؤلفين",
   favoritesUpdateFailed: "تعذر تحديث المفضلة",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1589,6 +1589,7 @@ export const de = {
   topRated: "Top bewertet",
   topRatedSubtitle: "Am besten bewertete Videos aus der Bibliothek",
   featured: "Hervorgehoben",
+  continueWatching: "Weiterschauen",
   browseCollections: "Sammlungen durchsuchen",
   findAuthors: "Autoren suchen",
   favoritesUpdateFailed: "Favoriten konnten nicht aktualisiert werden",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1542,6 +1542,7 @@ export const en = {
   topRated: "Top Rated",
   topRatedSubtitle: "Top-rated videos from the library",
   featured: "Featured",
+  continueWatching: "Continue watching",
   browseCollections: "Browse collections",
   findAuthors: "Find authors",
   favoritesUpdateFailed: "Could not update favorites",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1592,6 +1592,7 @@ export const es = {
   topRated: "Más valorados",
   topRatedSubtitle: "Vídeos mejor valorados de la biblioteca",
   featured: "Destacado",
+  continueWatching: "Seguir viendo",
   browseCollections: "Explorar colecciones",
   findAuthors: "Buscar autores",
   favoritesUpdateFailed: "No se pudieron actualizar los favoritos",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1603,6 +1603,7 @@ export const fr = {
   topRated: "Les mieux notés",
   topRatedSubtitle: "Vidéos les mieux notées de la bibliothèque",
   featured: "À la une",
+  continueWatching: "Reprendre la lecture",
   browseCollections: "Parcourir les collections",
   findAuthors: "Rechercher des auteurs",
   favoritesUpdateFailed: "Impossible de mettre à jour les favoris",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1570,6 +1570,7 @@ export const ja = {
   topRated: "高評価",
   topRatedSubtitle: "ライブラリの高評価動画",
   featured: "おすすめ",
+  continueWatching: "続きを見る",
   browseCollections: "コレクションを閲覧",
   findAuthors: "作者を検索",
   favoritesUpdateFailed: "お気に入りを更新できませんでした",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1547,6 +1547,7 @@ export const ko = {
   topRated: "최고 평점",
   topRatedSubtitle: "라이브러리의 최고 평점 동영상",
   featured: "추천",
+  continueWatching: "계속 시청",
   browseCollections: "컬렉션 찾아보기",
   findAuthors: "제작자 찾기",
   favoritesUpdateFailed: "즐겨찾기를 업데이트할 수 없습니다",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1580,6 +1580,7 @@ export const pt = {
   topRated: "Mais bem avaliados",
   topRatedSubtitle: "Vídeos mais bem avaliados da biblioteca",
   featured: "Destaque",
+  continueWatching: "Continuar assistindo",
   browseCollections: "Explorar coleções",
   findAuthors: "Encontrar autores",
   favoritesUpdateFailed: "Não foi possível atualizar os favoritos",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1574,6 +1574,7 @@ export const ru = {
   topRated: "Лучшие оценки",
   topRatedSubtitle: "Видео с лучшими оценками в библиотеке",
   featured: "Рекомендуемое",
+  continueWatching: "Продолжить просмотр",
   browseCollections: "Просмотреть коллекции",
   findAuthors: "Найти авторов",
   favoritesUpdateFailed: "Не удалось обновить избранное",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1488,6 +1488,7 @@ export const zh = {
   topRated: "高评分",
   topRatedSubtitle: "媒体库中的高评分视频",
   featured: "精选",
+  continueWatching: "继续观看",
   browseCollections: "浏览合集",
   findAuthors: "查找作者",
   favoritesUpdateFailed: "无法更新收藏",


### PR DESCRIPTION
## Summary

Reworks the Favorites page hero card and fixes a cross-page scroll issue.

### Navigation
- Add a global `ScrollToTop` that resets scroll on every route change, so opening a favorite author/collection lands at the top of the page instead of mid-page.

### Favorite Authors rail
- Remove the star (unfavorite) toggle from author avatars.

### Hero card
- **Layout:** author name now sits inline with the chip; card height is fully content-driven (no empty band on mobile or desktop); title clamps to 2 lines on mobile / 3 on desktop; removed the 5-star row and the bottom duration text.
- **Description:** desktop-only, clamped to 3 lines. Fetches the full video record (`/videos/:id`) because the list projection omits the heavy `description` column. Added `overflowWrap`/`wordBreak` so long hashtag/URL runs wrap instead of overflowing the card horizontally.
- **Continue watching:** the carousel now leads with up to 2 most-recently-watched, still-unfinished videos — each shows a "Continue watching" chip and a 2px playback-progress line on the thumbnail — followed by 3 random 5-star videos (deduped so no slide repeats).

### i18n
- Added the `continueWatching` key to all 10 locale files.

## Verification
- Verified live in the browser preview across mobile and desktop widths: scroll reset, author-rail star removal, hero layout/height, description rendering + wrapping (no horizontal overflow), continue-watching chip, and progress-line fill matching each video's real ratio.
- `tsc --noEmit` clean; affected FavoritePage / FavoriteHeroCarousel tests pass (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)