### PR TITLE
Add keep-original-audio option for live translation

### DIFF
--- a/backend/src/__tests__/services/liveTranslationValidation.test.ts
+++ b/backend/src/__tests__/services/liveTranslationValidation.test.ts
@@ -13,8 +13,33 @@ describe("live translation settings validation", () => {
           liveTranslationModel: "gemini-3.5-live-translate-preview",
           liveTranslationSourceLanguage: "auto",
           liveTranslationTargetLanguage: "es",
+          liveTranslationKeepOriginalAudio: true,
         });
       }).not.toThrow();
+    });
+
+    it("accepts false for keep-original audio", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationKeepOriginalAudio: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("rejects a non-boolean keep-original audio flag", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationKeepOriginalAudio: "yes" as unknown as boolean,
+        });
+      }).toThrow(ValidationError);
+    });
+
+    it("rejects null for keep-original audio", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationKeepOriginalAudio: null as unknown as boolean,
+        });
+      }).toThrow(ValidationError);
     });
 
     it("rejects a non-boolean enabled flag", () => {
@@ -122,6 +147,7 @@ describe("live translation settings validation", () => {
       );
       expect(defaultSettings.liveTranslationSourceLanguage).toBe("auto");
       expect(defaultSettings.liveTranslationTargetLanguage).toBe("en");
+      expect(defaultSettings.liveTranslationKeepOriginalAudio).toBe(false);
       expect(defaultSettings.liveTranslationApiKey).toBe("");
     });
 

--- a/backend/src/services/settingsValidationService.ts
+++ b/backend/src/services/settingsValidationService.ts
@@ -278,6 +278,16 @@ function validateLiveTranslationIncomingSettings(
   }
 
   if (
+    newSettings.liveTranslationKeepOriginalAudio !== undefined &&
+    typeof newSettings.liveTranslationKeepOriginalAudio !== "boolean"
+  ) {
+    throw new ValidationError(
+      "Live translation keep-original-audio flag must be a boolean.",
+      "liveTranslationKeepOriginalAudio"
+    );
+  }
+
+  if (
     newSettings.liveTranslationModel !== undefined &&
     !LIVE_TRANSLATION_MODELS.has(newSettings.liveTranslationModel)
   ) {

--- a/backend/src/services/storageService/__tests__/settings.test.ts
+++ b/backend/src/services/storageService/__tests__/settings.test.ts
@@ -99,6 +99,14 @@ describe('storageService settings', () => {
             // but we expect insert to be called for each key.
         });
 
+        it('should persist liveTranslationKeepOriginalAudio', () => {
+            saveSettings({ liveTranslationKeepOriginalAudio: true });
+
+            expect(db.transaction).toHaveBeenCalled();
+            expect(db.insert).toHaveBeenCalledTimes(1);
+            expect(db.insert).toHaveBeenCalledWith(expect.anything());
+        });
+
         it('should skip undefined values', () => {
             saveSettings({ key1: undefined });
             expect(db.insert).not.toHaveBeenCalled();

--- a/backend/src/services/storageService/settings.ts
+++ b/backend/src/services/storageService/settings.ts
@@ -196,6 +196,7 @@ export const WHITELISTED_SETTINGS = [
   "liveTranslationApiKey",
   "liveTranslationSourceLanguage",
   "liveTranslationTargetLanguage",
+  "liveTranslationKeepOriginalAudio",
 ] as const;
 
 export interface SaveSettingsOptions {

--- a/backend/src/types/settings.ts
+++ b/backend/src/types/settings.ts
@@ -130,6 +130,7 @@ export interface Settings {
   liveTranslationApiKey?: string;
   liveTranslationSourceLanguage?: string; // currently "auto" only
   liveTranslationTargetLanguage?: string; // BCP-47
+  liveTranslationKeepOriginalAudio?: boolean;
   liveTranslationApiKeyConfigured?: boolean; // response-only, not persisted
 }
 
@@ -197,6 +198,7 @@ export const defaultSettings: Settings = {
   liveTranslationApiKey: "",
   liveTranslationSourceLanguage: "auto",
   liveTranslationTargetLanguage: "en",
+  liveTranslationKeepOriginalAudio: false,
 };
 
 export function isAuthorOrganizationMode(

--- a/frontend/src/components/Settings/LiveTranslationSettings.tsx
+++ b/frontend/src/components/Settings/LiveTranslationSettings.tsx
@@ -76,6 +76,26 @@ const LiveTranslationSettings: React.FC<LiveTranslationSettingsProps> = ({
             {enabled && (
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
                     <Box>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={settings.liveTranslationKeepOriginalAudio === true}
+                                    onChange={(e) =>
+                                        onChange(
+                                            'liveTranslationKeepOriginalAudio',
+                                            e.target.checked,
+                                        )
+                                    }
+                                />
+                            }
+                            label={t('liveTranslationKeepOriginalAudio')}
+                        />
+                        <Typography variant="body2" color="text.secondary" sx={{ ml: 4 }}>
+                            {t('liveTranslationKeepOriginalAudioDescription')}
+                        </Typography>
+                    </Box>
+
+                    <Box>
                         <TextField
                             fullWidth
                             label={t('liveTranslationApiKey')}

--- a/frontend/src/components/Settings/__tests__/LiveTranslationSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/LiveTranslationSettings.test.tsx
@@ -60,16 +60,53 @@ describe('LiveTranslationSettings', () => {
     it('hides model/API/language fields when the feature is disabled', () => {
         renderComponent();
         expect(screen.getByRole('switch', { name: 'enableLiveTranslation' })).toBeInTheDocument();
+        expect(
+            screen.queryByRole('switch', { name: 'liveTranslationKeepOriginalAudio' }),
+        ).not.toBeInTheDocument();
         expect(screen.queryByLabelText('liveTranslationApiKey')).not.toBeInTheDocument();
         expect(screen.queryByText('liveTranslationModel')).not.toBeInTheDocument();
     });
 
     it('shows the fields when enabled', () => {
         renderComponent({ settings: { liveTranslationEnabled: true } });
+        expect(
+            screen.getByRole('switch', { name: 'liveTranslationKeepOriginalAudio' }),
+        ).toBeInTheDocument();
+        expect(screen.getByText('liveTranslationKeepOriginalAudioDescription')).toBeInTheDocument();
         expect(screen.getByLabelText('liveTranslationApiKey')).toBeInTheDocument();
         expect(screen.getAllByText('liveTranslationModel').length).toBeGreaterThan(0);
         expect(screen.queryByText('liveTranslationSourceLanguage')).not.toBeInTheDocument();
         expect(screen.getAllByText('liveTranslationTargetLanguage').length).toBeGreaterThan(0);
+    });
+
+    it('renders keep-original unchecked when the setting is missing', () => {
+        renderComponent({ settings: { liveTranslationEnabled: true } });
+        const keepOriginal = screen.getByRole('switch', {
+            name: 'liveTranslationKeepOriginalAudio',
+        }) as HTMLInputElement;
+        expect(keepOriginal.checked).toBe(false);
+    });
+
+    it('reflects a persisted keep-original value', () => {
+        renderComponent({
+            settings: {
+                liveTranslationEnabled: true,
+                liveTranslationKeepOriginalAudio: true,
+            },
+        });
+        const keepOriginal = screen.getByRole('switch', {
+            name: 'liveTranslationKeepOriginalAudio',
+        }) as HTMLInputElement;
+        expect(keepOriginal.checked).toBe(true);
+    });
+
+    it('toggles keep-original via the switch', async () => {
+        const user = userEvent.setup();
+        const { onChange } = renderComponent({ settings: { liveTranslationEnabled: true } });
+        await user.click(
+            screen.getByRole('switch', { name: 'liveTranslationKeepOriginalAudio' }),
+        );
+        expect(onChange).toHaveBeenCalledWith('liveTranslationKeepOriginalAudio', true);
     });
 
     it('toggles the feature via the switch', async () => {

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -91,6 +91,7 @@ interface LiveTranslationProviderProps {
     videoId: string;
     videoElement: HTMLVideoElement | null;
     src: string | null;
+    keepOriginalAudio?: boolean;
     onTranscript?: (event: LiveTranslationTranscriptEvent) => void;
     onActiveChange?: (active: boolean) => void;
     children: React.ReactNode;
@@ -105,13 +106,19 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
     videoId,
     videoElement,
     src,
+    keepOriginalAudio = false,
     onTranscript,
     onActiveChange,
     children,
 }) => {
     const { t } = useLanguage();
     const { data: availability } = useLiveTranslationAvailability();
-    const session = useLiveTranslationSession({ videoElement, videoId, onTranscript });
+    const session = useLiveTranslationSession({
+        videoElement,
+        videoId,
+        keepOriginalAudio,
+        onTranscript,
+    });
 
     // Report active-state transitions so the player can create/clear the dynamic
     // live subtitle track.

--- a/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
+++ b/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
@@ -84,12 +84,13 @@ const Probe: React.FC = () => {
     );
 };
 
-function renderProvider() {
+function renderProvider(keepOriginalAudio = false) {
     return render(
         <LiveTranslationProvider
             videoId="v1"
             videoElement={{ playbackRate: 1 } as unknown as HTMLVideoElement}
             src="/videos/clip.mp4"
+            keepOriginalAudio={keepOriginalAudio}
         >
             <Probe />
         </LiveTranslationProvider>,
@@ -171,5 +172,27 @@ describe('LiveTranslationContext', () => {
         renderProvider();
         expect(screen.getByTestId('errorVisible').textContent).toBe('true');
         expect(screen.getByTestId('errorText').textContent).toBe('liveTranslationErrorSessionTimeout');
+    });
+
+    it('passes keepOriginalAudio through to the session hook', () => {
+        setAvailability();
+        setSession();
+        renderProvider(true);
+        expect(mockSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+                keepOriginalAudio: true,
+            }),
+        );
+    });
+
+    it('defaults keepOriginalAudio to false when omitted', () => {
+        setAvailability();
+        setSession();
+        renderProvider();
+        expect(mockSession).toHaveBeenCalledWith(
+            expect.objectContaining({
+                keepOriginalAudio: false,
+            }),
+        );
     });
 });

--- a/frontend/src/hooks/__tests__/useLiveTranslationAudioCapture.test.ts
+++ b/frontend/src/hooks/__tests__/useLiveTranslationAudioCapture.test.ts
@@ -134,7 +134,7 @@ describe('capture graph wiring', () => {
     const { result } = renderHook(() => useLiveTranslationAudioCapture());
     const el = {} as HTMLMediaElement;
     await act(async () => {
-      await result.current.start(el, () => {});
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
     });
 
     // The worklet must connect to a zero-gain node that reaches the destination.
@@ -150,7 +150,7 @@ describe('capture graph wiring', () => {
     const { result } = renderHook(() => useLiveTranslationAudioCapture());
     const el = {} as HTMLMediaElement;
     await act(async () => {
-      await result.current.start(el, () => {});
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
     });
 
     expect(audioContextOptions[0]).toBeUndefined();
@@ -161,11 +161,11 @@ describe('capture graph wiring', () => {
     const { result } = renderHook(() => useLiveTranslationAudioCapture());
     const el = {} as HTMLMediaElement;
     await act(async () => {
-      await result.current.start(el, () => {});
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
     });
     result.current.stop(el);
     await act(async () => {
-      await result.current.start(el, () => {});
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
     });
     expect(mediaSourceCalls).toBe(1);
     result.current.dispose(el);
@@ -183,11 +183,11 @@ describe('capture graph wiring', () => {
     const { result } = renderHook(() => useLiveTranslationAudioCapture());
     const el = {} as HTMLMediaElement;
 
-    const firstStart = result.current.start(el, onOldChunk);
+    const firstStart = result.current.start(el, onOldChunk, { keepOriginalAudio: false });
     await act(async () => {
       await Promise.resolve();
     });
-    const secondStart = result.current.start(el, onNewChunk);
+    const secondStart = result.current.start(el, onNewChunk, { keepOriginalAudio: true });
     await act(async () => {
       await Promise.resolve();
     });
@@ -207,6 +207,63 @@ describe('capture graph wiring', () => {
 
     expect(onOldChunk).not.toHaveBeenCalled();
     expect(onNewChunk).toHaveBeenCalledTimes(1);
+    result.current.dispose(el);
+  });
+
+  it('mutes the speaker gain by default when keep-original is off', async () => {
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
+    });
+
+    expect(gains[0].gain.value).toBe(0);
+    result.current.dispose(el);
+  });
+
+  it('keeps the speaker gain audible when keep-original is on', async () => {
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: true });
+    });
+
+    expect(gains[0].gain.value).toBe(1);
+    result.current.dispose(el);
+  });
+
+  it('restores the speaker gain after stop in both modes', async () => {
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
+    });
+    result.current.stop(el);
+    expect(gains[0].gain.value).toBe(1);
+
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: true });
+    });
+    result.current.stop(el);
+    expect(gains[0].gain.value).toBe(1);
+    result.current.dispose(el);
+  });
+
+  it('can switch keep-original across start -> stop -> start on the same element', async () => {
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: false });
+    });
+    expect(gains[0].gain.value).toBe(0);
+    result.current.stop(el);
+
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudio: true });
+    });
+    expect(gains[0].gain.value).toBe(1);
     result.current.dispose(el);
   });
 });

