### PR TITLE
Implement button loading states

### DIFF
--- a/frontend/src/components/BatchDownloadModal.tsx
+++ b/frontend/src/components/BatchDownloadModal.tsx
@@ -13,31 +13,38 @@ import { useLanguage } from '../contexts/LanguageContext';
 interface BatchDownloadModalProps {
     open: boolean;
     onClose: () => void;
-    onConfirm: (urls: string[]) => void;
+    onConfirm: (urls: string[]) => void | Promise<void>;
 }
 
 const BatchDownloadModal: React.FC<BatchDownloadModalProps> = ({ open, onClose, onConfirm }) => {
     const { t } = useLanguage();
     const [text, setText] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
 
-    const handleConfirm = () => {
+    const handleConfirm = async () => {
         const urls = text
             .split('\n')
             .map(line => line.trim())
             .filter(line => line.length > 0);
 
-        onConfirm(urls);
-        setText('');
-        onClose();
+        setIsSubmitting(true);
+        try {
+            await onConfirm(urls);
+            setText('');
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     const handleClose = () => {
+        if (isSubmitting) return;
         setText('');
         onClose();
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={isSubmitting} maxWidth="sm" fullWidth>
             <DialogTitle>{t('batchDownload') || 'Batch Download'}</DialogTitle>
             <DialogContent>
                 <DialogContentText sx={{ mb: 2 }}>
@@ -55,12 +62,19 @@ const BatchDownloadModal: React.FC<BatchDownloadModalProps> = ({ open, onClose, 
                     variant="outlined"
                     value={text}
                     onChange={(e) => setText(e.target.value)}
+                    disabled={isSubmitting}
                     placeholder="https://www.youtube.com/watch?v=...\nhttps://www.bilibili.com/video/..."
                 />
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose}>{t('cancel') || 'Cancel'}</Button>
-                <Button onClick={handleConfirm} variant="contained" disabled={!text.trim()}>
+                <Button onClick={handleClose} disabled={isSubmitting}>{t('cancel') || 'Cancel'}</Button>
+                <Button
+                    onClick={() => { void handleConfirm(); }}
+                    variant="contained"
+                    disabled={!text.trim()}
+                    loading={isSubmitting}
+                    loadingPosition="start"
+                >
                     {t('addToQueue') || 'Add to Queue'}
                 </Button>
             </DialogActions>

--- a/frontend/src/components/BilibiliPartsModal.tsx
+++ b/frontend/src/components/BilibiliPartsModal.tsx
@@ -47,6 +47,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
 
     // Reset state when modal closes
     const handleClose = () => {
+        if (isLoading) return;
         setSubscribeToPlaylist(false);
         setSubscriptionInterval(60);
         onClose();
@@ -80,8 +81,6 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     };
 
     const getDownloadAllButtonText = () => {
-        if (isLoading) return t('processing');
-
         switch (type) {
             case 'collection':
                 return t('downloadAllVideos', { count: videosNumber });
@@ -95,8 +94,6 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     };
 
     const getCurrentButtonText = () => {
-        if (isLoading) return t('processing');
-
         switch (type) {
             case 'collection':
                 return t('downloadThisVideoOnly');
@@ -113,6 +110,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
         <Dialog
             open={isOpen}
             onClose={handleClose}
+            disableEscapeKeyDown={isLoading}
             maxWidth="sm"
             fullWidth
             slotProps={{
@@ -121,7 +119,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                 }
             }}
         >
-            <DialogHeader title={getHeaderText()} onClose={handleClose} closeLabel={t('close')} />
+            <DialogHeader title={getHeaderText()} onClose={handleClose} closeDisabled={isLoading} closeLabel={t('close')} />
             <DialogContent dividers>
                 <DialogContentText sx={{ mb: 2 }}>
                     {getDescriptionText()}
@@ -184,13 +182,16 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                         onDownloadCurrent();
                     }}
                     disabled={isLoading}
+                    loading={isLoading}
+                    loadingPosition="start"
                     color="inherit"
                 >
                     {getCurrentButtonText()}
                 </Button>
                 <Button
                     onClick={handleDownloadAll}
-                    disabled={isLoading}
+                    loading={isLoading}
+                    loadingPosition="start"
                     variant="contained"
                     color="primary"
                 >

--- a/frontend/src/components/ChannelSubscribeChoiceModal.tsx
+++ b/frontend/src/components/ChannelSubscribeChoiceModal.tsx
@@ -6,15 +6,15 @@ import {
     DialogContentText,
     Typography
 } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 
 interface ChannelSubscribeChoiceModalProps {
     open: boolean;
     onClose: () => void;
-    onChooseVideos: () => void;
-    onChoosePlaylists: () => void;
+    onChooseVideos: () => void | Promise<void>;
+    onChoosePlaylists: () => void | Promise<void>;
 }
 
 const ChannelSubscribeChoiceModal: React.FC<ChannelSubscribeChoiceModalProps> = ({
@@ -24,11 +24,31 @@ const ChannelSubscribeChoiceModal: React.FC<ChannelSubscribeChoiceModalProps> = 
     onChoosePlaylists
 }) => {
     const { t } = useLanguage();
+    const [pendingAction, setPendingAction] = useState<'playlists' | 'videos' | null>(null);
+
+    const handleClose = () => {
+        if (!pendingAction) {
+            onClose();
+        }
+    };
+
+    const handleChoose = async (action: 'playlists' | 'videos') => {
+        setPendingAction(action);
+        try {
+            await (action === 'playlists' ? onChoosePlaylists() : onChooseVideos());
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
+    };
 
     return (
         <Dialog
             open={open}
-            onClose={onClose}
+            onClose={handleClose}
+            disableEscapeKeyDown={Boolean(pendingAction)}
             maxWidth="sm"
             fullWidth
             slotProps={{
@@ -37,7 +57,12 @@ const ChannelSubscribeChoiceModal: React.FC<ChannelSubscribeChoiceModalProps> = 
                 }
             }}
         >
-            <DialogHeader title={t('subscribeToChannel') || 'Subscribe to Channel'} onClose={onClose} closeLabel={t('close')} />
+            <DialogHeader
+                title={t('subscribeToChannel') || 'Subscribe to Channel'}
+                onClose={handleClose}
+                closeDisabled={Boolean(pendingAction)}
+                closeLabel={t('close')}
+            />
             <DialogContent dividers>
                 <DialogContentText sx={{ mb: 3, color: 'text.primary' }}>
                     {t('subscribeChannelChoiceMessage') || 'How would you like to subscribe to this channel?'}
@@ -47,25 +72,27 @@ const ChannelSubscribeChoiceModal: React.FC<ChannelSubscribeChoiceModalProps> = 
                 </Typography>
             </DialogContent>
             <DialogActions sx={{ p: 2, gap: 1, flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'flex-end' }}>
-                <Button onClick={onClose} color="inherit" variant="outlined" sx={{ width: { xs: '100%', sm: 'auto' } }}>
+                <Button onClick={handleClose} color="inherit" variant="outlined" disabled={Boolean(pendingAction)} sx={{ width: { xs: '100%', sm: 'auto' } }}>
                     {t('cancel')}
                 </Button>
                 <Button
-                    onClick={() => {
-                        onChoosePlaylists();
-                    }}
+                    onClick={() => { void handleChoose('playlists'); }}
                     variant="contained"
                     color="primary"
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'playlists'}
+                    loadingPosition="start"
                     sx={{ width: { xs: '100%', sm: 'auto' } }}
                 >
                     {t('subscribeAllPlaylists') || 'Subscribe All Playlists'}
                 </Button>
                 <Button
-                    onClick={() => {
-                        onChooseVideos();
-                    }}
+                    onClick={() => { void handleChoose('videos'); }}
                     variant="contained"
                     color="primary"
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'videos'}
+                    loadingPosition="start"
                     sx={{ width: { xs: '100%', sm: 'auto' } }}
                 >
                     {t('subscribeAllVideos') || 'Subscribe All Videos'}

--- a/frontend/src/components/CollectionModal.tsx
+++ b/frontend/src/components/CollectionModal.tsx
@@ -25,8 +25,10 @@ interface CollectionModalProps {
     collections?: Collection[];
     onAddToCollection?: (collectionId: string) => Promise<void>;
     onCreateCollection?: (name: string) => Promise<void>;
-    onRemoveFromCollection?: (collectionId: string) => void;
+    onRemoveFromCollection?: (collectionId: string) => void | Promise<void>;
 }
+
+type PendingAction = 'add' | 'create' | `remove:${string}` | null;
 
 const CollectionModal: React.FC<CollectionModalProps> = ({
     open,
@@ -40,8 +42,10 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
     const { t } = useLanguage();
     const [newCollectionName, setNewCollectionName] = useState<string>('');
     const [selectedCollection, setSelectedCollection] = useState<string>('');
+    const [pendingAction, setPendingAction] = useState<PendingAction>(null);
 
     const handleClose = () => {
+        if (pendingAction) return;
         setNewCollectionName('');
         setSelectedCollection('');
         onClose();
@@ -49,18 +53,51 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
 
     const handleCreate = async () => {
         if (!newCollectionName.trim() || !onCreateCollection) return;
-        await onCreateCollection(newCollectionName);
-        handleClose();
+        setPendingAction('create');
+        try {
+            await onCreateCollection(newCollectionName);
+            setNewCollectionName('');
+            setSelectedCollection('');
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
     };
 
     const handleAdd = async () => {
         if (!selectedCollection || !onAddToCollection) return;
-        await onAddToCollection(selectedCollection);
-        handleClose();
+        setPendingAction('add');
+        try {
+            await onAddToCollection(selectedCollection);
+            setNewCollectionName('');
+            setSelectedCollection('');
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const handleRemove = async (collectionId: string) => {
+        if (!onRemoveFromCollection) return;
+        setPendingAction(`remove:${collectionId}`);
+        try {
+            await onRemoveFromCollection(collectionId);
+            setNewCollectionName('');
+            setSelectedCollection('');
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
     };
 
     return (
-        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={Boolean(pendingAction)} maxWidth="sm" fullWidth>
             <DialogTitle>{t('addToCollection')}</DialogTitle>
             <DialogContent dividers>
                 {videoCollections && videoCollections.length > 0 && onRemoveFromCollection && (
@@ -70,10 +107,14 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                 key={collection.id}
                                 severity="info"
                                 action={
-                                    <Button color="error" size="small" onClick={() => {
-                                        onRemoveFromCollection(collection.id);
-                                        handleClose();
-                                    }}>
+                                    <Button
+                                        color="error"
+                                        size="small"
+                                        onClick={() => { void handleRemove(collection.id); }}
+                                        disabled={Boolean(pendingAction)}
+                                        loading={pendingAction === `remove:${collection.id}`}
+                                        loadingPosition="start"
+                                    >
                                         {t('remove')}
                                     </Button>
                                 }
@@ -97,6 +138,7 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                     value={selectedCollection}
                                     label={t('selectCollection')}
                                     onChange={(e) => setSelectedCollection(e.target.value)}
+                                    disabled={Boolean(pendingAction)}
                                 >
                                     {collections.map(collection => {
                                         const isCurrentCollection = videoCollections?.some(
@@ -117,8 +159,10 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                             </FormControl>
                             <Button
                                 variant="contained"
-                                onClick={handleAdd}
-                                disabled={!selectedCollection}
+                                onClick={() => { void handleAdd(); }}
+                                disabled={!selectedCollection || Boolean(pendingAction)}
+                                loading={pendingAction === 'add'}
+                                loadingPosition="start"
                             >
                                 {t('add')}
                             </Button>
@@ -136,12 +180,15 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                 label={t('collectionName')}
                                 value={newCollectionName}
                                 onChange={(e) => setNewCollectionName(e.target.value)}
-                                onKeyPress={(e) => e.key === 'Enter' && newCollectionName.trim() && handleCreate()}
+                                onKeyPress={(e) => e.key === 'Enter' && newCollectionName.trim() && !pendingAction && void handleCreate()}
+                                disabled={Boolean(pendingAction)}
                             />
                             <Button
                                 variant="contained"
-                                onClick={handleCreate}
-                                disabled={!newCollectionName.trim()}
+                                onClick={() => { void handleCreate(); }}
+                                disabled={!newCollectionName.trim() || Boolean(pendingAction)}
+                                loading={pendingAction === 'create'}
+                                loadingPosition="start"
                             >
                                 {t('create')}
                             </Button>
@@ -150,7 +197,7 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                 )}
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose} color="inherit">{t('cancel')}</Button>
+                <Button onClick={handleClose} color="inherit" disabled={Boolean(pendingAction)}>{t('cancel')}</Button>
             </DialogActions>
         </Dialog>
     );

--- a/frontend/src/components/ConfirmationModal.tsx
+++ b/frontend/src/components/ConfirmationModal.tsx
@@ -5,13 +5,13 @@ import {
     DialogContent,
     DialogContentText
 } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import DialogHeader from './DialogHeader';
 
 interface ConfirmationModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onConfirm: () => void;
+    onConfirm: () => void | Promise<void>;
     title: string;
     message: string;
     confirmText?: string;
@@ -31,10 +31,31 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
     isDanger = false,
     showCancel = true
 }) => {
+    const [confirming, setConfirming] = useState(false);
+
+    const handleClose = () => {
+        if (!confirming) {
+            onClose();
+        }
+    };
+
+    const handleConfirm = async () => {
+        setConfirming(true);
+        try {
+            await onConfirm();
+            onClose();
+        } catch {
+            // Keep the modal open on failure so the user can retry.
+        } finally {
+            setConfirming(false);
+        }
+    };
+
     return (
         <Dialog
             open={isOpen}
-            onClose={onClose}
+            onClose={handleClose}
+            disableEscapeKeyDown={confirming}
             aria-labelledby="alert-dialog-title"
             aria-describedby="alert-dialog-description"
             slotProps={{
@@ -48,7 +69,12 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
                 }
             }}
         >
-            <DialogHeader id="alert-dialog-title" title={title} onClose={onClose} />
+            <DialogHeader
+                id="alert-dialog-title"
+                title={title}
+                onClose={handleClose}
+                closeDisabled={confirming}
+            />
             <DialogContent dividers>
                 <DialogContentText id="alert-dialog-description" sx={{ whiteSpace: 'pre-wrap' }}>
                     {message}
@@ -56,17 +82,16 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
             </DialogContent>
             <DialogActions sx={{ p: 2 }}>
                 {showCancel && (
-                    <Button onClick={onClose} color="inherit" variant="text">
+                    <Button onClick={handleClose} color="inherit" variant="text" disabled={confirming}>
                         {cancelText}
                     </Button>
                 )}
                 <Button
-                    onClick={() => {
-                        onConfirm();
-                        onClose();
-                    }}
+                    onClick={handleConfirm}
                     color={isDanger ? 'error' : 'primary'}
                     variant="outlined"
+                    loading={confirming}
+                    loadingPosition="start"
                     autoFocus
                 >
                     {confirmText}

--- a/frontend/src/components/DeleteCollectionModal.tsx
+++ b/frontend/src/components/DeleteCollectionModal.tsx
@@ -7,14 +7,14 @@ import {
     DialogContentText,
     Stack
 } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import DialogHeader from './DialogHeader';
 
 interface DeleteCollectionModalProps {
     isOpen: boolean;
     onClose: () => void;
-    onDeleteCollectionOnly: () => void;
-    onDeleteCollectionAndVideos: () => void;
+    onDeleteCollectionOnly: () => void | Promise<void>;
+    onDeleteCollectionAndVideos: () => void | Promise<void>;
     collectionName: string;
     videoCount: number;
 }
@@ -30,10 +30,31 @@ const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
     videoCount
 }) => {
     const { t } = useLanguage();
+    const [pendingAction, setPendingAction] = useState<'collection' | 'collectionAndVideos' | null>(null);
+
+    const handleClose = () => {
+        if (!pendingAction) {
+            onClose();
+        }
+    };
+
+    const handleDelete = async (action: 'collection' | 'collectionAndVideos') => {
+        setPendingAction(action);
+        try {
+            await (action === 'collection' ? onDeleteCollectionOnly() : onDeleteCollectionAndVideos());
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
     return (
         <Dialog
             open={isOpen}
-            onClose={onClose}
+            onClose={handleClose}
+            disableEscapeKeyDown={Boolean(pendingAction)}
             maxWidth="sm"
             fullWidth
             slotProps={{
@@ -42,7 +63,12 @@ const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
                 }
             }}
         >
-            <DialogHeader title={t('deleteCollectionTitle')} onClose={onClose} closeLabel={t('close')} />
+            <DialogHeader
+                title={t('deleteCollectionTitle')}
+                onClose={handleClose}
+                closeDisabled={Boolean(pendingAction)}
+                closeLabel={t('close')}
+            />
             <DialogContent dividers>
                 <DialogContentText sx={{ mb: 2, color: 'text.primary' }}>
                     {t('deleteCollectionConfirmation')} <strong>"{collectionName}"</strong>?
@@ -55,7 +81,10 @@ const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
                     <Button
                         variant="outlined"
                         color="inherit"
-                        onClick={onDeleteCollectionOnly}
+                        onClick={() => { void handleDelete('collection'); }}
+                        disabled={Boolean(pendingAction)}
+                        loading={pendingAction === 'collection'}
+                        loadingPosition="start"
                         fullWidth
                         sx={{ justifyContent: 'center', py: 1.5 }}
                     >
@@ -66,7 +95,10 @@ const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
                         <Button
                             variant="outlined"
                             color="error"
-                            onClick={onDeleteCollectionAndVideos}
+                            onClick={() => { void handleDelete('collectionAndVideos'); }}
+                            disabled={Boolean(pendingAction)}
+                            loading={pendingAction === 'collectionAndVideos'}
+                            loadingPosition="start"
                             fullWidth
                             startIcon={<Warning />}
                             sx={{
@@ -82,7 +114,7 @@ const DeleteCollectionModal: React.FC<DeleteCollectionModalProps> = ({
                 </Stack>
             </DialogContent>
             <DialogActions sx={{ p: 2 }}>
-                <Button onClick={onClose} color="inherit">
+                <Button onClick={handleClose} color="inherit" disabled={Boolean(pendingAction)}>
                     {t('cancel')}
                 </Button>
             </DialogActions>

--- a/frontend/src/components/Header/SearchInput.tsx
+++ b/frontend/src/components/Header/SearchInput.tsx
@@ -4,7 +4,6 @@ import {
     Box,
     ButtonGroup,
     Button,
-    CircularProgress,
     IconButton,
     InputAdornment,
     TextField,
@@ -250,9 +249,10 @@ const SearchInput: React.FC<SearchInputProps> = ({
                                     <Button
                                         type="submit"
                                         aria-label={t('download')}
+                                        loading={isSubmitting}
                                         sx={{ minWidth: 'auto', px: 2.5 }}
                                     >
-                                        {isSubmitting ? <CircularProgress size={24} color="inherit" /> : <Search />}
+                                        <Search />
                                     </Button>
                                 </ButtonGroup>
                             </InputAdornment>

--- a/frontend/src/components/ManagePage/CollectionsTable.tsx
+++ b/frontend/src/components/ManagePage/CollectionsTable.tsx
@@ -3,7 +3,6 @@ import { Check, Close, Delete, Edit, Folder } from '@mui/icons-material';
 import {
     Alert,
     Box,
-    CircularProgress,
     IconButton,
     Pagination,
     Paper,
@@ -217,10 +216,10 @@ const CollectionsTable: React.FC<CollectionsTableProps> = ({
                                                     size="small"
                                                     color="primary"
                                                     onClick={() => handleSave(collection.id)}
-                                                    disabled={isSaving}
+                                                    loading={isSaving}
                                                     aria-label="save collection name"
                                                 >
-                                                    {isSaving ? <CircularProgress size={20} /> : <Check />}
+                                                    <Check />
                                                 </IconButton>
                                                 <IconButton
                                                     size="small"

--- a/frontend/src/components/ManagePage/VideosTable.tsx
+++ b/frontend/src/components/ManagePage/VideosTable.tsx
@@ -16,7 +16,6 @@ import {
     Box,
     Button,
     Checkbox,
-    CircularProgress,
     IconButton,
     InputAdornment,
     Pagination,
@@ -193,7 +192,7 @@ const VideosTable: React.FC<VideosTableProps> = ({
     const [uploadThumbnailVideoId, setUploadThumbnailVideoId] = useState<string | null>(null);
 
     // Re-download hook
-    const { handleReDownload } = useVideoReDownload();
+    const { handleReDownload, isReDownloading } = useVideoReDownload();
 
     // Helper function to check if a video is currently downloading
     const isVideoDownloading = (sourceUrl: string | undefined) => {
@@ -217,10 +216,13 @@ const VideosTable: React.FC<VideosTableProps> = ({
         if (!editTitle.trim()) return;
 
         setIsSavingTitle(true);
-        await onUpdateVideo(id, { title: editTitle });
-        setIsSavingTitle(false);
-        setEditingVideoId(null);
-        setEditTitle('');
+        try {
+            await onUpdateVideo(id, { title: editTitle });
+            setEditingVideoId(null);
+            setEditTitle('');
+        } finally {
+            setIsSavingTitle(false);
+        }
     };
 
     const handleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -247,6 +249,7 @@ const VideosTable: React.FC<VideosTableProps> = ({
             setIsBulkDeleteModalOpen(false);
         } catch (error) {
             console.error('Failed to delete videos', error);
+            throw error;
         } finally {
             setIsBulkDeleting(false);
         }
@@ -385,14 +388,10 @@ const VideosTable: React.FC<VideosTableProps> = ({
                                                     <IconButton
                                                         size="small"
                                                         onClick={onRefreshFileSizes}
-                                                        disabled={isRefreshingFileSizes}
+                                                        loading={isRefreshingFileSizes}
                                                         aria-label="Refresh all file sizes"
                                                     >
-                                                        {isRefreshingFileSizes ? (
-                                                            <CircularProgress size={16} />
-                                                        ) : (
-                                                            <Refresh sx={{ fontSize: 18 }} />
-                                                        )}
+                                                        <Refresh sx={{ fontSize: 18 }} />
                                                     </IconButton>
                                                 </span>
                                             </Tooltip>
@@ -440,34 +439,36 @@ const VideosTable: React.FC<VideosTableProps> = ({
                                                         <IconButton
                                                             size="small"
                                                             onClick={() => onRefreshThumbnail(video.id)}
-                                                            aria-label={refreshThumbnailLabel}
-                                                            disabled={refreshingId === video.id || redownloadingThumbnailIds[video.id] === true}
-                                                            sx={{
+	                                                            aria-label={refreshThumbnailLabel}
+	                                                            disabled={redownloadingThumbnailIds[video.id] === true}
+	                                                            loading={refreshingId === video.id}
+	                                                            sx={{
                                                                 position: 'absolute',
                                                                 top: 0,
                                                                 right: 0,
                                                                 ...thumbnailActionButtonSx
                                                             }}
                                                         >
-                                                            {refreshingId === video.id ? <CircularProgress size={14} color="inherit" /> : <Refresh sx={{ fontSize: 16 }} />}
-                                                        </IconButton>
+	                                                            <Refresh sx={{ fontSize: 16 }} />
+	                                                        </IconButton>
                                                     </Tooltip>
                                                     {video.sourceUrl && (
                                                         <Tooltip title={redownloadThumbnailLabel} disableHoverListener={isTouch}>
                                                             <IconButton
                                                                 size="small"
                                                                 onClick={() => onRedownloadThumbnail(video.id)}
-                                                                aria-label={redownloadThumbnailLabel}
-                                                                disabled={redownloadingThumbnailIds[video.id] === true || refreshingId === video.id}
-                                                                sx={{
+	                                                                aria-label={redownloadThumbnailLabel}
+	                                                                disabled={refreshingId === video.id}
+	                                                                loading={redownloadingThumbnailIds[video.id] === true}
+	                                                                sx={{
                                                                     position: 'absolute',
                                                                     top: 0,
                                                                     left: 0,
                                                                     ...thumbnailActionButtonSx
                                                                 }}
                                                             >
-                                                                {redownloadingThumbnailIds[video.id] === true ? <CircularProgress size={14} color="inherit" /> : <CloudDownload sx={{ fontSize: 16 }} />}
-                                                            </IconButton>
+	                                                                <CloudDownload sx={{ fontSize: 16 }} />
+	                                                            </IconButton>
                                                         </Tooltip>
                                                     )}
                                                     <Tooltip title={uploadThumbnailLabel} disableHoverListener={isTouch}>
@@ -509,12 +510,12 @@ const VideosTable: React.FC<VideosTableProps> = ({
                                                 <IconButton
                                                     size="small"
                                                     color="primary"
-                                                    aria-label={t('save')}
-                                                    onClick={() => handleSaveTitle(video.id)}
-                                                    disabled={isSavingTitle}
-                                                >
-                                                    {isSavingTitle ? <CircularProgress size={20} /> : <Check />}
-                                                </IconButton>
+	                                                    aria-label={t('save')}
+	                                                    onClick={() => handleSaveTitle(video.id)}
+	                                                    loading={isSavingTitle}
+	                                                >
+	                                                    <Check />
+	                                                </IconButton>
                                                 <IconButton
                                                     size="small"
                                                     color="error"
@@ -571,16 +572,17 @@ const VideosTable: React.FC<VideosTableProps> = ({
                                     <TableCell>{formatSize(video.fileSize)}</TableCell>
                                     {!isVisitor && (
                                         <TableCell align="right">
-                                            {video.sourceUrl && !isVideoDownloading(video.sourceUrl) && (
-                                                <Tooltip
+	                                            {video.sourceUrl && (!isVideoDownloading(video.sourceUrl) || isReDownloading(video.sourceUrl)) && (
+	                                                <Tooltip
                                                     title={redownloadVideoLabel}
                                                     disableHoverListener={isTouch}
                                                 >
                                                     <IconButton
                                                         color="primary"
-                                                        aria-label={redownloadVideoLabel}
-                                                        onClick={() => handleReDownload(video)}
-                                                    >
+	                                                        aria-label={redownloadVideoLabel}
+	                                                        onClick={() => { void handleReDownload(video); }}
+	                                                        loading={isReDownloading(video.sourceUrl)}
+	                                                    >
                                                         <Replay />
                                                     </IconButton>
                                                 </Tooltip>
@@ -589,11 +591,11 @@ const VideosTable: React.FC<VideosTableProps> = ({
                                                 <IconButton
                                                     color="error"
                                                     aria-label={deleteVideoLabel}
-                                                    onClick={() => onDeleteClick(video.id)}
-                                                    disabled={deletingId === video.id}
-                                                >
-                                                    {deletingId === video.id ? <CircularProgress size={24} /> : <Delete />}
-                                                </IconButton>
+	                                                    onClick={() => onDeleteClick(video.id)}
+	                                                    loading={deletingId === video.id}
+	                                                >
+	                                                    <Delete />
+	                                                </IconButton>
                                             </Tooltip>
                                         </TableCell>
                                     )}

--- a/frontend/src/components/ManagePage/hooks/useVideoReDownload.ts
+++ b/frontend/src/components/ManagePage/hooks/useVideoReDownload.ts
@@ -50,5 +50,9 @@ export const useVideoReDownload = () => {
         }
     };
 
-    return { handleReDownload };
+    const isReDownloading = (sourceUrl: string | undefined) => (
+        Boolean(sourceUrl && downloadingItems.has(sourceUrl))
+    );
+
+    return { handleReDownload, isReDownloading };
 };

--- a/frontend/src/components/PasswordModal.tsx
+++ b/frontend/src/components/PasswordModal.tsx
@@ -1,7 +1,6 @@
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import {
     Button,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -125,10 +124,11 @@ const PasswordModal: React.FC<PasswordModalProps> = ({
                         type="submit"
                         color="primary"
                         variant="contained"
-                        disabled={isLoading || !password}
-                        startIcon={isLoading ? <CircularProgress size={20} color="inherit" /> : null}
+                        disabled={!password}
+                        loading={isLoading}
+                        loadingPosition="start"
                     >
-                        {isLoading ? t('verifying') : t('confirm')}
+                        {t('confirm')}
                     </Button>
                 </DialogActions>
             </form>

--- a/frontend/src/components/Settings/AdvancedSettings.tsx
+++ b/frontend/src/components/Settings/AdvancedSettings.tsx
@@ -1,5 +1,5 @@
 import { getApiErrorMessage } from '../../utils/errors';
-import { Alert, Box, Button, CircularProgress, Divider, FormControlLabel, Switch, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, Divider, FormControlLabel, Switch, TextField, Typography } from '@mui/material';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { Settings } from '../../types';
@@ -152,8 +152,9 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
                     <Button
                         variant="outlined"
                         onClick={handleTestTelegram}
-                        disabled={!telegramEnabled || !telegramBotToken || !telegramChatId || testing}
-                        startIcon={testing ? <CircularProgress size={16} /> : undefined}
+                        disabled={!telegramEnabled || !telegramBotToken || !telegramChatId}
+                        loading={testing}
+                        loadingPosition="start"
                     >
                         {t('telegramTestButton')}
                     </Button>

--- a/frontend/src/components/Settings/CloudDriveSettings.tsx
+++ b/frontend/src/components/Settings/CloudDriveSettings.tsx
@@ -1,5 +1,5 @@
 import { getApiErrorMessage, hasAnyAxiosStatus } from '../../utils/errors';
-import { Alert, Box, Button, CircularProgress, FormControlLabel, LinearProgress, Switch, TextField, Typography } from '@mui/material';
+import { Alert, Box, Button, FormControlLabel, LinearProgress, Switch, TextField, Typography } from '@mui/material';
 import axios from 'axios';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -186,7 +186,6 @@ const CloudDriveSettings: React.FC<CloudDriveSettingsProps> = ({ settings, onCha
     };
 
     const handleSync = async () => {
-        setShowSyncModal(false);
         setSyncing(true);
         setSyncProgress(null);
         setTestResult(null);
@@ -258,11 +257,11 @@ const CloudDriveSettings: React.FC<CloudDriveSettingsProps> = ({ settings, onCha
                 type: 'error',
                 message: getApiErrorMessage(error) || t('syncFailedMessage'),
             });
+            throw error;
         }
     };
 
     const handleClearThumbnailCache = async () => {
-        setShowClearCacheModal(false);
         setClearingCache(true);
         setTestResult(null);
 
@@ -282,6 +281,7 @@ const CloudDriveSettings: React.FC<CloudDriveSettingsProps> = ({ settings, onCha
                 type: 'error',
                 message: getApiErrorMessage(error) || t('clearThumbnailCacheError'),
             });
+            throw error;
         } finally {
             setClearingCache(false);
         }
@@ -381,17 +381,20 @@ const CloudDriveSettings: React.FC<CloudDriveSettingsProps> = ({ settings, onCha
                         <Button
                             variant="outlined"
                             onClick={handleTestConnection}
-                            disabled={testing || syncing || clearingCache || !settings.openListApiUrl || !settings.openListToken}
-                            startIcon={testing ? <CircularProgress size={16} /> : null}
+                            disabled={syncing || clearingCache || !settings.openListApiUrl || !settings.openListToken}
+                            loading={testing}
+                            loadingPosition="start"
                         >
-                            {testing ? t('testing') : t('testConnection')}
+                            {t('testConnection')}
                         </Button>
 
                         <Button
                             variant="contained"
                             color="primary"
                             onClick={() => setShowSyncModal(true)}
-                            disabled={testing || syncing || clearingCache || !settings.openListApiUrl || !settings.openListToken}
+                            disabled={testing || clearingCache || !settings.openListApiUrl || !settings.openListToken}
+                            loading={syncing}
+                            loadingPosition="start"
                         >
                             {t('sync')}
                         </Button>
@@ -400,10 +403,11 @@ const CloudDriveSettings: React.FC<CloudDriveSettingsProps> = ({ settings, onCha
                             variant="outlined"
                             color="warning"
                             onClick={() => setShowClearCacheModal(true)}
-                            disabled={testing || syncing || clearingCache}
-                            startIcon={clearingCache ? <CircularProgress size={16} /> : null}
+                            disabled={testing || syncing}
+                            loading={clearingCache}
+                            loadingPosition="start"
                         >
-                            {clearingCache ? t('clearing') : t('clearThumbnailCache')}
+                            {t('clearThumbnailCache')}
                         </Button>
                     </Box>
 

--- a/frontend/src/components/Settings/CookieSettings.tsx
+++ b/frontend/src/components/Settings/CookieSettings.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { api, getApiErrorMessage } from '../../utils/apiClient';
+import { runMutationAsync } from '../../utils/mutationUtils';
 import ConfirmationModal from '../ConfirmationModal';
 
 interface CookieSettingsProps {
@@ -13,6 +14,7 @@ interface CookieSettingsProps {
 
 const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) => {
     const { t } = useLanguage();
+    const [uploadingCookies, setUploadingCookies] = useState(false);
 
     const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -26,6 +28,7 @@ const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) =
         const formData = new FormData();
         formData.append('file', file);
 
+        setUploadingCookies(true);
         try {
             await api.post('/settings/upload-cookies', formData, {
                 headers: {
@@ -36,6 +39,9 @@ const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) =
         } catch (error) {
             console.error('Error uploading cookies:', error);
             onError(await getApiErrorMessage(error, t) || t('cookiesUploadFailed') || 'Failed to upload cookies');
+        } finally {
+            setUploadingCookies(false);
+            e.target.value = '';
         }
 
     };
@@ -74,9 +80,8 @@ const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) =
         setShowDeleteConfirm(true);
     };
 
-    const confirmDelete = () => {
-        deleteMutation.mutate();
-        setShowDeleteConfirm(false);
+    const confirmDelete = async () => {
+        await runMutationAsync(deleteMutation, undefined);
     };
 
     return (
@@ -92,6 +97,8 @@ const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) =
                     variant="outlined"
                     component="label"
                     startIcon={<CloudUpload />}
+                    loading={uploadingCookies}
+                    loadingPosition="start"
                 >
                     {t('uploadCookies') || 'Upload Cookies'}
                     <input
@@ -109,7 +116,8 @@ const CookieSettings: React.FC<CookieSettingsProps> = ({ onSuccess, onError }) =
                             color="error"
                             startIcon={<Delete />}
                             onClick={handleDelete}
-                            disabled={deleteMutation.isPending}
+                            loading={deleteMutation.isPending}
+                            loadingPosition="start"
                         >
                             {t('deleteCookies') || 'Delete Cookies'}
                         </Button>

--- a/frontend/src/components/Settings/FilenameBatchRenameSection.tsx
+++ b/frontend/src/components/Settings/FilenameBatchRenameSection.tsx
@@ -44,6 +44,7 @@ const FilenameBatchRenameSection: React.FC<FilenameBatchRenameSectionProps> = ({
     const [confirmOpen, setConfirmOpen] = useState(false);
     const [renameJob, setRenameJob] = useState<RenameJob | null>(null);
     const [renameError, setRenameError] = useState<string | null>(null);
+    const [startingRename, setStartingRename] = useState(false);
 
     // On rename completion the library's paths changed on disk: refresh every
     // query that renders them.
@@ -56,7 +57,7 @@ const FilenameBatchRenameSection: React.FC<FilenameBatchRenameSectionProps> = ({
     useSettingsJobPolling(renameJob, renameJobUrl, setRenameJob, handleRenameCompleted);
 
     const handleStartRename = async () => {
-        setConfirmOpen(false);
+        setStartingRename(true);
         setRenameError(null);
         try {
             const res = await api.post<{ jobId: string; status: string; total: number }>(
@@ -84,10 +85,13 @@ const FilenameBatchRenameSection: React.FC<FilenameBatchRenameSectionProps> = ({
                 failed: 0,
                 items: [],
             });
+            setConfirmOpen(false);
         } catch (e: unknown) {
             setRenameError(
                 getApiErrorMessage(e) || t('filenameBatchRenameError')
             );
+        } finally {
+            setStartingRename(false);
         }
     };
 
@@ -159,7 +163,15 @@ const FilenameBatchRenameSection: React.FC<FilenameBatchRenameSectionProps> = ({
                 </span>
             </Tooltip>
 
-            <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+            <Dialog
+                open={confirmOpen}
+                onClose={() => {
+                    if (!startingRename) {
+                        setConfirmOpen(false);
+                    }
+                }}
+                disableEscapeKeyDown={startingRename}
+            >
                 <DialogTitle>{t('filenameBatchRenameConfirmTitle')}</DialogTitle>
                 <DialogContent>
                     <DialogContentText>
@@ -167,8 +179,14 @@ const FilenameBatchRenameSection: React.FC<FilenameBatchRenameSectionProps> = ({
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => setConfirmOpen(false)}>{t('cancel')}</Button>
-                    <Button onClick={handleStartRename} color="warning" variant="contained">
+                    <Button onClick={() => setConfirmOpen(false)} disabled={startingRename}>{t('cancel')}</Button>
+                    <Button
+                        onClick={() => { void handleStartRename(); }}
+                        color="warning"
+                        variant="contained"
+                        loading={startingRename}
+                        loadingPosition="start"
+                    >
                         {t('filenameBatchRenameConfirm')}
                     </Button>
                 </DialogActions>

--- a/frontend/src/components/Settings/HookSettings.tsx
+++ b/frontend/src/components/Settings/HookSettings.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { Settings } from '../../types';
 import { api, getApiErrorMessage, getWaitTime, isRateLimitError } from '../../utils/apiClient';
+import { runMutationAsync } from '../../utils/mutationUtils';
 import ConfirmationModal from '../ConfirmationModal';
 import PasswordModal from '../PasswordModal';
 
@@ -120,9 +121,9 @@ const HookSettings: React.FC<HookSettingsProps> = () => {
         setDeleteHookName(hookName);
     };
 
-    const confirmDelete = () => {
+    const confirmDelete = async () => {
         if (deleteHookName) {
-            deleteMutation.mutate(deleteHookName);
+            await runMutationAsync(deleteMutation, deleteHookName);
         }
     };
 
@@ -201,9 +202,10 @@ const HookSettings: React.FC<HookSettingsProps> = () => {
                                                 component="label"
                                                 size="small"
                                                 startIcon={<CloudUpload />}
-                                                disabled={uploadMutation.isPending}
+                                                loading={uploadMutation.isPending && pendingUpload?.hookName === hook.name}
+                                                loadingPosition="start"
                                             >
-                                                {uploadMutation.isPending ? 'Up...' : (t('uploadHook') || 'Upload .sh')}
+                                                {t('uploadHook') || 'Upload .sh'}
                                                 <input
                                                     type="file"
                                                     hidden
@@ -219,7 +221,8 @@ const HookSettings: React.FC<HookSettingsProps> = () => {
                                                     size="small"
                                                     startIcon={<Delete />}
                                                     onClick={() => { handleDelete(hook.name); }}
-                                                    disabled={deleteMutation.isPending}
+                                                    loading={deleteMutation.isPending && deleteHookName === hook.name}
+                                                    loadingPosition="start"
                                                 >
                                                     {t('delete') || 'Delete'}
                                                 </Button>

--- a/frontend/src/components/Settings/MediaServerExportSettings.tsx
+++ b/frontend/src/components/Settings/MediaServerExportSettings.tsx
@@ -50,11 +50,12 @@ const MediaServerExportSettings: React.FC<MediaServerExportSettingsProps> = ({
     const [exportConfirmOpen, setExportConfirmOpen] = useState(false);
     const [exportJob, setExportJob] = useState<MediaServerExportJob | null>(null);
     const [exportError, setExportError] = useState<string | null>(null);
+    const [startingExport, setStartingExport] = useState(false);
 
     useSettingsJobPolling(exportJob, mediaServerExportJobUrl, setExportJob);
 
     const handleStartMediaServerExportRebuild = async () => {
-        setExportConfirmOpen(false);
+        setStartingExport(true);
         setExportError(null);
         const mode = settings.mediaServerExportMode || 'off';
         try {
@@ -86,8 +87,11 @@ const MediaServerExportSettings: React.FC<MediaServerExportSettingsProps> = ({
                 failed: jobData.failed,
                 items: [],
             });
+            setExportConfirmOpen(false);
         } catch (e: unknown) {
             setExportError(getMediaServerExportErrorMessage(e, mode, t));
+        } finally {
+            setStartingExport(false);
         }
     };
 
@@ -193,7 +197,15 @@ const MediaServerExportSettings: React.FC<MediaServerExportSettingsProps> = ({
                 </span>
             </Tooltip>
 
-            <Dialog open={exportConfirmOpen} onClose={() => setExportConfirmOpen(false)}>
+            <Dialog
+                open={exportConfirmOpen}
+                onClose={() => {
+                    if (!startingExport) {
+                        setExportConfirmOpen(false);
+                    }
+                }}
+                disableEscapeKeyDown={startingExport}
+            >
                 <DialogTitle>{t(exportAction === 'cleanup'
                     ? 'mediaServerExportCleanupConfirmTitle'
                     : 'mediaServerExportRebuildConfirmTitle')}</DialogTitle>
@@ -205,8 +217,13 @@ const MediaServerExportSettings: React.FC<MediaServerExportSettingsProps> = ({
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>
-                    <Button onClick={() => setExportConfirmOpen(false)}>{t('cancel')}</Button>
-                    <Button onClick={handleStartMediaServerExportRebuild} variant="contained">
+                    <Button onClick={() => setExportConfirmOpen(false)} disabled={startingExport}>{t('cancel')}</Button>
+                    <Button
+                        onClick={() => { void handleStartMediaServerExportRebuild(); }}
+                        variant="contained"
+                        loading={startingExport}
+                        loadingPosition="start"
+                    >
                         {t(exportAction === 'cleanup'
                             ? 'mediaServerExportCleanup'
                             : 'mediaServerExportRebuild')}

--- a/frontend/src/components/Settings/MountDirectoriesSettings.tsx
+++ b/frontend/src/components/Settings/MountDirectoriesSettings.tsx
@@ -148,9 +148,10 @@ const MountDirectoriesSettings: React.FC<MountDirectoriesSettingsProps> = ({
                             variant="outlined"
                             startIcon={<FindInPage />}
                             onClick={handleScanMountDirectories}
-                            disabled={scanMountDirectoriesMutation.isPending}
+                            loading={scanMountDirectoriesMutation.isPending}
+                            loadingPosition="start"
                         >
-                            {scanMountDirectoriesMutation.isPending ? (t('scanning') || 'Scanning...') : (t('scanFiles') || 'Scan Files')}
+                            {t('scanFiles') || 'Scan Files'}
                         </Button>
                     </Box>
                 </>

--- a/frontend/src/components/Settings/RssFeedSettings/RssTokenCard.tsx
+++ b/frontend/src/components/Settings/RssFeedSettings/RssTokenCard.tsx
@@ -20,9 +20,9 @@ interface RssTokenCardProps {
     channelOptions?: { channelUrl: string; author: string }[];
     authorOptions?: string[];
     tagOptions?: string[];
-    onUpdate: (id: string, patch: UpdateTokenInput) => void;
-    onDelete: (id: string) => void;
-    onReset: (id: string) => void;
+    onUpdate: (id: string, patch: UpdateTokenInput) => void | Promise<unknown>;
+    onDelete: (id: string) => void | Promise<unknown>;
+    onReset: (id: string) => void | Promise<unknown>;
     isUpdating?: boolean;
 }
 
@@ -68,7 +68,7 @@ const RssTokenCard: React.FC<RssTokenCardProps> = ({
     };
 
     const handleToggleActive = () => {
-        onUpdate(token.id, { isActive: !token.isActive });
+        void onUpdate(token.id, { isActive: !token.isActive });
     };
 
     const filterSummary = () => {
@@ -176,7 +176,8 @@ const RssTokenCard: React.FC<RssTokenCardProps> = ({
                     onClick={handleToggleActive}
                     variant="outlined"
                     color={token.isActive ? 'error' : 'success'}
-                    disabled={isUpdating}
+                    loading={isUpdating}
+                    loadingPosition="start"
                 >
                     {token.isActive ? t('rssDisableLink') : t('rssEnableLink')}
                 </Button>
@@ -203,8 +204,8 @@ const RssTokenCard: React.FC<RssTokenCardProps> = ({
                 onClose={() => {
                     setShowEditDialog(false);
                 }}
-                onUpdate={(id, patch) => {
-                    onUpdate(id, patch);
+                onUpdate={async (id, patch) => {
+                    await onUpdate(id, patch);
                     setShowEditDialog(false);
                 }}
                 isLoading={isUpdating}
@@ -217,9 +218,8 @@ const RssTokenCard: React.FC<RssTokenCardProps> = ({
                 message={t('rssDeleteLinkConfirm')}
                 confirmText={t('delete')}
                 cancelText={t('cancel')}
-                onConfirm={() => {
-                    setShowDeleteConfirm(false);
-                    onDelete(token.id);
+                onConfirm={async () => {
+                    await onDelete(token.id);
                 }}
                 onClose={() => {
                     setShowDeleteConfirm(false);
@@ -234,9 +234,8 @@ const RssTokenCard: React.FC<RssTokenCardProps> = ({
                 message={t('rssResetLinkConfirm')}
                 confirmText={t('reset')}
                 cancelText={t('cancel')}
-                onConfirm={() => {
-                    setShowResetConfirm(false);
-                    onReset(token.id);
+                onConfirm={async () => {
+                    await onReset(token.id);
                 }}
                 onClose={() => {
                     setShowResetConfirm(false);

--- a/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
+++ b/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
@@ -30,8 +30,8 @@ interface RssTokenDialogProps {
     authorOptions?: string[];
     tagOptions?: string[];
     onClose: () => void;
-    onCreate?: (input: CreateTokenInput) => void;
-    onUpdate?: (id: string, patch: UpdateTokenInput) => void;
+    onCreate?: (input: CreateTokenInput) => void | Promise<unknown>;
+    onUpdate?: (id: string, patch: UpdateTokenInput) => void | Promise<unknown>;
     isLoading?: boolean;
 }
 
@@ -89,7 +89,17 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
     const title = mode === 'create' ? t('rssCreateToken') : t('rssEditToken');
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+        <Dialog
+            open={open}
+            onClose={() => {
+                if (!isLoading) {
+                    onClose();
+                }
+            }}
+            disableEscapeKeyDown={isLoading}
+            maxWidth="sm"
+            fullWidth
+        >
             <DialogTitle>{title}</DialogTitle>
             <DialogContent>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
@@ -156,7 +166,12 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
                 <Button onClick={onClose} disabled={isLoading}>
                     {t('cancel')}
                 </Button>
-                <Button onClick={handleSubmit} variant="contained" disabled={isLoading}>
+                <Button
+                    onClick={handleSubmit}
+                    variant="contained"
+                    loading={isLoading}
+                    loadingPosition="start"
+                >
                     {mode === 'create' ? t('rssCreateToken') : t('save')}
                 </Button>
             </DialogActions>

--- a/frontend/src/components/Settings/RssFeedSettings/RssTokenList.tsx
+++ b/frontend/src/components/Settings/RssFeedSettings/RssTokenList.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useMemo, useState } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { api } from '../../../utils/apiClient';
+import { runMutationAsync } from '../../../utils/mutationUtils';
 import { CreateTokenInput, RssToken, UpdateTokenInput, rssApi } from '../../../utils/rssApi';
 import RssTokenCard from './RssTokenCard';
 import RssTokenDialog from './RssTokenDialog';
@@ -165,15 +166,19 @@ const RssTokenList: React.FC = () => {
                     authorOptions={authorOptions}
                     tagOptions={tagOptions}
                     onUpdate={(id, patch) => {
-                        updateMutation.mutate({ id, patch });
+                        return runMutationAsync(updateMutation, { id, patch });
                     }}
                     onDelete={(id) => {
-                        deleteMutation.mutate(id);
+                        return runMutationAsync(deleteMutation, id);
                     }}
                     onReset={(id) => {
-                        resetMutation.mutate(id);
+                        return runMutationAsync(resetMutation, id);
                     }}
-                    isUpdating={updateMutation.isPending}
+                    isUpdating={
+                        (updateMutation.isPending && updateMutation.variables?.id === token.id) ||
+                        (deleteMutation.isPending && deleteMutation.variables === token.id) ||
+                        (resetMutation.isPending && resetMutation.variables === token.id)
+                    }
                 />
             ))}
 
@@ -187,7 +192,7 @@ const RssTokenList: React.FC = () => {
                     setShowCreateDialog(false);
                 }}
                 onCreate={(input) => {
-                    createMutation.mutate(input);
+                    return runMutationAsync(createMutation, input);
                 }}
                 isLoading={createMutation.isPending}
             />

--- a/frontend/src/components/Settings/SecuritySettings.tsx
+++ b/frontend/src/components/Settings/SecuritySettings.tsx
@@ -10,6 +10,7 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { Settings } from '../../types';
 import { api } from '../../utils/apiClient';
 import { copyTextToClipboard } from '../../utils/clipboard';
+import { runMutationAsync } from '../../utils/mutationUtils';
 import { getWebAuthnErrorTranslationKey } from '../../utils/translations';
 import AlertModal from '../AlertModal';
 import ConfirmationModal from '../ConfirmationModal';
@@ -164,8 +165,8 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
         createPasskeyMutation.mutate();
     };
 
-    const handleRemovePasskeys = () => {
-        removePasskeysMutation.mutate();
+    const handleRemovePasskeys = async () => {
+        await runMutationAsync(removePasskeysMutation, undefined);
     };
 
     const handleApiKeyToggle = (enabled: boolean) => {
@@ -307,12 +308,12 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
                                 variant="outlined"
                                 startIcon={<FingerprintIcon />}
                                 onClick={handleCreatePasskey}
-                                disabled={!settings.loginEnabled || createPasskeyMutation.isPending}
+                                disabled={!settings.loginEnabled}
+                                loading={createPasskeyMutation.isPending}
+                                loadingPosition="start"
                                 fullWidth
                             >
-                                {createPasskeyMutation.isPending
-                                    ? (t('creatingPasskey') || 'Creating...')
-                                    : (t('createPasskey') || 'Create Passkey')}
+                                {t('createPasskey') || 'Create Passkey'}
                             </Button>
                         </Box>
                         <Button
@@ -320,7 +321,9 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
                             color="error"
                             startIcon={<DeleteIcon />}
                             onClick={() => setShowRemoveModal(true)}
-                            disabled={!settings.loginEnabled || !passkeysExist || removePasskeysMutation.isPending}
+                            disabled={!settings.loginEnabled || !passkeysExist}
+                            loading={removePasskeysMutation.isPending}
+                            loadingPosition="start"
                             fullWidth
                         >
                             {t('removePasskeys') || 'Remove All Passkeys'}
@@ -361,7 +364,6 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
                 onClose={() => setShowRefreshKeyModal(false)}
                 onConfirm={() => {
                     handleRefreshApiKey();
-                    setShowRefreshKeyModal(false);
                 }}
                 title={t('refreshApiKeyTitle') || 'Refresh API Key'}
                 message={t('refreshApiKeyConfirm') || 'Regenerating the API key will invalidate the existing one. All clients using the old key will need to be updated after saving.'}

--- a/frontend/src/components/Settings/StatisticsSettings.tsx
+++ b/frontend/src/components/Settings/StatisticsSettings.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     Box,
     Button,
-    CircularProgress,
     FormControl,
     FormControlLabel,
     InputLabel,
@@ -143,13 +142,10 @@ const StatisticsSettings: React.FC<StatisticsSettingsProps> = ({ settings, onCha
                     variant="outlined"
                     color="error"
                     onClick={handleClear}
-                    disabled={clearing}
+                    loading={clearing}
+                    loadingPosition="start"
                 >
-                    {clearing ? (
-                        <CircularProgress size={16} />
-                    ) : (
-                        t('statisticsClear') || 'Clear collected statistics'
-                    )}
+                    {t('statisticsClear') || 'Clear collected statistics'}
                 </Button>
             </Box>
 

--- a/frontend/src/components/Settings/TagsSettings.tsx
+++ b/frontend/src/components/Settings/TagsSettings.tsx
@@ -2,7 +2,6 @@ import {
     Box,
     Button,
     Chip,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -139,8 +138,13 @@ const TagsSettings: React.FC<TagsSettingsProps> = ({ tags, onTagsChange, onRenam
                     <Button onClick={() => setRenameDialogOpen(false)} disabled={isRenaming}>
                         {t('cancel') || 'Cancel'}
                     </Button>
-                    <Button onClick={handleRenameSubmit} disabled={isRenaming || !newTagName || newTagName === tagToRename}>
-                        {isRenaming ? <CircularProgress size={24} /> : (t('confirmRenameTag') || 'Rename')}
+                    <Button
+                        onClick={handleRenameSubmit}
+                        disabled={!newTagName || newTagName === tagToRename}
+                        loading={isRenaming}
+                        loadingPosition="start"
+                    >
+                        {t('confirmRenameTag') || 'Rename'}
                     </Button>
                 </DialogActions>
             </Dialog>

--- a/frontend/src/components/Settings/TmdbApiKeySettings.tsx
+++ b/frontend/src/components/Settings/TmdbApiKeySettings.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     Box,
     Button,
-    CircularProgress,
     TextField,
     Typography,
 } from '@mui/material';
@@ -132,13 +131,13 @@ const TmdbApiKeySettings: React.FC<TmdbApiKeySettingsProps> = ({
             <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
                 <Button
                     variant="outlined"
-                    startIcon={tmdbCredentialTesting ? <CircularProgress size={16} /> : <FindInPage />}
+                    startIcon={<FindInPage />}
                     onClick={handleTestTMDBCredential}
-                    disabled={!tmdbApiKey?.trim() || tmdbCredentialTesting}
+                    disabled={!tmdbApiKey?.trim()}
+                    loading={tmdbCredentialTesting}
+                    loadingPosition="start"
                 >
-                    {tmdbCredentialTesting
-                        ? translateOrFallback('testing', 'Testing...')
-                        : translateOrFallback('testTmdbCredential', 'Test Credential')}
+                    {translateOrFallback('testTmdbCredential', 'Test Credential')}
                 </Button>
             </Box>
             {tmdbCredentialTestResult && (

--- a/frontend/src/components/Settings/UserManagementSettings.tsx
+++ b/frontend/src/components/Settings/UserManagementSettings.tsx
@@ -35,6 +35,7 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { VisitorUser } from '../../types';
 import { getApiErrorMessage } from '../../utils/apiClient';
 import { copyTextToClipboard } from '../../utils/clipboard';
+import { runMutationAsync } from '../../utils/mutationUtils';
 import { userApi } from '../../utils/userApi';
 import AlertModal from '../AlertModal';
 import ConfirmationModal from '../ConfirmationModal';
@@ -412,10 +413,21 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
                 {t('addVisitorUser')}
             </Button>
 
-            <Dialog open={dialogMode !== null} onClose={closeDialog} fullWidth maxWidth="sm">
+            <Dialog
+                open={dialogMode !== null}
+                onClose={() => {
+                    if (!mutationPending) {
+                        closeDialog();
+                    }
+                }}
+                disableEscapeKeyDown={mutationPending}
+                fullWidth
+                maxWidth="sm"
+            >
                 <DialogHeader
                     title={dialogMode === 'create' ? t('addVisitorUser') : t('editVisitorUser')}
                     onClose={closeDialog}
+                    closeDisabled={mutationPending}
                 />
                 <Box component="form" onSubmit={handleSubmit}>
                     <DialogContent dividers>
@@ -503,8 +515,14 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
                         <Button onClick={closeDialog} color="inherit" disabled={mutationPending}>
                             {t('cancel')}
                         </Button>
-                        <Button type="submit" variant="contained" disabled={!canSubmit || mutationPending}>
-                            {mutationPending ? t('saving') || t('loading') : t('save')}
+                        <Button
+                            type="submit"
+                            variant="contained"
+                            disabled={!canSubmit}
+                            loading={createMutation.isPending || updateMutation.isPending}
+                            loadingPosition="start"
+                        >
+                            {t('save')}
                         </Button>
                     </DialogActions>
                 </Box>
@@ -513,9 +531,9 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
             <ConfirmationModal
                 isOpen={confirmDisableUser !== null}
                 onClose={() => setConfirmDisableUser(null)}
-                onConfirm={() => {
+                onConfirm={async () => {
                     if (confirmDisableUser) {
-                        updateMutation.mutate({ id: confirmDisableUser.id, patch: { enabled: false } });
+                        await runMutationAsync(updateMutation, { id: confirmDisableUser.id, patch: { enabled: false } });
                     }
                 }}
                 title={t('disableUser')}
@@ -528,9 +546,9 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
             <ConfirmationModal
                 isOpen={confirmDeleteUser !== null}
                 onClose={() => setConfirmDeleteUser(null)}
-                onConfirm={() => {
+                onConfirm={async () => {
                     if (confirmDeleteUser) {
-                        deleteMutation.mutate(confirmDeleteUser.id);
+                        await runMutationAsync(deleteMutation, confirmDeleteUser.id);
                     }
                 }}
                 title={t('deleteUser')}

--- a/frontend/src/components/Settings/__tests__/HookSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/HookSettings.test.tsx
@@ -60,7 +60,7 @@ vi.mock('../../ConfirmationModal', () => ({
             <div data-testid="confirmation-modal">
                 <div>{title}</div>
                 <div>{message}</div>
-                <button onClick={onConfirm}>Confirm delete</button>
+                <button onClick={() => { void Promise.resolve(onConfirm()).catch(() => undefined); }}>Confirm delete</button>
                 <button onClick={onClose}>Cancel delete</button>
             </div>
         );

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -24,7 +24,7 @@ type DownloadOrder = 'dateDesc' | 'dateAsc' | 'viewsDesc' | 'viewsAsc';
 interface SubscribeModalProps {
     open: boolean;
     onClose: () => void;
-    onConfirm: (interval: number, downloadAllPrevious: boolean, downloadShorts: boolean, downloadOrder: DownloadOrder) => void;
+    onConfirm: (interval: number, downloadAllPrevious: boolean, downloadShorts: boolean, downloadOrder: DownloadOrder) => void | Promise<void>;
     authorName?: string;
     url: string;
     source?: string;
@@ -49,6 +49,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     const [downloadAllPrevious, setDownloadAllPrevious] = useState<boolean>(false);
     const [downloadShorts, setDownloadShorts] = useState<boolean>(false);
     const [downloadOrder, setDownloadOrder] = useState<DownloadOrder>('dateDesc');
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const isTwitch = source === 'twitch';
     const showDownloadShorts = source !== 'bilibili' && source !== 'twitch';
     const resolvedTitle =
@@ -63,9 +64,22 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
         ? t('twitchSubscriptionVodsOnly')
         : t('subscribeDescription');
 
-    const handleConfirm = () => {
-        onConfirm(interval, downloadAllPrevious, downloadShorts, downloadOrder);
-        onClose();
+    const handleClose = () => {
+        if (!isSubmitting) {
+            onClose();
+        }
+    };
+
+    const handleConfirm = async () => {
+        setIsSubmitting(true);
+        try {
+            await onConfirm(interval, downloadAllPrevious, downloadShorts, downloadOrder);
+            onClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     const showOrderDropdown = downloadAllPrevious && enableDownloadOrder;
@@ -73,7 +87,8 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     return (
         <Dialog
             open={open}
-            onClose={onClose}
+            onClose={handleClose}
+            disableEscapeKeyDown={isSubmitting}
             maxWidth="sm"
             fullWidth
             slotProps={{
@@ -82,7 +97,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                 }
             }}
         >
-            <DialogHeader title={resolvedTitle} onClose={onClose} closeLabel={t('close')} />
+            <DialogHeader title={resolvedTitle} onClose={handleClose} closeDisabled={isSubmitting} closeLabel={t('close')} />
             <DialogContent dividers>
                 <DialogContentText sx={{ mb: 2, color: 'text.primary' }}>
                     {resolvedDescription}
@@ -101,6 +116,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                     value={interval}
                     onChange={(e) => setInterval(Number(e.target.value))}
                     slotProps={{ htmlInput: { min: 1 } }}
+                    disabled={isSubmitting}
                     sx={{ mb: 2 }}
                 />
                 {showDownloadShorts && (
@@ -109,6 +125,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                             <Checkbox
                                 checked={downloadShorts}
                                 onChange={(e) => setDownloadShorts(e.target.checked)}
+                                disabled={isSubmitting}
                             />
                         }
                         label={t('downloadShorts') || "Download Shorts"}
@@ -119,6 +136,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                         <Checkbox
                             checked={downloadAllPrevious}
                             onChange={(e) => setDownloadAllPrevious(e.target.checked)}
+                            disabled={isSubmitting}
                         />
                     }
                     label={t('downloadAllPreviousVideos')}
@@ -131,6 +149,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                             value={downloadOrder}
                             label={t('downloadOrder') || 'Download Order'}
                             onChange={(e) => setDownloadOrder(e.target.value as DownloadOrder)}
+                            disabled={isSubmitting}
                         >
                             <MenuItem value="dateDesc">{t('downloadOrderDateDesc') || 'Date (Newest First)'}</MenuItem>
                             <MenuItem value="dateAsc">{t('downloadOrderDateAsc') || 'Date (Oldest First)'}</MenuItem>
@@ -162,10 +181,16 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                 )}
             </DialogContent>
             <DialogActions sx={{ p: 2 }}>
-                <Button onClick={onClose} color="inherit">
+                <Button onClick={handleClose} color="inherit" disabled={isSubmitting}>
                     {t('cancel')}
                 </Button>
-                <Button onClick={handleConfirm} variant="contained" color="primary">
+                <Button
+                    onClick={() => { void handleConfirm(); }}
+                    variant="contained"
+                    color="primary"
+                    loading={isSubmitting}
+                    loadingPosition="start"
+                >
                     {t('subscribe')}
                 </Button>
             </DialogActions>

--- a/frontend/src/components/TagsModal.tsx
+++ b/frontend/src/components/TagsModal.tsx
@@ -194,8 +194,8 @@ const TagsModal: React.FC<TagsModalProps> = ({
             </DialogContent>
             <DialogActions>
                 <Button onClick={handleClose} color="inherit" disabled={saving}>{t('cancel')}</Button>
-                <Button onClick={handleSave} variant="contained" disabled={saving}>
-                    {saving ? t('saving') : t('save')}
+                <Button onClick={handleSave} variant="contained" loading={saving} loadingPosition="start">
+                    {t('save')}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -2,7 +2,6 @@ import { CloudUpload, CreateNewFolder } from '@mui/icons-material';
 import {
     Box,
     Button,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -363,9 +362,11 @@ const UploadModal: React.FC<UploadModalProps> = ({ open, onClose, onUploadSucces
                 <Button
                     onClick={handleUpload}
                     variant="contained"
-                    disabled={files.length === 0 || uploadMutation.isPending}
+                    disabled={files.length === 0}
+                    loading={uploadMutation.isPending}
+                    loadingPosition="start"
                 >
-                    {uploadMutation.isPending ? <CircularProgress size={24} /> : t('upload')}
+                    {t('upload')}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/UploadThumbnailModal.tsx
+++ b/frontend/src/components/UploadThumbnailModal.tsx
@@ -3,7 +3,6 @@ import {
     Alert,
     Box,
     Button,
-    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -154,10 +153,12 @@ const UploadThumbnailModal: React.FC<UploadThumbnailModalProps> = ({ open, onClo
                 <Button
                     variant="contained"
                     onClick={() => { void handleUpload(); }}
-                    disabled={!selectedFile || isUploading}
-                    startIcon={isUploading ? <CircularProgress size={16} color="inherit" /> : <CloudUpload />}
+                    disabled={!selectedFile}
+                    loading={isUploading}
+                    loadingPosition="start"
+                    startIcon={<CloudUpload />}
                 >
-                    {isUploading ? (t('uploading') || 'Uploading...') : (t('upload') || 'Upload')}
+                    {t('upload') || 'Upload'}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -174,6 +174,7 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
                 confirmDelete={actions.confirmDelete}
                 isDeleting={actions.isDeleting}
                 handleToggleVisibility={actions.handleToggleVisibility}
+                isTogglingVisibility={actions.isTogglingVisibility}
                 canDelete={actions.canDelete}
                 isMobile={isMobile}
                 isTouch={isTouch}

--- a/frontend/src/components/VideoCard/VideoCardActions.tsx
+++ b/frontend/src/components/VideoCard/VideoCardActions.tsx
@@ -22,6 +22,7 @@ interface VideoCardActionsProps {
     confirmDelete: () => void;
     isDeleting: boolean;
     handleToggleVisibility: () => void;
+    isTogglingVisibility?: boolean;
     canDelete: boolean;
     isMobile: boolean;
     isTouch: boolean;
@@ -39,6 +40,7 @@ export const VideoCardActions: React.FC<VideoCardActionsProps> = ({
     confirmDelete,
     isDeleting,
     handleToggleVisibility,
+    isTogglingVisibility = false,
     canDelete,
     isMobile,
     isTouch,
@@ -103,6 +105,7 @@ export const VideoCardActions: React.FC<VideoCardActionsProps> = ({
                     onAddToCollection={() => setShowCollectionModal(true)}
                     onDelete={canDelete ? () => setShowDeleteModal(true) : undefined}
                     isDeleting={isDeleting}
+                    isTogglingVisibility={isTogglingVisibility}
                     onToggleVisibility={handleToggleVisibility}
                     onAddTag={() => setShowTagsModal(true)}
                     video={video}

--- a/frontend/src/components/VideoPlayer/LiveTranslationStatusAlert.tsx
+++ b/frontend/src/components/VideoPlayer/LiveTranslationStatusAlert.tsx
@@ -2,6 +2,7 @@ import { Alert, Box, Button } from '@mui/material';
 import React from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useLiveTranslationControl } from '../../contexts/LiveTranslationContext';
+import { useAsyncAction } from '../../hooks/useAsyncAction';
 
 interface LiveTranslationStatusAlertProps {
     isCinemaMode?: boolean;
@@ -17,6 +18,9 @@ const LiveTranslationStatusAlert: React.FC<LiveTranslationStatusAlertProps> = ({
 }) => {
     const { t } = useLanguage();
     const { errorVisible, errorText, retryable, retry } = useLiveTranslationControl();
+    const { run: runRetry, pending: retrying } = useAsyncAction(async () => {
+        await retry();
+    });
 
     if (!errorVisible) {
         return null;
@@ -36,7 +40,13 @@ const LiveTranslationStatusAlert: React.FC<LiveTranslationStatusAlertProps> = ({
                 severity="error"
                 action={
                     retryable ? (
-                        <Button color="inherit" size="small" onClick={retry}>
+                        <Button
+                            color="inherit"
+                            size="small"
+                            onClick={() => { void runRetry(); }}
+                            loading={retrying}
+                            loadingPosition="start"
+                        >
                             {t('liveTranslationRetry')}
                         </Button>
                     ) : undefined

--- a/frontend/src/components/VideoPlayer/VideoInfo.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo.tsx
@@ -20,6 +20,8 @@ interface VideoInfoProps {
     onAddToCollection: () => void;
     onDelete: () => void;
     isDeleting: boolean;
+    isSavingTitle?: boolean;
+    isTogglingVisibility?: boolean;
     deleteError: string | null;
     videoCollections: Collection[];
     onCollectionClick: (id: string) => void;
@@ -40,6 +42,8 @@ const VideoInfo: React.FC<VideoInfoProps> = ({
     onAddToCollection,
     onDelete,
     isDeleting,
+    isSavingTitle = false,
+    isTogglingVisibility = false,
     deleteError,
     videoCollections,
     onCollectionClick,
@@ -89,7 +93,7 @@ const VideoInfo: React.FC<VideoInfoProps> = ({
                 />
             )}
 
-            <EditableTitle title={video.title} onSave={onTitleSave} />
+            <EditableTitle title={video.title} onSave={onTitleSave} isSaving={isSavingTitle} />
 
             <VideoRating
                 rating={video.rating}
@@ -127,6 +131,7 @@ const VideoInfo: React.FC<VideoInfoProps> = ({
                     onAddToCollection={onAddToCollection}
                     onDelete={onDelete}
                     isDeleting={isDeleting}
+                    isTogglingVisibility={isTogglingVisibility}
                     onToggleVisibility={onToggleVisibility}
                 />
             </Stack>

--- a/frontend/src/components/VideoPlayer/VideoInfo/EditableTitle.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/EditableTitle.tsx
@@ -7,9 +7,10 @@ import { useAuth } from '../../../contexts/AuthContext';
 interface EditableTitleProps {
     title: string;
     onSave: (newTitle: string) => Promise<void>;
+    isSaving?: boolean;
 }
 
-const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave }) => {
+const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave, isSaving = false }) => {
     const { t } = useLanguage();
     const { userRole } = useAuth();
     const isVisitor = userRole === 'visitor';
@@ -45,8 +46,12 @@ const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave }) => {
 
     const handleSaveTitle = async () => {
         if (!editedTitle.trim()) return;
-        await onSave(editedTitle);
-        setIsEditingTitle(false);
+        try {
+            await onSave(editedTitle);
+            setIsEditingTitle(false);
+        } catch {
+            // Keep editing open so the title can be retried.
+        }
     };
 
     if (isEditingTitle) {
@@ -59,16 +64,18 @@ const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave }) => {
                     variant="outlined"
                     size="small"
                     autoFocus
+                    disabled={isSaving}
                     onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                            handleSaveTitle();
+                        if (e.key === 'Enter' && !isSaving) {
+                            void handleSaveTitle();
                         }
                     }}
                 />
                 <Button
                     variant="contained"
                     color="primary"
-                    onClick={handleSaveTitle}
+                    onClick={() => { void handleSaveTitle(); }}
+                    loading={isSaving}
                     sx={{ minWidth: 'auto', p: 0.5 }}
                 >
                     <Check />
@@ -77,6 +84,7 @@ const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave }) => {
                     variant="outlined"
                     color="secondary"
                     onClick={handleCancelEditingTitle}
+                    disabled={isSaving}
                     sx={{ minWidth: 'auto', p: 0.5 }}
                 >
                     <Close />
@@ -135,4 +143,3 @@ const EditableTitle: React.FC<EditableTitleProps> = ({ title, onSave }) => {
 };
 
 export default EditableTitle;
-

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoActionButtons.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoActionButtons.tsx
@@ -16,6 +16,7 @@ interface VideoActionButtonsProps {
     onAddToCollection: () => void;
     onDelete: () => void;
     isDeleting: boolean;
+    isTogglingVisibility?: boolean;
     onToggleVisibility?: () => void;
 }
 
@@ -24,6 +25,7 @@ const VideoActionButtons: React.FC<VideoActionButtonsProps> = ({
     onAddToCollection,
     onDelete,
     isDeleting,
+    isTogglingVisibility = false,
     onToggleVisibility
 }) => {
     const { t } = useLanguage();
@@ -257,6 +259,7 @@ const VideoActionButtons: React.FC<VideoActionButtonsProps> = ({
                                 variant="outlined"
                                 color="inherit"
                                 onClick={onToggleVisibility}
+                                loading={isTogglingVisibility}
                                 sx={{ minWidth: 'auto', p: 1, color: 'text.secondary', borderColor: 'text.secondary', '&:hover': { color: 'primary.main', borderColor: 'primary.main' } }}
                             >
                                 {video.visibility === 0 ? <Visibility /> : <VisibilityOff />}
@@ -278,7 +281,7 @@ const VideoActionButtons: React.FC<VideoActionButtonsProps> = ({
                             variant="outlined"
                             color="inherit"
                             onClick={onDelete}
-                            disabled={isDeleting}
+                            loading={isDeleting}
                             sx={{ minWidth: 'auto', p: 1, color: 'text.secondary', borderColor: 'text.secondary', '&:hover': { color: 'error.main', borderColor: 'error.main' } }}
                         >
                             <Delete />
@@ -298,6 +301,7 @@ const VideoActionButtons: React.FC<VideoActionButtonsProps> = ({
                     onAddToCollection={onAddToCollection}
                     onDelete={onDelete}
                     isDeleting={isDeleting}
+                    isTogglingVisibility={isTogglingVisibility}
                     onToggleVisibility={onToggleVisibility}
                     video={video}
                 />

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenu.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenu.tsx
@@ -12,6 +12,7 @@ interface VideoKebabMenuProps {
     onAddToCollection: () => void;
     onDelete?: () => void;
     isDeleting?: boolean;
+    isTogglingVisibility?: boolean;
     onToggleVisibility?: () => void;
     onAddTag?: () => void;
     video?: { visibility?: number };
@@ -25,6 +26,7 @@ const VideoKebabMenu: React.FC<VideoKebabMenuProps> = ({
     onAddToCollection,
     onDelete,
     isDeleting = false,
+    isTogglingVisibility = false,
     onToggleVisibility,
     onAddTag,
     video,
@@ -113,6 +115,7 @@ const VideoKebabMenu: React.FC<VideoKebabMenuProps> = ({
                                     variant="outlined"
                                     color="inherit"
                                     onClick={handleToggleVisibility}
+                                    loading={isTogglingVisibility}
                                     sx={{ minWidth: 'auto', p: 1, color: 'text.secondary', borderColor: 'text.secondary', '&:hover': { color: 'primary.main', borderColor: 'primary.main' } }}
                                 >
                                     {video?.visibility === 0 ? <Visibility /> : <VisibilityOff />}
@@ -135,7 +138,7 @@ const VideoKebabMenu: React.FC<VideoKebabMenuProps> = ({
                                     variant="outlined"
                                     color="inherit"
                                     onClick={handleDelete}
-                                    disabled={isDeleting}
+                                    loading={isDeleting}
                                     sx={{ minWidth: 'auto', p: 1, color: 'text.secondary', borderColor: 'text.secondary', '&:hover': { color: 'error.main', borderColor: 'error.main' } }}
                                 >
                                     <Delete />

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenuButtons.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenuButtons.tsx
@@ -14,6 +14,7 @@ interface VideoKebabMenuButtonsProps {
     onAddToCollection: () => void;
     onDelete?: () => void;
     isDeleting?: boolean;
+    isTogglingVisibility?: boolean;
     onToggleVisibility?: () => void;
     onAddTag?: () => void;
     video?: { visibility?: number };
@@ -26,6 +27,7 @@ const VideoKebabMenuButtons: React.FC<VideoKebabMenuButtonsProps> = ({
     onAddToCollection,
     onDelete,
     isDeleting = false,
+    isTogglingVisibility = false,
     onToggleVisibility,
     onAddTag,
     video,
@@ -80,6 +82,7 @@ const VideoKebabMenuButtons: React.FC<VideoKebabMenuButtonsProps> = ({
                         onAddToCollection={onAddToCollection}
                         onDelete={onDelete}
                         isDeleting={isDeleting}
+                        isTogglingVisibility={isTogglingVisibility}
                         onToggleVisibility={onToggleVisibility}
                         onAddTag={onAddTag}
                         video={video}

--- a/frontend/src/components/__tests__/ConfirmationModal.test.tsx
+++ b/frontend/src/components/__tests__/ConfirmationModal.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { act } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ConfirmationModal from '../ConfirmationModal';
 
@@ -64,5 +65,46 @@ describe('ConfirmationModal', () => {
 
         expect(screen.getByText('Yes, do it')).toBeInTheDocument();
         expect(screen.getByText('No, wait')).toBeInTheDocument();
+    });
+
+    it('shows loading state and disables cancel while async confirm is pending', async () => {
+        let resolveConfirm!: () => void;
+        const onConfirm = vi.fn(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveConfirm = resolve;
+                })
+        );
+        const onClose = vi.fn();
+
+        render(<ConfirmationModal {...defaultProps} onConfirm={onConfirm} onClose={onClose} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+        expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+        expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        expect(onClose).not.toHaveBeenCalled();
+
+        await act(async () => {
+            resolveConfirm();
+        });
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the modal open when async confirm rejects', async () => {
+        const onConfirm = vi.fn(() => Promise.reject(new Error('failed')));
+        const onClose = vi.fn();
+
+        render(<ConfirmationModal {...defaultProps} onConfirm={onConfirm} onClose={onClose} />);
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(onClose).not.toHaveBeenCalled();
+        expect(screen.getByText('Confirm Action')).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/__tests__/PasswordModal.test.tsx
+++ b/frontend/src/components/__tests__/PasswordModal.test.tsx
@@ -47,7 +47,8 @@ describe('PasswordModal', () => {
     it('should disable inputs and show loading when isLoading is true', () => {
         render(<PasswordModal {...defaultProps} isLoading={true} />);
         expect(screen.getByLabelText('password')).toBeDisabled();
-        expect(screen.getByText('verifying')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'confirm' })).toBeDisabled();
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
     });
 
     it('should toggle password visibility', async () => {

--- a/frontend/src/components/__tests__/UploadThumbnailModal.test.tsx
+++ b/frontend/src/components/__tests__/UploadThumbnailModal.test.tsx
@@ -137,8 +137,11 @@ describe('UploadThumbnailModal', () => {
         fireEvent.click(screen.getByRole('button', { name: 'upload' }));
 
         const cancelButton = await screen.findByRole('button', { name: 'cancel' });
+        const uploadButton = screen.getByRole('button', { name: 'upload' });
+
         expect(cancelButton).toBeDisabled();
-        expect(screen.getByRole('button', { name: 'uploading' })).toBeDisabled();
+        expect(uploadButton).toBeDisabled();
+        expect(within(uploadButton).getByRole('progressbar')).toBeInTheDocument();
         fireEvent.click(cancelButton);
         expect(onClose).not.toHaveBeenCalled();
     });

--- a/frontend/src/hooks/__tests__/useAsyncAction.test.tsx
+++ b/frontend/src/hooks/__tests__/useAsyncAction.test.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAsyncAction } from '../useAsyncAction';
+
+const deferred = () => {
+    let resolve!: () => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+
+    return { promise, resolve, reject };
+};
+
+describe('useAsyncAction', () => {
+    it('sets pending while the action is in flight and clears after resolve', async () => {
+        const request = deferred();
+        const action = vi.fn((id: string) => {
+            String(id);
+            return request.promise;
+        });
+        const { result } = renderHook(() => useAsyncAction(action));
+
+        act(() => {
+            void result.current.run('video-1');
+        });
+
+        expect(action).toHaveBeenCalledWith('video-1');
+        expect(result.current.pending).toBe(true);
+
+        await act(async () => {
+            request.resolve();
+            await request.promise;
+        });
+
+        await waitFor(() => expect(result.current.pending).toBe(false));
+    });
+
+    it('clears pending after reject', async () => {
+        const request = deferred();
+        const action = vi.fn(() => request.promise);
+        const { result } = renderHook(() => useAsyncAction(action));
+
+        let runPromise!: Promise<void>;
+        act(() => {
+            runPromise = result.current.run();
+        });
+
+        await act(async () => {
+            request.reject(new Error('failed'));
+            await expect(runPromise).rejects.toThrow('failed');
+        });
+
+        await waitFor(() => expect(result.current.pending).toBe(false));
+    });
+
+    it('ignores overlapping invocations while one action is pending', async () => {
+        const request = deferred();
+        const action = vi.fn((id: string) => {
+            String(id);
+            return request.promise;
+        });
+        const { result } = renderHook(() => useAsyncAction(action));
+
+        act(() => {
+            void result.current.run('first');
+            void result.current.run('second');
+        });
+
+        expect(action).toHaveBeenCalledTimes(1);
+        expect(action).toHaveBeenCalledWith('first');
+
+        await act(async () => {
+            request.resolve();
+            await request.promise;
+        });
+    });
+});

--- a/frontend/src/hooks/__tests__/useVideoCardActions.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoCardActions.test.ts
@@ -99,7 +99,7 @@ describe('useVideoCardActions', () => {
         }));
 
         await act(async () => {
-            await result.current.confirmDelete();
+            await expect(result.current.confirmDelete()).rejects.toThrow('delete failed');
         });
 
         expect(consoleErrorSpy).toHaveBeenCalled();

--- a/frontend/src/hooks/useAsyncAction.ts
+++ b/frontend/src/hooks/useAsyncAction.ts
@@ -1,0 +1,29 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useAsyncAction<A extends unknown[]>(
+    action: (...args: A) => Promise<unknown>
+): { run: (...args: A) => Promise<void>; pending: boolean } {
+    const [pending, setPending] = useState(false);
+    const inFlight = useRef(false);
+
+    const run = useCallback(
+        async (...args: A) => {
+            if (inFlight.current) {
+                return;
+            }
+
+            inFlight.current = true;
+            setPending(true);
+
+            try {
+                await action(...args);
+            } finally {
+                inFlight.current = false;
+                setPending(false);
+            }
+        },
+        [action]
+    );
+
+    return { run, pending };
+}

--- a/frontend/src/hooks/useVideoCardActions.ts
+++ b/frontend/src/hooks/useVideoCardActions.ts
@@ -22,6 +22,7 @@ export const useVideoCardActions = ({
     const { showSnackbar } = useSnackbar();
     const { updateVideo } = useVideoActions();
     const [isDeleting, setIsDeleting] = useState(false);
+    const [isTogglingVisibility, setIsTogglingVisibility] = useState(false);
     const [showDeleteModal, setShowDeleteModal] = useState(false);
 
     // Handle confirm delete
@@ -33,6 +34,8 @@ export const useVideoCardActions = ({
             await onDeleteVideo(video.id);
         } catch (error) {
             console.error('Error deleting video:', error);
+            throw error;
+        } finally {
             setIsDeleting(false);
         }
     };
@@ -41,11 +44,16 @@ export const useVideoCardActions = ({
     const handleToggleVisibility = async () => {
         if (!video.id) return;
         const newVisibility = (video.visibility ?? 1) === 0 ? 1 : 0;
-        const result = await updateVideo(video.id, { visibility: newVisibility });
-        if (result.success) {
-            showSnackbar(newVisibility === 1 ? t('showVideo') : t('hideVideo'), 'success');
-        } else {
-            showSnackbar(t('error'), 'error');
+        setIsTogglingVisibility(true);
+        try {
+            const result = await updateVideo(video.id, { visibility: newVisibility });
+            if (result.success) {
+                showSnackbar(newVisibility === 1 ? t('showVideo') : t('hideVideo'), 'success');
+            } else {
+                showSnackbar(t('error'), 'error');
+            }
+        } finally {
+            setIsTogglingVisibility(false);
         }
     };
 
@@ -55,6 +63,7 @@ export const useVideoCardActions = ({
         setShowDeleteModal,
         confirmDelete,
         handleToggleVisibility,
+        isTogglingVisibility,
         canDelete: showDeleteButton && !!onDeleteVideo
     };
 };

--- a/frontend/src/pages/DownloadPage/ActiveDownloadsTab.tsx
+++ b/frontend/src/pages/DownloadPage/ActiveDownloadsTab.tsx
@@ -23,9 +23,10 @@ interface Download {
 interface ActiveDownloadsTabProps {
     downloads: Download[];
     onCancel: (id: string) => void;
+    cancellingId?: string | null;
 }
 
-export function ActiveDownloadsTab({ downloads, onCancel }: ActiveDownloadsTabProps) {
+export function ActiveDownloadsTab({ downloads, onCancel, cancellingId = null }: ActiveDownloadsTabProps) {
     const { t } = useLanguage();
 
     if (downloads.length === 0) {
@@ -39,7 +40,12 @@ export function ActiveDownloadsTab({ downloads, onCancel }: ActiveDownloadsTabPr
                     <ListItem
                         disableGutters
                         secondaryAction={
-                            <IconButton edge="end" aria-label="cancel" onClick={() => onCancel(download.id)}>
+                            <IconButton
+                                edge="end"
+                                aria-label="cancel"
+                                onClick={() => onCancel(download.id)}
+                                loading={cancellingId === download.id}
+                            >
                                 <CancelIcon />
                             </IconButton>
                         }

--- a/frontend/src/pages/DownloadPage/HistoryItem.tsx
+++ b/frontend/src/pages/DownloadPage/HistoryItem.tsx
@@ -56,6 +56,8 @@ interface HistoryItemProps {
     onReDownload: (sourceUrl: string) => void;
     onViewVideo: (videoId: string) => void;
     isDownloadInProgress: (sourceUrl: string) => boolean;
+    isRemoving?: boolean;
+    isCancellingRetry?: boolean;
     dontSkipDeletedVideo?: boolean;
 }
 
@@ -67,6 +69,8 @@ export function HistoryItem({
     onReDownload,
     onViewVideo,
     isDownloadInProgress,
+    isRemoving = false,
+    isCancellingRetry = false,
     dontSkipDeletedVideo
 }: HistoryItemProps) {
     const { t } = useLanguage();
@@ -278,6 +282,8 @@ export function HistoryItem({
                                 startIcon={<ReplayIcon />}
                                 onClick={() => onRetry(item.sourceUrl!)}
                                 disabled={isDownloadInProgress(item.sourceUrl)}
+                                loading={isDownloadInProgress(item.sourceUrl)}
+                                loadingPosition="start"
                                 sx={{ minWidth: actionButtonMinWidth, order: { xs: 1, md: 2 } }}
                             >
                                 {t('retry') || 'Retry'}
@@ -290,6 +296,8 @@ export function HistoryItem({
                                 size="small"
                                 startIcon={<CancelIcon />}
                                 onClick={() => onCancelRetry(item.id)}
+                                loading={isCancellingRetry}
+                                loadingPosition="start"
                                 sx={{ minWidth: actionButtonMinWidth, order: { xs: 1, md: 2 } }}
                             >
                                 {t('cancelRetry') || 'Cancel Retry'}
@@ -327,6 +335,8 @@ export function HistoryItem({
                                 startIcon={<ReplayIcon />}
                                 onClick={() => onReDownload(item.sourceUrl!)}
                                 disabled={isDownloadInProgress(item.sourceUrl)}
+                                loading={isDownloadInProgress(item.sourceUrl)}
+                                loadingPosition="start"
                                 sx={{ minWidth: actionButtonMinWidth, order: { xs: 1, md: 2 } }}
                             >
                                 {t('downloadAgain') || 'Download Again'}
@@ -336,6 +346,7 @@ export function HistoryItem({
                             aria-label="remove"
                             onClick={() => onRemove(item.id)}
                             disabled={isPendingRetry}
+                            loading={isRemoving}
                             sx={{ order: { xs: 3, md: 1 }, alignSelf: { xs: 'center', md: 'flex-end' } }}
                         >
                             <DeleteIcon />

--- a/frontend/src/pages/DownloadPage/HistoryTab.tsx
+++ b/frontend/src/pages/DownloadPage/HistoryTab.tsx
@@ -25,6 +25,9 @@ interface HistoryTabProps {
     onReDownload: (sourceUrl: string) => void;
     onViewVideo: (videoId: string) => void;
     isDownloadInProgress: (sourceUrl: string) => boolean;
+    removingId?: string | null;
+    cancellingRetryId?: string | null;
+    clearing?: boolean;
 }
 
 const ITEMS_PER_PAGE = 20;
@@ -37,7 +40,10 @@ export function HistoryTab({
     onRetry,
     onReDownload,
     onViewVideo,
-    isDownloadInProgress
+    isDownloadInProgress,
+    removingId = null,
+    cancellingRetryId = null,
+    clearing = false
 }: HistoryTabProps) {
     const { t } = useLanguage();
     const theme = useTheme();
@@ -80,6 +86,8 @@ export function HistoryTab({
                     startIcon={<ClearAllIcon />}
                     onClick={onClear}
                     disabled={history.length === 0}
+                    loading={clearing}
+                    loadingPosition="start"
                 >
                     {t('clearHistory') || 'Clear History'}
                 </Button>
@@ -101,6 +109,8 @@ export function HistoryTab({
                                     onReDownload={onReDownload}
                                     onViewVideo={onViewVideo}
                                     isDownloadInProgress={isDownloadInProgress}
+                                    isRemoving={removingId === item.id}
+                                    isCancellingRetry={cancellingRetryId === item.id}
                                     dontSkipDeletedVideo={settings?.dontSkipDeletedVideo}
                                 />
                             ))}

--- a/frontend/src/pages/DownloadPage/QueueTab.tsx
+++ b/frontend/src/pages/DownloadPage/QueueTab.tsx
@@ -23,11 +23,13 @@ interface QueueTabProps {
     downloads: Download[];
     onRemove: (id: string) => void;
     onClear: () => void;
+    removingId?: string | null;
+    clearing?: boolean;
 }
 
 const ITEMS_PER_PAGE = 20;
 
-export function QueueTab({ downloads, onRemove, onClear }: QueueTabProps) {
+export function QueueTab({ downloads, onRemove, onClear, removingId = null, clearing = false }: QueueTabProps) {
     const { t } = useLanguage();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -41,6 +43,8 @@ export function QueueTab({ downloads, onRemove, onClear }: QueueTabProps) {
                     startIcon={<ClearAllIcon />}
                     onClick={onClear}
                     disabled={downloads.length === 0}
+                    loading={clearing}
+                    loadingPosition="start"
                 >
                     {t('clearQueue') || 'Clear Queue'}
                 </Button>
@@ -57,7 +61,12 @@ export function QueueTab({ downloads, onRemove, onClear }: QueueTabProps) {
                                     <ListItem
                                         disableGutters
                                         secondaryAction={
-                                            <IconButton edge="end" aria-label="remove" onClick={() => onRemove(download.id)}>
+                                            <IconButton
+                                                edge="end"
+                                                aria-label="remove"
+                                                onClick={() => onRemove(download.id)}
+                                                loading={removingId === download.id}
+                                            >
                                                 <DeleteIcon />
                                             </IconButton>
                                         }
@@ -86,4 +95,3 @@ export function QueueTab({ downloads, onRemove, onClear }: QueueTabProps) {
         </>
     );
 }
-

--- a/frontend/src/pages/DownloadPage/index.tsx
+++ b/frontend/src/pages/DownloadPage/index.tsx
@@ -262,11 +262,23 @@ const DownloadPage: React.FC = () => {
         clearHistoryMutation.mutate();
     };
 
-    const handleRetry = (sourceUrl: string) => {
-        if (!isDownloadInProgress(sourceUrl)) {
-            handleVideoSubmit(sourceUrl);
-        } else {
+    const handleRetry = async (sourceUrl: string) => {
+        if (isDownloadInProgress(sourceUrl)) {
             showSnackbar('Download already in progress or queued');
+            return;
+        }
+
+        setDownloadingItems(prev => new Set(prev).add(sourceUrl));
+        try {
+            await handleVideoSubmit(sourceUrl);
+        } finally {
+            setTimeout(() => {
+                setDownloadingItems(prev => {
+                    const next = new Set(prev);
+                    next.delete(sourceUrl);
+                    return next;
+                });
+            }, 1000);
         }
     };
 
@@ -328,6 +340,7 @@ const DownloadPage: React.FC = () => {
                 <ActiveDownloadsTab
                     downloads={activeDownloads}
                     onCancel={handleCancelDownload}
+                    cancellingId={cancelMutation.isPending ? cancelMutation.variables ?? null : null}
                 />
             </CustomTabPanel>
 
@@ -336,6 +349,8 @@ const DownloadPage: React.FC = () => {
                     downloads={queuedDownloads}
                     onRemove={handleRemoveFromQueue}
                     onClear={handleClearQueue}
+                    removingId={removeFromQueueMutation.isPending ? removeFromQueueMutation.variables ?? null : null}
+                    clearing={clearQueueMutation.isPending}
                 />
             </CustomTabPanel>
 
@@ -349,6 +364,9 @@ const DownloadPage: React.FC = () => {
                     onReDownload={handleReDownload}
                     onViewVideo={handleViewVideo}
                     isDownloadInProgress={isDownloadInProgress}
+                    removingId={removeFromHistoryMutation.isPending ? removeFromHistoryMutation.variables ?? null : null}
+                    cancellingRetryId={cancelRetryMutation.isPending ? cancelRetryMutation.variables ?? null : null}
+                    clearing={clearHistoryMutation.isPending}
                 />
             </CustomTabPanel>
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -484,9 +484,11 @@ const LoginPage: React.FC = () => {
                                                         fullWidth
                                                         variant="contained"
                                                         sx={{ mt: 3, mb: 2 }}
-                                                        disabled={adminLoginMutation.isPending || waitTime > 0}
+                                                        disabled={waitTime > 0}
+                                                        loading={adminLoginMutation.isPending}
+                                                        loadingPosition="start"
                                                     >
-                                                        {adminLoginMutation.isPending ? (t('verifying') || 'Verifying...') : (t('signIn') || 'Admin Sign In')}
+                                                        {t('signIn') || 'Admin Sign In'}
                                                     </Button>
                                                 </Box>
                                             )}
@@ -500,11 +502,11 @@ const LoginPage: React.FC = () => {
                                                         startIcon={<Fingerprint />}
                                                         onClick={handlePasskeyLogin}
                                                         sx={{ mb: 2 }}
-                                                        disabled={passkeyLoginMutation.isPending || waitTime > 0}
+                                                        disabled={waitTime > 0}
+                                                        loading={passkeyLoginMutation.isPending}
+                                                        loadingPosition="start"
                                                     >
-                                                        {passkeyLoginMutation.isPending
-                                                            ? (t('authenticating') || 'Authenticating...')
-                                                            : (t('loginWithPasskey') || 'Login with Passkey')}
+                                                        {t('loginWithPasskey') || 'Login with Passkey'}
                                                     </Button>
                                                 </>
                                             )}
@@ -516,11 +518,11 @@ const LoginPage: React.FC = () => {
                                                     startIcon={<Fingerprint />}
                                                     onClick={handlePasskeyLogin}
                                                     sx={{ mt: 3, mb: 2 }}
-                                                    disabled={passkeyLoginMutation.isPending || waitTime > 0}
+                                                    disabled={waitTime > 0}
+                                                    loading={passkeyLoginMutation.isPending}
+                                                    loadingPosition="start"
                                                 >
-                                                    {passkeyLoginMutation.isPending
-                                                        ? (t('authenticating') || 'Authenticating...')
-                                                        : (t('loginWithPasskey') || 'Login with Passkey')}
+                                                    {t('loginWithPasskey') || 'Login with Passkey'}
                                                 </Button>
                                             )}
 
@@ -595,9 +597,11 @@ const LoginPage: React.FC = () => {
                                                     fullWidth
                                                     variant="contained"
                                                     sx={{ mt: 3, mb: 2 }}
-                                                    disabled={visitorLoginMutation.isPending || waitTime > 0}
+                                                    disabled={waitTime > 0}
+                                                    loading={visitorLoginMutation.isPending}
+                                                    loadingPosition="start"
                                                 >
-                                                    {visitorLoginMutation.isPending ? (t('verifying') || 'Verifying...') : (t('visitorSignIn') || 'Visitor Sign In')}
+                                                    {t('visitorSignIn') || 'Visitor Sign In'}
                                                 </Button>
                                             </Box>
                                         )}

--- a/frontend/src/pages/ManagePage.tsx
+++ b/frontend/src/pages/ManagePage.tsx
@@ -24,6 +24,7 @@ import { useSnackbar } from '../contexts/SnackbarContext';
 import { useVideo } from '../contexts/VideoContext';
 import { Collection, Video } from '../types';
 import { formatSize } from '../utils/formatUtils';
+import { runMutationAsync } from '../utils/mutationUtils';
 
 const ManagePage: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
@@ -229,10 +230,13 @@ const ManagePage: React.FC = () => {
         if (!videoToDelete) return;
 
         setDeletingId(videoToDelete);
-        await deleteVideo(videoToDelete);
-        setDeletingId(null);
-        setVideoToDelete(null);
-        setShowVideoDeleteModal(false); // Close the modal after deletion
+        try {
+            await deleteVideo(videoToDelete);
+            setVideoToDelete(null);
+            setShowVideoDeleteModal(false);
+        } finally {
+            setDeletingId(null);
+        }
     };
 
     const handleDelete = (id: string) => {
@@ -247,17 +251,23 @@ const ManagePage: React.FC = () => {
     const handleCollectionDeleteOnly = async () => {
         if (!collectionToDelete) return;
         setIsDeletingCollection(true);
-        await deleteCollection(collectionToDelete.id, false);
-        setIsDeletingCollection(false);
-        setCollectionToDelete(null);
+        try {
+            await deleteCollection(collectionToDelete.id, false);
+            setCollectionToDelete(null);
+        } finally {
+            setIsDeletingCollection(false);
+        }
     };
 
     const handleCollectionDeleteAll = async () => {
         if (!collectionToDelete) return;
         setIsDeletingCollection(true);
-        await deleteCollection(collectionToDelete.id, true);
-        setIsDeletingCollection(false);
-        setCollectionToDelete(null);
+        try {
+            await deleteCollection(collectionToDelete.id, true);
+            setCollectionToDelete(null);
+        } finally {
+            setIsDeletingCollection(false);
+        }
     };
 
     const handleRefreshThumbnail = async (id: string) => {
@@ -302,9 +312,10 @@ const ManagePage: React.FC = () => {
                             variant="outlined"
                             startIcon={<FindInPage />}
                             onClick={() => setShowScanConfirmModal(true)}
-                            disabled={scanMutation.isPending}
+                            loading={scanMutation.isPending}
+                            loadingPosition="start"
                         >
-                            {scanMutation.isPending ? (t('scanning') || 'Scanning...') : (t('scanFiles') || 'Scan Files')}
+                            {t('scanFiles') || 'Scan Files'}
                         </Button>
                     </Box>
                 )}
@@ -336,9 +347,8 @@ const ManagePage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showScanConfirmModal}
                 onClose={() => setShowScanConfirmModal(false)}
-                onConfirm={() => {
-                    setShowScanConfirmModal(false);
-                    scanMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(scanMutation, undefined);
                 }}
                 title={t('scanFiles') || 'Scan Files'}
                 message={t('scanFilesConfirmMessage') || 'The system will scan the root folder of the video path. New files will be added, and missing video files will be removed from the system.'}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -223,8 +223,9 @@ const SearchPage: React.FC = () => {
                                                     fullWidth
                                                     variant="contained"
                                                     startIcon={<Download />}
-                                                    onClick={() => handleDownload(result.id, result.sourceUrl)}
-                                                    disabled={downloadingId === result.id}
+                                                    onClick={() => { void handleDownload(result.id, result.sourceUrl); }}
+                                                    loading={downloadingId === result.id}
+                                                    loadingPosition="start"
                                                 >
                                                     {t('download')}
                                                 </Button>
@@ -237,10 +238,10 @@ const SearchPage: React.FC = () => {
                                 <Button
                                     variant="outlined"
                                     onClick={loadMoreSearchResults}
-                                    disabled={loadingMore}
-                                    startIcon={loadingMore ? <CircularProgress size={20} color="inherit" /> : null}
+                                    loading={loadingMore}
+                                    loadingPosition="start"
                                 >
-                                    {loadingMore ? t('loading') : t('more')}
+                                    {t('more')}
                                 </Button>
                             </Box>
                         </>

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -197,8 +197,9 @@ const SearchResults: React.FC = () => {
                                                 fullWidth
                                                 variant="contained"
                                                 startIcon={<Download />}
-                                                onClick={() => handleDownload(result.id, result.sourceUrl)}
-                                                disabled={downloadingId === result.id}
+                                                onClick={() => { void handleDownload(result.id, result.sourceUrl); }}
+                                                loading={downloadingId === result.id}
+                                                loadingPosition="start"
                                             >
                                                 Download
                                             </Button>
@@ -211,10 +212,10 @@ const SearchResults: React.FC = () => {
                                 <Button
                                     variant="outlined"
                                     onClick={loadMoreSearchResults}
-                                    disabled={loadingMore}
-                                    startIcon={loadingMore ? <CircularProgress size={20} color="inherit" /> : null}
+                                    loading={loadingMore}
+                                    loadingPosition="start"
                                 >
-                                    {loadingMore ? t('loading') : t('more')}
+                                    {t('more')}
                                 </Button>
                             </Box>
                         </>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -53,6 +53,7 @@ import { SNACKBAR_AUTO_HIDE_DURATION } from '../utils/constants';
 import { getTwitchCredentialValidationCode } from '../utils/twitch';
 import { createTranslateOrFallback } from '../utils/translateOrFallback';
 import { Language } from '../utils/translations';
+import { runMutationAsync } from '../utils/mutationUtils';
 
 const SettingsPage: React.FC = () => {
     const { t, setLanguage } = useLanguage();
@@ -720,12 +721,14 @@ const SettingsPage: React.FC = () => {
                     color="primary"
                     size="large"
                     onClick={handleSave}
-                    disabled={saveMutation.isPending || hasTwitchCredentialValidationError}
+                    disabled={hasTwitchCredentialValidationError}
+                    loading={saveMutation.isPending}
+                    loadingPosition="start"
                     sx={{ visibility: isSticky ? 'hidden' : 'visible' }}
                     className={isGlowing ? 'button-glow-animation' : ''}
                     onAnimationEnd={() => setIsGlowing(false)}
                 >
-                    {saveMutation.isPending ? t('saving') || 'Saving...' : t('save') || 'Save'}
+                    {t('save') || 'Save'}
                 </Button>
             </Box>
 
@@ -753,11 +756,13 @@ const SettingsPage: React.FC = () => {
                                 color="primary"
                                 size="large"
                                 onClick={handleSave}
-                                disabled={saveMutation.isPending || hasTwitchCredentialValidationError}
+                                disabled={hasTwitchCredentialValidationError}
+                                loading={saveMutation.isPending}
+                                loadingPosition="start"
                                 className={isGlowing ? 'button-glow-animation' : ''}
                                 onAnimationEnd={() => setIsGlowing(false)}
                             >
-                                {saveMutation.isPending ? t('saving') || 'Saving...' : t('save') || 'Save'}
+                                {t('save') || 'Save'}
                             </Button>
                         </Box>
                     </Container>
@@ -777,9 +782,8 @@ const SettingsPage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showCleanupAuthorCollectionsModal}
                 onClose={() => setShowCleanupAuthorCollectionsModal(false)}
-                onConfirm={() => {
-                    setShowCleanupAuthorCollectionsModal(false);
-                    cleanupAuthorCollectionsMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(cleanupAuthorCollectionsMutation, undefined);
                 }}
                 title={t('cleanupAuthorCollectionsConfirmTitle')}
                 message={t('cleanupAuthorCollectionsConfirmMessage')}
@@ -789,9 +793,8 @@ const SettingsPage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showDeleteLegacyModal}
                 onClose={() => setShowDeleteLegacyModal(false)}
-                onConfirm={() => {
-                    setShowDeleteLegacyModal(false);
-                    deleteLegacyMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(deleteLegacyMutation, undefined);
                 }}
                 title={t('removeLegacyDataConfirmTitle')}
                 message={t('removeLegacyDataConfirmMessage')}
@@ -804,9 +807,8 @@ const SettingsPage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showMigrateConfirmModal}
                 onClose={() => setShowMigrateConfirmModal(false)}
-                onConfirm={() => {
-                    setShowMigrateConfirmModal(false);
-                    migrateMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(migrateMutation, undefined);
                 }}
                 title={t('migrateDataButton')}
                 message={t('migrateConfirmation')}
@@ -818,9 +820,8 @@ const SettingsPage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showFormatConfirmModal}
                 onClose={() => setShowFormatConfirmModal(false)}
-                onConfirm={() => {
-                    setShowFormatConfirmModal(false);
-                    formatFilenamesMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(formatFilenamesMutation, undefined);
                 }}
                 title={t('formatLegacyFilenamesButton')}
                 message={t('formatLegacyFilenamesDescription')} // Reusing description as message, or could add a specific confirm message
@@ -833,9 +834,8 @@ const SettingsPage: React.FC = () => {
             <ConfirmationModal
                 isOpen={showCleanupTempFilesModal}
                 onClose={() => setShowCleanupTempFilesModal(false)}
-                onConfirm={() => {
-                    setShowCleanupTempFilesModal(false);
-                    cleanupMutation.mutate();
+                onConfirm={async () => {
+                    await runMutationAsync(cleanupMutation, undefined);
                 }}
                 title={t('cleanupTempFilesConfirmTitle')}
                 message={t('cleanupTempFilesConfirmMessage')}

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -380,44 +380,83 @@ const StatisticsToolbar: React.FC<{
     onRecompute: () => Promise<void>;
     onClear: () => Promise<void>;
     t: TranslateFn;
-}> = ({ rangeDays, setRangeDays, onExport, onRecompute, onClear, t }) => (
-    <Stack
-        direction={{ xs: 'column', md: 'row' }}
-        justifyContent="space-between"
-        alignItems={{ xs: 'flex-start', md: 'center' }}
-        spacing={2}
-        sx={{ mb: 3 }}
-    >
-        <Typography variant="h4" component="h1" fontWeight="bold">
-            {translateOrFallback(t, 'statisticsTitle', 'Statistics')}
-        </Typography>
-        <Stack direction="row" spacing={1} flexWrap="wrap">
-            <Select
-                size="small"
-                value={rangeDays}
-                onChange={(event) => setRangeDays(Number(event.target.value))}
-            >
-                {RANGE_OPTIONS.map((option) => (
-                    <MenuItem key={option.value} value={option.value}>
-                        {translateOrFallback(t, option.labelKey, option.fallback)}
-                    </MenuItem>
-                ))}
-            </Select>
-            <Button variant="outlined" onClick={() => void onExport('csv')}>
-                {translateOrFallback(t, 'exportCsv', 'Export CSV')}
-            </Button>
-            <Button variant="outlined" onClick={() => void onExport('json')}>
-                {translateOrFallback(t, 'exportJson', 'Export JSON')}
-            </Button>
-            <Button variant="outlined" onClick={() => void onRecompute()}>
-                {translateOrFallback(t, 'recomputeStatistics', 'Recompute')}
-            </Button>
-            <Button variant="outlined" color="error" onClick={() => void onClear()}>
-                {translateOrFallback(t, 'statisticsClear', 'Clear')}
-            </Button>
+}> = ({ rangeDays, setRangeDays, onExport, onRecompute, onClear, t }) => {
+    const [pendingAction, setPendingAction] = useState<'csv' | 'json' | 'recompute' | 'clear' | null>(null);
+
+    const runAction = async (action: NonNullable<typeof pendingAction>, task: () => Promise<void>) => {
+        setPendingAction(action);
+        try {
+            await task();
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    return (
+        <Stack
+            direction={{ xs: 'column', md: 'row' }}
+            justifyContent="space-between"
+            alignItems={{ xs: 'flex-start', md: 'center' }}
+            spacing={2}
+            sx={{ mb: 3 }}
+        >
+            <Typography variant="h4" component="h1" fontWeight="bold">
+                {translateOrFallback(t, 'statisticsTitle', 'Statistics')}
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+                <Select
+                    size="small"
+                    value={rangeDays}
+                    onChange={(event) => setRangeDays(Number(event.target.value))}
+                    disabled={Boolean(pendingAction)}
+                >
+                    {RANGE_OPTIONS.map((option) => (
+                        <MenuItem key={option.value} value={option.value}>
+                            {translateOrFallback(t, option.labelKey, option.fallback)}
+                        </MenuItem>
+                    ))}
+                </Select>
+                <Button
+                    variant="outlined"
+                    onClick={() => { void runAction('csv', () => onExport('csv')); }}
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'csv'}
+                    loadingPosition="start"
+                >
+                    {translateOrFallback(t, 'exportCsv', 'Export CSV')}
+                </Button>
+                <Button
+                    variant="outlined"
+                    onClick={() => { void runAction('json', () => onExport('json')); }}
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'json'}
+                    loadingPosition="start"
+                >
+                    {translateOrFallback(t, 'exportJson', 'Export JSON')}
+                </Button>
+                <Button
+                    variant="outlined"
+                    onClick={() => { void runAction('recompute', onRecompute); }}
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'recompute'}
+                    loadingPosition="start"
+                >
+                    {translateOrFallback(t, 'recomputeStatistics', 'Recompute')}
+                </Button>
+                <Button
+                    variant="outlined"
+                    color="error"
+                    onClick={() => { void runAction('clear', onClear); }}
+                    disabled={Boolean(pendingAction)}
+                    loading={pendingAction === 'clear'}
+                    loadingPosition="start"
+                >
+                    {translateOrFallback(t, 'statisticsClear', 'Clear')}
+                </Button>
+            </Stack>
         </Stack>
-    </Stack>
-);
+    );
+};
 
 const StatisticsPage: React.FC = () => {
     const { t } = useLanguage();

--- a/frontend/src/pages/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage.tsx
@@ -2,7 +2,6 @@ import { AutoDelete, Cancel, Check, Close, Delete, DeleteOutline, Edit, HelpOutl
 import {
     Box,
     Button,
-    CircularProgress,
     Container,
     IconButton,
     LinearProgress,
@@ -112,6 +111,8 @@ const SubscriptionsPage: React.FC = () => {
     const [isRetentionHelpOpen, setIsRetentionHelpOpen] = useState(false);
     const [subscriptionsPage, setSubscriptionsPage] = useState(0);
     const [subscriptionsRowsPerPage, setSubscriptionsRowsPerPage] = useState(DEFAULT_SUBSCRIPTIONS_ROWS_PER_PAGE);
+    const [subscriptionActionId, setSubscriptionActionId] = useState<string | null>(null);
+    const [taskActionId, setTaskActionId] = useState<string | null>(null);
 
     // Use React Query for better caching and memory management
     const { data: subscriptions = [], refetch: refetchSubscriptions } = useSubscriptions<Subscription[]>({
@@ -178,10 +179,9 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error unsubscribing:', error);
             showSnackbar(t('error'));
-        } finally {
-            setIsUnsubscribeModalOpen(false);
-            setSelectedSubscription(null);
+            throw error;
         }
+        setSelectedSubscription(null);
     };
 
     const handleCancelTaskClick = (task: ContinuousDownloadTask) => {
@@ -199,10 +199,9 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error cancelling task:', error);
             showSnackbar(t('error'));
-        } finally {
-            setIsCancelTaskModalOpen(false);
-            setSelectedTask(null);
+            throw error;
         }
+        setSelectedTask(null);
     };
 
     const handleDeleteTaskClick = (task: ContinuousDownloadTask) => {
@@ -220,10 +219,9 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error deleting task:', error);
             showSnackbar(t('error'));
-        } finally {
-            setIsDeleteTaskModalOpen(false);
-            setSelectedTask(null);
+            throw error;
         }
+        setSelectedTask(null);
     };
 
     const handleClearFinishedClick = () => {
@@ -238,12 +236,12 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error clearing finished tasks:', error);
             showSnackbar(t('error'));
-        } finally {
-            setIsClearFinishedModalOpen(false);
+            throw error;
         }
     };
 
     const handlePauseSubscription = async (id: string) => {
+        setSubscriptionActionId(id);
         try {
             await api.put(`/subscriptions/${id}/pause`);
             showSnackbar(t('subscriptionPaused'));
@@ -251,10 +249,13 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error pausing subscription:', error);
             showSnackbar(t('error'));
+        } finally {
+            setSubscriptionActionId(null);
         }
     };
 
     const handleResumeSubscription = async (id: string) => {
+        setSubscriptionActionId(id);
         try {
             await api.put(`/subscriptions/${id}/resume`);
             showSnackbar(t('subscriptionResumed'));
@@ -262,6 +263,8 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error resuming subscription:', error);
             showSnackbar(t('error'));
+        } finally {
+            setSubscriptionActionId(null);
         }
     };
 
@@ -354,6 +357,7 @@ const SubscriptionsPage: React.FC = () => {
     );
 
     const handlePauseTask = async (task: ContinuousDownloadTask) => {
+        setTaskActionId(task.id);
         try {
             await api.put(`/subscriptions/tasks/${task.id}/pause`);
             showSnackbar(t('taskPaused'));
@@ -361,10 +365,13 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error pausing task:', error);
             showSnackbar(t('error'));
+        } finally {
+            setTaskActionId(null);
         }
     };
 
     const handleResumeTask = async (task: ContinuousDownloadTask) => {
+        setTaskActionId(task.id);
         try {
             await api.put(`/subscriptions/tasks/${task.id}/resume`);
             showSnackbar(t('taskResumed'));
@@ -372,6 +379,8 @@ const SubscriptionsPage: React.FC = () => {
         } catch (error) {
             console.error('Error resuming task:', error);
             showSnackbar(t('error'));
+        } finally {
+            setTaskActionId(null);
         }
     };
 
@@ -421,9 +430,10 @@ const SubscriptionsPage: React.FC = () => {
                 color="primary"
                 title={t('save')}
                 onClick={() => void handleSaveSubscriptionInterval(subscriptionId)}
-                disabled={!isEditedIntervalValid || isSavingInterval}
+                disabled={!isEditedIntervalValid}
+                loading={isSavingInterval}
             >
-                {isSavingInterval ? <CircularProgress size={18} /> : <Check fontSize="small" />}
+                <Check fontSize="small" />
             </IconButton>
             <IconButton
                 size="small"
@@ -482,9 +492,10 @@ const SubscriptionsPage: React.FC = () => {
                     onClick={() => {
                         void handleSaveRetention(subscriptionId);
                     }}
-                    disabled={!isEditedRetentionValid || isSavingRetention}
+                    disabled={!isEditedRetentionValid}
+                    loading={isSavingRetention}
                 >
-                    {isSavingRetention ? <CircularProgress size={18} /> : <Check fontSize="small" />}
+                    <Check fontSize="small" />
                 </IconButton>
                 <IconButton
                     size="small"
@@ -646,6 +657,7 @@ const SubscriptionsPage: React.FC = () => {
                                                     }}
                                                     title={t('resumeSubscription')}
                                                     disabled={(isEditingInterval && isSavingInterval) || (isEditingRetention && isSavingRetention)}
+                                                    loading={subscriptionActionId === sub.id}
                                                 >
                                                     <PlayArrow />
                                                 </IconButton>
@@ -657,6 +669,7 @@ const SubscriptionsPage: React.FC = () => {
                                                     }}
                                                     title={t('pauseSubscription')}
                                                     disabled={(isEditingInterval && isSavingInterval) || (isEditingRetention && isSavingRetention)}
+                                                    loading={subscriptionActionId === sub.id}
                                                 >
                                                     <Pause />
                                                 </IconButton>
@@ -766,6 +779,7 @@ const SubscriptionsPage: React.FC = () => {
                                                             onClick={() => handlePauseTask(task)}
                                                             title={t('pauseTask')}
                                                             size="small"
+                                                            loading={taskActionId === task.id}
                                                         >
                                                             <Pause />
                                                         </IconButton>
@@ -776,6 +790,7 @@ const SubscriptionsPage: React.FC = () => {
                                                             onClick={() => handleResumeTask(task)}
                                                             title={t('resumeTask')}
                                                             size="small"
+                                                            loading={taskActionId === task.id}
                                                         >
                                                             <PlayArrow />
                                                         </IconButton>

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -576,6 +576,8 @@ const VideoPlayer: React.FC = () => {
                             onAddToCollection={handleAddToCollection}
                             onDelete={handleDelete}
                             isDeleting={deleteMutation.isPending}
+                            isSavingTitle={titleMutation.isPending}
+                            isTogglingVisibility={visibilityMutation.isPending}
                             deleteError={deleteMutation.error ? (deleteMutation.error as any).message || t('deleteFailed') : null}
                             videoCollections={videoCollections}
                             onCollectionClick={handleCollectionClick}

--- a/frontend/src/pages/__tests__/ManagePage.test.tsx
+++ b/frontend/src/pages/__tests__/ManagePage.test.tsx
@@ -670,7 +670,9 @@ describe('ManagePage', () => {
 
             renderManagePage();
 
-            expect(screen.getByText('scanning')).toBeInTheDocument();
+            const scanButton = screen.getByRole('button', { name: 'scanFiles' });
+            expect(scanButton).toBeDisabled();
+            expect(within(scanButton).getByRole('progressbar')).toBeInTheDocument();
 
             fireEvent.click(screen.getByRole('tab', { name: /videos/i }));
             expect(capturedVideosTableProps!.isRefreshingFileSizes).toBe(true);

--- a/frontend/src/pages/__tests__/SearchResults.test.tsx
+++ b/frontend/src/pages/__tests__/SearchResults.test.tsx
@@ -1,5 +1,5 @@
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SearchResults from '../SearchResults';
 
@@ -253,8 +253,9 @@ describe('SearchResults Page', () => {
         ];
         renderSearchResults();
 
-        const loadMoreBtn = screen.getByRole('button', { name: /loading/i });
+        const loadMoreBtn = screen.getByRole('button', { name: 'more' });
         expect(loadMoreBtn).toBeDisabled();
+        expect(within(loadMoreBtn).getByRole('progressbar')).toBeInTheDocument();
     });
 
     // --- 13. formatViewCount ---

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -513,8 +513,12 @@ describe('SettingsPage', () => {
     saveIsPending = true;
     renderPage('/settings');
 
-    const savingButton = screen.getByRole('button', { name: 'saving' });
-    expect(savingButton).toBeDisabled();
+    const disabledSaveButton = screen
+      .getAllByRole('button', { name: 'save' })
+      .find((button) => button.hasAttribute('disabled'));
+    expect(disabledSaveButton).toBeDefined();
+    expect(disabledSaveButton).toBeDisabled();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('disables live translation when clearing a configured API key before save', async () => {
@@ -895,11 +899,6 @@ describe('SettingsPage', () => {
     expect(mockMigrateMutate).toHaveBeenCalled();
     expect(mockFormatFilenamesMutate).toHaveBeenCalled();
     expect(mockCleanupMutate).toHaveBeenCalled();
-    expect(mockSetShowCleanupAuthorCollectionsModal).toHaveBeenCalledWith(false);
-    expect(mockSetShowDeleteLegacyModal).toHaveBeenCalledWith(false);
-    expect(mockSetShowMigrateConfirmModal).toHaveBeenCalledWith(false);
-    expect(mockSetShowFormatConfirmModal).toHaveBeenCalledWith(false);
-    expect(mockSetShowCleanupTempFilesModal).toHaveBeenCalledWith(false);
     expect(mockSetInfoModal).toHaveBeenCalled();
 
     const stickySaveButton = screen.getByRole('button', { name: 'save' });

--- a/frontend/src/pages/__tests__/SubscriptionsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SubscriptionsPage.test.tsx
@@ -651,10 +651,7 @@ describe('SubscriptionsPage', () => {
         });
 
         expect(mockShowSnackbar).toHaveBeenCalledWith('error');
-        // Modal should be closed even on error (finally block closes it)
-        await waitFor(() => {
-            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-        });
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('handles api error during pause subscription gracefully', async () => {

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -48,6 +48,34 @@ const getTheme = (mode: ThemeMode) => {
             borderRadius: 8,
             textTransform: "none",
             fontWeight: 600,
+            "&.MuiButton-loading": {
+              textAlign: "center",
+              color: "transparent",
+              "& .MuiButton-loadingIndicator": {
+                color: colors.textSecondary,
+              },
+            },
+            "&.MuiButton-loadingPositionStart.MuiButton-loading": {
+              "& .MuiButton-startIcon": {
+                display: "none",
+              },
+              "& .MuiButton-loadingIndicator": {
+                left: "50%",
+                position: "absolute",
+                transform: "translateX(-50%)",
+              },
+            },
+            "&.MuiButton-loadingPositionEnd.MuiButton-loading": {
+              "& .MuiButton-endIcon": {
+                display: "none",
+              },
+              "& .MuiButton-loadingIndicator": {
+                position: "absolute",
+                right: "auto",
+                left: "50%",
+                transform: "translateX(-50%)",
+              },
+            },
           },
           containedPrimary: {
             boxShadow: mode === "dark" ? shadow.primaryGlow : "none",

--- a/frontend/src/utils/mutationUtils.ts
+++ b/frontend/src/utils/mutationUtils.ts
@@ -1,0 +1,25 @@
+interface MutationCallbacks {
+    onSuccess?: () => void;
+    onError?: (error: unknown) => void;
+}
+
+interface AsyncCapableMutation<TVariables> {
+    mutate: (variables: TVariables, callbacks?: MutationCallbacks) => void;
+    mutateAsync?: (variables: TVariables) => Promise<unknown>;
+}
+
+export function runMutationAsync<TVariables>(
+    mutation: AsyncCapableMutation<TVariables>,
+    variables: TVariables
+): Promise<unknown> {
+    if (typeof mutation.mutateAsync === 'function') {
+        return mutation.mutateAsync(variables);
+    }
+
+    return new Promise((resolve, reject) => {
+        mutation.mutate(variables, {
+            onSuccess: () => resolve(undefined),
+            onError: reject,
+        });
+    });
+}


### PR DESCRIPTION
## Summary

- Standardize async button loading states across modals, settings, search, manage, download, subscriptions, login, statistics, and video-player surfaces.
- Add reusable async helpers for guarded button actions and mutation callbacks.
- Update confirmation flows so async confirms disable dismissal while running, close on success, and stay open on failure.
- Tune global MUI loading-button styling so the label is replaced by a centered spinner without changing button height.

## Why

The app had inconsistent loading behavior: some actions changed labels, some showed manual spinners, and some could be clicked or dismissed while async work was still running. The implementation makes loading states consistent and avoids layout shifts in compact buttons.

## Validation

- `npm run typecheck:frontend`
- `npm run lint:frontend`
- `npm run test:frontend` passed before the final style-only follow-ups: 173 files, 1,647 tests
- Focused loading tests passed after final styling changes: 3 files, 41 tests