### PR TITLE
feat(tags): add All Tags page with usage-ranked filtering

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ const BilibiliPartsModal = lazyWithRetry(
 );
 const AuthorVideos = lazyWithRetry(() => import('./pages/AuthorVideos'), 'author-videos');
 const AllAuthorsPage = lazyWithRetry(() => import('./pages/AllAuthorsPage'), 'all-authors');
+const AllTagsPage = lazyWithRetry(() => import('./pages/AllTagsPage'), 'all-tags');
 const CollectionPage = lazyWithRetry(
     () => import('./pages/CollectionPage'),
     'collection-page',
@@ -169,6 +170,7 @@ function AppContent() {
                                             <Route path="/downloads" element={<DownloadPage />} />
                                             <Route path="/collection/:id" element={<CollectionPage />} />
                                             <Route path="/authors" element={<AllAuthorsPage />} />
+                                            <Route path="/tags" element={<AllTagsPage />} />
                                             <Route path="/author/:authorName" element={<AuthorVideos />} />
                                             <Route path="/video/:id" element={<VideoPlayer />} />
                                             <Route path="/subscriptions" element={<SubscriptionsPage />} />

--- a/frontend/src/components/ExpandableTagsStrip.tsx
+++ b/frontend/src/components/ExpandableTagsStrip.tsx
@@ -1,0 +1,150 @@
+import { LocalOffer } from '@mui/icons-material';
+import { Box, Button, Chip } from '@mui/material';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useLanguage } from '../contexts/LanguageContext';
+
+const DEFAULT_MAX_COLLAPSED_LINES = 3;
+const CHIP_ROW_GAP_PX = 8;
+const FALLBACK_CHIP_HEIGHT_PX = 32;
+
+export interface ExpandableTagsStripProps {
+    tags: string[];
+    selectedTags: string[];
+    onTagToggle: (tag: string) => void;
+    maxCollapsedLines?: number;
+    /** Test hook; default uses scrollHeight vs clientHeight. */
+    measureOverflow?: (element: HTMLElement) => boolean;
+}
+
+const defaultMeasureOverflow = (element: HTMLElement): boolean =>
+    element.scrollHeight > element.clientHeight + 1;
+
+const ExpandableTagsStrip: React.FC<ExpandableTagsStripProps> = ({
+    tags,
+    selectedTags,
+    onTagToggle,
+    maxCollapsedLines = DEFAULT_MAX_COLLAPSED_LINES,
+    measureOverflow = defaultMeasureOverflow,
+}) => {
+    const { t } = useLanguage();
+    const [expanded, setExpanded] = useState(false);
+    const [hasOverflow, setHasOverflow] = useState(false);
+    const [lineHeightPx, setLineHeightPx] = useState(
+        FALLBACK_CHIP_HEIGHT_PX + CHIP_ROW_GAP_PX
+    );
+    const containerRef = useRef<HTMLDivElement>(null);
+    const chipMeasureRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+        const chipEl = chipMeasureRef.current?.querySelector('.MuiChip-root') as HTMLElement | null;
+        if (chipEl) {
+            setLineHeightPx(chipEl.offsetHeight + CHIP_ROW_GAP_PX);
+        }
+    }, [tags, selectedTags]);
+
+    useEffect(() => {
+        const el = containerRef.current;
+        if (!el) return;
+
+        const updateOverflow = () => {
+            if (expanded) {
+                // Measure as if collapsed to know whether the control is needed
+                const previousMaxHeight = el.style.maxHeight;
+                const previousOverflow = el.style.overflow;
+                el.style.maxHeight = `${maxCollapsedLines * lineHeightPx}px`;
+                el.style.overflow = 'hidden';
+                setHasOverflow(measureOverflow(el));
+                el.style.maxHeight = previousMaxHeight;
+                el.style.overflow = previousOverflow;
+            } else {
+                setHasOverflow(measureOverflow(el));
+            }
+        };
+
+        updateOverflow();
+
+        const observer = typeof ResizeObserver !== 'undefined'
+            ? new ResizeObserver(updateOverflow)
+            : null;
+        observer?.observe(el);
+        window.addEventListener('resize', updateOverflow);
+
+        return () => {
+            observer?.disconnect();
+            window.removeEventListener('resize', updateOverflow);
+        };
+    }, [tags, selectedTags, expanded, maxCollapsedLines, lineHeightPx, measureOverflow]);
+
+    if (tags.length === 0) {
+        return null;
+    }
+
+    const collapsedMaxHeight = maxCollapsedLines * lineHeightPx;
+
+    return (
+        <Box sx={{ mb: 3 }}>
+            <Box
+                ref={containerRef}
+                role="list"
+                aria-label={t('tags')}
+                sx={{
+                    display: 'flex',
+                    flexWrap: 'wrap',
+                    gap: `${CHIP_ROW_GAP_PX}px`,
+                    maxHeight: expanded ? 'none' : `${collapsedMaxHeight}px`,
+                    overflow: expanded ? 'visible' : 'hidden',
+                }}
+            >
+                {/* Hidden probe for measuring chip height (first chip is enough) */}
+                <Box
+                    ref={chipMeasureRef}
+                    aria-hidden
+                    sx={{
+                        position: 'absolute',
+                        visibility: 'hidden',
+                        pointerEvents: 'none',
+                        height: 0,
+                        overflow: 'hidden',
+                    }}
+                >
+                    <Chip label="measure" size="medium" />
+                </Box>
+                {tags.map((tag) => {
+                    const isSelected = selectedTags.includes(tag);
+                    return (
+                        <Chip
+                            key={tag}
+                            role="listitem"
+                            label={tag}
+                            onClick={() => onTagToggle(tag)}
+                            color={isSelected ? 'primary' : 'default'}
+                            variant={isSelected ? 'filled' : 'outlined'}
+                            icon={isSelected ? <LocalOffer sx={{ fontSize: '1rem !important' }} /> : undefined}
+                            sx={{
+                                cursor: 'pointer',
+                                transition: 'background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s',
+                                '&:hover': {
+                                    bgcolor: isSelected ? 'primary.dark' : 'action.hover',
+                                },
+                            }}
+                        />
+                    );
+                })}
+            </Box>
+            {hasOverflow && (
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
+                    <Button
+                        size="small"
+                        onClick={() => setExpanded((prev) => !prev)}
+                        aria-expanded={expanded}
+                        sx={{ color: 'primary.main', fontWeight: 600, textTransform: 'none' }}
+                    >
+                        {expanded ? t('showLessTags') : t('showMoreTags')}
+                    </Button>
+                </Box>
+            )}
+        </Box>
+    );
+};
+
+export default ExpandableTagsStrip;

--- a/frontend/src/components/ExpandableTagsStrip.tsx
+++ b/frontend/src/components/ExpandableTagsStrip.tsx
@@ -2,6 +2,7 @@ import { LocalOffer } from '@mui/icons-material';
 import { Box, Button, Chip } from '@mui/material';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { normalizeTagKey } from '../utils/tagUtils';
 
 const DEFAULT_MAX_COLLAPSED_LINES = 3;
 const CHIP_ROW_GAP_PX = 8;