--- a/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
+++ b/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
@@ -106,17 +106,23 @@ describe('useLiveTranslationSession', () => {
     vi.unstubAllGlobals();
   });
 
-  function setup(onTranscript?: (e: LiveTranslationTranscriptEvent) => void) {
+  function setup(
+    onTranscript?: (e: LiveTranslationTranscriptEvent) => void,
+    keepOriginalAudio = false,
+  ) {
     const videoElement = createFakeVideo();
     const { capture, playback } = makeControllers();
-    const hook = renderHook(() =>
-      useLiveTranslationSession({
-        videoElement,
-        videoId: 'video-1',
-        onTranscript,
-        captureController: capture,
-        playbackController: playback as any,
-      }),
+    const hook = renderHook(
+      ({ keepOriginal }) =>
+        useLiveTranslationSession({
+          videoElement,
+          videoId: 'video-1',
+          keepOriginalAudio: keepOriginal,
+          onTranscript,
+          captureController: capture,
+          playbackController: playback as any,
+        }),
+      { initialProps: { keepOriginal: keepOriginalAudio } },
     );
     return { hook, videoElement, capture, playback };
   }
@@ -203,8 +209,36 @@ describe('useLiveTranslationSession', () => {
 
     // Server signals Gemini is ready -> capture starts, status -> translating.
     await act(async () => ws.serverSend({ type: 'status', status: 'translating' }));
-    expect(s.capture.start).toHaveBeenCalledWith(s.videoElement, expect.any(Function));
+    expect(s.capture.start).toHaveBeenCalledWith(s.videoElement, expect.any(Function), {
+      keepOriginalAudio: false,
+    });
     expect(s.hook.result.current.status).toBe('translating');
+  });
+
+  it('passes keep-original to capture when enabled', async () => {
+    const s = setup(undefined, true);
+    const ws = await startAndOpen(s);
+    expect(ws.typed('start')).toHaveLength(1);
+    expect(s.capture.start).toHaveBeenCalledWith(s.videoElement, expect.any(Function), {
+      keepOriginalAudio: true,
+    });
+  });
+
+  it('snapshots keep-original when start is called and ignores later prop changes', async () => {
+    const s = setup(undefined, true);
+    act(() => s.hook.result.current.start());
+    s.hook.rerender({ keepOriginal: false });
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const ws = MockWebSocket.instances[0];
+    await act(async () => {
+      ws.serverOpen();
+      ws.serverSend({ type: 'status', status: 'translating' });
+    });
+
+    expect(s.capture.start).toHaveBeenCalledWith(s.videoElement, expect.any(Function), {
+      keepOriginalAudio: true,
+    });
   });
 
   it('drops translated audio that arrives while paused', async () => {

--- a/frontend/src/hooks/useLiveTranslationAudioCapture.ts
+++ b/frontend/src/hooks/useLiveTranslationAudioCapture.ts
@@ -56,6 +56,10 @@ export function isSecureContextForCapture(): boolean {
   return window.isSecureContext !== false;
 }
 
+export interface LiveTranslationCaptureOptions {
+  keepOriginalAudio: boolean;
+}
+
 class MediaCaptureGraph {
   private readonly ctx: AudioContext;
   private readonly source: MediaElementAudioSourceNode;
@@ -93,7 +97,10 @@ class MediaCaptureGraph {
     }
   }
 
-  async start(onChunk: (pcm16: Int16Array) => void): Promise<void> {
+  async start(
+    onChunk: (pcm16: Int16Array) => void,
+    options: LiveTranslationCaptureOptions,
+  ): Promise<void> {
     const generation = (this.startGeneration += 1);
     await this.prime();
     if (generation !== this.startGeneration) {
@@ -118,12 +125,18 @@ class MediaCaptureGraph {
       // Render the tap (silently) so the processor is pulled.
       this.worklet.connect(this.workletSink);
     }
+    if (generation !== this.startGeneration) {
+      return;
+    }
     this.worklet.port.onmessage = (event: MessageEvent) => {
       onChunk(new Int16Array(event.data as ArrayBuffer));
     };
-    // Suppress the original audio while translating (translated speech plays via
-    // the separate playback context).
-    this.gain.gain.value = 0;
+    if (generation !== this.startGeneration) {
+      return;
+    }
+    // Suppress the original audio while translating unless the admin enabled
+    // keep-original-audio (translated speech plays via the separate playback context).
+    this.gain.gain.value = options.keepOriginalAudio ? 1 : 0;
   }
 
   stop(): void {
@@ -178,6 +191,7 @@ export interface LiveTranslationAudioCaptureController {
   start(
     element: HTMLMediaElement,
     onChunk: (pcm16: Int16Array) => void,
+    options: LiveTranslationCaptureOptions,
   ): Promise<void>;
   stop(element: HTMLMediaElement): void;
   /** Fully tear down the per-element graph (only on unmount/replace). */
@@ -190,12 +204,12 @@ const controller: LiveTranslationAudioCaptureController = {
     const graph = ensureGraph(element);
     void graph?.prime();
   },
-  async start(element, onChunk) {
+  async start(element, onChunk, options) {
     const graph = ensureGraph(element);
     if (!graph) {
       throw new Error('Audio capture is not supported in this browser.');
     }
-    await graph.start(onChunk);
+    await graph.start(onChunk, options);
   },
   stop(element) {
     graphs.get(element)?.stop();

--- a/frontend/src/hooks/useLiveTranslationSession.ts
+++ b/frontend/src/hooks/useLiveTranslationSession.ts
@@ -36,6 +36,7 @@ export interface LiveTranslationTranscriptEvent {
 export interface UseLiveTranslationSessionOptions {
   videoElement: HTMLVideoElement | null;
   videoId: string;
+  keepOriginalAudio?: boolean;
   onTranscript?: (event: LiveTranslationTranscriptEvent) => void;
   /** Injectable for tests; default to the real controllers. */
   captureController?: LiveTranslationAudioCaptureController;
@@ -63,7 +64,7 @@ function buildLiveTranslationWsUrl(wsPath: string): string {
 export function useLiveTranslationSession(
   options: UseLiveTranslationSessionOptions,
 ): UseLiveTranslationSessionResult {
-  const { videoElement, videoId, onTranscript } = options;
+  const { videoElement, videoId, onTranscript, keepOriginalAudio = false } = options;
   const defaultCapture = useLiveTranslationAudioCapture();
   const defaultPlayback = useTranslatedAudioPlayback();
   const capture = options.captureController ?? defaultCapture;
@@ -263,6 +264,7 @@ export function useLiveTranslationSession(
     if (!element || wsRef.current) {
       return;
     }
+    const keepOriginalAudioForSession = keepOriginalAudio;
     // MVP supports only normal playback rate (Gemini expects real-time cadence).
     if (element.playbackRate !== 1) {
       fail(
@@ -350,28 +352,32 @@ export function useLiveTranslationSession(
             }
             captureStartedRef.current = true;
             void capture
-              .start(element, (pcm16) => {
-                const socket = wsRef.current;
-                if (!isCurrentStart() || socket !== ws) {
-                  return;
-                }
-                // Only forward audio while the video is actually playing.
-                if (element.paused) {
-                  return;
-                }
-                if (socket && socket.readyState === WS_OPEN) {
-                  socket.send(
-                    encodeClientMessage({
-                      type: 'audio',
-                      seq: audioSeqRef.current++,
-                      mediaTime: element.currentTime,
-                      sampleRate: 16000,
-                      channels: 1,
-                      pcm16Base64: int16ToBase64(pcm16),
-                    }),
-                  );
-                }
-              })
+              .start(
+                element,
+                (pcm16) => {
+                  const socket = wsRef.current;
+                  if (!isCurrentStart() || socket !== ws) {
+                    return;
+                  }
+                  // Only forward audio while the video is actually playing.
+                  if (element.paused) {
+                    return;
+                  }
+                  if (socket && socket.readyState === WS_OPEN) {
+                    socket.send(
+                      encodeClientMessage({
+                        type: 'audio',
+                        seq: audioSeqRef.current++,
+                        mediaTime: element.currentTime,
+                        sampleRate: 16000,
+                        channels: 1,
+                        pcm16Base64: int16ToBase64(pcm16),
+                      }),
+                    );
+                  }
+                },
+                { keepOriginalAudio: keepOriginalAudioForSession },
+              )
               .then(() => {
                 if (!isCurrentStart() || wsRef.current !== ws) {
                   const currentSessionOwnsElement =
@@ -443,6 +449,7 @@ export function useLiveTranslationSession(
     capture,
     playback,
     videoId,
+    keepOriginalAudio,
     sendControl,
     attachMediaListeners,
     handleServerData,

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -474,6 +474,7 @@ const VideoPlayer: React.FC = () => {
                         videoId={video.id}
                         videoElement={videoElement}
                         src={(videoUrl || video?.sourceUrl) || null}
+                        keepOriginalAudio={settings?.liveTranslationKeepOriginalAudio === true}
                         onTranscript={liveSubtitleTrack.addCue}
                         onActiveChange={(active) => {
                             if (active) {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -228,5 +228,6 @@ export interface Settings {
   liveTranslationApiKey?: string;
   liveTranslationSourceLanguage?: string; // currently "auto" only
   liveTranslationTargetLanguage?: string; // BCP-47
+  liveTranslationKeepOriginalAudio?: boolean;
   liveTranslationApiKeyConfigured?: boolean; // response-only, not persisted
 }

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -4,21 +4,21 @@ Canonical locale key order derived from `frontend/src/utils/locales/en.ts`.
 
 This list is intentionally unnumbered. When new keys are inserted, only the local section order changes.
 
-Total keys: 1044
+Total keys: 1153
 
 ## Summary
 
 | Section | Keys | First Key | Last Key |
 | --- | ---: | --- | --- |
 | Header | 11 | `myTube` | `instruction` |
-| Home | 23 | `pasteUrl` | `views` |
+| Home | 21 | `pasteUrl` | `views` |
 | Settings | 4 | `general` | `downloadSettings` |
-| Settings Categories | 188 | `basicSettings` | `enterNewTagName` |
+| Settings Categories | 227 | `basicSettings` | `enterNewTagName` |
 | Database | 40 | `database` | `cleanupTempFilesConfirmMessage` |
-| Task Hooks | 69 | `taskHooks` | `cleanupTempFilesFailed` |
+| Task Hooks | 104 | `taskHooks` | `cleanupTempFilesFailed` |
 | Cookie Settings | 12 | `cookieSettings` | `cookiesDeleteFailed` |
 | Cloud Drive | 38 | `cloudDriveSettings` | `clearThumbnailCacheConfirmMessage` |
-| Manage | 33 | `manageContent` | `confirmBulkDelete` |
+| Manage | 36 | `manageContent` | `confirmBulkDelete` |
 | Video Player | 62 | `playing` | `deletingVideos` |
 | Login | 23 | `signIn` | `tooManyAttempts` |
 | Passkeys | 19 | `createPasskey` | `copyUrl` |
@@ -29,23 +29,23 @@ Total keys: 1044
 | Video Card | 9 | `unknownDate` | `weeksAgo` |
 | Upload Modal | 19 | `selectVideoFile` | `thumbnailUploaded` |
 | Bilibili Modal | 22 | `bilibiliCollectionDetected` | `waitingInQueue` |
-| Downloads | 20 | `downloads` | `failed` |
-| Snackbar Messages | 19 | `videoDownloading` | `subtitleDeleted` |
+| Downloads | 24 | `downloads` | `retryAttemptProgress` |
+| Snackbar Messages | 20 | `videoDownloading` | `subtitleDeleted` |
 | Batch Download | 6 | `batchDownload` | `addBatchTasks` |
-| Subscriptions | 62 | `subscribeToAuthor` | `retentionDaysUpdateFailed` |
+| Subscriptions | 63 | `subscribeToAuthor` | `retentionDaysUpdateFailed` |
 | Subscription Pause/Resume | 12 | `pause` | `viaContinuousDownload` |
 | Playlist Subscription | 5 | `subscribeToPlaylist` | `playlistSubscription` |
 | Instruction Page | 39 | `instructionSection1Title` | `instructionSection3Item3Text` |
 | Disclaimer | 3 | `disclaimerTitle` | `history` |
 | Existing Video Detection | 16 | `existingVideoDetected` | `changeSettings` |
 | Sorting | 10 | `sort` | `random` |
-| yt-dlp Configuration | 23 | `ytDlpConfiguration` | `saveAuthorFilesToCollectionDescription` |
+| yt-dlp Configuration | 41 | `ytDlpConfiguration` | `cleanupAuthorCollectionsFailed` |
 | Cloudflare Tunnel | 16 | `cloudflaredTunnel` | `managedInDashboard` |
-| Database Export/Import | 39 | `exportImportDatabase` | `backupDatabasesCleanedUp` |
+| Database Export/Import | 41 | `exportImportDatabase` | `backupDatabasesCleanedUp` |
 | History Filter | 33 | `filterAll` | `browserVideoFormatNotSupported` |
-| RSS Feed Settings | 40 | `rssFeedSettings` | `rssDays` |
+| RSS Feed Settings | 42 | `rssFeedSettings` | `rssDays` |
 | Role-based settings middleware errors | 5 | `settingsApiKeyForbidden` | `settingsAuthRequired` |
-| Filename Template | 30 | `filenameTemplate` | `filenameBatchRenameError` |
+| Filename Template | 35 | `filenameTemplate` | `filenameBatchRenameError` |
 | Statistics | 54 | `statisticsTitle` | `recomputeStatistics` |
 
 ## Details
@@ -206,6 +206,8 @@ Total keys: 1044
 | `liveTranslation` |
 | `liveTranslationDescription` |
 | `enableLiveTranslation` |
+| `liveTranslationKeepOriginalAudio` |
+| `liveTranslationKeepOriginalAudioDescription` |
 | `liveTranslationApiKey` |
 | `liveTranslationApiKeyConfigured` |
 | `liveTranslationApiKeyReplaceHelper` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -176,6 +176,9 @@ export const ar = {
   liveTranslation: "الترجمة الصوتية المباشرة",
   liveTranslationDescription: "يبث صوت الفيديو الحالي إلى Gemini Live Translation ويشغّل الكلام المترجَم مع ترجمات مباشرة. أثناء التفعيل، يُرسل صوت الفيديو إلى واجهة برمجة تطبيقات Gemini من Google.",
   enableLiveTranslation: "تفعيل الترجمة الصوتية المباشرة",
+  liveTranslationKeepOriginalAudio: "الإبقاء على الصوت الأصلي",
+  liveTranslationKeepOriginalAudioDescription:
+    "تشغيل الصوت الأصلي للفيديو مع الكلام المترجم.",
   liveTranslationApiKey: "مفتاح Gemini API",
   liveTranslationApiKeyConfigured: "تم تكوين مفتاح API",
   liveTranslationApiKeyReplaceHelper: "تم تكوين مفتاح API. أدخل مفتاحًا جديدًا لاستبداله، أو اتركه فارغًا للاحتفاظ بالمفتاح الحالي.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -186,6 +186,9 @@ export const de = {
   liveTranslation: "Live-Audioübersetzung",
   liveTranslationDescription: "Überträgt den Ton des aktuellen Videos an Gemini Live Translation und gibt die übersetzte Sprache mit Live-Untertiteln wieder. Während der Nutzung wird der Videoton an die Gemini-API von Google gesendet.",
   enableLiveTranslation: "Live-Audioübersetzung aktivieren",
+  liveTranslationKeepOriginalAudio: "Originalton beibehalten",
+  liveTranslationKeepOriginalAudioDescription:
+    "Spiele den Originalton des Videos zusammen mit der übersetzten Sprache ab.",
   liveTranslationApiKey: "Gemini-API-Schlüssel",
   liveTranslationApiKeyConfigured: "API-Schlüssel ist konfiguriert",
   liveTranslationApiKeyReplaceHelper: "Ein API-Schlüssel ist konfiguriert. Geben Sie einen neuen Schlüssel ein, um ihn zu ersetzen, oder lassen Sie das Feld leer, um den aktuellen Schlüssel zu behalten.",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -178,6 +178,9 @@ export const en = {
   liveTranslationDescription:
     "Stream the current video's audio to Gemini Live Translation and play translated speech with live subtitles. While active, the video's audio is sent to Google's Gemini API.",
   enableLiveTranslation: "Enable live audio translation",
+  liveTranslationKeepOriginalAudio: "Keep original audio",
+  liveTranslationKeepOriginalAudioDescription:
+    "Play the video's original audio together with translated speech.",
   liveTranslationApiKey: "Gemini API key",
   liveTranslationApiKeyConfigured: "API key is configured",
   liveTranslationApiKeyReplaceHelper:

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -183,6 +183,9 @@ export const es = {
   liveTranslation: "Traducción de audio en vivo",
   liveTranslationDescription: "Transmite el audio del video actual a Gemini Live Translation y reproduce el habla traducida con subtítulos en vivo. Mientras está activo, el audio del video se envía a la API de Gemini de Google.",
   enableLiveTranslation: "Activar traducción de audio en vivo",
+  liveTranslationKeepOriginalAudio: "Mantener audio original",
+  liveTranslationKeepOriginalAudioDescription:
+    "Reproduce el audio original del video junto con la voz traducida.",
   liveTranslationApiKey: "Clave de API de Gemini",
   liveTranslationApiKeyConfigured: "La clave de API está configurada",
   liveTranslationApiKeyReplaceHelper: "Hay una clave de API configurada. Introduce una nueva clave para reemplazarla o déjalo en blanco para mantener la actual.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -184,6 +184,9 @@ export const fr = {
   liveTranslation: "Traduction audio en direct",
   liveTranslationDescription: "Diffuse l'audio de la vidéo en cours vers Gemini Live Translation et lit la voix traduite avec des sous-titres en direct. Lorsque la fonction est active, l'audio de la vidéo est envoyé à l'API Gemini de Google.",
   enableLiveTranslation: "Activer la traduction audio en direct",
+  liveTranslationKeepOriginalAudio: "Conserver l'audio original",
+  liveTranslationKeepOriginalAudioDescription:
+    "Lire l'audio original de la vidéo en même temps que la voix traduite.",
   liveTranslationApiKey: "Clé API Gemini",
   liveTranslationApiKeyConfigured: "La clé API est configurée",
   liveTranslationApiKeyReplaceHelper: "Une clé API est configurée. Saisissez une nouvelle clé pour la remplacer, ou laissez le champ vide pour conserver la clé actuelle.",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -183,6 +183,9 @@ export const ja = {
   liveTranslation: "ライブ音声翻訳",
   liveTranslationDescription: "現在の動画の音声を Gemini ライブ翻訳にストリーミングし、翻訳された音声とライブ字幕を再生します。有効にすると、動画の音声が Google の Gemini API に送信されます。",
   enableLiveTranslation: "ライブ音声翻訳を有効にする",
+  liveTranslationKeepOriginalAudio: "オリジナル音声を維持",
+  liveTranslationKeepOriginalAudioDescription:
+    "動画のオリジナル音声と翻訳された音声を同時に再生します。",
   liveTranslationApiKey: "Gemini API キー",
   liveTranslationApiKeyConfigured: "API キーが設定されています",
   liveTranslationApiKeyReplaceHelper: "API キーが設定されています。新しいキーを入力すると置き換えられます。空欄のままにすると現在のキーが保持されます。",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -180,6 +180,9 @@ export const ko = {
   liveTranslation: "실시간 오디오 번역",
   liveTranslationDescription: "현재 동영상의 오디오를 Gemini 실시간 번역으로 스트리밍하고 번역된 음성과 실시간 자막을 재생합니다. 활성화되어 있는 동안 동영상 오디오가 Google Gemini API로 전송됩니다.",
   enableLiveTranslation: "실시간 오디오 번역 사용",
+  liveTranslationKeepOriginalAudio: "원본 오디오 유지",
+  liveTranslationKeepOriginalAudioDescription:
+    "동영상의 원본 오디오와 번역된 음성을 함께 재생합니다.",
   liveTranslationApiKey: "Gemini API 키",
   liveTranslationApiKeyConfigured: "API 키가 구성됨",
   liveTranslationApiKeyReplaceHelper: "API 키가 구성되어 있습니다. 새 키를 입력하면 교체되며, 비워 두면 현재 키가 유지됩니다.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -183,6 +183,9 @@ export const pt = {
   liveTranslation: "Tradução de áudio ao vivo",
   liveTranslationDescription: "Transmite o áudio do vídeo atual para o Gemini Live Translation e reproduz a fala traduzida com legendas ao vivo. Enquanto ativo, o áudio do vídeo é enviado para a API Gemini do Google.",
   enableLiveTranslation: "Ativar tradução de áudio ao vivo",
+  liveTranslationKeepOriginalAudio: "Manter áudio original",
+  liveTranslationKeepOriginalAudioDescription:
+    "Reproduz o áudio original do vídeo junto com a fala traduzida.",
   liveTranslationApiKey: "Chave de API do Gemini",
   liveTranslationApiKeyConfigured: "A chave de API está configurada",
   liveTranslationApiKeyReplaceHelper: "Há uma chave de API configurada. Insira uma nova chave para substituí-la ou deixe em branco para manter a atual.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -183,6 +183,9 @@ export const ru = {
   liveTranslation: "Живой перевод аудио",
   liveTranslationDescription: "Передаёт звук текущего видео в Gemini Live Translation и воспроизводит переведённую речь с живыми субтитрами. Во время работы звук видео отправляется в API Gemini от Google.",
   enableLiveTranslation: "Включить живой перевод аудио",
+  liveTranslationKeepOriginalAudio: "Сохранять оригинальный звук",
+  liveTranslationKeepOriginalAudioDescription:
+    "Воспроизводить оригинальный звук видео вместе с переведённой речью.",
   liveTranslationApiKey: "Ключ API Gemini",
   liveTranslationApiKeyConfigured: "Ключ API настроен",
   liveTranslationApiKeyReplaceHelper: "Ключ API настроен. Введите новый ключ, чтобы заменить его, или оставьте поле пустым, чтобы сохранить текущий ключ.",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -176,6 +176,9 @@ export const zh = {
   liveTranslation: "实时音频翻译",
   liveTranslationDescription: "将当前视频的音频流式传输到 Gemini 实时翻译，并播放翻译后的语音和实时字幕。启用后，视频音频会发送到 Google Gemini API。",
   enableLiveTranslation: "启用实时音频翻译",
+  liveTranslationKeepOriginalAudio: "保留原始音频",
+  liveTranslationKeepOriginalAudioDescription:
+    "同时播放视频的原始音频和翻译后的语音。",
   liveTranslationApiKey: "Gemini API 密钥",
   liveTranslationApiKeyConfigured: "已配置 API 密钥",
   liveTranslationApiKeyReplaceHelper: "已配置 API 密钥。输入新密钥可替换，留空则保留当前密钥。",


### PR DESCRIPTION
## Summary
- Add a **Keep original audio** toggle under **Enable live audio translation** in Settings → Basic → Video Playback.
- Persist the new `liveTranslationKeepOriginalAudio` setting (default `false`) so existing deployments keep the current translated-audio-only behavior.
- When enabled, live translation keeps the original video audio audible while translated speech plays through the existing separate playback context.

## Test plan
- [x] Frontend unit tests for settings UI, capture graph, session hook, and provider wiring
- [x] Backend validation and settings persistence tests
- [x] Frontend typecheck and lint
- [x] Backend TypeScript build
- [ ] Manual: toggle off → start live translation → original audio mutes after translation becomes ready
- [ ] Manual: toggle on → start live translation → original and translated audio play together
- [ ] Manual: verify player volume/mute, pause, seek, stop, and settings persistence across refresh