### PR TITLE
fix(collections): enforce unique collection names

### DIFF
--- a/backend/src/__tests__/controllers/collectionController.test.ts
+++ b/backend/src/__tests__/controllers/collectionController.test.ts
@@ -73,6 +73,46 @@ describe('CollectionController', () => {
       }
     });
 
+    it('should throw DuplicateError if name already exists', async () => {
+      req.body = { name: 'Existing Col' };
+      (storageService.getCollectionByName as any).mockReturnValueOnce({
+        id: '99',
+        title: 'Existing Col',
+        videos: [],
+      });
+
+      try {
+        await createCollection(req as Request, res as Response);
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error.name).toBe('DuplicateError');
+      }
+
+      expect(storageService.saveCollection).not.toHaveBeenCalled();
+    });
+
+    it('should add video to existing collection instead of duplicating when name exists', () => {
+      req.body = { name: 'Existing Col', videoId: 'v1' };
+      (storageService.getCollectionByName as any).mockReturnValueOnce({
+        id: '99',
+        title: 'Existing Col',
+        videos: [],
+      });
+      const merged = { id: '99', title: 'Existing Col', videos: ['v1'] };
+      (storageService.addVideoToCollection as any).mockReturnValue(merged);
+
+      createCollection(req as Request, res as Response);
+
+      expect(storageService.saveCollection).not.toHaveBeenCalled();
+      expect(storageService.addVideoToCollection).toHaveBeenCalledWith(
+        '99',
+        'v1',
+        { moveFiles: false }
+      );
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith(merged);
+    });
+
     it('should add video if videoId provided', () => {
       req.body = { name: 'New Col', videoId: 'v1' };
       const mockCollection = { id: '1', title: 'New Col', videos: ['v1'] };

--- a/backend/src/controllers/collectionController.ts
+++ b/backend/src/controllers/collectionController.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { NotFoundError, ValidationError } from "../errors/DownloadErrors";
+import {
+  DuplicateError,
+  NotFoundError,
+  ValidationError,
+} from "../errors/DownloadErrors";
 import * as storageService from "../services/storageService";
 import { Collection } from "../services/storageService";
 import { getStringParam } from "../utils/paramUtils";
@@ -32,6 +36,29 @@ export const createCollection = async (
 
   if (!name) {
     throw new ValidationError("Collection name is required", "name");
+  }
+
+  // Collection names must be unique.
+  const existing = storageService.getCollectionByName(name);
+  if (existing) {
+    // If a video is being added, merge it into the existing collection
+    // instead of creating a duplicate. Signalled with 200 (vs 201 for a new
+    // collection) so the frontend can tell the user it was added to an
+    // existing collection.
+    if (videoId) {
+      const updatedCollection = storageService.addVideoToCollection(
+        existing.id,
+        videoId,
+        { moveFiles: false }
+      );
+      res.status(200).json(updatedCollection ?? existing);
+      return;
+    }
+
+    throw new DuplicateError(
+      "Collection",
+      `Collection name "${name}" already exists`
+    );
   }
 
   // Create a new collection

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -70,6 +70,10 @@ export const CollectionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
             // 200 means the name already existed and the video was merged into
             // the existing collection; 201 means a new collection was created.
             if (response.status === 200) {
+                // The merge target may be a favorited collection whose derived
+                // videoCount/cover changed, so refresh favorites to avoid a
+                // stale rail card (matches addToCollection).
+                queryClient.invalidateQueries({ queryKey: ['favorite-collections'] });
                 showSnackbar(t('collectionExistsVideoAdded'));
             } else {
                 showSnackbar(t('collectionCreatedSuccessfully'));

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -62,21 +62,29 @@ export const CollectionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
                 name,
                 videoId
             });
-            return response.data;
+            return response;
         },
-        onSuccess: () => {
+        onSuccess: (response) => {
             queryClient.invalidateQueries({ queryKey: ['collections'] });
             queryClient.invalidateQueries({ queryKey: ['videos'] });
-            showSnackbar(t('collectionCreatedSuccessfully'));
+            // 200 means the name already existed and the video was merged into
+            // the existing collection; 201 means a new collection was created.
+            if (response.status === 200) {
+                showSnackbar(t('collectionExistsVideoAdded'));
+            } else {
+                showSnackbar(t('collectionCreatedSuccessfully'));
+            }
         },
-        onError: (error) => {
+        onError: (error: unknown) => {
             console.error('Error creating collection:', error);
+            showSnackbar(getApiErrorMessage(error) || t('createCollectionFailed'), 'error');
         }
     });
 
     const createCollection = useCallback(async (name: string, videoId: string) => {
         try {
-            return await createCollectionMutation.mutateAsync({ name, videoId });
+            const response = await createCollectionMutation.mutateAsync({ name, videoId });
+            return response.data as Collection;
         } catch {
             return null;
         }

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -4,7 +4,7 @@ Canonical locale key order derived from `frontend/src/utils/locales/en.ts`.
 
 This list is intentionally unnumbered. When new keys are inserted, only the local section order changes.
 
-Total keys: 1044
+Total keys: 1046
 
 ## Summary
 
@@ -30,7 +30,7 @@ Total keys: 1044
 | Upload Modal | 19 | `selectVideoFile` | `thumbnailUploaded` |
 | Bilibili Modal | 22 | `bilibiliCollectionDetected` | `waitingInQueue` |
 | Downloads | 20 | `downloads` | `failed` |
-| Snackbar Messages | 19 | `videoDownloading` | `subtitleDeleted` |
+| Snackbar Messages | 21 | `videoDownloading` | `subtitleDeleted` |
 | Batch Download | 6 | `batchDownload` | `addBatchTasks` |
 | Subscriptions | 62 | `subscribeToAuthor` | `retentionDaysUpdateFailed` |
 | Subscription Pause/Resume | 12 | `pause` | `viaContinuousDownload` |
@@ -882,6 +882,8 @@ Total keys: 1044
 | `collectionNameInvalidChars` |
 | `collectionNameReserved` |
 | `updateCollectionFailed` |
+| `createCollectionFailed` |
+| `collectionExistsVideoAdded` |
 | `uploadSubtitle` |
 | `subtitleUploaded` |
 | `confirmDeleteSubtitle` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -912,6 +912,8 @@ export const ar = {
   collectionNameInvalidChars: "اسم المجموعة يحتوي على أحرف غير صالحة",
   collectionNameReserved: "اسم المجموعة محجوز",
   updateCollectionFailed: "فشل تحديث المجموعة",
+  createCollectionFailed: "فشل إنشاء المجموعة",
+  collectionExistsVideoAdded: "المجموعة موجودة بالفعل — تمت إضافة الفيديو إليها",
   uploadSubtitle: "رفع الترجمة",
   subtitleUploaded: "تم رفع الترجمة بنجاح",
   confirmDeleteSubtitle: "حذف هذه الترجمة؟",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -949,6 +949,9 @@ export const de = {
   collectionNameInvalidChars: "Name der Sammlung enthält ungültige Zeichen",
   collectionNameReserved: "Name der Sammlung ist reserviert",
   updateCollectionFailed: "Sammlung konnte nicht aktualisiert werden",
+  createCollectionFailed: "Sammlung konnte nicht erstellt werden",
+  collectionExistsVideoAdded:
+    "Sammlung existiert bereits – Video wurde stattdessen hinzugefügt",
   uploadSubtitle: "Untertitel hochladen",
   subtitleUploaded: "Untertitel erfolgreich hochgeladen",
   confirmDeleteSubtitle: "Diesen Untertitel löschen?",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -919,6 +919,9 @@ export const en = {
   collectionNameInvalidChars: "Collection name contains invalid characters",
   collectionNameReserved: "Collection name is reserved",
   updateCollectionFailed: "Failed to update collection",
+  createCollectionFailed: "Failed to create collection",
+  collectionExistsVideoAdded:
+    "Collection already exists — video added to it instead",
   uploadSubtitle: "Upload Subtitle",
   subtitleUploaded: "Subtitle uploaded successfully",
   confirmDeleteSubtitle: "Delete this subtitle?",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -947,6 +947,9 @@ export const es = {
     "El nombre de la colección contiene caracteres no válidos",
   collectionNameReserved: "El nombre de la colección está reservado",
   updateCollectionFailed: "Error al actualizar la colección",
+  createCollectionFailed: "Error al crear la colección",
+  collectionExistsVideoAdded:
+    "La colección ya existe: el video se agregó a ella",
   uploadSubtitle: "Subir subtítulo",
   subtitleUploaded: "Subtítulo subido correctamente",
   confirmDeleteSubtitle: "¿Eliminar este subtítulo?",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -950,6 +950,9 @@ export const fr = {
     "Le nom de la collection contient des caractères invalides",
   collectionNameReserved: "Le nom de la collection est réservé",
   updateCollectionFailed: "Échec de la mise à jour de la collection",
+  createCollectionFailed: "Échec de la création de la collection",
+  collectionExistsVideoAdded:
+    "La collection existe déjà — la vidéo y a été ajoutée",
   uploadSubtitle: "Télécharger le sous-titre",
   subtitleUploaded: "Sous-titre téléchargé avec succès",
   confirmDeleteSubtitle: "Supprimer ce sous-titre ?",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -936,6 +936,9 @@ export const ja = {
   collectionNameInvalidChars: "コレクション名に無効な文字が含まれています",
   collectionNameReserved: "コレクション名は予約されています",
   updateCollectionFailed: "コレクションの更新に失敗しました",
+  createCollectionFailed: "コレクションの作成に失敗しました",
+  collectionExistsVideoAdded:
+    "コレクションは既に存在します — 動画を既存のコレクションに追加しました",
   uploadSubtitle: "字幕をアップロード",
   subtitleUploaded: "字幕のアップロードに成功しました",
   confirmDeleteSubtitle: "この字幕を削除しますか？",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -922,6 +922,8 @@ export const ko = {
     "컬렉션 이름에 유효하지 않은 문자가 포함되어 있습니다",
   collectionNameReserved: "컬렉션 이름은 예약어입니다",
   updateCollectionFailed: "컬렉션 업데이트 실패",
+  createCollectionFailed: "컬렉션 생성 실패",
+  collectionExistsVideoAdded: "컬렉션이 이미 존재합니다 — 동영상을 기존 컬렉션에 추가했습니다",
   uploadSubtitle: "자막 업로드",
   subtitleUploaded: "자막이 성공적으로 업로드되었습니다",
   confirmDeleteSubtitle: "이 자막을 삭제하시겠습니까?",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -939,6 +939,9 @@ export const pt = {
   collectionNameInvalidChars: "O nome da coleção contém caracteres inválidos",
   collectionNameReserved: "O nome da coleção é reservado",
   updateCollectionFailed: "Falha ao atualizar coleção",
+  createCollectionFailed: "Falha ao criar coleção",
+  collectionExistsVideoAdded:
+    "A coleção já existe — o vídeo foi adicionado a ela",
   uploadSubtitle: "Enviar legenda",
   subtitleUploaded: "Legenda enviada com sucesso",
   confirmDeleteSubtitle: "Excluir esta legenda?",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -935,6 +935,9 @@ export const ru = {
     "Название коллекции содержит недопустимые символы",
   collectionNameReserved: "Название коллекции зарезервировано",
   updateCollectionFailed: "Не удалось обновить коллекцию",
+  createCollectionFailed: "Не удалось создать коллекцию",
+  collectionExistsVideoAdded:
+    "Коллекция уже существует — видео добавлено в неё",
   uploadSubtitle: "Загрузить субтитры",
   subtitleUploaded: "Субтитры успешно загружены",
   confirmDeleteSubtitle: "Удалить этот субтитр?",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -898,6 +898,8 @@ export const zh = {
   collectionNameInvalidChars: "合集名称包含无效字符",
   collectionNameReserved: "合集名称为保留名称",
   updateCollectionFailed: "更新合集失败",
+  createCollectionFailed: "创建合集失败",
+  collectionExistsVideoAdded: "合集已存在——已将视频添加到该合集",
   uploadSubtitle: "上传字幕",
   subtitleUploaded: "字幕上传成功",
   confirmDeleteSubtitle: "确定要删除这条字幕吗？",


### PR DESCRIPTION
## Problem

On `master`, creating a collection whose name already existed still succeeded, producing multiple collections with the same name. Collection names should be unique.

## Changes

**Backend** — `createCollection` ([collectionController.ts](backend/src/controllers/collectionController.ts)) now checks for an existing name via `getCollectionByName`:
- **Plain creation** (no `videoId`) with a duplicate name → **409 `DuplicateError`**.
- **From the "Add to Collection" modal** (`videoId` present) with a duplicate name → the video is merged into the **existing** collection and responds **200** instead of creating a duplicate.
- New name → created as before (**201**).

**Frontend** — the create mutation ([CollectionContext.tsx](frontend/src/contexts/CollectionContext.tsx)) now surfaces the outcome via snackbar (previously the error was only `console.error`'d):
- `200` → "Collection already exists — video added to it instead"
- `201` → "Collection created successfully"
- error → server message / "Failed to create collection"

**i18n** — added `createCollectionFailed` and `collectionExistsVideoAdded` to **all 10 locales** and updated `KEY_LIST.md` (counts + total).

## Notes
- Name matching is exact and case-sensitive (existing `getCollectionByName` behavior), so "Music" vs "music" remain distinct. Happy to make it case-insensitive if preferred.

## Testing
- Backend controller tests: **14/14** (added duplicate + merge cases)
- Frontend translations test: **5/5**
- `tsc --noEmit` clean on both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)