@@ -110,7 +111,9 @@ const ExpandableTagsStrip: React.FC<ExpandableTagsStripProps> = ({
                     <Chip label="measure" size="medium" />
                 </Box>
                 {tags.map((tag) => {
-                    const isSelected = selectedTags.includes(tag);
+                    const isSelected = selectedTags.some(
+                        (selected) => normalizeTagKey(selected) === normalizeTagKey(tag)
+                    );
                     return (
                         <Chip
                             key={tag}

--- a/frontend/src/components/Header/HeaderContainer.tsx
+++ b/frontend/src/components/Header/HeaderContainer.tsx
@@ -73,6 +73,7 @@ const HeaderContainer: React.FC<HeaderProps> = ({
     const isAuthorPage = location.pathname.startsWith('/author/');
     const isCollectionPage = location.pathname.startsWith('/collection/');
     const showTagsInMobileMenu = isHomePage || isAuthorPage || isCollectionPage;
+    const linkToAllTagsInMobileMenu = isHomePage;
     const handleMobileTagToggle = useCallback((tag: string) => {
         if (isHomePage) {
             homeViewModeRequest?.requestHomeViewMode('all-videos');
@@ -208,6 +209,7 @@ const HeaderContainer: React.FC<HeaderProps> = ({
                             collections={collections}
                             videos={videos}
                             showTagsInMobileMenu={showTagsInMobileMenu}
+                            linkToAllTagsInMobileMenu={linkToAllTagsInMobileMenu}
                             effectiveTags={mobileEffectiveTags}
                         />
                     </Toolbar>

--- a/frontend/src/components/Header/HeaderToolbarContent.tsx
+++ b/frontend/src/components/Header/HeaderToolbarContent.tsx
@@ -77,6 +77,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
     onSubmit,
     onAudioOnlySubmit,
     showTagsInMobileMenu,
+    videos,
     effectiveTags
 }) => {
     const { t } = useLanguage();
@@ -191,6 +192,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
                     availableTags={effectiveTags.availableTags}
                     selectedTags={effectiveTags.selectedTags}
                     onTagToggle={effectiveTags.onTagToggle}
+                    videos={videos}
                 />
             )}
         </>

--- a/frontend/src/components/Header/HeaderToolbarContent.tsx
+++ b/frontend/src/components/Header/HeaderToolbarContent.tsx
@@ -46,6 +46,7 @@ interface HeaderToolbarContentProps {
     collections: Collection[];
     videos: Video[];
     showTagsInMobileMenu: boolean;
+    linkToAllTagsInMobileMenu?: boolean;
     effectiveTags: EffectiveTags;
 }
 
@@ -77,6 +78,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
     onSubmit,
     onAudioOnlySubmit,
     showTagsInMobileMenu,
+    linkToAllTagsInMobileMenu = false,
     videos,
     effectiveTags
 }) => {
@@ -193,6 +195,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
                     selectedTags={effectiveTags.selectedTags}
                     onTagToggle={effectiveTags.onTagToggle}
                     videos={videos}
+                    linkToAllTags={linkToAllTagsInMobileMenu}
                 />
             )}
         </>

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -23,6 +23,7 @@ interface MobileMenuProps {
     availableTags?: string[];
     selectedTags?: string[];
     onTagToggle?: (tag: string) => void;
+    videos?: Array<{ tags?: string[] }>;
 }
 
 const MobileMenu: React.FC<MobileMenuProps> = ({
@@ -40,7 +41,8 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
     showTags = false,
     availableTags = [],
     selectedTags = [],
-    onTagToggle = () => { }
+    onTagToggle = () => { },
+    videos,
 }) => {
     const { t } = useLanguage();
     const { logout } = useAuth();
@@ -132,6 +134,9 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
                                     availableTags={availableTags}
                                     selectedTags={selectedTags}
                                     onTagToggle={onTagToggle}
+                                    onItemClick={onClose}
+                                    videos={videos}
+                                    linkToAllTags
                                 />
                             </Box>
                         )}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -24,6 +24,8 @@ interface MobileMenuProps {
     selectedTags?: string[];
     onTagToggle?: (tag: string) => void;
     videos?: Array<{ tags?: string[] }>;
+    /** Home only: cap tags and link to /tags. Author/collection keep full local lists. */
+    linkToAllTags?: boolean;
 }
 
 const MobileMenu: React.FC<MobileMenuProps> = ({
@@ -43,6 +45,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
     selectedTags = [],
     onTagToggle = () => { },
     videos,
+    linkToAllTags = false,
 }) => {
     const { t } = useLanguage();
     const { logout } = useAuth();
@@ -136,7 +139,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
                                     onTagToggle={onTagToggle}
                                     onItemClick={onClose}
                                     videos={videos}
-                                    linkToAllTags
+                                    linkToAllTags={linkToAllTags}
                                 />
                             </Box>
                         )}

--- a/frontend/src/components/Header/__tests__/HeaderContainer.test.tsx
+++ b/frontend/src/components/Header/__tests__/HeaderContainer.test.tsx
@@ -89,6 +89,7 @@ vi.mock('../HeaderToolbarContent', () => ({
             <button onClick={props.onCloseMobileMenu}>close-mobile-menu</button>
             <button onClick={() => props.effectiveTags.onTagToggle('tag1')}>toggle-tag</button>
             <span data-testid="show-tags-in-mobile-menu">{String(props.showTagsInMobileMenu)}</span>
+            <span data-testid="link-to-all-tags-in-mobile-menu">{String(props.linkToAllTagsInMobileMenu)}</span>
         </div>
     ),
 }));
@@ -120,6 +121,17 @@ describe('HeaderContainer', () => {
         mockPathname = pathname;
         renderHeader();
         expect(screen.getByTestId('show-tags-in-mobile-menu').textContent).toBe(expected);
+    });
+
+    it.each([
+        ['/', 'true'],
+        ['/collections', 'true'],
+        ['/author/Alice', 'false'],
+        ['/collection/1', 'false'],
+    ])('links mobile tags to /tags only on home routes: %s -> %s', (pathname, expected) => {
+        mockPathname = pathname;
+        renderHeader();
+        expect(screen.getByTestId('link-to-all-tags-in-mobile-menu').textContent).toBe(expected);
     });
 
     it('handles toolbar callbacks, click-away, and scroll-to-top button click', () => {

--- a/frontend/src/components/HomeHeader.tsx
+++ b/frontend/src/components/HomeHeader.tsx
@@ -42,6 +42,7 @@ interface HomeHeaderProps {
     onSidebarToggle: () => void;
     selectedTagsCount: number;
     onDeleteFilteredClick: () => void;
+    onClearTagFilter?: () => void;
     sortOption: string;
     sortAnchorEl: HTMLElement | null;
     onSortClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -54,6 +55,7 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
     onSidebarToggle,
     selectedTagsCount,
     onDeleteFilteredClick,
+    onClearTagFilter,
     sortOption,
     sortAnchorEl,
     onSortClick,
@@ -85,16 +87,32 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
                     <ViewSidebar sx={{ transform: 'rotate(180deg)' }} />
                 </Button>
                 {selectedTagsCount > 0 && viewMode !== 'favorite' && (
-                    <Tooltip title={t('deleteAllFilteredVideos')}>
-                        <IconButton
-                            color="error"
-                            onClick={onDeleteFilteredClick}
-                            size="small"
-                            sx={{ ml: 1 }}
-                        >
-                            <DeleteIcon />
-                        </IconButton>
-                    </Tooltip>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
+                        {onClearTagFilter && (
+                            <Button
+                                size="small"
+                                onClick={onClearTagFilter}
+                                sx={{
+                                    textTransform: 'none',
+                                    fontWeight: 600,
+                                    minWidth: 0,
+                                    px: { xs: 0.5, sm: 1 },
+                                    whiteSpace: 'nowrap',
+                                }}
+                            >
+                                {t('filteredByTags', { count: selectedTagsCount })} — {t('clear')}
+                            </Button>
+                        )}
+                        <Tooltip title={t('deleteAllFilteredVideos')}>
+                            <IconButton
+                                color="error"
+                                onClick={onDeleteFilteredClick}
+                                size="small"
+                            >
+                                <DeleteIcon />
+                            </IconButton>
+                        </Tooltip>
+                    </Box>
                 )}
                 <Box
                     component="span"

--- a/frontend/src/components/HomeSidebar.tsx
+++ b/frontend/src/components/HomeSidebar.tsx
@@ -63,6 +63,8 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
                             availableTags={availableTags}
                             selectedTags={selectedTags}
                             onTagToggle={onTagToggle}
+                            videos={videos}
+                            linkToAllTags
                         />
                     </Box>
                     <Box sx={{ mt: 2 }}>

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -14,7 +14,7 @@ import {
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
-import { sortTagsByUsage } from '../utils/tagUtils';
+import { normalizeTagKey, sortTagsByUsage } from '../utils/tagUtils';
 
 const TOP_TAGS_LIMIT = 20;
 
@@ -68,11 +68,22 @@ const TagsList: React.FC<TagsListProps> = ({
         }
 
         const top = ordered.slice(0, TOP_TAGS_LIMIT);
-        const topSet = new Set(top);
-        // Keep selected tags visible even when they fall outside the top N
-        const selectedOutsideTop = selectedTags.filter(
-            (tag) => availableTags.includes(tag) && !topSet.has(tag)
+        const topKeys = new Set(top.map(normalizeTagKey));
+        const catalogByKey = new Map(
+            availableTags.map((tag) => [normalizeTagKey(tag), tag])
         );
+        // Keep selected tags visible even when they fall outside the top N.
+        // Match case-insensitively so thumbnail-selected casing still maps to catalog.
+        const selectedOutsideTop: string[] = [];
+        const seenKeys = new Set(topKeys);
+        for (const tag of selectedTags) {
+            const canonical = catalogByKey.get(normalizeTagKey(tag));
+            if (!canonical) continue;
+            const key = normalizeTagKey(canonical);
+            if (seenKeys.has(key)) continue;
+            seenKeys.add(key);
+            selectedOutsideTop.push(canonical);
+        }
 
         return {
             displayTags: [...top, ...selectedOutsideTop],
@@ -80,6 +91,10 @@ const TagsList: React.FC<TagsListProps> = ({
         };
     }, [availableTags, linkToAllTags, videos, selectedTags]);
 
+    const selectedTagKeys = useMemo(
+        () => new Set(selectedTags.map(normalizeTagKey)),
+        [selectedTags]
+    );
     if (displayTags.length === 0) {
         return null;
     }
@@ -111,7 +126,7 @@ const TagsList: React.FC<TagsListProps> = ({
             <Collapse in={isOpen} timeout="auto" unmountOnExit>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, px: 2, pb: 2 }}>
                     {displayTags.map(tag => {
-                        const isSelected = selectedTags.includes(tag);
+                        const isSelected = selectedTagKeys.has(normalizeTagKey(tag));
                         return (
                             <Chip
                                 key={tag}

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -1,24 +1,45 @@
-import { ExpandLess, ExpandMore, LocalOffer } from '@mui/icons-material';
+import { ExpandLess, ExpandMore, GridView, LocalOffer } from '@mui/icons-material';
 import {
     Box,
     Chip,
     Collapse,
+    IconButton,
     ListItemButton,
+    ListItemText,
     Paper,
     Typography,
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
+import { sortTagsByUsage } from '../utils/tagUtils';
+
+const TOP_TAGS_LIMIT = 20;
 
 interface TagsListProps {
     availableTags: string[];
     selectedTags: string[];
     onTagToggle: (tag: string) => void;
+    onItemClick?: () => void;
+    /** When provided, sidebar tags are ranked by explicit video.tags usage. */
+    videos?: Array<{ tags?: string[] }>;
+    /**
+     * Home / mobile menu: cap at top N and link to global /tags.
+     * Author / collection sidebars: show every page-local tag, no global link.
+     */
+    linkToAllTags?: boolean;
 }
 
-const TagsList: React.FC<TagsListProps> = ({ availableTags, selectedTags, onTagToggle }) => {
+const TagsList: React.FC<TagsListProps> = ({
+    availableTags,
+    selectedTags,
+    onTagToggle,
+    onItemClick,
+    videos,
+    linkToAllTags = false,
+}) => {
     const { t } = useLanguage();
     const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
@@ -33,7 +54,33 @@ const TagsList: React.FC<TagsListProps> = ({ availableTags, selectedTags, onTagT
         }
     }, [isMobile]);
 
-    if (!availableTags || availableTags.length === 0) {
+    const { displayTags, hasMore } = useMemo(() => {
+        if (!availableTags || availableTags.length === 0) {
+            return { displayTags: [] as string[], hasMore: false };
+        }
+
+        const ordered = videos
+            ? sortTagsByUsage(availableTags, videos)
+            : [...availableTags];
+
+        if (!linkToAllTags) {
+            return { displayTags: ordered, hasMore: false };
+        }
+
+        const top = ordered.slice(0, TOP_TAGS_LIMIT);
+        const topSet = new Set(top);
+        // Keep selected tags visible even when they fall outside the top N
+        const selectedOutsideTop = selectedTags.filter(
+            (tag) => availableTags.includes(tag) && !topSet.has(tag)
+        );
+
+        return {
+            displayTags: [...top, ...selectedOutsideTop],
+            hasMore: ordered.length > TOP_TAGS_LIMIT,
+        };
+    }, [availableTags, linkToAllTags, videos, selectedTags]);
+
+    if (displayTags.length === 0) {
         return null;
     }
 
@@ -43,11 +90,27 @@ const TagsList: React.FC<TagsListProps> = ({ availableTags, selectedTags, onTagT
                 <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 600 }}>
                     {t('tags') || 'Tags'}
                 </Typography>
+                {linkToAllTags && (
+                    <IconButton
+                        component={Link}
+                        to="/tags"
+                        size="small"
+                        aria-label={t('allTags')}
+                        title={t('allTags')}
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            onItemClick?.();
+                        }}
+                        sx={{ mr: 1 }}
+                    >
+                        <GridView fontSize="small" />
+                    </IconButton>
+                )}
                 {isOpen ? <ExpandLess /> : <ExpandMore />}
             </ListItemButton>
             <Collapse in={isOpen} timeout="auto" unmountOnExit>
                 <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, px: 2, pb: 2 }}>
-                    {availableTags.map(tag => {
+                    {displayTags.map(tag => {
                         const isSelected = selectedTags.includes(tag);
                         return (
                             <Chip
@@ -68,6 +131,23 @@ const TagsList: React.FC<TagsListProps> = ({ availableTags, selectedTags, onTagT
                         );
                     })}
                 </Box>
+                {linkToAllTags && hasMore && (
+                    <ListItemButton
+                        component={Link}
+                        to="/tags"
+                        onClick={onItemClick}
+                        sx={{ pl: 2, borderRadius: 1, mb: 1 }}
+                    >
+                        <ListItemText
+                            primary={t('showAll')}
+                            primaryTypographyProps={{
+                                variant: 'body2',
+                                color: 'primary',
+                                fontWeight: 600,
+                            }}
+                        />
+                    </ListItemButton>
+                )}
             </Collapse>
         </Paper>
     );

--- a/frontend/src/components/__tests__/ExpandableTagsStrip.test.tsx
+++ b/frontend/src/components/__tests__/ExpandableTagsStrip.test.tsx
@@ -66,4 +66,14 @@ describe('ExpandableTagsStrip', () => {
         fireEvent.click(screen.getByText('b'));
         expect(onTagToggle).toHaveBeenCalledWith('b');
     });
+
+    it('highlights selected tags case-insensitively', () => {
+        renderStrip({
+            tags: ['Music', 'Tech'],
+            selectedTags: ['music'],
+            measureOverflow: () => false,
+        });
+        expect(screen.getByText('Music').closest('.MuiChip-root')).toHaveClass('MuiChip-colorPrimary');
+        expect(screen.getByText('Tech').closest('.MuiChip-root')).not.toHaveClass('MuiChip-colorPrimary');
+    });
 });

--- a/frontend/src/components/__tests__/ExpandableTagsStrip.test.tsx
+++ b/frontend/src/components/__tests__/ExpandableTagsStrip.test.tsx
@@ -1,0 +1,69 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ExpandableTagsStrip from '../ExpandableTagsStrip';
+
+vi.mock('../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+const theme = createTheme();
+
+const renderStrip = (
+    props: Partial<React.ComponentProps<typeof ExpandableTagsStrip>> & {
+        measureOverflow?: (el: HTMLElement) => boolean;
+    } = {}
+) => {
+    const onTagToggle = props.onTagToggle ?? vi.fn();
+    render(
+        <ThemeProvider theme={theme}>
+            <ExpandableTagsStrip
+                tags={props.tags ?? ['a', 'b', 'c']}
+                selectedTags={props.selectedTags ?? []}
+                onTagToggle={onTagToggle}
+                measureOverflow={props.measureOverflow}
+                maxCollapsedLines={props.maxCollapsedLines}
+            />
+        </ThemeProvider>
+    );
+    return { onTagToggle };
+};
+
+describe('ExpandableTagsStrip', () => {
+    it('renders nothing when there are no tags', () => {
+        const { container } = render(
+            <ThemeProvider theme={theme}>
+                <ExpandableTagsStrip tags={[]} selectedTags={[]} onTagToggle={vi.fn()} />
+            </ThemeProvider>
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('hides expand control when measureOverflow reports no overflow', () => {
+        renderStrip({ measureOverflow: () => false });
+        expect(screen.queryByRole('button', { name: 'showMoreTags' })).not.toBeInTheDocument();
+        expect(screen.getByText('a')).toBeInTheDocument();
+    });
+
+    it('shows expand control when measureOverflow reports overflow', () => {
+        renderStrip({ measureOverflow: () => true });
+        expect(screen.getByRole('button', { name: 'showMoreTags' })).toBeInTheDocument();
+    });
+
+    it('expands and collapses via the control', () => {
+        renderStrip({ measureOverflow: () => true });
+        const toggle = screen.getByRole('button', { name: 'showMoreTags' });
+        fireEvent.click(toggle);
+        expect(screen.getByRole('button', { name: 'showLessTags' })).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.click(screen.getByRole('button', { name: 'showLessTags' }));
+        expect(screen.getByRole('button', { name: 'showMoreTags' })).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('calls onTagToggle when a chip is clicked', () => {
+        const { onTagToggle } = renderStrip({ measureOverflow: () => false });
+        fireEvent.click(screen.getByText('b'));
+        expect(onTagToggle).toHaveBeenCalledWith('b');
+    });
+});

--- a/frontend/src/components/__tests__/HomeHeader.test.tsx
+++ b/frontend/src/components/__tests__/HomeHeader.test.tsx
@@ -107,4 +107,18 @@ describe('HomeHeader', () => {
         // Actually, let's mock the Delete icon? 
         // Or simpler: Mock Tooltip to just render children with a data attribute.
     });
+
+    it('shows clear filter affordance when tags are selected', () => {
+        const onClearTagFilter = vi.fn();
+        render(
+            <HomeHeader
+                {...defaultProps}
+                selectedTagsCount={2}
+                onClearTagFilter={onClearTagFilter}
+            />
+        );
+        const clearButton = screen.getByRole('button', { name: /filteredByTags/i });
+        fireEvent.click(clearButton);
+        expect(onClearTagFilter).toHaveBeenCalledTimes(1);
+    });
 });

--- a/frontend/src/components/__tests__/TagsList.test.tsx
+++ b/frontend/src/components/__tests__/TagsList.test.tsx
@@ -134,6 +134,24 @@ describe('TagsList', () => {
         expect(screen.getByRole('link', { name: 'Show all' })).toBeInTheDocument();
     });
 
+    it('keeps case-insensitive selected tags outside the top 20 using catalog casing', () => {
+        const popularTags = Array.from({ length: 20 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
+        const availableTags = [...popularTags, 'Music'];
+        const videos = [
+            ...popularTags.flatMap((tag) => Array.from({ length: 3 }, () => ({ tags: [tag] }))),
+            { tags: ['Music'] },
+        ];
+        renderTagsList({
+            availableTags,
+            videos,
+            selectedTags: ['music'],
+            linkToAllTags: true,
+        });
+
+        expect(screen.getByText('Music')).toBeInTheDocument();
+        expect(screen.getByText('Music').closest('.MuiChip-root')).toHaveClass('MuiChip-colorPrimary');
+    });
+
     it('hides Show all when 20 or fewer tags', () => {
         const availableTags = Array.from({ length: 20 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
         renderTagsList({ availableTags, linkToAllTags: true });

--- a/frontend/src/components/__tests__/TagsList.test.tsx
+++ b/frontend/src/components/__tests__/TagsList.test.tsx
@@ -1,45 +1,69 @@
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import TagsList from '../TagsList';
 
-// Mock LanguageContext
 vi.mock('../../contexts/LanguageContext', () => ({
     useLanguage: () => ({
-        t: (key: string) => key === 'tags' ? 'Tags' : key,
+        t: (key: string) => {
+            if (key === 'tags') return 'Tags';
+            if (key === 'all') return 'All';
+            if (key === 'allTags') return 'All Tags';
+            if (key === 'showAll') return 'Show all';
+            return key;
+        },
     }),
 }));
 
-describe('TagsList', () => {
-    const mockOnTagToggle = vi.fn();
+const theme = createTheme();
 
+const renderTagsList = (props: {
+    availableTags?: string[];
+    selectedTags?: string[];
+    onTagToggle?: (tag: string) => void;
+    onItemClick?: () => void;
+    videos?: Array<{ tags?: string[] }>;
+    linkToAllTags?: boolean;
+} = {}) => {
+    const onTagToggle = props.onTagToggle ?? vi.fn();
+    const onItemClick = props.onItemClick;
+    render(
+        <MemoryRouter>
+            <ThemeProvider theme={theme}>
+                <TagsList
+                    availableTags={props.availableTags ?? ['tag1', 'tag2', 'tag3']}
+                    selectedTags={props.selectedTags ?? []}
+                    onTagToggle={onTagToggle}
+                    onItemClick={onItemClick}
+                    videos={props.videos}
+                    linkToAllTags={props.linkToAllTags ?? true}
+                />
+            </ThemeProvider>
+        </MemoryRouter>
+    );
+    return { onTagToggle, onItemClick };
+};
+
+describe('TagsList', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
     it('renders nothing when no tags available', () => {
-        const theme = createTheme();
         const { container } = render(
-            <ThemeProvider theme={theme}>
-                <TagsList availableTags={[]} selectedTags={[]} onTagToggle={mockOnTagToggle} />
-            </ThemeProvider>
+            <MemoryRouter>
+                <ThemeProvider theme={theme}>
+                    <TagsList availableTags={[]} selectedTags={[]} onTagToggle={vi.fn()} />
+                </ThemeProvider>
+            </MemoryRouter>
         );
 
         expect(container.firstChild).toBeNull();
     });
 
     it('renders tags list with available tags', () => {
-        const theme = createTheme();
-        render(
-            <ThemeProvider theme={theme}>
-                <TagsList
-                    availableTags={['tag1', 'tag2', 'tag3']}
-                    selectedTags={[]}
-                    onTagToggle={mockOnTagToggle}
-                />
-            </ThemeProvider>
-        );
-
+        renderTagsList();
         expect(screen.getByText('Tags')).toBeInTheDocument();
         expect(screen.getByText('tag1')).toBeInTheDocument();
         expect(screen.getByText('tag2')).toBeInTheDocument();
@@ -47,70 +71,83 @@ describe('TagsList', () => {
     });
 
     it('highlights selected tags', () => {
-        const theme = createTheme();
-        render(
-            <ThemeProvider theme={theme}>
-                <TagsList
-                    availableTags={['tag1', 'tag2', 'tag3']}
-                    selectedTags={['tag1', 'tag3']}
-                    onTagToggle={mockOnTagToggle}
-                />
-            </ThemeProvider>
-        );
-
-        const tag1 = screen.getByText('tag1');
-        const tag2 = screen.getByText('tag2');
-        const tag3 = screen.getByText('tag3');
-
-        // Selected tags should have different styling (we can check by role or parent)
-        expect(tag1).toBeInTheDocument();
-        expect(tag2).toBeInTheDocument();
-        expect(tag3).toBeInTheDocument();
+        renderTagsList({ selectedTags: ['tag1', 'tag3'] });
+        expect(screen.getByText('tag1')).toBeInTheDocument();
+        expect(screen.getByText('tag2')).toBeInTheDocument();
+        expect(screen.getByText('tag3')).toBeInTheDocument();
     });
 
     it('calls onTagToggle when tag is clicked', () => {
-        const theme = createTheme();
-        render(
-            <ThemeProvider theme={theme}>
-                <TagsList
-                    availableTags={['tag1', 'tag2']}
-                    selectedTags={[]}
-                    onTagToggle={mockOnTagToggle}
-                />
-            </ThemeProvider>
-        );
+        const { onTagToggle } = renderTagsList({ availableTags: ['tag1', 'tag2'] });
+        fireEvent.click(screen.getByText('tag1'));
+        expect(onTagToggle).toHaveBeenCalledWith('tag1');
+        expect(onTagToggle).toHaveBeenCalledTimes(1);
+    });
 
-        const tag1 = screen.getByText('tag1');
-        fireEvent.click(tag1);
-
-        expect(mockOnTagToggle).toHaveBeenCalledWith('tag1');
-        expect(mockOnTagToggle).toHaveBeenCalledTimes(1);
+    it('links All icon to /tags without toggling collapse', () => {
+        const onItemClick = vi.fn();
+        renderTagsList({ onItemClick, linkToAllTags: true });
+        const allLink = screen.getByRole('link', { name: 'All Tags' });
+        expect(allLink).toHaveAttribute('href', '/tags');
+        expect(screen.getByText('tag1')).toBeInTheDocument();
+        fireEvent.click(allLink);
+        expect(onItemClick).toHaveBeenCalledTimes(1);
+        // Collapse was not toggled — tags remain visible
+        expect(screen.getByText('tag1')).toBeInTheDocument();
     });
 
     it('toggles collapse when header is clicked', () => {
-        const theme = createTheme();
-        render(
-            <ThemeProvider theme={theme}>
-                <TagsList
-                    availableTags={['tag1', 'tag2']}
-                    selectedTags={[]}
-                    onTagToggle={mockOnTagToggle}
-                />
-            </ThemeProvider>
-        );
-
+        renderTagsList({ availableTags: ['tag1', 'tag2'] });
         const header = screen.getByText('Tags');
-        header.closest('div')?.querySelector('[role="region"]');
-
-        // Initially should be open (tags visible)
         expect(screen.getByText('tag1')).toBeInTheDocument();
-
-        // Click to collapse
         fireEvent.click(header);
-
-        // Tags should still be in DOM but collapsed (MUI Collapse keeps them)
-        // We can verify by checking the collapse state
         expect(screen.getByText('tag1')).toBeInTheDocument();
     });
-});
 
+    it('shows at most 20 tags and a Show all link when catalog is larger', () => {
+        const availableTags = Array.from({ length: 25 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
+        const videos = availableTags.map((tag) => ({ tags: [tag] }));
+        renderTagsList({ availableTags, videos, linkToAllTags: true });
+
+        const chips = screen.getAllByRole('button').filter((el) => el.className.includes('MuiChip-root'));
+        expect(chips).toHaveLength(20);
+        expect(screen.queryByText('tag24')).not.toBeInTheDocument();
+        const showAll = screen.getByRole('link', { name: 'Show all' });
+        expect(showAll).toHaveAttribute('href', '/tags');
+    });
+
+    it('orders by usage and keeps selected tags outside the top 20 visible', () => {
+        const availableTags = Array.from({ length: 22 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
+        const videos = [
+            ...Array.from({ length: 5 }, () => ({ tags: ['tag21'] })),
+            ...Array.from({ length: 19 }, (_, i) => ({ tags: [`tag${String(i).padStart(2, '0')}`] })),
+        ];
+        renderTagsList({
+            availableTags,
+            videos,
+            selectedTags: ['tag20'],
+            linkToAllTags: true,
+        });
+
+        expect(screen.getByText('tag21')).toBeInTheDocument();
+        expect(screen.getByText('tag20')).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Show all' })).toBeInTheDocument();
+    });
+
+    it('hides Show all when 20 or fewer tags', () => {
+        const availableTags = Array.from({ length: 20 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
+        renderTagsList({ availableTags, linkToAllTags: true });
+        expect(screen.queryByRole('link', { name: 'Show all' })).not.toBeInTheDocument();
+    });
+
+    it('shows all page-local tags without global links when linkToAllTags is false', () => {
+        const availableTags = Array.from({ length: 25 }, (_, i) => `tag${String(i).padStart(2, '0')}`);
+        renderTagsList({ availableTags, linkToAllTags: false });
+
+        const chips = screen.getAllByRole('button').filter((el) => el.className.includes('MuiChip-root'));
+        expect(chips).toHaveLength(25);
+        expect(screen.getByText('tag24')).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'All Tags' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: 'Show all' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/contexts/VideoContext.tsx
+++ b/frontend/src/contexts/VideoContext.tsx
@@ -6,6 +6,7 @@ import { api } from '../utils/apiClient';
 import { withCanonicalAuthorAvatars } from '../utils/authorAvatar';
 import { hasAxiosStatus } from '../utils/errors';
 import { settingsQueryOptions } from '../utils/settingsQueries';
+import { normalizeTagKey } from '../utils/tagUtils';
 import { useAuth } from './AuthContext';
 import { useLanguage } from './LanguageContext';
 import { useSnackbar } from './SnackbarContext';
@@ -434,11 +435,14 @@ export const VideoProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     }, [searchTerm, loadingMore, showYoutubeSearch, searchResults.length, showSnackbar, t]);
 
     const handleTagToggle = useCallback((tag: string) => {
-        setSelectedTags(prev =>
-            prev.includes(tag)
-                ? prev.filter(t => t !== tag)
-                : [...prev, tag]
-        );
+        setSelectedTags((prev) => {
+            const key = normalizeTagKey(tag);
+            const alreadySelected = prev.some((t) => normalizeTagKey(t) === key);
+            if (alreadySelected) {
+                return prev.filter((t) => normalizeTagKey(t) !== key);
+            }
+            return [...prev, tag];
+        });
     }, []);
 
     const clearSelectedTags = useCallback(() => {

--- a/frontend/src/contexts/VideoContext.tsx
+++ b/frontend/src/contexts/VideoContext.tsx
@@ -37,6 +37,7 @@ interface VideoContextType {
     availableTags: string[];
     selectedTags: string[];
     handleTagToggle: (tag: string) => void;
+    clearSelectedTags: () => void;
     showYoutubeSearch: boolean;
     loadMoreSearchResults: () => Promise<void>;
     loadingMore: boolean;
@@ -46,6 +47,7 @@ interface VideoTagsContextType {
     availableTags: string[];
     selectedTags: string[];
     handleTagToggle: (tag: string) => void;
+    clearSelectedTags: () => void;
 }
 
 interface VideoActionsContextType {
@@ -439,6 +441,10 @@ export const VideoProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         );
     }, []);
 
+    const clearSelectedTags = useCallback(() => {
+        setSelectedTags([]);
+    }, []);
+
     // Cleanup search on unmount
     useEffect(() => {
         return () => {
@@ -644,6 +650,7 @@ export const VideoProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         availableTags,
         selectedTags,
         handleTagToggle,
+        clearSelectedTags,
         showYoutubeSearch,
         loadMoreSearchResults,
         loadingMore,
@@ -653,14 +660,15 @@ export const VideoProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         incrementView, searchLocalVideos, searchResults, localSearchResults,
         isSearchMode, searchTerm, youtubeLoading, handleSearch, lastSearchEventId,
         resetSearch, setVideos, availableTags, selectedTags, handleTagToggle,
-        showYoutubeSearch, loadMoreSearchResults, loadingMore,
+        clearSelectedTags, showYoutubeSearch, loadMoreSearchResults, loadingMore,
     ]);
 
     const tagsValue = useMemo<VideoTagsContextType>(() => ({
         availableTags,
         selectedTags,
         handleTagToggle,
-    }), [availableTags, selectedTags, handleTagToggle]);
+        clearSelectedTags,
+    }), [availableTags, selectedTags, handleTagToggle, clearSelectedTags]);
 
     const actionsValue = useMemo<VideoActionsContextType>(() => ({
         updateVideo,

--- a/frontend/src/contexts/__tests__/VideoContext.test.tsx
+++ b/frontend/src/contexts/__tests__/VideoContext.test.tsx
@@ -446,6 +446,13 @@ describe('VideoContext', () => {
 
     expect(result.current.selectedTags).toEqual(['vue']);
 
+    act(() => {
+      result.current.handleTagToggle('Music');
+      result.current.handleTagToggle('music');
+    });
+
+    expect(result.current.selectedTags).toEqual(['vue']);
+
     await act(async () => {
       await result.current.handleSearch('react');
     });

--- a/frontend/src/hooks/__tests__/useHomePagination.test.tsx
+++ b/frontend/src/hooks/__tests__/useHomePagination.test.tsx
@@ -102,4 +102,41 @@ describe('useHomePagination', () => {
         act(() => { window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' })); });
         expect(mockSetSearchParams).not.toHaveBeenCalled();
     });
+
+    it('clamps out-of-range page to 1 and preserves other query params', () => {
+        mockSearchParams.set('page', '99');
+        mockSearchParams.set('sort', 'dateAsc');
+        mockSearchParams.set('seed', 'abc');
+        setupHook({ videos: mockVideos.slice(0, 5) });
+        expect(mockSetSearchParams).toHaveBeenCalled();
+        const newParams = mockSetSearchParams.mock.calls[0][0](
+            new URLSearchParams('page=99&sort=dateAsc&seed=abc')
+        );
+        expect(newParams.get('page')).toBe('1');
+        expect(newParams.get('sort')).toBe('dateAsc');
+        expect(newParams.get('seed')).toBe('abc');
+    });
+
+    it.each(['abc', '0', '-3', '1.5'])('normalizes invalid page %s to 1', (page) => {
+        mockSearchParams.set('page', page);
+        setupHook();
+        expect(mockSetSearchParams).toHaveBeenCalled();
+        const newParams = mockSetSearchParams.mock.calls[0][0](
+            new URLSearchParams(`page=${page}&sort=dateAsc`)
+        );
+        expect(newParams.get('page')).toBe('1');
+        expect(newParams.get('sort')).toBe('dateAsc');
+    });
+
+    it('does not clamp page when infiniteScroll is enabled', () => {
+        mockSearchParams.set('page', '99');
+        setupHook({ infiniteScroll: true, videos: mockVideos.slice(0, 5) });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+
+    it('does not clamp a valid page', () => {
+        mockSearchParams.set('page', '2');
+        setupHook();
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/hooks/__tests__/useHomePagination.test.tsx
+++ b/frontend/src/hooks/__tests__/useHomePagination.test.tsx
@@ -139,4 +139,10 @@ describe('useHomePagination', () => {
         setupHook();
         expect(mockSetSearchParams).not.toHaveBeenCalled();
     });
+
+    it('does not clamp page while videos are still loading (empty list)', () => {
+        mockSearchParams.set('page', '2');
+        setupHook({ videos: [] });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
 });

--- a/frontend/src/hooks/useHomePagination.ts
+++ b/frontend/src/hooks/useHomePagination.ts
@@ -45,14 +45,16 @@ export const useHomePagination = ({
 
     // Normalize invalid or out-of-range page params while preserving other
     // query params (sort / seed). Fixes Home and /tags together.
+    // Skip out-of-range clamping while videos are still loading (totalPages === 0)
+    // so deep links like /?page=2 are not rewritten to page=1 prematurely.
     useEffect(() => {
         if (infiniteScroll) return;
-        const safeTotal = Math.max(totalPages, 1);
         const isInvalidPageParam = pageParam != null && (
             !Number.isInteger(parsedPage) ||
             parsedPage < 1
         );
-        if (isInvalidPageParam || page > safeTotal) {
+        const isOutOfRange = totalPages > 0 && page > totalPages;
+        if (isInvalidPageParam || isOutOfRange) {
             setSearchParams((prev: URLSearchParams) => {
                 const newParams = new URLSearchParams(prev);
                 newParams.set('page', '1');

--- a/frontend/src/hooks/useHomePagination.ts
+++ b/frontend/src/hooks/useHomePagination.ts
@@ -23,7 +23,9 @@ export const useHomePagination = ({
     selectedTags
 }: UseHomePaginationProps): UseHomePaginationReturn => {
     const [searchParams, setSearchParams] = useSearchParams();
-    const page = parseInt(searchParams.get('page') || '1', 10);
+    const pageParam = searchParams.get('page');
+    const parsedPage = pageParam == null ? 1 : Number(pageParam);
+    const page = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
 
     // Reset page when switching tags (paginated mode only)
     const prevTagsRef = useRef(selectedTags);
@@ -40,6 +42,24 @@ export const useHomePagination = ({
 
     // Pagination logic
     const totalPages = Math.ceil(sortedVideos.length / itemsPerPage);
+
+    // Normalize invalid or out-of-range page params while preserving other
+    // query params (sort / seed). Fixes Home and /tags together.
+    useEffect(() => {
+        if (infiniteScroll) return;
+        const safeTotal = Math.max(totalPages, 1);
+        const isInvalidPageParam = pageParam != null && (
+            !Number.isInteger(parsedPage) ||
+            parsedPage < 1
+        );
+        if (isInvalidPageParam || page > safeTotal) {
+            setSearchParams((prev: URLSearchParams) => {
+                const newParams = new URLSearchParams(prev);
+                newParams.set('page', '1');
+                return newParams;
+            });
+        }
+    }, [infiniteScroll, page, pageParam, parsedPage, totalPages, setSearchParams]);
 
     // Get displayed videos based on mode (Only used for PAGINATION)
     const displayedVideos = useMemo(() => {

--- a/frontend/src/hooks/useVideoFiltering.ts
+++ b/frontend/src/hooks/useVideoFiltering.ts
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 import { Collection, Video } from "../types";
+import { normalizeTagKey } from "../utils/tagUtils";
 import { ViewMode } from "./useViewMode";
 
 const EMPTY_TAG_SET = new Set<string>();
 
 function normalizeTag(value: string | undefined | null): string {
-  if (value == null) return "";
-  return String(value).trim().toLowerCase();
+  return normalizeTagKey(value);
 }
 
 function normalizeTagList(tags: string[] | undefined | null): string[] {

--- a/frontend/src/pages/AllTagsPage.tsx
+++ b/frontend/src/pages/AllTagsPage.tsx
@@ -43,6 +43,7 @@ const AllTagsPage: React.FC = () => {
     const {
         videos,
         loading,
+        error,
         availableTags,
         selectedTags,
         handleTagToggle,
@@ -119,6 +120,14 @@ const AllTagsPage: React.FC = () => {
             <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
                 <CircularProgress />
             </Box>
+        );
+    }
+
+    if (error && videoArray.length === 0) {
+        return (
+            <Container sx={{ mt: 4 }}>
+                <Alert severity="error">{error}</Alert>
+            </Container>
         );
     }
 

--- a/frontend/src/pages/AllTagsPage.tsx
+++ b/frontend/src/pages/AllTagsPage.tsx
@@ -1,0 +1,247 @@
+import { Delete as DeleteIcon } from '@mui/icons-material';
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    Container,
+    IconButton,
+    Pagination,
+    Tooltip,
+    Typography,
+    useMediaQuery,
+    useTheme,
+} from '@mui/material';
+import React, { Suspense, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import ExpandableTagsStrip from '../components/ExpandableTagsStrip';
+import SortControl from '../components/SortControl';
+import { VideoGrid } from '../components/VideoGrid';
+import { useCollection } from '../contexts/CollectionContext';
+import { useLanguage } from '../contexts/LanguageContext';
+import { useVideo } from '../contexts/VideoContext';
+import { useGridLayout } from '../hooks/useGridLayout';
+import { useHomePagination } from '../hooks/useHomePagination';
+import { useHomeSettings } from '../hooks/useHomeSettings';
+import { useSettings } from '../hooks/useSettings';
+import { useVideoFiltering } from '../hooks/useVideoFiltering';
+import { useVideoSort } from '../hooks/useVideoSort';
+import { lazyWithRetry } from '../utils/lazyWithRetry';
+import { sortTagsByUsage } from '../utils/tagUtils';
+
+const ALL_TAGS_SORT_STORAGE_SLOT = 'allTagsSortOption';
+
+const ConfirmationModal = lazyWithRetry(
+    () => import('../components/ConfirmationModal'),
+    'confirmation-modal',
+);
+
+const AllTagsPage: React.FC = () => {
+    const { t } = useLanguage();
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const {
+        videos,
+        loading,
+        availableTags,
+        selectedTags,
+        handleTagToggle,
+        clearSelectedTags,
+        deleteVideo,
+        deleteVideos,
+    } = useVideo();
+    const { collections } = useCollection();
+    const { data: settings, isLoading: settingsLoading } = useSettings();
+    const [, setSearchParams] = useSearchParams();
+    const [isDeleteFilteredOpen, setIsDeleteFilteredOpen] = useState(false);
+
+    const {
+        itemsPerPage,
+        infiniteScroll,
+        videoColumns,
+        defaultSort,
+        showTagsOnThumbnail,
+        settingsLoaded,
+    } = useHomeSettings({ settings, settingsLoading });
+
+    const gridProps = useGridLayout({ isSidebarOpen: false, videoColumns });
+    const videoArray = useMemo(() => (Array.isArray(videos) ? videos : []), [videos]);
+
+    const tagMembershipKey = useMemo(
+        () => videoArray.map((v) => `${v.id}:${(v.tags ?? []).join(',')}`).join('|'),
+        [videoArray]
+    );
+
+    const orderedTags = useMemo(
+        () => sortTagsByUsage(availableTags, videoArray),
+        // tagMembershipKey avoids reordering on unrelated video field changes
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional tag-only signal
+        [availableTags, tagMembershipKey]
+    );
+
+    const filteredVideos = useVideoFiltering({
+        videos: videoArray,
+        viewMode: 'all-videos',
+        selectedTags,
+        collections,
+        authorTags: settings?.authorTags,
+        collectionTags: settings?.collectionTags,
+    });
+
+    const {
+        sortedVideos,
+        sortOption,
+        sortAnchorEl,
+        handleSortClick,
+        handleSortClose,
+    } = useVideoSort({
+        videos: filteredVideos,
+        defaultSort,
+        storageKey: ALL_TAGS_SORT_STORAGE_SLOT,
+        onSortChange: () => {
+            setSearchParams((prev: URLSearchParams) => {
+                const newParams = new URLSearchParams(prev);
+                newParams.set('page', '1');
+                return newParams;
+            });
+        },
+    });
+
+    const { page, totalPages, displayedVideos, handlePageChange } = useHomePagination({
+        sortedVideos,
+        itemsPerPage,
+        infiniteScroll,
+        selectedTags,
+    });
+
+    if (!settingsLoaded || (loading && videoArray.length === 0)) {
+        return (
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    return (
+        <Container maxWidth={false} sx={{ py: 4, px: { xs: 2, sm: 3 } }}>
+            {isDeleteFilteredOpen && (
+                <Suspense fallback={null}>
+                    <ConfirmationModal
+                        isOpen={isDeleteFilteredOpen}
+                        onClose={() => setIsDeleteFilteredOpen(false)}
+                        onConfirm={async () => {
+                            if (filteredVideos.length > 0) {
+                                await deleteVideos(filteredVideos.map((v) => v.id));
+                            }
+                        }}
+                        title={t('deleteAllFilteredVideos')}
+                        message={t('confirmDeleteFilteredVideos', {
+                            count: filteredVideos.length,
+                        })}
+                        confirmText={t('delete')}
+                        cancelText={t('cancel')}
+                        isDanger={true}
+                    />
+                </Suspense>
+            )}
+
+            <Typography variant="h4" component="h1" gutterBottom fontWeight="bold">
+                {t('allTags')}
+            </Typography>
+
+            {orderedTags.length === 0 ? (
+                <Alert severity="info" sx={{ mb: 3 }}>
+                    {t('noTagsAvailable')}
+                </Alert>
+            ) : (
+                <ExpandableTagsStrip
+                    tags={orderedTags}
+                    selectedTags={selectedTags}
+                    onTagToggle={handleTagToggle}
+                    maxCollapsedLines={3}
+                />
+            )}
+
+            <Box
+                sx={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    gap: 2,
+                    mb: 3,
+                    flexWrap: 'wrap',
+                }}
+            >
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
+                    {selectedTags.length > 0 && (
+                        <>
+                            <Button
+                                size="small"
+                                onClick={clearSelectedTags}
+                                sx={{ textTransform: 'none', fontWeight: 600 }}
+                            >
+                                {t('filteredByTags', { count: selectedTags.length })} — {t('clear')}
+                            </Button>
+                            <Tooltip title={t('deleteAllFilteredVideos')}>
+                                <IconButton
+                                    color="error"
+                                    onClick={() => setIsDeleteFilteredOpen(true)}
+                                    size="small"
+                                >
+                                    <DeleteIcon />
+                                </IconButton>
+                            </Tooltip>
+                        </>
+                    )}
+                </Box>
+                <SortControl
+                    sortOption={sortOption}
+                    sortAnchorEl={sortAnchorEl}
+                    onSortClick={handleSortClick}
+                    onSortClose={handleSortClose}
+                />
+            </Box>
+
+            {videoArray.length === 0 ? (
+                <Typography color="text.secondary" sx={{ py: 6, textAlign: 'center' }}>
+                    {t('noVideosYet')}
+                </Typography>
+            ) : filteredVideos.length === 0 ? (
+                <Typography color="text.secondary" sx={{ py: 6, textAlign: 'center' }}>
+                    {t('noVideos')}
+                </Typography>
+            ) : (
+                <>
+                    <VideoGrid
+                        videos={videoArray}
+                        sortedVideos={sortedVideos}
+                        displayedVideos={displayedVideos}
+                        collections={collections}
+                        viewMode="all-videos"
+                        infiniteScroll={infiniteScroll}
+                        gridProps={gridProps}
+                        onDeleteVideo={deleteVideo}
+                        showTagsOnThumbnail={showTagsOnThumbnail}
+                        onTagToggle={handleTagToggle}
+                    />
+                    {!infiniteScroll && totalPages > 1 && (
+                        <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
+                            <Pagination
+                                count={totalPages}
+                                page={page}
+                                onChange={handlePageChange}
+                                color="primary"
+                                size={isMobile ? 'medium' : 'large'}
+                                siblingCount={isMobile ? 0 : 1}
+                                showFirstButton
+                                showLastButton
+                            />
+                        </Box>
+                    )}
+                </>
+            )}
+        </Container>
+    );
+};
+
+export default AllTagsPage;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -43,6 +43,7 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
         availableTags,
         selectedTags,
         handleTagToggle,
+        clearSelectedTags,
         deleteVideo,
         deleteVideos
     } = useVideo();
@@ -209,6 +210,7 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                             onSidebarToggle={handleSidebarToggle}
                             selectedTagsCount={selectedTags.length}
                             onDeleteFilteredClick={() => setIsDeleteFilteredOpen(true)}
+                            onClearTagFilter={clearSelectedTags}
                             sortOption={sortOption}
                             sortAnchorEl={sortAnchorEl}
                             onSortClick={handleSortClick}

--- a/frontend/src/pages/__tests__/AllTagsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AllTagsPage.test.tsx
@@ -1,0 +1,185 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AllTagsPage from '../AllTagsPage';
+import { Video } from '../../types';
+
+const mockHandleTagToggle = vi.fn();
+const mockClearSelectedTags = vi.fn();
+const mockUseVideoReturn = {
+    videos: [
+        { id: 'v1', title: 'One', tags: ['Music'] },
+        { id: 'v2', title: 'Two', tags: ['Tech'] },
+        { id: 'v3', title: 'Three', tags: ['Music', 'Tech'] },
+    ] as Video[],
+    loading: false,
+    availableTags: ['Music', 'Tech', 'Unused'],
+    selectedTags: [] as string[],
+    handleTagToggle: mockHandleTagToggle,
+    clearSelectedTags: mockClearSelectedTags,
+    deleteVideo: vi.fn(),
+    deleteVideos: vi.fn(),
+};
+
+vi.mock('../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({
+        t: (key: string, replacements?: Record<string, string | number>) => {
+            if (replacements?.count != null) {
+                return `${key}:${replacements.count}`;
+            }
+            return key;
+        },
+    }),
+}));
+
+vi.mock('../../contexts/VideoContext', () => ({
+    useVideo: () => mockUseVideoReturn,
+}));
+
+vi.mock('../../contexts/CollectionContext', () => ({
+    useCollection: () => ({ collections: [] }),
+}));
+
+vi.mock('../../hooks/useSettings', () => ({
+    useSettings: () => ({
+        data: { authorTags: {}, collectionTags: {} },
+        isLoading: false,
+    }),
+}));
+
+vi.mock('../../hooks/useHomeSettings', () => ({
+    useHomeSettings: () => ({
+        itemsPerPage: 20,
+        infiniteScroll: false,
+        videoColumns: 4,
+        defaultSort: 'dateDesc',
+        showTagsOnThumbnail: true,
+        settingsLoaded: true,
+    }),
+}));
+
+vi.mock('../../hooks/useGridLayout', () => ({
+    useGridLayout: () => ({ xs: 12, sm: 6, lg: 4, xl: 3 }),
+}));
+
+vi.mock('../../hooks/useVideoFiltering', () => ({
+    useVideoFiltering: ({ selectedTags, videos }: { selectedTags: string[]; videos: Video[] }) => {
+        if (selectedTags.length === 0) return videos;
+        return videos.filter((video) =>
+            selectedTags.every((tag) => (video.tags ?? []).includes(tag))
+        );
+    },
+}));
+
+vi.mock('../../hooks/useVideoSort', () => ({
+    useVideoSort: ({ videos }: { videos: Video[] }) => ({
+        sortedVideos: videos,
+        sortOption: 'dateDesc',
+        sortAnchorEl: null,
+        handleSortClick: vi.fn(),
+        handleSortClose: vi.fn(),
+    }),
+}));
+
+vi.mock('../../hooks/useHomePagination', () => ({
+    useHomePagination: ({ sortedVideos }: { sortedVideos: Video[] }) => ({
+        page: 1,
+        totalPages: 1,
+        displayedVideos: sortedVideos,
+        handlePageChange: vi.fn(),
+    }),
+}));
+
+vi.mock('../../components/ExpandableTagsStrip', () => ({
+    default: ({
+        tags,
+        onTagToggle,
+    }: {
+        tags: string[];
+        onTagToggle: (tag: string) => void;
+    }) => (
+        <div data-testid="tags-strip">
+            {tags.map((tag) => (
+                <button key={tag} type="button" onClick={() => onTagToggle(tag)}>
+                    {tag}
+                </button>
+            ))}
+        </div>
+    ),
+}));
+
+vi.mock('../../components/VideoGrid', () => ({
+    VideoGrid: ({ displayedVideos }: { displayedVideos: Video[] }) => (
+        <div data-testid="video-grid">
+            {displayedVideos.map((v) => (
+                <div key={v.id}>{v.title}</div>
+            ))}
+        </div>
+    ),
+}));
+
+vi.mock('../../components/SortControl', () => ({
+    default: () => <div data-testid="sort-control" />,
+}));
+
+describe('AllTagsPage', () => {
+    const theme = createTheme();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseVideoReturn.selectedTags = [];
+        mockUseVideoReturn.loading = false;
+        mockUseVideoReturn.videos = [
+            { id: 'v1', title: 'One', tags: ['Music'] },
+            { id: 'v2', title: 'Two', tags: ['Tech'] },
+            { id: 'v3', title: 'Three', tags: ['Music', 'Tech'] },
+        ] as Video[];
+        mockUseVideoReturn.availableTags = ['Music', 'Tech', 'Unused'];
+    });
+
+    const renderPage = () =>
+        render(
+            <MemoryRouter>
+                <ThemeProvider theme={theme}>
+                    <AllTagsPage />
+                </ThemeProvider>
+            </MemoryRouter>
+        );
+
+    it('renders title and most-used ordered tags strip', () => {
+        renderPage();
+        expect(screen.getByText('allTags')).toBeInTheDocument();
+        const strip = screen.getByTestId('tags-strip');
+        const buttons = Array.from(strip.querySelectorAll('button')).map((b) => b.textContent);
+        // Music (2), Tech (1), Unused (0)
+        expect(buttons).toEqual(['Music', 'Tech', 'Unused']);
+    });
+
+    it('toggles a tag via the strip', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: 'Music' }));
+        expect(mockHandleTagToggle).toHaveBeenCalledWith('Music');
+    });
+
+    it('filters the grid when tags are selected (AND)', () => {
+        mockUseVideoReturn.selectedTags = ['Music', 'Tech'];
+        renderPage();
+        expect(screen.getByText('Three')).toBeInTheDocument();
+        expect(screen.queryByText('One')).not.toBeInTheDocument();
+        expect(screen.queryByText('Two')).not.toBeInTheDocument();
+    });
+
+    it('shows loading spinner while videos load', () => {
+        mockUseVideoReturn.loading = true;
+        mockUseVideoReturn.videos = [];
+        renderPage();
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('shows empty catalog message when no tags exist', () => {
+        mockUseVideoReturn.availableTags = [];
+        renderPage();
+        expect(screen.getByText('noTagsAvailable')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/__tests__/AllTagsPage.test.tsx
+++ b/frontend/src/pages/__tests__/AllTagsPage.test.tsx
@@ -14,6 +14,7 @@ const mockUseVideoReturn = {
         { id: 'v3', title: 'Three', tags: ['Music', 'Tech'] },
     ] as Video[],
     loading: false,
+    error: null as string | null,
     availableTags: ['Music', 'Tech', 'Unused'],
     selectedTags: [] as string[],
     handleTagToggle: mockHandleTagToggle,
@@ -130,6 +131,7 @@ describe('AllTagsPage', () => {
         vi.clearAllMocks();
         mockUseVideoReturn.selectedTags = [];
         mockUseVideoReturn.loading = false;
+        mockUseVideoReturn.error = null;
         mockUseVideoReturn.videos = [
             { id: 'v1', title: 'One', tags: ['Music'] },
             { id: 'v2', title: 'Two', tags: ['Tech'] },
@@ -175,6 +177,14 @@ describe('AllTagsPage', () => {
         mockUseVideoReturn.videos = [];
         renderPage();
         expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+
+    it('shows error alert when video load fails and there are no videos', () => {
+        mockUseVideoReturn.error = 'Failed to load videos';
+        mockUseVideoReturn.videos = [];
+        renderPage();
+        expect(screen.getByText('Failed to load videos')).toBeInTheDocument();
+        expect(screen.queryByText('noVideosYet')).not.toBeInTheDocument();
     });
 
     it('shows empty catalog message when no tags exist', () => {

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -25,6 +25,7 @@ const mockUseVideoReturn = {
     availableTags: [],
     selectedTags: [] as string[],
     handleTagToggle: vi.fn(),
+    clearSelectedTags: vi.fn(),
     deleteVideo: vi.fn(),
     deleteVideos: vi.fn(),
 };

--- a/frontend/src/utils/__tests__/tagUtils.test.ts
+++ b/frontend/src/utils/__tests__/tagUtils.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { countTagUsage, normalizeTagKey, sortTagsByUsage } from "../tagUtils";
+
+describe("normalizeTagKey", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeTagKey("  Music ")).toBe("music");
+  });
+
+  it("returns empty string for nullish", () => {
+    expect(normalizeTagKey(null)).toBe("");
+    expect(normalizeTagKey(undefined)).toBe("");
+  });
+});
+
+describe("countTagUsage", () => {
+  it("counts case-insensitive matches against catalog casing", () => {
+    const counts = countTagUsage(
+      ["Music", "Tech"],
+      [{ tags: ["music", "TECH"] }, { tags: ["Music"] }]
+    );
+    expect(counts.get("Music")).toBe(2);
+    expect(counts.get("Tech")).toBe(1);
+  });
+
+  it("counts duplicate tags on one video only once", () => {
+    const counts = countTagUsage(
+      ["Music"],
+      [{ tags: ["Music", "music", "MUSIC"] }]
+    );
+    expect(counts.get("Music")).toBe(1);
+  });
+
+  it("leaves unused catalog tags at zero", () => {
+    const counts = countTagUsage(["A", "B"], [{ tags: ["A"] }]);
+    expect(counts.get("A")).toBe(1);
+    expect(counts.get("B")).toBe(0);
+  });
+
+  it("ignores orphan video tags not in the catalog", () => {
+    const counts = countTagUsage(["A"], [{ tags: ["orphan", "A"] }]);
+    expect(counts.size).toBe(1);
+    expect(counts.get("A")).toBe(1);
+  });
+});
+
+describe("sortTagsByUsage", () => {
+  it("orders by descending usage then alphabetical", () => {
+    const sorted = sortTagsByUsage(
+      ["Zebra", "Apple", "Music", "Banana"],
+      [
+        { tags: ["Music"] },
+        { tags: ["Music", "Apple"] },
+        { tags: ["Banana"] },
+      ]
+    );
+    expect(sorted).toEqual(["Music", "Apple", "Banana", "Zebra"]);
+  });
+
+  it("returns empty array for empty catalog", () => {
+    expect(sortTagsByUsage([], [{ tags: ["x"] }])).toEqual([]);
+  });
+
+  it("keeps catalog order stable when all unused (alphabetical)", () => {
+    expect(sortTagsByUsage(["b", "a", "c"], [])).toEqual(["a", "b", "c"]);
+  });
+});

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -582,6 +582,10 @@ export const ar = {
   all: "الكل",
   showAll: "عرض الكل",
   allAuthors: "كل المؤلفين",
+  allTags: "كل الوسوم",
+  showMoreTags: "عرض المزيد من الوسوم",
+  showLessTags: "عرض عدد أقل من الوسوم",
+  filteredByTags: "تمت التصفية حسب {count} وسوم",
 
   created: "تاريخ الإنشاء",
   name: "الاسم",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -607,6 +607,10 @@ export const de = {
   all: "Alle",
   showAll: "Alle anzeigen",
   allAuthors: "Alle Autoren",
+  allTags: "Alle Tags",
+  showMoreTags: "Mehr Tags anzeigen",
+  showLessTags: "Weniger Tags anzeigen",
+  filteredByTags: "Gefiltert nach {count} Tags",
 
   created: "Erstellt",
   name: "Name",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -602,6 +602,10 @@ export const en = {
   all: "All",
   showAll: "Show all",
   allAuthors: "All Authors",
+  allTags: "All Tags",
+  showMoreTags: "Show more tags",
+  showLessTags: "Show fewer tags",
+  filteredByTags: "Filtered by {count} tags",
 
   created: "Created",
   name: "Name",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -603,6 +603,10 @@ export const es = {
   all: "Todos",
   showAll: "Ver todos",
   allAuthors: "Todos los autores",
+  allTags: "Todas las etiquetas",
+  showMoreTags: "Mostrar más etiquetas",
+  showLessTags: "Mostrar menos etiquetas",
+  filteredByTags: "Filtrado por {count} etiquetas",
 
   created: "Creado",
   name: "Nombre",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -603,6 +603,10 @@ export const fr = {
   all: "Tous",
   showAll: "Tout afficher",
   allAuthors: "Tous les auteurs",
+  allTags: "Tous les tags",
+  showMoreTags: "Afficher plus de tags",
+  showLessTags: "Afficher moins de tags",
+  filteredByTags: "Filtré par {count} tags",
 
   created: "Créé",
   name: "Nom",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -598,6 +598,10 @@ export const ja = {
   all: "すべて",
   showAll: "すべて表示",
   allAuthors: "すべての作成者",
+  allTags: "すべてのタグ",
+  showMoreTags: "タグをもっと表示",
+  showLessTags: "タグを少なく表示",
+  filteredByTags: "{count} 個のタグで絞り込み中",
 
   created: "作成日",
   name: "名前",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -591,6 +591,10 @@ export const ko = {
   all: "전체",
   showAll: "전체 보기",
   allAuthors: "모든 작성자",
+  allTags: "모든 태그",
+  showMoreTags: "태그 더 보기",
+  showLessTags: "태그 접기",
+  filteredByTags: "{count}개 태그로 필터링됨",
 
   created: "생성일",
   name: "이름",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -600,6 +600,10 @@ export const pt = {
   all: "Todos",
   showAll: "Ver todos",
   allAuthors: "Todos os autores",
+  allTags: "Todas as tags",
+  showMoreTags: "Mostrar mais tags",
+  showLessTags: "Mostrar menos tags",
+  filteredByTags: "Filtrado por {count} tags",
 
   created: "Criado",
   name: "Nome",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -596,6 +596,10 @@ export const ru = {
   all: "Все",
   showAll: "Показать все",
   allAuthors: "Все авторы",
+  allTags: "Все теги",
+  showMoreTags: "Показать больше тегов",
+  showLessTags: "Показать меньше тегов",
+  filteredByTags: "Отфильтровано по {count} тегам",
 
   created: "Создано",
   name: "Имя",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -578,6 +578,10 @@ export const zh = {
   all: "全部",
   showAll: "显示全部",
   allAuthors: "所有作者",
+  allTags: "所有标签",
+  showMoreTags: "显示更多标签",
+  showLessTags: "显示更少标签",
+  filteredByTags: "已按 {count} 个标签筛选",
 
   created: "创建时间",
   name: "名称",

--- a/frontend/src/utils/tagUtils.ts
+++ b/frontend/src/utils/tagUtils.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared tag normalization and usage ranking.
+ * Matching is case-insensitive / trim-based; display keeps catalog casing.
+ */
+
+export function normalizeTagKey(tag: string | null | undefined): string {
+  if (tag == null) return "";
+  return String(tag).trim().toLowerCase();
+}
+
+/** Count videos that explicitly include each catalog tag (case-insensitive). */
+export function countTagUsage(
+  availableTags: string[],
+  videos: Array<{ tags?: string[] }>
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const tag of availableTags) {
+    counts.set(tag, 0);
+  }
+
+  const catalogByKey = new Map(
+    availableTags.map((tag) => [normalizeTagKey(tag), tag])
+  );
+
+  for (const video of videos) {
+    const seen = new Set<string>();
+    for (const raw of video.tags ?? []) {
+      const canonical = catalogByKey.get(normalizeTagKey(raw));
+      if (!canonical || seen.has(canonical)) continue;
+      seen.add(canonical);
+      counts.set(canonical, (counts.get(canonical) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+/** Most-used first; alphabetical tie-break. Unused catalog tags stay at the end. */
+export function sortTagsByUsage(
+  availableTags: string[],
+  videos: Array<{ tags?: string[] }>
+): string[] {
+  const counts = countTagUsage(availableTags, videos);
+  return [...availableTags].sort((a, b) => {
+    const diff = (counts.get(b) ?? 0) - (counts.get(a) ?? 0);
+    if (diff !== 0) return diff;
+    return a.localeCompare(b);
+  });
+}


### PR DESCRIPTION
## Summary
- Add `/tags` (`AllTagsPage`) with usage-ranked tags, expandable tag strip, sorting, pagination, and filtered video grid
- Enhance Home/mobile tag sidebars with top-20 usage ranking, links to All Tags, and a clear-filter control in the header
- Introduce shared `tagUtils` for case-insensitive tag matching and usage counts; clamp invalid `?page=` query params
- Scope `TagsList` via `linkToAllTags` so author/collection sidebars show all page-local tags without global `/tags` links

## Test plan
- [ ] Open Home sidebar: verify top tags by usage, “Show all” / grid icon navigates to `/tags`
- [ ] On `/tags`: toggle tags, expand/collapse strip, sort, paginate, and clear filters
- [ ] On author/collection pages: sidebar shows all local tags with no link to global `/tags`
- [ ] Visit `/?page=99` or invalid page values and confirm page resets to 1 while preserving sort/seed
- [ ] Run frontend tests: `npm test -- --run src/components/__tests__/TagsList.test.tsx src/pages/__tests__/AllTagsPage.test.tsx`