### PR TITLE
Add subtitle-only live translation mode with original audio

### DIFF
--- a/backend/src/__tests__/services/liveTranslationValidation.test.ts
+++ b/backend/src/__tests__/services/liveTranslationValidation.test.ts
@@ -65,6 +65,33 @@ describe("live translation settings validation", () => {
       }).toThrow(ValidationError);
     });
 
+    it("rejects a non-boolean original-audio subtitle flag", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationOriginalAudioWithSubtitles: "yes" as unknown as boolean,
+        });
+      }).toThrow(ValidationError);
+    });
+
+    it("accepts boolean original-audio subtitle values", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationOriginalAudioWithSubtitles: true,
+        });
+        settingsValidationService.validateSettings({
+          liveTranslationOriginalAudioWithSubtitles: false,
+        });
+      }).not.toThrow();
+    });
+
+    it("rejects null for original-audio subtitle flag", () => {
+      expect(() => {
+        settingsValidationService.validateSettings({
+          liveTranslationOriginalAudioWithSubtitles: null as unknown as boolean,
+        });
+      }).toThrow(ValidationError);
+    });
+
     it("trims the API key", () => {
       const settings = { liveTranslationApiKey: "  secret-key  " };
       settingsValidationService.validateSettings(settings);
@@ -123,6 +150,7 @@ describe("live translation settings validation", () => {
       expect(defaultSettings.liveTranslationSourceLanguage).toBe("auto");
       expect(defaultSettings.liveTranslationTargetLanguage).toBe("en");
       expect(defaultSettings.liveTranslationApiKey).toBe("");
+      expect(defaultSettings.liveTranslationOriginalAudioWithSubtitles).toBe(false);
     });
 
     it("clamps legacy non-auto source settings to auto in server config", () => {

--- a/backend/src/services/settingsValidationService.ts
+++ b/backend/src/services/settingsValidationService.ts
@@ -278,6 +278,16 @@ function validateLiveTranslationIncomingSettings(
   }
 
   if (
+    newSettings.liveTranslationOriginalAudioWithSubtitles !== undefined &&
+    typeof newSettings.liveTranslationOriginalAudioWithSubtitles !== "boolean"
+  ) {
+    throw new ValidationError(
+      "Live translation original audio with subtitles flag must be a boolean.",
+      "liveTranslationOriginalAudioWithSubtitles"
+    );
+  }
+
+  if (
     newSettings.liveTranslationModel !== undefined &&
     !LIVE_TRANSLATION_MODELS.has(newSettings.liveTranslationModel)
   ) {

--- a/backend/src/services/storageService/__tests__/settings.test.ts
+++ b/backend/src/services/storageService/__tests__/settings.test.ts
@@ -2,7 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { db } from '../../../db';
 import { DatabaseError } from '../../../errors/DownloadErrors';
 import { logger } from '../../../utils/logger';
-import { getSettings, invalidateSettingsCache, saveSettings } from '../settings';
+import {
+  WHITELISTED_SETTINGS,
+  getSettings,
+  invalidateSettingsCache,
+  saveSettings,
+} from '../settings';
 
 // Mock DB and Logger
 vi.mock('../../../db', () => ({
@@ -38,6 +43,7 @@ describe('storageService settings', () => {
         const mockOnConflict = vi.fn().mockReturnValue({ run: mockRun });
         const mockValues = vi.fn().mockReturnValue({ onConflictDoUpdate: mockOnConflict });
         vi.mocked(db.insert).mockReturnValue({ values: mockValues } as any);
+        vi.mocked(db.transaction).mockImplementation((cb) => (cb as () => void)());
     });
 
     describe('getSettings', () => {
@@ -111,6 +117,23 @@ describe('storageService settings', () => {
 
             expect(() => saveSettings({ key: 'value' })).toThrow(DatabaseError);
             expect(logger.error).toHaveBeenCalled();
+        });
+
+        it('persists liveTranslationOriginalAudioWithSubtitles when whitelisted', () => {
+            saveSettings({ liveTranslationOriginalAudioWithSubtitles: true });
+            expect(db.transaction).toHaveBeenCalled();
+            expect(db.insert).toHaveBeenCalledTimes(1);
+        });
+
+        it('ignores non-whitelisted keys', () => {
+            saveSettings({ notARealSetting: true });
+            expect(db.insert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('WHITELISTED_SETTINGS', () => {
+        it('includes liveTranslationOriginalAudioWithSubtitles', () => {
+            expect(WHITELISTED_SETTINGS).toContain('liveTranslationOriginalAudioWithSubtitles');
         });
     });
 });

--- a/backend/src/services/storageService/settings.ts
+++ b/backend/src/services/storageService/settings.ts
@@ -196,6 +196,7 @@ export const WHITELISTED_SETTINGS = [
   "liveTranslationApiKey",
   "liveTranslationSourceLanguage",
   "liveTranslationTargetLanguage",
+  "liveTranslationOriginalAudioWithSubtitles",
 ] as const;
 
 export interface SaveSettingsOptions {

--- a/backend/src/types/settings.ts
+++ b/backend/src/types/settings.ts
@@ -130,6 +130,8 @@ export interface Settings {
   liveTranslationApiKey?: string;
   liveTranslationSourceLanguage?: string; // currently "auto" only
   liveTranslationTargetLanguage?: string; // BCP-47
+  /** When true, live translation shows subtitles and keeps original audio; translated speech is not played. */
+  liveTranslationOriginalAudioWithSubtitles?: boolean;
   liveTranslationApiKeyConfigured?: boolean; // response-only, not persisted
 }
 
@@ -197,6 +199,7 @@ export const defaultSettings: Settings = {
   liveTranslationApiKey: "",
   liveTranslationSourceLanguage: "auto",
   liveTranslationTargetLanguage: "en",
+  liveTranslationOriginalAudioWithSubtitles: false,
 };
 
 export function isAuthorOrganizationMode(

--- a/frontend/src/components/Header/HeaderToolbarContent.tsx
+++ b/frontend/src/components/Header/HeaderToolbarContent.tsx
@@ -79,6 +79,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
     onAudioOnlySubmit,
     showTagsInMobileMenu,
     linkToAllTagsInMobileMenu = false,
+    collections,
     videos,
     effectiveTags
 }) => {
@@ -190,6 +191,7 @@ const HeaderToolbarContent: React.FC<HeaderToolbarContentProps> = ({
                     onAudioOnlySubmit={onAudioOnlySubmit}
                     showAudioDownloadButton={showAudioDownloadButton}
                     onClose={onCloseMobileMenu}
+                    collections={collections}
                     showTags={showTagsInMobileMenu}
                     availableTags={effectiveTags.availableTags}
                     selectedTags={effectiveTags.selectedTags}

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -4,6 +4,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useSettings } from '../../hooks/useSettings';
+import { Collection } from '../../types';
+import Collections from '../Collections';
 import TagsList from '../TagsList';
 import SearchInput from './SearchInput';
 
@@ -19,6 +21,7 @@ interface MobileMenuProps {
     onAudioOnlySubmit?: (url: string) => Promise<any>;
     showAudioDownloadButton?: boolean;
     onClose: () => void;
+    collections?: Collection[];
     showTags?: boolean;
     availableTags?: string[];
     selectedTags?: string[];
@@ -40,6 +43,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
     onAudioOnlySubmit,
     showAudioDownloadButton = true,
     onClose,
+    collections = [],
     showTags = false,
     availableTags = [],
     selectedTags = [],
@@ -119,18 +123,26 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
                         </>
                     )}
 
-                    {/* Mobile navigation sections */}
+                    {/* Mobile navigation sections — Collections keeps direct
+                        /collection/:id links for empty and first-video-collision
+                        collections that the /collections card grid cannot show. */}
                     <Box sx={{ mt: 2 }}>
-                        <Button
-                            component={Link}
-                            to="/authors"
-                            variant="outlined"
-                            fullWidth
-                            onClick={onClose}
-                            startIcon={<Group />}
-                        >
-                            {t('authors')}
-                        </Button>
+                        <Collections
+                            collections={collections}
+                            onItemClick={onClose}
+                        />
+                        <Box sx={{ mt: 2 }}>
+                            <Button
+                                component={Link}
+                                to="/authors"
+                                variant="outlined"
+                                fullWidth
+                                onClick={onClose}
+                                startIcon={<Group />}
+                            >
+                                {t('authors')}
+                            </Button>
+                        </Box>
                         {showTags && (
                             <Box sx={{ mt: 2 }}>
                                 <TagsList

--- a/frontend/src/components/Header/__tests__/MobileMenu.test.tsx
+++ b/frontend/src/components/Header/__tests__/MobileMenu.test.tsx
@@ -32,6 +32,12 @@ vi.mock('../../../hooks/useSettings', () => ({
     useSettings: mockUseSettings,
 }));
 
+vi.mock('../../Collections', () => ({
+    default: ({ onItemClick }: { onItemClick: () => void }) => (
+        <button onClick={onItemClick}>collections-item</button>
+    ),
+}));
+
 vi.mock('../../TagsList', () => ({
     default: ({ onTagToggle }: { onTagToggle: (tag: string) => void }) => (
         <button onClick={() => onTagToggle('tag-1')}>tags-item</button>
@@ -60,6 +66,7 @@ describe('MobileMenu', () => {
         onResetSearch: vi.fn(),
         onSubmit: vi.fn(),
         onClose: vi.fn(),
+        collections: [],
         showTags: false,
         availableTags: [],
         selectedTags: [],
@@ -94,12 +101,12 @@ describe('MobileMenu', () => {
         expect(screen.getByRole('link', { name: 'authors' })).toHaveAttribute('href', '/authors');
         expect(screen.queryByRole('button', { name: 'logout' })).not.toBeInTheDocument();
         expect(screen.queryByText('tags-item')).not.toBeInTheDocument();
-        expect(screen.queryByText('collections-item')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('link', { name: 'manageVideos' }));
         fireEvent.click(screen.getByRole('link', { name: 'settings' }));
+        fireEvent.click(screen.getByText('collections-item'));
         fireEvent.click(screen.getByRole('link', { name: 'authors' }));
-        expect(onClose).toHaveBeenCalledTimes(3);
+        expect(onClose).toHaveBeenCalledTimes(4);
 
         fireEvent.click(screen.getByText('search-submit'));
         fireEvent.click(screen.getByText('search-reset'));
@@ -107,7 +114,7 @@ describe('MobileMenu', () => {
         expect(onResetSearch).toHaveBeenCalledTimes(1);
     });
 
-    it('renders tags section and forwards tag toggle callback', () => {
+    it('renders collections before authors and tags', () => {
         const onTagToggle = vi.fn();
         renderMenu({
             showTags: true,
@@ -116,13 +123,18 @@ describe('MobileMenu', () => {
             selectedTags: ['tag-1'],
         });
 
+        const collectionsItem = screen.getByText('collections-item');
         const authorsLink = screen.getByRole('link', { name: 'authors' });
         const tagsItem = screen.getByText('tags-item');
+
+        expect(
+            collectionsItem.compareDocumentPosition(authorsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+        ).toBeTruthy();
         expect(
             authorsLink.compareDocumentPosition(tagsItem) & Node.DOCUMENT_POSITION_FOLLOWING
         ).toBeTruthy();
 
-        fireEvent.click(screen.getByText('tags-item'));
+        fireEvent.click(tagsItem);
         expect(onTagToggle).toHaveBeenCalledWith('tag-1');
     });
 

--- a/frontend/src/components/Settings/LiveTranslationSettings.tsx
+++ b/frontend/src/components/Settings/LiveTranslationSettings.tsx
@@ -76,6 +76,28 @@ const LiveTranslationSettings: React.FC<LiveTranslationSettingsProps> = ({
             {enabled && (
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5 }}>
                     <Box>
+                        <FormControlLabel
+                            control={
+                                <Switch
+                                    checked={
+                                        settings.liveTranslationOriginalAudioWithSubtitles === true
+                                    }
+                                    onChange={(e) =>
+                                        onChange(
+                                            'liveTranslationOriginalAudioWithSubtitles',
+                                            e.target.checked,
+                                        )
+                                    }
+                                />
+                            }
+                            label={t('liveTranslationOriginalAudioWithSubtitles')}
+                        />
+                        <Typography variant="body2" color="text.secondary" sx={{ ml: 4 }}>
+                            {t('liveTranslationOriginalAudioWithSubtitlesDescription')}
+                        </Typography>
+                    </Box>
+
+                    <Box>
                         <TextField
                             fullWidth
                             label={t('liveTranslationApiKey')}

--- a/frontend/src/components/Settings/__tests__/LiveTranslationSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/LiveTranslationSettings.test.tsx
@@ -60,8 +60,44 @@ describe('LiveTranslationSettings', () => {
     it('hides model/API/language fields when the feature is disabled', () => {
         renderComponent();
         expect(screen.getByRole('switch', { name: 'enableLiveTranslation' })).toBeInTheDocument();
+        expect(
+            screen.queryByRole('switch', { name: 'liveTranslationOriginalAudioWithSubtitles' }),
+        ).not.toBeInTheDocument();
         expect(screen.queryByLabelText('liveTranslationApiKey')).not.toBeInTheDocument();
         expect(screen.queryByText('liveTranslationModel')).not.toBeInTheDocument();
+    });
+
+    it('shows the original-audio subtitle switch when enabled', () => {
+        renderComponent({ settings: { liveTranslationEnabled: true } });
+        const subtitleSwitch = screen.getByRole('switch', {
+            name: 'liveTranslationOriginalAudioWithSubtitles',
+        });
+        expect(subtitleSwitch).toBeInTheDocument();
+        expect(subtitleSwitch).not.toBeChecked();
+        expect(
+            screen.getByText('liveTranslationOriginalAudioWithSubtitlesDescription'),
+        ).toBeInTheDocument();
+    });
+
+    it('reflects a persisted original-audio subtitle preference', () => {
+        renderComponent({
+            settings: {
+                liveTranslationEnabled: true,
+                liveTranslationOriginalAudioWithSubtitles: true,
+            },
+        });
+        expect(
+            screen.getByRole('switch', { name: 'liveTranslationOriginalAudioWithSubtitles' }),
+        ).toBeChecked();
+    });
+
+    it('toggles the original-audio subtitle switch', async () => {
+        const user = userEvent.setup();
+        const { onChange } = renderComponent({ settings: { liveTranslationEnabled: true } });
+        await user.click(
+            screen.getByRole('switch', { name: 'liveTranslationOriginalAudioWithSubtitles' }),
+        );
+        expect(onChange).toHaveBeenCalledWith('liveTranslationOriginalAudioWithSubtitles', true);
     });
 
     it('shows the fields when enabled', () => {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useSubtitles.live.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useSubtitles.live.test.ts
@@ -51,6 +51,47 @@ describe('useSubtitles — live translation option', () => {
     expect(result.current.subtitlesEnabled).toBe(false);
   });
 
+  it('auto-selects the live track in subtitle-only mode even when file subtitles are globally disabled', () => {
+    const liveTrack = { mode: 'hidden' } as unknown as TextTrack;
+    const { result } = renderHook(() =>
+      useSubtitles({
+        subtitles: subtitles2,
+        initialSubtitlesEnabled: false,
+        videoRef: makeVideoRef(2),
+        liveSubtitle: { available: true, label: 'Live', track: liveTrack },
+        forceLiveSubtitleOnAvailable: true,
+      }),
+    );
+    expect(result.current.liveSubtitleAvailable).toBe(true);
+    expect(result.current.liveSubtitleSelected).toBe(true);
+    expect(liveTrack.mode).toBe('showing');
+    expect(result.current.subtitlesEnabled).toBe(true);
+  });
+
+  it('auto-selects the live track when subtitle-only mode activates after the track exists', () => {
+    const liveTrack = { mode: 'hidden' } as unknown as TextTrack;
+    const { result, rerender } = renderHook(
+      ({ force }: { force: boolean }) =>
+        useSubtitles({
+          subtitles: subtitles2,
+          initialSubtitlesEnabled: false,
+          videoRef: makeVideoRef(2),
+          liveSubtitle: { available: true, label: 'Live', track: liveTrack },
+          forceLiveSubtitleOnAvailable: force,
+        }),
+      { initialProps: { force: false } },
+    );
+
+    expect(result.current.liveSubtitleSelected).toBe(false);
+    expect(liveTrack.mode).toBe('hidden');
+
+    rerender({ force: true });
+
+    expect(result.current.liveSubtitleSelected).toBe(true);
+    expect(liveTrack.mode).toBe('showing');
+    expect(result.current.subtitlesEnabled).toBe(true);
+  });
+
   it('toggles the live track on and off', () => {
     const liveTrack = { mode: 'hidden' } as unknown as TextTrack;
     const { result } = renderHook(() =>

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
@@ -19,6 +19,12 @@ interface UseSubtitlesProps {
     onSubtitlesToggle?: (enabled: boolean) => void;
     // Optional dynamic "Live translation" subtitle track (design §9.5/§9.6).
     liveSubtitle?: LiveSubtitleInput;
+    /**
+     * When true, auto-select the live track as soon as it becomes available even
+     * if file subtitles are globally off. Used by subtitle-only live translation
+     * where translated speech is suppressed and captions are the only output.
+     */
+    forceLiveSubtitleOnAvailable?: boolean;
 }
 
 const MAX_ACTIVE_TRACKS = 2;
@@ -29,6 +35,7 @@ export const useSubtitles = ({
     videoRef,
     onSubtitlesToggle,
     liveSubtitle,
+    forceLiveSubtitleOnAvailable = false,
 }: UseSubtitlesProps) => {
     const [subtitlesEnabled, setSubtitlesEnabled] = useState<boolean>(
         initialSubtitlesEnabled && subtitles.length > 0
@@ -41,6 +48,7 @@ export const useSubtitles = ({
 
     const liveAvailable = liveSubtitle?.available === true;
     const prevLiveAvailableRef = useRef(false);
+    const prevForceLiveSubtitleRef = useRef(false);
 
     // Apply showing/hidden modes by identity: file tracks occupy textTracks
     // [0..subtitles.length-1] (in array order); the dynamic live track — added via
@@ -58,6 +66,20 @@ export const useSubtitles = ({
         if (liveTrack) {
             liveTrack.mode = liveSelected ? 'showing' : 'hidden';
         }
+    };
+
+    const selectLiveSubtitleTrack = () => {
+        setSelectedSubtitleIndices((fileIndices) => {
+            let nextFile = fileIndices;
+            if (fileIndices.length >= MAX_ACTIVE_TRACKS) {
+                // Replace the oldest selected file subtitle.
+                nextFile = fileIndices.slice(1);
+            }
+            applyTrackModes(nextFile, true);
+            return nextFile;
+        });
+        setLiveSubtitleSelected(true);
+        setSubtitlesEnabled(true);
     };
 
     // Re-initialize FILE subtitle tracks only when the subtitles array changes
@@ -78,26 +100,21 @@ export const useSubtitles = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [subtitles]); // intentionally omit initialSubtitlesEnabled — see comment above
 
-    // Auto-select the live track when it becomes available only if subtitles are
-    // globally enabled. If the user has subtitles off, keep the live option
-    // available in the menu without showing it.
+    // Auto-select the live track when it becomes available if subtitles are
+    // globally enabled, or when subtitle-only live translation requires captions
+    // as its only output. Otherwise keep the live option in the menu without showing it.
     useEffect(() => {
         const wasAvailable = prevLiveAvailableRef.current;
+        const wasForceLiveSubtitle = prevForceLiveSubtitleRef.current;
         prevLiveAvailableRef.current = liveAvailable;
+        prevForceLiveSubtitleRef.current = forceLiveSubtitleOnAvailable;
+
+        const shouldAutoSelectLive =
+            initialSubtitlesEnabled || forceLiveSubtitleOnAvailable;
 
         if (liveAvailable && !wasAvailable) {
-            if (initialSubtitlesEnabled) {
-                setSelectedSubtitleIndices((fileIndices) => {
-                    let nextFile = fileIndices;
-                    if (fileIndices.length >= MAX_ACTIVE_TRACKS) {
-                        // Replace the oldest selected file subtitle.
-                        nextFile = fileIndices.slice(1);
-                    }
-                    applyTrackModes(nextFile, true);
-                    return nextFile;
-                });
-                setLiveSubtitleSelected(true);
-                setSubtitlesEnabled(true);
+            if (shouldAutoSelectLive) {
+                selectLiveSubtitleTrack();
             } else {
                 applyTrackModes(selectedSubtitleIndices, false);
                 setLiveSubtitleSelected(false);
@@ -110,9 +127,16 @@ export const useSubtitles = ({
                 setSubtitlesEnabled(fileIndices.length > 0);
                 return fileIndices;
             });
+        } else if (
+            liveAvailable &&
+            forceLiveSubtitleOnAvailable &&
+            !wasForceLiveSubtitle
+        ) {
+            // Subtitle-only mode became active after the live track already existed.
+            selectLiveSubtitleTrack();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [liveAvailable]);
+    }, [liveAvailable, forceLiveSubtitleOnAvailable]);
 
     const handleSubtitleClick = (event: React.MouseEvent<HTMLElement>) => {
         setSubtitleMenuAnchor(event.currentTarget);

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@mui/material';
 import React, { useCallback, useEffect } from 'react';
+import { useLiveTranslationControl } from '../../../contexts/LiveTranslationContext';
 import { neutral } from '../../../theme/colors';
 import { useStatisticsWatchTracker } from '../../../hooks/useStatisticsWatchTracker';
 import ControlsOverlay from './ControlsOverlay';
@@ -110,13 +111,21 @@ const VideoControls: React.FC<VideoControlsProps> = ({
     // Volume control
     const volume = useVolume(videoPlayer.videoRef);
 
+    // In subtitle-only live translation, force-show the live track even when the
+    // user normally has file subtitles disabled — translated speech is suppressed.
+    const { isActive: liveTranslationActive, originalAudioWithSubtitles } =
+        useLiveTranslationControl();
+    const forceLiveSubtitleOnAvailable =
+        originalAudioWithSubtitles && liveTranslationActive;
+
     // Subtitle management
     const subtitlesHook = useSubtitles({
         subtitles,
         initialSubtitlesEnabled,
         videoRef: videoPlayer.videoRef,
         onSubtitlesToggle,
-        liveSubtitle
+        liveSubtitle,
+        forceLiveSubtitleOnAvailable,
     });
 
     // Memoize seek callbacks to prevent unnecessary re-registration of keyboard listeners

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -92,6 +92,7 @@ interface LiveTranslationProviderProps {
     videoElement: HTMLVideoElement | null;
     src: string | null;
     originalAudioWithSubtitles?: boolean;
+    originalAudioWithSubtitlesReady?: boolean;
     onTranscript?: (event: LiveTranslationTranscriptEvent) => void;
     onActiveChange?: (active: boolean) => void;
     children: React.ReactNode;
@@ -107,6 +108,7 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
     videoElement,
     src,
     originalAudioWithSubtitles,
+    originalAudioWithSubtitlesReady = true,
     onTranscript,
     onActiveChange,
     children,
@@ -127,7 +129,7 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
     }, [session.isActive, onActiveChange]);
 
     const value = useMemo<LiveTranslationControl>(() => {
-        const shouldRender = !!availability && availability.enabled;
+        const shouldRender = !!availability && availability.enabled && originalAudioWithSubtitlesReady;
         if (!shouldRender) {
             return DEFAULT_CONTROL;
         }
@@ -188,7 +190,7 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
             retryable: session.retryable,
             retry: () => session.start(),
         };
-    }, [availability, session, src, videoElement, t]);
+    }, [availability, originalAudioWithSubtitlesReady, session, src, videoElement, t]);
 
     return (
         <LiveTranslationContext.Provider value={value}>

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -91,6 +91,7 @@ interface LiveTranslationProviderProps {
     videoId: string;
     videoElement: HTMLVideoElement | null;
     src: string | null;
+    originalAudioWithSubtitles?: boolean;
     onTranscript?: (event: LiveTranslationTranscriptEvent) => void;
     onActiveChange?: (active: boolean) => void;
     children: React.ReactNode;
@@ -105,13 +106,19 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
     videoId,
     videoElement,
     src,
+    originalAudioWithSubtitles,
     onTranscript,
     onActiveChange,
     children,
 }) => {
     const { t } = useLanguage();
     const { data: availability } = useLiveTranslationAvailability();
-    const session = useLiveTranslationSession({ videoElement, videoId, onTranscript });
+    const session = useLiveTranslationSession({
+        videoElement,
+        videoId,
+        onTranscript,
+        originalAudioWithSubtitles,
+    });
 
     // Report active-state transitions so the player can create/clear the dynamic
     // live subtitle track.

--- a/frontend/src/contexts/LiveTranslationContext.tsx
+++ b/frontend/src/contexts/LiveTranslationContext.tsx
@@ -45,6 +45,8 @@ export interface LiveTranslationControl {
     isActive: boolean;
     isConnecting: boolean;
     isPaused: boolean;
+    /** True when the active session (or pending start) keeps original audio and shows translated subtitles only. */
+    originalAudioWithSubtitles: boolean;
     /** Non-null when the control must be disabled; value is a localized reason. */
     disabledReason: string | null;
     /** Short uppercase badge for the active target language (e.g. "EN", "CN"). */
@@ -66,6 +68,7 @@ const DEFAULT_CONTROL: LiveTranslationControl = {
     isActive: false,
     isConnecting: false,
     isPaused: false,
+    originalAudioWithSubtitles: false,
     disabledReason: null,
     targetAbbreviation: '',
     targetLabel: '',
@@ -175,6 +178,7 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
             isActive,
             isConnecting,
             isPaused,
+            originalAudioWithSubtitles: !!originalAudioWithSubtitles,
             disabledReason,
             targetAbbreviation: getLiveTranslationLanguageAbbreviation(availability.targetLanguage),
             targetLabel: getLiveTranslationLanguageLabel(availability.targetLanguage),
@@ -190,7 +194,7 @@ export const LiveTranslationProvider: React.FC<LiveTranslationProviderProps> = (
             retryable: session.retryable,
             retry: () => session.start(),
         };
-    }, [availability, originalAudioWithSubtitlesReady, session, src, videoElement, t]);
+    }, [availability, originalAudioWithSubtitles, originalAudioWithSubtitlesReady, session, src, videoElement, t]);
 
     return (
         <LiveTranslationContext.Provider value={value}>

--- a/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
+++ b/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
@@ -78,6 +78,9 @@ const Probe: React.FC = () => {
             <span data-testid="disabled">{control.disabledReason ?? ''}</span>
             <span data-testid="errorVisible">{String(control.errorVisible)}</span>
             <span data-testid="errorText">{control.errorText}</span>
+            <span data-testid="originalAudioWithSubtitles">
+                {String(control.originalAudioWithSubtitles)}
+            </span>
             <button onClick={control.onToggle}>toggle</button>
             <button onClick={control.retry}>retry</button>
         </div>
@@ -120,6 +123,7 @@ describe('LiveTranslationContext', () => {
         expect(mockSession).toHaveBeenCalledWith(
             expect.objectContaining({ originalAudioWithSubtitles: true }),
         );
+        expect(screen.getByTestId('originalAudioWithSubtitles').textContent).toBe('true');
     });
 
     it('normalizes a missing originalAudioWithSubtitles prop to false', () => {
@@ -129,6 +133,7 @@ describe('LiveTranslationContext', () => {
         expect(mockSession).toHaveBeenCalledWith(
             expect.objectContaining({ originalAudioWithSubtitles: undefined }),
         );
+        expect(screen.getByTestId('originalAudioWithSubtitles').textContent).toBe('false');
     });
 
     it('withholds the control until the subtitle-only setting is ready', () => {

--- a/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
+++ b/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
@@ -131,6 +131,22 @@ describe('LiveTranslationContext', () => {
         );
     });
 
+    it('withholds the control until the subtitle-only setting is ready', () => {
+        setAvailability();
+        setSession();
+        render(
+            <LiveTranslationProvider
+                videoId="v1"
+                videoElement={{ playbackRate: 1 } as unknown as HTMLVideoElement}
+                src="/videos/clip.mp4"
+                originalAudioWithSubtitlesReady={false}
+            >
+                <Probe />
+            </LiveTranslationProvider>,
+        );
+        expect(screen.getByTestId('shouldRender').textContent).toBe('false');
+    });
+
     it('does not render the control when the feature is disabled globally', () => {
         setAvailability({ enabled: false });
         setSession();

--- a/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
+++ b/frontend/src/contexts/__tests__/LiveTranslationContext.test.tsx
@@ -104,6 +104,33 @@ describe('LiveTranslationContext', () => {
         mockSecureContext.mockReturnValue(true);
     });
 
+    it('passes originalAudioWithSubtitles to the session hook', () => {
+        setAvailability();
+        setSession();
+        render(
+            <LiveTranslationProvider
+                videoId="v1"
+                videoElement={{ playbackRate: 1 } as unknown as HTMLVideoElement}
+                src="/videos/clip.mp4"
+                originalAudioWithSubtitles
+            >
+                <Probe />
+            </LiveTranslationProvider>,
+        );
+        expect(mockSession).toHaveBeenCalledWith(
+            expect.objectContaining({ originalAudioWithSubtitles: true }),
+        );
+    });
+
+    it('normalizes a missing originalAudioWithSubtitles prop to false', () => {
+        setAvailability();
+        setSession();
+        renderProvider();
+        expect(mockSession).toHaveBeenCalledWith(
+            expect.objectContaining({ originalAudioWithSubtitles: undefined }),
+        );
+    });
+
     it('does not render the control when the feature is disabled globally', () => {
         setAvailability({ enabled: false });
         setSession();

--- a/frontend/src/hooks/__tests__/useLiveTranslationAudioCapture.test.ts
+++ b/frontend/src/hooks/__tests__/useLiveTranslationAudioCapture.test.ts
@@ -157,6 +157,61 @@ describe('capture graph wiring', () => {
     result.current.dispose(el);
   });
 
+  it('mutes speaker gain by default and keeps it audible in subtitle-only mode', async () => {
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+
+    await act(async () => {
+      await result.current.start(el, () => {});
+    });
+    expect(gains[0].gain.value).toBe(0);
+
+    result.current.stop(el);
+    expect(gains[0].gain.value).toBe(1);
+
+    await act(async () => {
+      await result.current.start(el, () => {}, { keepOriginalAudioAudible: true });
+    });
+    expect(gains[0].gain.value).toBe(1);
+
+    result.current.stop(el);
+    expect(gains[0].gain.value).toBe(1);
+    result.current.dispose(el);
+  });
+
+  it('does not let a superseded async start apply a stale speaker gain', async () => {
+    const firstModule = deferred<void>();
+    const secondModule = deferred<void>();
+    addModuleImpl = vi
+      .fn()
+      .mockReturnValueOnce(firstModule.promise)
+      .mockReturnValueOnce(secondModule.promise);
+    const { result } = renderHook(() => useLiveTranslationAudioCapture());
+    const el = {} as HTMLMediaElement;
+
+    const firstStart = result.current.start(el, () => {}, { keepOriginalAudioAudible: false });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const secondStart = result.current.start(el, () => {}, { keepOriginalAudioAudible: true });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      secondModule.resolve();
+      await secondStart;
+    });
+    expect(gains[0].gain.value).toBe(1);
+
+    await act(async () => {
+      firstModule.resolve();
+      await firstStart;
+    });
+    expect(gains[0].gain.value).toBe(1);
+    result.current.dispose(el);
+  });
+
   it('reuses createMediaElementSource across start -> stop -> start', async () => {
     const { result } = renderHook(() => useLiveTranslationAudioCapture());
     const el = {} as HTMLMediaElement;

--- a/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
+++ b/frontend/src/hooks/__tests__/useLiveTranslationSession.test.tsx
@@ -106,17 +106,27 @@ describe('useLiveTranslationSession', () => {
     vi.unstubAllGlobals();
   });
 
-  function setup(onTranscript?: (e: LiveTranslationTranscriptEvent) => void) {
+  function setup(
+    onTranscript?: (e: LiveTranslationTranscriptEvent) => void,
+    options: { originalAudioWithSubtitles?: boolean } = {},
+  ) {
     const videoElement = createFakeVideo();
     const { capture, playback } = makeControllers();
-    const hook = renderHook(() =>
-      useLiveTranslationSession({
-        videoElement,
-        videoId: 'video-1',
-        onTranscript,
-        captureController: capture,
-        playbackController: playback as any,
-      }),
+    const hook = renderHook(
+      (props: { originalAudioWithSubtitles?: boolean }) =>
+        useLiveTranslationSession({
+          videoElement,
+          videoId: 'video-1',
+          onTranscript,
+          originalAudioWithSubtitles: props.originalAudioWithSubtitles,
+          captureController: capture,
+          playbackController: playback as any,
+        }),
+      {
+        initialProps: {
+          originalAudioWithSubtitles: options.originalAudioWithSubtitles,
+        },
+      },
     );
     return { hook, videoElement, capture, playback };
   }
@@ -203,8 +213,65 @@ describe('useLiveTranslationSession', () => {
 
     // Server signals Gemini is ready -> capture starts, status -> translating.
     await act(async () => ws.serverSend({ type: 'status', status: 'translating' }));
-    expect(s.capture.start).toHaveBeenCalledWith(s.videoElement, expect.any(Function));
+    expect(s.capture.start).toHaveBeenCalledWith(
+      s.videoElement,
+      expect.any(Function),
+      { keepOriginalAudioAudible: false },
+    );
     expect(s.hook.result.current.status).toBe('translating');
+  });
+
+  it('passes keepOriginalAudioAudible when subtitle-only mode is enabled', async () => {
+    const s = setup(undefined, { originalAudioWithSubtitles: true });
+    const ws = await startAndOpen(s);
+    expect(s.capture.start).toHaveBeenCalledWith(
+      s.videoElement,
+      expect.any(Function),
+      { keepOriginalAudioAudible: true },
+    );
+    expect(ws).toBeDefined();
+  });
+
+  it('does not enqueue translated audio in subtitle-only mode', async () => {
+    const onTranscript = vi.fn();
+    const s = setup(onTranscript, { originalAudioWithSubtitles: true });
+    const ws = await startAndOpen(s);
+
+    await act(async () => {
+      ws.serverSend({ type: 'audio', seq: 1, sampleRate: 24000, channels: 1, pcm16Base64: 'QUJD' });
+      ws.serverSend({ type: 'outputTranscript', text: 'hello', languageCode: 'en' });
+    });
+
+    expect(s.playback.enqueueBase64).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'output', text: 'hello' }),
+    );
+  });
+
+  it('snapshots subtitle-only mode at start and ignores later prop changes', async () => {
+    const s = setup(undefined, { originalAudioWithSubtitles: false });
+    act(() => s.hook.result.current.start());
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    const ws = MockWebSocket.instances[0];
+    await act(async () => {
+      ws.serverOpen();
+    });
+
+    s.hook.rerender({ originalAudioWithSubtitles: true });
+
+    await act(async () => {
+      ws.serverSend({ type: 'status', status: 'translating' });
+    });
+    expect(s.capture.start).toHaveBeenCalledWith(
+      s.videoElement,
+      expect.any(Function),
+      { keepOriginalAudioAudible: false },
+    );
+
+    await act(async () => {
+      ws.serverSend({ type: 'audio', seq: 1, sampleRate: 24000, channels: 1, pcm16Base64: 'QUJD' });
+    });
+    expect(s.playback.enqueueBase64).toHaveBeenCalledWith('QUJD');
   });
 
   it('drops translated audio that arrives while paused', async () => {

--- a/frontend/src/hooks/useLiveTranslationAudioCapture.ts
+++ b/frontend/src/hooks/useLiveTranslationAudioCapture.ts
@@ -93,7 +93,10 @@ class MediaCaptureGraph {
     }
   }
 
-  async start(onChunk: (pcm16: Int16Array) => void): Promise<void> {
+  async start(
+    onChunk: (pcm16: Int16Array) => void,
+    keepOriginalAudioAudible = false,
+  ): Promise<void> {
     const generation = (this.startGeneration += 1);
     await this.prime();
     if (generation !== this.startGeneration) {
@@ -118,12 +121,18 @@ class MediaCaptureGraph {
       // Render the tap (silently) so the processor is pulled.
       this.worklet.connect(this.workletSink);
     }
+    if (generation !== this.startGeneration) {
+      return;
+    }
     this.worklet.port.onmessage = (event: MessageEvent) => {
       onChunk(new Int16Array(event.data as ArrayBuffer));
     };
-    // Suppress the original audio while translating (translated speech plays via
-    // the separate playback context).
-    this.gain.gain.value = 0;
+    if (generation !== this.startGeneration) {
+      return;
+    }
+    // Suppress the original audio while translating unless subtitle-only mode
+    // keeps it audible (translated speech plays via the separate playback context).
+    this.gain.gain.value = keepOriginalAudioAudible ? 1 : 0;
   }
 
   stop(): void {
@@ -171,6 +180,11 @@ function ensureGraph(element: HTMLMediaElement): MediaCaptureGraph | null {
   return graph;
 }
 
+export interface LiveTranslationCaptureOptions {
+  /** When true, do not mute the speaker gain path. Defaults to false. */
+  keepOriginalAudioAudible?: boolean;
+}
+
 export interface LiveTranslationAudioCaptureController {
   isSupported(): boolean;
   /** Synchronously create + resume the graph within a user gesture. */
@@ -178,6 +192,7 @@ export interface LiveTranslationAudioCaptureController {
   start(
     element: HTMLMediaElement,
     onChunk: (pcm16: Int16Array) => void,
+    options?: LiveTranslationCaptureOptions,
   ): Promise<void>;
   stop(element: HTMLMediaElement): void;
   /** Fully tear down the per-element graph (only on unmount/replace). */
@@ -190,12 +205,12 @@ const controller: LiveTranslationAudioCaptureController = {
     const graph = ensureGraph(element);
     void graph?.prime();
   },
-  async start(element, onChunk) {
+  async start(element, onChunk, options) {
     const graph = ensureGraph(element);
     if (!graph) {
       throw new Error('Audio capture is not supported in this browser.');
     }
-    await graph.start(onChunk);
+    await graph.start(onChunk, options?.keepOriginalAudioAudible === true);
   },
   stop(element) {
     graphs.get(element)?.stop();

--- a/frontend/src/hooks/useLiveTranslationSession.ts
+++ b/frontend/src/hooks/useLiveTranslationSession.ts
@@ -36,6 +36,8 @@ export interface LiveTranslationTranscriptEvent {
 export interface UseLiveTranslationSessionOptions {
   videoElement: HTMLVideoElement | null;
   videoId: string;
+  /** When true, keep original audio and show subtitles without playing translated speech. */
+  originalAudioWithSubtitles?: boolean;
   onTranscript?: (event: LiveTranslationTranscriptEvent) => void;
   /** Injectable for tests; default to the real controllers. */
   captureController?: LiveTranslationAudioCaptureController;
@@ -63,7 +65,7 @@ function buildLiveTranslationWsUrl(wsPath: string): string {
 export function useLiveTranslationSession(
   options: UseLiveTranslationSessionOptions,
 ): UseLiveTranslationSessionResult {
-  const { videoElement, videoId, onTranscript } = options;
+  const { videoElement, videoId, onTranscript, originalAudioWithSubtitles } = options;
   const defaultCapture = useLiveTranslationAudioCapture();
   const defaultPlayback = useTranslatedAudioPlayback();
   const capture = options.captureController ?? defaultCapture;
@@ -92,6 +94,9 @@ export function useLiveTranslationSession(
   videoElementRef.current = videoElement;
   const onTranscriptRef = useRef(onTranscript);
   onTranscriptRef.current = onTranscript;
+  const latestOriginalAudioWithSubtitlesRef = useRef(false);
+  latestOriginalAudioWithSubtitlesRef.current = !!originalAudioWithSubtitles;
+  const sessionOriginalAudioWithSubtitlesRef = useRef(false);
 
   const detachMediaListeners = useCallback(() => {
     mediaListenersRef.current?.();
@@ -181,10 +186,13 @@ export function useLiveTranslationSession(
       fail('unsupported_playback_rate', UNSUPPORTED_PLAYBACK_RATE_MESSAGE, false);
     };
     const onVolumeChange = () => {
-      playback.setVolume(element.volume, element.muted);
+      if (!sessionOriginalAudioWithSubtitlesRef.current) {
+        playback.setVolume(element.volume, element.muted);
+      }
     };
-    // Apply the current volume/mute immediately, then track changes.
-    playback.setVolume(element.volume, element.muted);
+    if (!sessionOriginalAudioWithSubtitlesRef.current) {
+      playback.setVolume(element.volume, element.muted);
+    }
     element.addEventListener('pause', onPause);
     element.addEventListener('play', onPlay);
     element.addEventListener('seeking', onSeeking);
@@ -233,9 +241,9 @@ export function useLiveTranslationSession(
           });
           break;
         case 'audio':
-          // Ignore translated audio that arrives while paused; otherwise it
-          // would sit in the suspended context and play (stale) on resume.
-          if (pausedRef.current) {
+          // Ignore translated audio that arrives while paused, or in subtitle-only
+          // mode where translated speech is not played.
+          if (pausedRef.current || sessionOriginalAudioWithSubtitlesRef.current) {
             break;
           }
           playback.enqueueBase64(message.pcm16Base64);
@@ -280,6 +288,8 @@ export function useLiveTranslationSession(
     captureStartedRef.current = false;
     beginCaptureRef.current = null;
     pausedRef.current = false;
+    sessionOriginalAudioWithSubtitlesRef.current =
+      latestOriginalAudioWithSubtitlesRef.current;
 
     // Create + resume the audio contexts synchronously within this user gesture
     // so the browser autoplay policy allows them to run.
@@ -350,7 +360,9 @@ export function useLiveTranslationSession(
             }
             captureStartedRef.current = true;
             void capture
-              .start(element, (pcm16) => {
+              .start(
+                element,
+                (pcm16) => {
                 const socket = wsRef.current;
                 if (!isCurrentStart() || socket !== ws) {
                   return;
@@ -371,7 +383,12 @@ export function useLiveTranslationSession(
                     }),
                   );
                 }
-              })
+              },
+                {
+                  keepOriginalAudioAudible:
+                    sessionOriginalAudioWithSubtitlesRef.current,
+                },
+              )
               .then(() => {
                 if (!isCurrentStart() || wsRef.current !== ws) {
                   const currentSessionOwnsElement =

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -59,8 +59,20 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
     const { viewMode, handleViewModeChange } = useViewMode(initialViewMode);
     const handleHomeViewModeChange = useCallback((mode: ViewMode) => {
         handleViewModeChange(mode);
-        if ((location.pathname === '/favorites' || location.pathname === '/collections') && mode !== 'favorite') {
-            navigate('/?page=1');
+        // Keep deep-link routes aligned with the active tab so reload/share
+        // opens the same view the user switched to.
+        if (location.pathname === '/favorites') {
+            if (mode === 'collections') {
+                navigate('/collections');
+            } else if (mode !== 'favorite') {
+                navigate('/?page=1');
+            }
+        } else if (location.pathname === '/collections') {
+            if (mode === 'favorite') {
+                navigate('/favorites');
+            } else if (mode !== 'collections') {
+                navigate('/?page=1');
+            }
         }
     }, [handleViewModeChange, location.pathname, navigate]);
     const handleHomeTagToggle = useCallback((tag: string) => {

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -474,6 +474,9 @@ const VideoPlayer: React.FC = () => {
                         videoId={video.id}
                         videoElement={videoElement}
                         src={(videoUrl || video?.sourceUrl) || null}
+                        originalAudioWithSubtitles={
+                            settings?.liveTranslationOriginalAudioWithSubtitles === true
+                        }
                         onTranscript={liveSubtitleTrack.addCue}
                         onActiveChange={(active) => {
                             if (active) {

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -44,7 +44,7 @@ const VideoPlayer: React.FC = () => {
     const { t } = useLanguage();
     const { videos } = useVideo();
     const { userRole } = useAuth();
-    const { data: settings } = useSettings();
+    const { data: settings, isLoading: settingsLoading = false } = useSettings();
     const isVisitor = userRole === 'visitor';
     const navigationState = (location.state ?? null) as
         | {
@@ -477,6 +477,7 @@ const VideoPlayer: React.FC = () => {
                         originalAudioWithSubtitles={
                             settings?.liveTranslationOriginalAudioWithSubtitles === true
                         }
+                        originalAudioWithSubtitlesReady={!settingsLoading}
                         onTranscript={liveSubtitleTrack.addCue}
                         onActiveChange={(active) => {
                             if (active) {

--- a/frontend/src/pages/__tests__/Home.test.tsx
+++ b/frontend/src/pages/__tests__/Home.test.tsx
@@ -5,12 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Home from '../Home';
 
 const mockSetSearchParams = vi.fn();
+const mockNavigate = vi.fn();
 const mockHandleViewModeChange = vi.fn();
 let mockViewMode = 'all-videos';
+let mockPathname = '/';
 vi.mock('react-router-dom', () => ({
     useSearchParams: () => [new URLSearchParams(), mockSetSearchParams],
-    useLocation: () => ({ pathname: '/' }),
-    useNavigate: () => vi.fn(),
+    useLocation: () => ({ pathname: mockPathname }),
+    useNavigate: () => mockNavigate,
 }));
 
 vi.mock('../../contexts/LanguageContext', () => ({
@@ -109,9 +111,29 @@ vi.mock('../../components/ConfirmationModal', () => ({
     ),
 }));
 vi.mock('../../components/HomeHeader', () => ({
-    HomeHeader: ({ onDeleteFilteredClick }: { onDeleteFilteredClick: () => void }) => (
-        <button data-testid="delete-filtered-btn" onClick={onDeleteFilteredClick}>Delete Filtered</button>
+    HomeHeader: ({
+        onDeleteFilteredClick,
+        onViewModeChange,
+    }: {
+        onDeleteFilteredClick: () => void;
+        onViewModeChange: (mode: string) => void;
+    }) => (
+        <div>
+            <button data-testid="delete-filtered-btn" onClick={onDeleteFilteredClick}>Delete Filtered</button>
+            <button data-testid="switch-to-favorite" onClick={() => onViewModeChange('favorite')}>
+                Favorite
+            </button>
+            <button data-testid="switch-to-collections" onClick={() => onViewModeChange('collections')}>
+                Collections
+            </button>
+            <button data-testid="switch-to-all-videos" onClick={() => onViewModeChange('all-videos')}>
+                All Videos
+            </button>
+        </div>
     ),
+}));
+vi.mock('../FavoritePage', () => ({
+    default: () => <div data-testid="FavoritePage" />,
 }));
 vi.mock('../../components/HomeSidebar', () => ({
     HomeSidebar: ({ onTagToggle }: { onTagToggle: (tag: string) => void }) => (
@@ -138,10 +160,12 @@ describe('Home Page', () => {
         mockUseVideoReturn.videos = [];
         mockUseVideoReturn.selectedTags = [];
         mockViewMode = 'all-videos';
+        mockPathname = '/';
 
         // Reset specific mocks if needed
         mockUseVideoSort.mockClear();
         mockHandleViewModeChange.mockClear();
+        mockNavigate.mockClear();
         // Since we defined mockUseVideoSort with a specific implementation that returns an object, 
         // mockClear clears the call history but keeps the implementation.
         // mockClear clears the call history but keeps the implementation.
@@ -158,6 +182,42 @@ describe('Home Page', () => {
             </ThemeProvider>
         );
     };
+
+    it('navigates to /favorites when switching to Favorite from /collections', () => {
+        mockPathname = '/collections';
+        mockViewMode = 'collections';
+        mockUseVideoReturn.videos = [{ id: '1' }] as any;
+
+        renderHome();
+        fireEvent.click(screen.getByTestId('switch-to-favorite'));
+
+        expect(mockHandleViewModeChange).toHaveBeenCalledWith('favorite');
+        expect(mockNavigate).toHaveBeenCalledWith('/favorites');
+    });
+
+    it('navigates home when leaving /collections for a non-favorite tab', () => {
+        mockPathname = '/collections';
+        mockViewMode = 'collections';
+        mockUseVideoReturn.videos = [{ id: '1' }] as any;
+
+        renderHome();
+        fireEvent.click(screen.getByTestId('switch-to-all-videos'));
+
+        expect(mockHandleViewModeChange).toHaveBeenCalledWith('all-videos');
+        expect(mockNavigate).toHaveBeenCalledWith('/?page=1');
+    });
+
+    it('navigates to /collections when switching to Collections from /favorites', () => {
+        mockPathname = '/favorites';
+        mockViewMode = 'favorite';
+        mockUseVideoReturn.videos = [{ id: '1' }] as any;
+
+        renderHome();
+        fireEvent.click(screen.getByTestId('switch-to-collections'));
+
+        expect(mockHandleViewModeChange).toHaveBeenCalledWith('collections');
+        expect(mockNavigate).toHaveBeenCalledWith('/collections');
+    });
 
     it('renders loading skeleton when loading and no videos', () => {
         mockUseVideoReturn.loading = true;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -228,5 +228,7 @@ export interface Settings {
   liveTranslationApiKey?: string;
   liveTranslationSourceLanguage?: string; // currently "auto" only
   liveTranslationTargetLanguage?: string; // BCP-47
+  /** When true, live translation shows subtitles and keeps original audio; translated speech is not played. */
+  liveTranslationOriginalAudioWithSubtitles?: boolean;
   liveTranslationApiKeyConfigured?: boolean; // response-only, not persisted
 }

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -206,6 +206,8 @@ Total keys: 1044
 | `liveTranslation` |
 | `liveTranslationDescription` |
 | `enableLiveTranslation` |
+| `liveTranslationOriginalAudioWithSubtitles` |
+| `liveTranslationOriginalAudioWithSubtitlesDescription` |
 | `liveTranslationApiKey` |
 | `liveTranslationApiKeyConfigured` |
 | `liveTranslationApiKeyReplaceHelper` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -176,6 +176,9 @@ export const ar = {
   liveTranslation: "الترجمة الصوتية المباشرة",
   liveTranslationDescription: "يبث صوت الفيديو الحالي إلى Gemini Live Translation ويشغّل الكلام المترجَم مع ترجمات مباشرة. أثناء التفعيل، يُرسل صوت الفيديو إلى واجهة برمجة تطبيقات Gemini من Google.",
   enableLiveTranslation: "تفعيل الترجمة الصوتية المباشرة",
+  liveTranslationOriginalAudioWithSubtitles: "الصوت الأصلي والترجمة النصية",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "الإبقاء على الصوت الأصلي للفيديو وعرض الترجمات النصية دون تشغيل الكلام المترجَم.",
   liveTranslationApiKey: "مفتاح Gemini API",
   liveTranslationApiKeyConfigured: "تم تكوين مفتاح API",
   liveTranslationApiKeyReplaceHelper: "تم تكوين مفتاح API. أدخل مفتاحًا جديدًا لاستبداله، أو اتركه فارغًا للاحتفاظ بالمفتاح الحالي.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -186,6 +186,9 @@ export const de = {
   liveTranslation: "Live-Audioübersetzung",
   liveTranslationDescription: "Überträgt den Ton des aktuellen Videos an Gemini Live Translation und gibt die übersetzte Sprache mit Live-Untertiteln wieder. Während der Nutzung wird der Videoton an die Gemini-API von Google gesendet.",
   enableLiveTranslation: "Live-Audioübersetzung aktivieren",
+  liveTranslationOriginalAudioWithSubtitles: "Originalton und übersetzte Untertitel",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Den Originalton des Videos beibehalten und übersetzte Untertitel anzeigen, ohne übersetzte Sprache abzuspielen.",
   liveTranslationApiKey: "Gemini-API-Schlüssel",
   liveTranslationApiKeyConfigured: "API-Schlüssel ist konfiguriert",
   liveTranslationApiKeyReplaceHelper: "Ein API-Schlüssel ist konfiguriert. Geben Sie einen neuen Schlüssel ein, um ihn zu ersetzen, oder lassen Sie das Feld leer, um den aktuellen Schlüssel zu behalten.",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -176,8 +176,11 @@ export const en = {
     "This server version does not support cleanup while media server sidecar export is off.",
   liveTranslation: "Live audio translation",
   liveTranslationDescription:
-    "Stream the current video's audio to Gemini Live Translation and play translated speech with live subtitles. While active, the video's audio is sent to Google's Gemini API.",
+    "Stream the current video's audio to Gemini Live Translation and show live subtitles, with optional translated speech playback. While active, the video's audio is sent to Google's Gemini API.",
   enableLiveTranslation: "Enable live audio translation",
+  liveTranslationOriginalAudioWithSubtitles: "Original audio and translated subtitle",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Keep the video's original audio and show translated subtitles without playing translated speech.",
   liveTranslationApiKey: "Gemini API key",
   liveTranslationApiKeyConfigured: "API key is configured",
   liveTranslationApiKeyReplaceHelper:

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -183,6 +183,9 @@ export const es = {
   liveTranslation: "Traducción de audio en vivo",
   liveTranslationDescription: "Transmite el audio del video actual a Gemini Live Translation y reproduce el habla traducida con subtítulos en vivo. Mientras está activo, el audio del video se envía a la API de Gemini de Google.",
   enableLiveTranslation: "Activar traducción de audio en vivo",
+  liveTranslationOriginalAudioWithSubtitles: "Audio original y subtítulo traducido",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Mantener el audio original del video y mostrar subtítulos traducidos sin reproducir el habla traducida.",
   liveTranslationApiKey: "Clave de API de Gemini",
   liveTranslationApiKeyConfigured: "La clave de API está configurada",
   liveTranslationApiKeyReplaceHelper: "Hay una clave de API configurada. Introduce una nueva clave para reemplazarla o déjalo en blanco para mantener la actual.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -184,6 +184,9 @@ export const fr = {
   liveTranslation: "Traduction audio en direct",
   liveTranslationDescription: "Diffuse l'audio de la vidéo en cours vers Gemini Live Translation et lit la voix traduite avec des sous-titres en direct. Lorsque la fonction est active, l'audio de la vidéo est envoyé à l'API Gemini de Google.",
   enableLiveTranslation: "Activer la traduction audio en direct",
+  liveTranslationOriginalAudioWithSubtitles: "Audio original et sous-titres traduits",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Conserver l'audio original de la vidéo et afficher des sous-titres traduits sans lire la voix traduite.",
   liveTranslationApiKey: "Clé API Gemini",
   liveTranslationApiKeyConfigured: "La clé API est configurée",
   liveTranslationApiKeyReplaceHelper: "Une clé API est configurée. Saisissez une nouvelle clé pour la remplacer, ou laissez le champ vide pour conserver la clé actuelle.",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -183,6 +183,9 @@ export const ja = {
   liveTranslation: "ライブ音声翻訳",
   liveTranslationDescription: "現在の動画の音声を Gemini ライブ翻訳にストリーミングし、翻訳された音声とライブ字幕を再生します。有効にすると、動画の音声が Google の Gemini API に送信されます。",
   enableLiveTranslation: "ライブ音声翻訳を有効にする",
+  liveTranslationOriginalAudioWithSubtitles: "原音声と翻訳字幕",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "動画の原音声を維持し、翻訳された音声を再生せずに翻訳字幕を表示します。",
   liveTranslationApiKey: "Gemini API キー",
   liveTranslationApiKeyConfigured: "API キーが設定されています",
   liveTranslationApiKeyReplaceHelper: "API キーが設定されています。新しいキーを入力すると置き換えられます。空欄のままにすると現在のキーが保持されます。",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -180,6 +180,9 @@ export const ko = {
   liveTranslation: "실시간 오디오 번역",
   liveTranslationDescription: "현재 동영상의 오디오를 Gemini 실시간 번역으로 스트리밍하고 번역된 음성과 실시간 자막을 재생합니다. 활성화되어 있는 동안 동영상 오디오가 Google Gemini API로 전송됩니다.",
   enableLiveTranslation: "실시간 오디오 번역 사용",
+  liveTranslationOriginalAudioWithSubtitles: "원본 오디오 및 번역 자막",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "동영상의 원본 오디오를 유지하고 번역된 음성을 재생하지 않고 번역 자막을 표시합니다.",
   liveTranslationApiKey: "Gemini API 키",
   liveTranslationApiKeyConfigured: "API 키가 구성됨",
   liveTranslationApiKeyReplaceHelper: "API 키가 구성되어 있습니다. 새 키를 입력하면 교체되며, 비워 두면 현재 키가 유지됩니다.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -183,6 +183,9 @@ export const pt = {
   liveTranslation: "Tradução de áudio ao vivo",
   liveTranslationDescription: "Transmite o áudio do vídeo atual para o Gemini Live Translation e reproduz a fala traduzida com legendas ao vivo. Enquanto ativo, o áudio do vídeo é enviado para a API Gemini do Google.",
   enableLiveTranslation: "Ativar tradução de áudio ao vivo",
+  liveTranslationOriginalAudioWithSubtitles: "Áudio original e legenda traduzida",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Manter o áudio original do vídeo e exibir legendas traduzidas sem reproduzir a fala traduzida.",
   liveTranslationApiKey: "Chave de API do Gemini",
   liveTranslationApiKeyConfigured: "A chave de API está configurada",
   liveTranslationApiKeyReplaceHelper: "Há uma chave de API configurada. Insira uma nova chave para substituí-la ou deixe em branco para manter a atual.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -183,6 +183,9 @@ export const ru = {
   liveTranslation: "Живой перевод аудио",
   liveTranslationDescription: "Передаёт звук текущего видео в Gemini Live Translation и воспроизводит переведённую речь с живыми субтитрами. Во время работы звук видео отправляется в API Gemini от Google.",
   enableLiveTranslation: "Включить живой перевод аудио",
+  liveTranslationOriginalAudioWithSubtitles: "Оригинальный звук и переведённые субтитры",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "Сохранять оригинальный звук видео и показывать переведённые субтитры без воспроизведения переведённой речи.",
   liveTranslationApiKey: "Ключ API Gemini",
   liveTranslationApiKeyConfigured: "Ключ API настроен",
   liveTranslationApiKeyReplaceHelper: "Ключ API настроен. Введите новый ключ, чтобы заменить его, или оставьте поле пустым, чтобы сохранить текущий ключ.",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -176,6 +176,9 @@ export const zh = {
   liveTranslation: "实时音频翻译",
   liveTranslationDescription: "将当前视频的音频流式传输到 Gemini 实时翻译，并播放翻译后的语音和实时字幕。启用后，视频音频会发送到 Google Gemini API。",
   enableLiveTranslation: "启用实时音频翻译",
+  liveTranslationOriginalAudioWithSubtitles: "原声与翻译字幕",
+  liveTranslationOriginalAudioWithSubtitlesDescription:
+    "保留视频原声并显示翻译字幕，不播放翻译后的语音。",
   liveTranslationApiKey: "Gemini API 密钥",
   liveTranslationApiKeyConfigured: "已配置 API 密钥",
   liveTranslationApiKeyReplaceHelper: "已配置 API 密钥。输入新密钥可替换，留空则保留当前密钥。",


### PR DESCRIPTION
## Summary
- Adds a global admin setting, **Original audio and translated subtitle**, directly under **Enable live audio translation** in Settings → Basic → Video Playback.
- When enabled, live translation keeps the video's original audio audible, shows translated subtitles, and does not play translated speech.
- Default remains unchanged (`false`): original audio is muted after Gemini is ready and translated speech plays as today.
- Session mode is snapshotted at start so mid-session settings changes do not alter active playback.

## Test plan
- [ ] Enable live translation and confirm the new toggle appears under the enable switch.
- [ ] With toggle **off**, start live translation: original mutes after ready, translated speech plays, subtitles appear.
- [ ] With toggle **on**, start live translation: original stays audible, no translated speech, subtitles appear.
- [ ] Pause, resume, seek, and stop in both modes; confirm original audio is not left muted after stop/error.
- [ ] Change the toggle during an active session; confirm current session behavior is unchanged and the next start picks up the new value.
- [ ] Reload and confirm the persisted preference is honored.