### PR TITLE
Unify collection modal input

### DIFF
--- a/frontend/src/components/CollectionModal.tsx
+++ b/frontend/src/components/CollectionModal.tsx
@@ -13,7 +13,7 @@ import {
     Typography
 } from '@mui/material';
 import type { FilterOptionsState } from '@mui/material/useAutocomplete';
-import React, { useCallback, useId, useMemo, useState } from 'react';
+import React, { useCallback, useId, useMemo, useRef, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
 
@@ -43,6 +43,7 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
     const [textInput, setTextInput] = useState<string>('');
     const [selectedOption, setSelectedOption] = useState<CollectionOption | null>(null);
     const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+    const highlightedOptionRef = useRef<CollectionOption | null>(null);
     const nativeAutocompleteId = useId();
     const nativeAutocompleteToken = useMemo(
         () => `collection-lookup-${nativeAutocompleteId.replace(/[^a-zA-Z0-9_-]/g, '')}`,
@@ -92,6 +93,29 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
         [onCreateCollection]
     );
 
+    const resolveHighlightedOption = useCallback(
+        (input: HTMLInputElement): CollectionOption | null => {
+            if (highlightedOptionRef.current !== null) {
+                return highlightedOptionRef.current;
+            }
+
+            const activeDescendantId = input.getAttribute('aria-activedescendant');
+            if (!activeDescendantId) return null;
+
+            const activeOption = document.getElementById(activeDescendantId);
+            const optionIndex = activeOption?.getAttribute('data-option-index');
+            if (optionIndex == null) return null;
+
+            const filtered = filterCollectionOptions(collectionOptions, {
+                inputValue: textInput,
+                getOptionLabel: (option) => (typeof option === 'string' ? option : option.name),
+            } as FilterOptionsState<CollectionOption>);
+
+            return filtered[Number(optionIndex)] ?? null;
+        },
+        [collectionOptions, filterCollectionOptions, textInput]
+    );
+
     const resolvedCollection = trimmedInput
         ? collectionOptions.find(
               (c) => c.name.trim().toLowerCase() === trimmedInput.toLowerCase()
@@ -128,25 +152,12 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
         onClose();
     };
 
-    const submit = async () => {
+    const submitSelection = async (selection: CollectionOption) => {
         if (pendingAction) return;
 
-        const name = trimmedInput;
-        if (!name) return;
-
-        if (resolvedCollection) {
-            if (isCurrentCollection(resolvedCollection.id) || !onAddToCollection) return;
-            setPendingAction('add');
-            try {
-                await onAddToCollection(resolvedCollection.id);
-                resetAndClose();
-            } catch {
-                // Keep the modal open so the action can be retried.
-            } finally {
-                setPendingAction(null);
-            }
-        } else {
-            if (!onCreateCollection) return;
+        if (typeof selection === 'string') {
+            const name = selection.trim();
+            if (!name || !onCreateCollection) return;
             setPendingAction('create');
             try {
                 await onCreateCollection(name);
@@ -156,6 +167,31 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
             } finally {
                 setPendingAction(null);
             }
+            return;
+        }
+
+        if (isCurrentCollection(selection.id) || !onAddToCollection) return;
+        setPendingAction('add');
+        try {
+            await onAddToCollection(selection.id);
+            resetAndClose();
+        } catch {
+            // Keep the modal open so the action can be retried.
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const submit = async () => {
+        if (pendingAction) return;
+
+        const name = trimmedInput;
+        if (!name) return;
+
+        if (resolvedCollection) {
+            await submitSelection(resolvedCollection);
+        } else {
+            await submitSelection(name);
         }
     };
 
@@ -170,6 +206,28 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
         } finally {
             setPendingAction(null);
         }
+    };
+
+    const handleInputEnterKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key !== 'Enter') return;
+
+        const isExpanded = event.currentTarget.getAttribute('aria-expanded') === 'true';
+        if (isExpanded) {
+            const highlighted = resolveHighlightedOption(event.currentTarget);
+            if (highlighted !== null) {
+                event.preventDefault();
+                (event as React.KeyboardEvent & { defaultMuiPrevented?: boolean }).defaultMuiPrevented = true;
+                setSelectedOption(highlighted);
+                setTextInput(
+                    typeof highlighted === 'string' ? highlighted : highlighted.name
+                );
+                void submitSelection(highlighted);
+                return;
+            }
+        }
+
+        event.preventDefault();
+        void submit();
     };
 
     const renderCollectionOption = (
@@ -250,6 +308,7 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                         <Stack direction="row" spacing={2}>
                             <Autocomplete<CollectionOption, false, false, true>
                                 freeSolo
+                                autoHighlight
                                 fullWidth
                                 size="small"
                                 options={collectionOptions}
@@ -274,7 +333,13 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                             : newValue?.name ?? ''
                                     );
                                 }}
+                                onHighlightChange={(_, option) => {
+                                    highlightedOptionRef.current = option;
+                                }}
                                 filterOptions={filterCollectionOptions}
+                                onClose={() => {
+                                    highlightedOptionRef.current = null;
+                                }}
                                 getOptionDisabled={(option) =>
                                     typeof option !== 'string' && isCurrentCollection(option.id)
                                 }
@@ -285,6 +350,14 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                         label={t('selectOrCreateCollection')}
                                         placeholder={t('selectOrCreateCollection')}
                                         autoComplete="off"
+                                        InputProps={{
+                                            ...params.InputProps,
+                                            onKeyDown: (event) => {
+                                                handleInputEnterKeyDown(
+                                                    event as React.KeyboardEvent<HTMLInputElement>
+                                                );
+                                            },
+                                        }}
                                         slotProps={{
                                             htmlInput: {
                                                 ...params.inputProps,
@@ -296,12 +369,6 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                                                 spellCheck: false,
                                                 type: 'search',
                                             },
-                                        }}
-                                        onKeyDown={(e) => {
-                                            if (e.key === 'Enter') {
-                                                e.preventDefault();
-                                                void submit();
-                                            }
                                         }}
                                     />
                                 )}

--- a/frontend/src/components/CollectionModal.tsx
+++ b/frontend/src/components/CollectionModal.tsx
@@ -1,20 +1,19 @@
+import { Add } from '@mui/icons-material';
 import {
     Alert,
+    Autocomplete,
     Box,
     Button,
     Dialog,
     DialogActions,
     DialogContent,
     DialogTitle,
-    FormControl,
-    InputLabel,
-    MenuItem,
-    Select,
     Stack,
     TextField,
     Typography
 } from '@mui/material';
-import React, { useState } from 'react';
+import type { FilterOptionsState } from '@mui/material/useAutocomplete';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
 
@@ -29,6 +28,7 @@ interface CollectionModalProps {
 }
 
 type PendingAction = 'add' | 'create' | `remove:${string}` | null;
+type CollectionOption = Collection | string;
 
 const CollectionModal: React.FC<CollectionModalProps> = ({
     open,
@@ -40,44 +40,121 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
     onRemoveFromCollection
 }) => {
     const { t } = useLanguage();
-    const [newCollectionName, setNewCollectionName] = useState<string>('');
-    const [selectedCollection, setSelectedCollection] = useState<string>('');
+    const [textInput, setTextInput] = useState<string>('');
+    const [selectedOption, setSelectedOption] = useState<CollectionOption | null>(null);
     const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+    const nativeAutocompleteToken = useMemo(
+        () => `collection-lookup-${Math.random().toString(36).slice(2)}`,
+        []
+    );
 
-    const handleClose = () => {
-        if (pendingAction) return;
-        setNewCollectionName('');
-        setSelectedCollection('');
+    const isCurrentCollection = useCallback(
+        (collectionId: string) =>
+            videoCollections?.some((vc) => vc.id === collectionId) ?? false,
+        [videoCollections]
+    );
+
+    const collectionOptions = useMemo(
+        () =>
+            [...(collections ?? [])].sort((a, b) =>
+                a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+            ),
+        [collections]
+    );
+
+    const trimmedInput = textInput.trim();
+
+    const matchedExisting = trimmedInput
+        ? collectionOptions.find(
+              (c) => c.name.trim().toLowerCase() === trimmedInput.toLowerCase()
+          )
+        : undefined;
+
+    const hasExactMatch = Boolean(matchedExisting);
+
+    const filterCollectionOptions = useCallback(
+        (options: CollectionOption[], { inputValue }: FilterOptionsState<CollectionOption>): CollectionOption[] => {
+            const collectionsOnly = options.filter((o): o is Collection => typeof o !== 'string');
+            const q = inputValue.trim().toLowerCase();
+            if (!q) return collectionsOnly;
+
+            const filtered = collectionsOnly.filter((c) => c.name.toLowerCase().includes(q));
+
+            if (!onCreateCollection) return filtered;
+
+            const isExisting = collectionsOnly.some((c) => c.name.trim().toLowerCase() === q);
+            if (inputValue.trim() !== '' && !isExisting) {
+                return [inputValue.trim(), ...filtered];
+            }
+            return filtered;
+        },
+        [onCreateCollection]
+    );
+
+    const resolvedCollection = trimmedInput
+        ? collectionOptions.find(
+              (c) => c.name.trim().toLowerCase() === trimmedInput.toLowerCase()
+          )
+        : undefined;
+
+    const canSubmit = Boolean(
+        trimmedInput &&
+            (!resolvedCollection || !isCurrentCollection(resolvedCollection.id)) &&
+            (resolvedCollection ? onAddToCollection : onCreateCollection)
+    );
+
+    const submitLabel = hasExactMatch
+        ? (matchedExisting && isCurrentCollection(matchedExisting.id) ? t('current') : t('add'))
+        : (onCreateCollection ? t('create') : t('add'));
+
+    const showUnifiedInput =
+        Boolean(onAddToCollection || onCreateCollection) &&
+        !(onAddToCollection && !onCreateCollection && collectionOptions.length === 0);
+
+    const resetInputs = () => {
+        setTextInput('');
+        setSelectedOption(null);
+    };
+
+    const resetAndClose = () => {
+        resetInputs();
         onClose();
     };
 
-    const handleCreate = async () => {
-        if (!newCollectionName.trim() || !onCreateCollection) return;
-        setPendingAction('create');
-        try {
-            await onCreateCollection(newCollectionName);
-            setNewCollectionName('');
-            setSelectedCollection('');
-            onClose();
-        } catch {
-            // Keep the modal open so the action can be retried.
-        } finally {
-            setPendingAction(null);
-        }
+    const handleClose = () => {
+        if (pendingAction) return;
+        resetInputs();
+        onClose();
     };
 
-    const handleAdd = async () => {
-        if (!selectedCollection || !onAddToCollection) return;
-        setPendingAction('add');
-        try {
-            await onAddToCollection(selectedCollection);
-            setNewCollectionName('');
-            setSelectedCollection('');
-            onClose();
-        } catch {
-            // Keep the modal open so the action can be retried.
-        } finally {
-            setPendingAction(null);
+    const submit = async () => {
+        if (pendingAction) return;
+
+        const name = trimmedInput;
+        if (!name) return;
+
+        if (resolvedCollection) {
+            if (isCurrentCollection(resolvedCollection.id) || !onAddToCollection) return;
+            setPendingAction('add');
+            try {
+                await onAddToCollection(resolvedCollection.id);
+                resetAndClose();
+            } catch {
+                // Keep the modal open so the action can be retried.
+            } finally {
+                setPendingAction(null);
+            }
+        } else {
+            if (!onCreateCollection) return;
+            setPendingAction('create');
+            try {
+                await onCreateCollection(name);
+                resetAndClose();
+            } catch {
+                // Keep the modal open so the action can be retried.
+            } finally {
+                setPendingAction(null);
+            }
         }
     };
 
@@ -86,9 +163,7 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
         setPendingAction(`remove:${collectionId}`);
         try {
             await onRemoveFromCollection(collectionId);
-            setNewCollectionName('');
-            setSelectedCollection('');
-            onClose();
+            resetAndClose();
         } catch {
             // Keep the modal open so the action can be retried.
         } finally {
@@ -96,8 +171,49 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
         }
     };
 
+    const renderCollectionOption = (
+        props: React.HTMLAttributes<HTMLLIElement> & { key: string },
+        option: CollectionOption
+    ) => {
+        const { key, ...otherProps } = props;
+        const isStr = typeof option === 'string';
+        const coll = isStr ? null : option;
+        const current = coll ? isCurrentCollection(coll.id) : false;
+
+        return (
+            <li key={key} {...otherProps}>
+                {isStr ? (
+                    <span>
+                        <Add fontSize="small" sx={{ mr: 1, verticalAlign: 'middle' }} />
+                        {t('createNewCollectionLabel', { name: option })}
+                    </span>
+                ) : (
+                    <span>
+                        {coll!.name}
+                        {current ? (
+                            <>
+                                {' '}
+                                <Typography component="span" variant="caption">
+                                    ({t('current')})
+                                </Typography>
+                            </>
+                        ) : null}
+                    </span>
+                )}
+            </li>
+        );
+    };
+
     return (
-        <Dialog open={open} onClose={handleClose} disableEscapeKeyDown={Boolean(pendingAction)} maxWidth="sm" fullWidth>
+        <Dialog
+            open={open}
+            onClose={() => {
+                if (!pendingAction) handleClose();
+            }}
+            disableEscapeKeyDown={Boolean(pendingAction)}
+            maxWidth="sm"
+            fullWidth
+        >
             <DialogTitle>{t('addToCollection')}</DialogTitle>
             <DialogContent dividers>
                 {videoCollections && videoCollections.length > 0 && onRemoveFromCollection && (
@@ -128,76 +244,86 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
                     </Stack>
                 )}
 
-                {collections && collections.length > 0 && onAddToCollection && (
-                    <Box sx={{ mb: 4 }}>
-                        <Typography variant="subtitle2" gutterBottom>{t('addToExistingCollection')}</Typography>
-                        <Stack direction="row" spacing={2}>
-                            <FormControl fullWidth size="small">
-                                <InputLabel>{t('selectCollection')}</InputLabel>
-                                <Select
-                                    value={selectedCollection}
-                                    label={t('selectCollection')}
-                                    onChange={(e) => setSelectedCollection(e.target.value)}
-                                    disabled={Boolean(pendingAction)}
-                                >
-                                    {collections.map(collection => {
-                                        const isCurrentCollection = videoCollections?.some(
-                                            (videoCollection) => videoCollection.id === collection.id
-                                        ) || false;
-
-                                        return (
-                                        <MenuItem
-                                            key={collection.id}
-                                            value={collection.id}
-                                            disabled={isCurrentCollection}
-                                        >
-                                            {collection.name} {isCurrentCollection ? t('current') : ''}
-                                        </MenuItem>
-                                        );
-                                    })}
-                                </Select>
-                            </FormControl>
-                            <Button
-                                variant="contained"
-                                onClick={() => { void handleAdd(); }}
-                                disabled={!selectedCollection || Boolean(pendingAction)}
-                                loading={pendingAction === 'add'}
-                                loadingPosition="start"
-                            >
-                                {t('add')}
-                            </Button>
-                        </Stack>
-                    </Box>
-                )}
-
-                {onCreateCollection && (
+                {showUnifiedInput && (
                     <Box>
-                        <Typography variant="subtitle2" gutterBottom>{t('createNewCollection')}</Typography>
                         <Stack direction="row" spacing={2}>
-                            <TextField
+                            <Autocomplete<CollectionOption, false, false, true>
+                                freeSolo
                                 fullWidth
                                 size="small"
-                                label={t('collectionName')}
-                                value={newCollectionName}
-                                onChange={(e) => setNewCollectionName(e.target.value)}
-                                onKeyPress={(e) => e.key === 'Enter' && newCollectionName.trim() && !pendingAction && void handleCreate()}
+                                options={collectionOptions}
+                                getOptionLabel={(option) =>
+                                    typeof option === 'string' ? option : option.name
+                                }
+                                isOptionEqualToValue={(opt, val) =>
+                                    typeof opt === 'string' || typeof val === 'string'
+                                        ? opt === val
+                                        : opt.id === val.id
+                                }
+                                value={selectedOption}
+                                inputValue={textInput}
+                                onInputChange={(_, text, reason) => {
+                                    if (reason !== 'reset') setTextInput(text);
+                                }}
+                                onChange={(_, newValue) => {
+                                    setSelectedOption(newValue);
+                                    setTextInput(
+                                        typeof newValue === 'string'
+                                            ? newValue
+                                            : newValue?.name ?? ''
+                                    );
+                                }}
+                                filterOptions={filterCollectionOptions}
+                                getOptionDisabled={(option) =>
+                                    typeof option !== 'string' && isCurrentCollection(option.id)
+                                }
+                                renderOption={renderCollectionOption}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        label={t('selectOrCreateCollection')}
+                                        placeholder={t('selectOrCreateCollection')}
+                                        autoComplete="off"
+                                        slotProps={{
+                                            htmlInput: {
+                                                ...params.inputProps,
+                                                autoCapitalize: 'none',
+                                                autoComplete: nativeAutocompleteToken,
+                                                autoCorrect: 'off',
+                                                id: nativeAutocompleteToken,
+                                                name: nativeAutocompleteToken,
+                                                spellCheck: false,
+                                                type: 'search',
+                                            },
+                                        }}
+                                        onKeyDown={(e) => {
+                                            if (e.key === 'Enter') {
+                                                e.preventDefault();
+                                                void submit();
+                                            }
+                                        }}
+                                    />
+                                )}
                                 disabled={Boolean(pendingAction)}
+                                slotProps={{ listbox: { sx: { maxHeight: 280, overflow: 'auto' } } }}
                             />
                             <Button
                                 variant="contained"
-                                onClick={() => { void handleCreate(); }}
-                                disabled={!newCollectionName.trim() || Boolean(pendingAction)}
-                                loading={pendingAction === 'create'}
+                                onClick={() => { void submit(); }}
+                                disabled={!canSubmit || Boolean(pendingAction)}
+                                loading={pendingAction === 'create' || pendingAction === 'add'}
                                 loadingPosition="start"
                             >
-                                {t('create')}
+                                {submitLabel}
                             </Button>
                         </Stack>
                     </Box>
                 )}
             </DialogContent>
             <DialogActions>
-                <Button onClick={handleClose} color="inherit" disabled={Boolean(pendingAction)}>{t('cancel')}</Button>
+                <Button onClick={handleClose} color="inherit" disabled={Boolean(pendingAction)}>
+                    {t('cancel')}
+                </Button>
             </DialogActions>
         </Dialog>
     );

--- a/frontend/src/components/CollectionModal.tsx
+++ b/frontend/src/components/CollectionModal.tsx
@@ -13,7 +13,7 @@ import {
     Typography
 } from '@mui/material';
 import type { FilterOptionsState } from '@mui/material/useAutocomplete';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useId, useMemo, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
 
@@ -43,9 +43,10 @@ const CollectionModal: React.FC<CollectionModalProps> = ({
     const [textInput, setTextInput] = useState<string>('');
     const [selectedOption, setSelectedOption] = useState<CollectionOption | null>(null);
     const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+    const nativeAutocompleteId = useId();
     const nativeAutocompleteToken = useMemo(
-        () => `collection-lookup-${Math.random().toString(36).slice(2)}`,
-        []
+        () => `collection-lookup-${nativeAutocompleteId.replace(/[^a-zA-Z0-9_-]/g, '')}`,
+        [nativeAutocompleteId]
     );
 
     const isCurrentCollection = useCallback(

--- a/frontend/src/components/ManagePage/VideosTable.tsx
+++ b/frontend/src/components/ManagePage/VideosTable.tsx
@@ -262,6 +262,7 @@ const VideosTable: React.FC<VideosTableProps> = ({
             setSelectedVideoIds([]);
         } catch (error) {
             console.error('Failed to add videos to collection', error);
+            throw error;
         }
     };
 
@@ -283,6 +284,7 @@ const VideosTable: React.FC<VideosTableProps> = ({
             setSelectedVideoIds([]);
         } catch (error) {
             console.error('Failed to create collection', error);
+            throw error;
         }
     };
 

--- a/frontend/src/components/__tests__/CollectionModal.test.tsx
+++ b/frontend/src/components/__tests__/CollectionModal.test.tsx
@@ -1,85 +1,151 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Collection } from '../../types';
 import CollectionModal from '../CollectionModal';
 
-// Mock language context
 vi.mock('../../contexts/LanguageContext', () => ({
-    useLanguage: () => ({ t: (key: string) => key }),
+    useLanguage: () => ({
+        t: (key: string, replacements?: Record<string, string | number>) => {
+            if (replacements) {
+                return Object.entries(replacements).reduce(
+                    (text, [placeholder, value]) =>
+                        text.replaceAll(`{${placeholder}}`, String(value)),
+                    key
+                );
+            }
+            return key;
+        },
+    }),
 }));
 
 describe('CollectionModal', () => {
     const mockCollections: Collection[] = [
         { id: '1', name: 'Collection 1', videos: [], createdAt: new Date().toISOString() },
         { id: '2', name: 'Collection 2', videos: [], createdAt: new Date().toISOString() },
+        { id: '3', name: 'Alpha Collection', videos: [], createdAt: new Date().toISOString() },
     ];
 
     const defaultProps = {
         open: true,
         onClose: vi.fn(),
         collections: mockCollections,
-        onAddToCollection: vi.fn(),
-        onCreateCollection: vi.fn(),
+        onAddToCollection: vi.fn().mockResolvedValue(undefined),
+        onCreateCollection: vi.fn().mockResolvedValue(undefined),
         videoCollections: [],
     };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
 
     it('should render when open', () => {
         render(<CollectionModal {...defaultProps} />);
         expect(screen.getByText('addToCollection')).toBeInTheDocument();
     });
 
-    it('should render existing collections dropdown', async () => {
-        const user = userEvent.setup();
+    it('should render a single combobox input instead of two separate inputs', () => {
         render(<CollectionModal {...defaultProps} />);
-
-        // Check if "Add to existing collection" section is present
-        expect(screen.getByText('addToExistingCollection')).toBeInTheDocument();
-
-        // Open select
-        const select = screen.getByRole('combobox');
-        await user.click(select);
-
-        // Check options
-        expect(screen.getByText('Collection 1')).toBeInTheDocument();
-        expect(screen.getByText('Collection 2')).toBeInTheDocument();
+        expect(screen.getAllByRole('combobox')).toHaveLength(1);
+        expect(screen.queryByText('addToExistingCollection')).not.toBeInTheDocument();
+        expect(screen.queryByText('createNewCollection')).not.toBeInTheDocument();
     });
 
-    it('should call onAddToCollection when add button is clicked', async () => {
+    it('should show the full alphabetical list when the input is empty', async () => {
         const user = userEvent.setup();
         render(<CollectionModal {...defaultProps} />);
 
-        // Select collection 1
+        await user.click(screen.getByRole('combobox'));
+
+        const options = screen.getAllByRole('option');
+        expect(options.map((o) => o.textContent)).toEqual([
+            'Alpha Collection',
+            'Collection 1',
+            'Collection 2',
+        ]);
+    });
+
+    it('should filter collections case-insensitively as the user types', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
+        const combobox = screen.getByRole('combobox');
+        await user.click(combobox);
+        await user.type(combobox, 'collection 1');
+
+        const options = screen.getAllByRole('option');
+        expect(options).toHaveLength(1);
+        expect(options[0]).toHaveTextContent('Collection 1');
+    });
+
+    it('should call onAddToCollection when an existing collection is selected and Add is clicked', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
         await user.click(screen.getByRole('combobox'));
         await user.click(screen.getByText('Collection 1'));
-
-        // Click Add
         await user.click(screen.getByRole('button', { name: 'add' }));
 
         expect(defaultProps.onAddToCollection).toHaveBeenCalledWith('1');
         expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
-    it('should call onCreateCollection when create button is clicked', async () => {
+    it('should show no create entry and enable Add for an exact case-insensitive match', async () => {
         const user = userEvent.setup();
         render(<CollectionModal {...defaultProps} />);
 
-        // Type new name
-        const input = screen.getByLabelText('collectionName');
-        await user.type(input, 'New Collection');
+        const combobox = screen.getByRole('combobox');
+        await user.type(combobox, 'collection 1');
+        await user.click(combobox);
 
-        // Click Create
+        expect(screen.queryByText(/createNewCollectionLabel/)).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'add' })).toBeEnabled();
+    });
+
+    it('should call onCreateCollection when a new name is typed and Create is clicked', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
+        const combobox = screen.getByRole('combobox');
+        await user.type(combobox, 'New Collection');
         await user.click(screen.getByRole('button', { name: 'create' }));
 
         expect(defaultProps.onCreateCollection).toHaveBeenCalledWith('New Collection');
         expect(defaultProps.onClose).toHaveBeenCalled();
     });
 
+    it('should submit the edited text instead of a stale selected collection', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
+        const combobox = screen.getByRole('combobox');
+        await user.click(combobox);
+        await user.click(screen.getByText('Collection 1'));
+        await user.clear(combobox);
+        await user.type(combobox, 'Fresh Collection');
+        await user.click(screen.getByRole('button', { name: 'create' }));
+
+        expect(defaultProps.onCreateCollection).toHaveBeenCalledWith('Fresh Collection');
+        expect(defaultProps.onAddToCollection).not.toHaveBeenCalled();
+    });
+
+    it('should show a create entry at the top for non-matching input', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
+        const combobox = screen.getByRole('combobox');
+        await user.type(combobox, 'Brand New');
+        await user.click(combobox);
+
+        const options = screen.getAllByRole('option');
+        expect(options[0]).toHaveTextContent('createNewCollectionLabel');
+    });
+
     it('should show info alert if video is already in a collection', () => {
         const props = {
             ...defaultProps,
-            videoCollections: [mockCollections[0]], // Video is in Collection 1
-            onRemoveFromCollection: vi.fn(),
+            videoCollections: [mockCollections[0]],
+            onRemoveFromCollection: vi.fn().mockResolvedValue(undefined),
         };
         render(<CollectionModal {...props} />);
 
@@ -92,7 +158,7 @@ describe('CollectionModal', () => {
         const props = {
             ...defaultProps,
             videoCollections: [mockCollections[0]],
-            onRemoveFromCollection: vi.fn(),
+            onRemoveFromCollection: vi.fn().mockResolvedValue(undefined),
         };
         const user = userEvent.setup();
         render(<CollectionModal {...props} />);
@@ -103,17 +169,68 @@ describe('CollectionModal', () => {
         expect(props.onClose).toHaveBeenCalled();
     });
 
-    it('should disable every collection the video already belongs to', async () => {
+    it('should disable collections the video already belongs to', async () => {
         const user = userEvent.setup();
-        render(<CollectionModal
-            {...defaultProps}
-            videoCollections={[mockCollections[0], mockCollections[1]]}
-        />);
+        render(
+            <CollectionModal
+                {...defaultProps}
+                videoCollections={[mockCollections[0], mockCollections[1]]}
+            />
+        );
 
         await user.click(screen.getByRole('combobox'));
 
         const options = screen.getAllByRole('option');
-        expect(options[0]).toHaveAttribute('aria-disabled', 'true');
-        expect(options[1]).toHaveAttribute('aria-disabled', 'true');
+        const collection1Option = options.find((o) => o.textContent?.includes('Collection 1'));
+        const collection2Option = options.find((o) => o.textContent?.includes('Collection 2'));
+
+        expect(collection1Option).toHaveAttribute('aria-disabled', 'true');
+        expect(collection2Option).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should keep the modal open when onAddToCollection rejects', async () => {
+        const onAddToCollection = vi.fn().mockRejectedValue(new Error('fail'));
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <CollectionModal
+                {...defaultProps}
+                onAddToCollection={onAddToCollection}
+                onClose={onClose}
+            />
+        );
+
+        await user.click(screen.getByRole('combobox'));
+        await user.click(screen.getByText('Collection 1'));
+        await user.click(screen.getByRole('button', { name: 'add' }));
+
+        await waitFor(() => {
+            expect(onAddToCollection).toHaveBeenCalled();
+        });
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('should keep the modal open when onCreateCollection rejects', async () => {
+        const onCreateCollection = vi.fn().mockRejectedValue(new Error('fail'));
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+
+        render(
+            <CollectionModal
+                {...defaultProps}
+                onCreateCollection={onCreateCollection}
+                onClose={onClose}
+            />
+        );
+
+        const combobox = screen.getByRole('combobox');
+        await user.type(combobox, 'New Collection');
+        await user.click(screen.getByRole('button', { name: 'create' }));
+
+        await waitFor(() => {
+            expect(onCreateCollection).toHaveBeenCalled();
+        });
+        expect(onClose).not.toHaveBeenCalled();
     });
 });

--- a/frontend/src/components/__tests__/CollectionModal.test.tsx
+++ b/frontend/src/components/__tests__/CollectionModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Collection } from '../../types';
@@ -87,6 +87,24 @@ describe('CollectionModal', () => {
         await user.click(screen.getByRole('button', { name: 'add' }));
 
         expect(defaultProps.onAddToCollection).toHaveBeenCalledWith('1');
+        expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+
+    it('should add highlighted existing collection when Enter is pressed in the open listbox', async () => {
+        const user = userEvent.setup();
+        render(<CollectionModal {...defaultProps} />);
+
+        const combobox = screen.getByRole('combobox');
+        await user.click(combobox);
+        await user.type(combobox, 'collection 2');
+        expect(screen.getAllByRole('option')).toHaveLength(1);
+        expect(combobox).toHaveAttribute('aria-expanded', 'true');
+        fireEvent.keyDown(combobox, { key: 'Enter', code: 'Enter' });
+
+        await waitFor(() => {
+            expect(defaultProps.onAddToCollection).toHaveBeenCalledWith('2');
+        });
+        expect(defaultProps.onCreateCollection).not.toHaveBeenCalled();
         expect(defaultProps.onClose).toHaveBeenCalled();
     });
 

--- a/frontend/src/contexts/CollectionContext.tsx
+++ b/frontend/src/contexts/CollectionContext.tsx
@@ -10,8 +10,10 @@ import { useSnackbar } from './SnackbarContext';
 interface CollectionContextType {
     collections: Collection[];
     fetchCollections: () => Promise<void>;
-    createCollection: (name: string, videoId: string) => Promise<Collection | null>;
-    addToCollection: (collectionId: string, videoId: string) => Promise<Collection | null>;
+    /** Rejects on failure; callers that need retry/open-modal behavior must handle errors. */
+    createCollection: (name: string, videoId: string) => Promise<Collection>;
+    /** Rejects on failure; callers that need retry/open-modal behavior must handle errors. */
+    addToCollection: (collectionId: string, videoId: string) => Promise<Collection>;
     removeFromCollection: (collectionId: string, videoId: string) => Promise<boolean>;
     deleteCollection: (collectionId: string, deleteVideos?: boolean) => Promise<{ success: boolean; error?: string }>;
     updateCollection: (id: string, name: string) => Promise<{ success: boolean; error?: string }>;
@@ -86,12 +88,8 @@ export const CollectionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     });
 
     const createCollection = useCallback(async (name: string, videoId: string) => {
-        try {
-            const response = await createCollectionMutation.mutateAsync({ name, videoId });
-            return response.data as Collection;
-        } catch {
-            return null;
-        }
+        const response = await createCollectionMutation.mutateAsync({ name, videoId });
+        return response.data as Collection;
     }, [createCollectionMutation]);
 
     const addToCollectionMutation = useMutation({
@@ -116,11 +114,8 @@ export const CollectionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     });
 
     const addToCollection = useCallback(async (collectionId: string, videoId: string) => {
-        try {
-            return await addToCollectionMutation.mutateAsync({ collectionId, videoId });
-        } catch {
-            return null;
-        }
+        const response = await addToCollectionMutation.mutateAsync({ collectionId, videoId });
+        return response as Collection;
     }, [addToCollectionMutation]);
 
     const removeFromCollection = useCallback(async (collectionId: string, videoId: string) => {

--- a/frontend/src/hooks/__tests__/useVideoCollections.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoCollections.test.ts
@@ -109,9 +109,8 @@ describe('useVideoCollections', () => {
         expect(mockCreateCollection).not.toHaveBeenCalled();
     });
 
-    it('should log create collection errors', async () => {
+    it('should propagate create collection errors', async () => {
         const createError = new Error('create failed');
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         mockCreateCollection.mockRejectedValueOnce(createError);
         const { result } = renderHook(() => useVideoCollections({ videoId: 'v1' }));
 
@@ -119,12 +118,11 @@ describe('useVideoCollections', () => {
             result.current.handleAddToCollection();
         });
 
-        await act(async () => {
-            await result.current.handleCreateCollection('New List');
-        });
-
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Error creating collection:', createError);
-        consoleErrorSpy.mockRestore();
+        await expect(
+            act(async () => {
+                await result.current.handleCreateCollection('New List');
+            })
+        ).rejects.toThrow('create failed');
     });
 
     it('should add the active video to an existing collection', async () => {
@@ -151,9 +149,8 @@ describe('useVideoCollections', () => {
         expect(mockAddToCollection).not.toHaveBeenCalled();
     });
 
-    it('should log add to existing collection errors', async () => {
+    it('should propagate add to existing collection errors', async () => {
         const addError = new Error('add failed');
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         mockAddToCollection.mockRejectedValueOnce(addError);
         const { result } = renderHook(() => useVideoCollections({ videoId: 'v1' }));
 
@@ -161,12 +158,11 @@ describe('useVideoCollections', () => {
             result.current.handleAddToCollection();
         });
 
-        await act(async () => {
-            await result.current.handleAddToExistingCollection('c1');
-        });
-
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Error adding to collection:', addError);
-        consoleErrorSpy.mockRestore();
+        await expect(
+            act(async () => {
+                await result.current.handleAddToExistingCollection('c1');
+            })
+        ).rejects.toThrow('add failed');
     });
 
     it('should remove from collection', async () => {
@@ -193,9 +189,8 @@ describe('useVideoCollections', () => {
         expect(mockRemoveFromCollection).not.toHaveBeenCalled();
     });
 
-    it('should log remove from collection errors', async () => {
+    it('should propagate remove from collection errors', async () => {
         const removeError = new Error('remove failed');
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
         mockRemoveFromCollection.mockRejectedValueOnce(removeError);
         const { result } = renderHook(() => useVideoCollections({ videoId: 'v1' }));
 
@@ -203,11 +198,10 @@ describe('useVideoCollections', () => {
             result.current.handleAddToCollection();
         });
 
-        await act(async () => {
-            await result.current.handleRemoveFromCollection('c1');
-        });
-
-        expect(consoleErrorSpy).toHaveBeenCalledWith('Error removing from collection:', removeError);
-        consoleErrorSpy.mockRestore();
+        await expect(
+            act(async () => {
+                await result.current.handleRemoveFromCollection('c1');
+            })
+        ).rejects.toThrow('remove failed');
     });
 });

--- a/frontend/src/hooks/useVideoCollections.ts
+++ b/frontend/src/hooks/useVideoCollections.ts
@@ -55,30 +55,17 @@ export function useVideoCollections({ videoId }: UseVideoCollectionsProps) {
 
     const handleCreateCollection = async (name: string) => {
         if (!activeCollectionVideoId) return;
-        try {
-            await createCollection(name, activeCollectionVideoId);
-        } catch (error) {
-            console.error('Error creating collection:', error);
-        }
+        await createCollection(name, activeCollectionVideoId);
     };
 
     const handleAddToExistingCollection = async (collectionId: string) => {
         if (!activeCollectionVideoId) return;
-        try {
-            await addToCollection(collectionId, activeCollectionVideoId);
-        } catch (error) {
-            console.error('Error adding to collection:', error);
-        }
+        await addToCollection(collectionId, activeCollectionVideoId);
     };
 
     const handleRemoveFromCollection = async (collectionId: string) => {
         if (!activeCollectionVideoId) return;
-
-        try {
-            await removeFromCollection(collectionId, activeCollectionVideoId);
-        } catch (error) {
-            console.error('Error removing from collection:', error);
-        }
+        await removeFromCollection(collectionId, activeCollectionVideoId);
     };
 
     return {

--- a/frontend/src/pages/authorVideos/useAuthorVideoActions.ts
+++ b/frontend/src/pages/authorVideos/useAuthorVideoActions.ts
@@ -21,8 +21,8 @@ interface UseAuthorVideoActionsParams {
     collections: Collection[];
     deleteVideo: (id: string, options?: { showSnackbar?: boolean }) => Promise<{ success: boolean; error?: string }>;
     updateVideo: (id: string, updates: Partial<Video>) => Promise<{ success: boolean; error?: string }>;
-    createCollection: (name: string, videoId: string) => Promise<Collection | null>;
-    addToCollection: (collectionId: string, videoId: string) => Promise<Collection | null>;
+    createCollection: (name: string, videoId: string) => Promise<Collection>;
+    addToCollection: (collectionId: string, videoId: string) => Promise<Collection>;
     showSnackbar: ShowSnackbarFn;
     t: TranslateFn;
     navigateHome: () => void;

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -620,6 +620,8 @@ Total keys: 1046
 | `add` |
 | `createNewCollection` |
 | `collectionName` |
+| `selectOrCreateCollection` |
+| `createNewCollectionLabel` |
 | `create` |
 | `removeFromCollection` |
 | `confirmRemoveFromCollection` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -642,6 +642,8 @@ export const ar = {
   add: "إضافة",
   createNewCollection: "إنشاء مجموعة جديدة:",
   collectionName: "اسم المجموعة",
+  selectOrCreateCollection: "اختر مجموعة أو أنشئ واحدة",
+  createNewCollectionLabel: 'إنشاء "{name}"',
   create: "إنشاء",
   removeFromCollection: "إزالة من المجموعة",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -668,6 +668,8 @@ export const de = {
   add: "Hinzufügen",
   createNewCollection: "Neue Sammlung erstellen:",
   collectionName: "Sammlungsname",
+  selectOrCreateCollection: "Sammlung auswählen oder erstellen",
+  createNewCollectionLabel: '„{name}" erstellen',
   create: "Erstellen",
   removeFromCollection: "Aus Sammlung Entfernen",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -661,6 +661,8 @@ export const en = {
   add: "Add",
   createNewCollection: "Create new collection:",
   collectionName: "Collection name",
+  selectOrCreateCollection: "Select or create a collection",
+  createNewCollectionLabel: 'Create "{name}"',
   create: "Create",
   removeFromCollection: "Remove from Collection",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -664,6 +664,8 @@ export const es = {
   add: "Agregar",
   createNewCollection: "Crear nueva colección:",
   collectionName: "Nombre de la colección",
+  selectOrCreateCollection: "Seleccionar o crear una colección",
+  createNewCollectionLabel: 'Crear "{name}"',
   create: "Crear",
   removeFromCollection: "Eliminar de la Colección",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -663,6 +663,8 @@ export const fr = {
   add: "Ajouter",
   createNewCollection: "Créer une nouvelle collection :",
   collectionName: "Nom de la collection",
+  selectOrCreateCollection: "Sélectionner ou créer une collection",
+  createNewCollectionLabel: 'Créer « {name} »',
   create: "Créer",
   removeFromCollection: "Retirer de la collection",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -658,6 +658,8 @@ export const ja = {
   add: "追加",
   createNewCollection: "新しいコレクションを作成:",
   collectionName: "コレクション名",
+  selectOrCreateCollection: "コレクションを選択または作成",
+  createNewCollectionLabel: "「{name}」を作成",
   create: "作成",
   removeFromCollection: "コレクションから削除",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -650,6 +650,8 @@ export const ko = {
   add: "추가",
   createNewCollection: "새 컬렉션 만들기:",
   collectionName: "컬렉션 이름",
+  selectOrCreateCollection: "컬렉션 선택 또는 만들기",
+  createNewCollectionLabel: '"{name}" 만들기',
   create: "만들기",
   removeFromCollection: "컬렉션에서 제거",
   confirmRemoveFromCollection: "이 동영상을 컬렉션에서 제거하시겠습니까?",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -660,6 +660,8 @@ export const pt = {
   add: "Adicionar",
   createNewCollection: "Criar nova coleção:",
   collectionName: "Nome da coleção",
+  selectOrCreateCollection: "Selecionar ou criar uma coleção",
+  createNewCollectionLabel: 'Criar "{name}"',
   create: "Criar",
   removeFromCollection: "Remover da Coleção",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -655,6 +655,8 @@ export const ru = {
   add: "Добавить",
   createNewCollection: "Создать новую коллекцию:",
   collectionName: "Название коллекции",
+  selectOrCreateCollection: "Выберите или создайте коллекцию",
+  createNewCollectionLabel: 'Создать «{name}»',
   create: "Создать",
   removeFromCollection: "Удалить из коллекции",
   confirmRemoveFromCollection:

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -636,6 +636,8 @@ export const zh = {
   add: "添加",
   createNewCollection: "创建新合集：",
   collectionName: "合集名称",
+  selectOrCreateCollection: "选择或创建合集",
+  createNewCollectionLabel: '创建"{name}"',
   create: "创建",
   removeFromCollection: "从合集中移除",
   confirmRemoveFromCollection: "确定要从合集中移除此视频吗？",


### PR DESCRIPTION
## Summary

- Replace the separate add/create collection controls with a unified autocomplete/free-text input.
- Keep the new throwing collection API contract explicit and update related tests/types.
- Prevent browser autofill from covering the collection autocomplete by using search-style, non-semantic native input attributes.

## Why

The previous collection modal split add/create flows and hid mutation failures in some layers. The unified input makes selection and creation a single flow while keeping retry behavior in the modal. Browser contact autofill also overlapped the collection suggestions, so the input now avoids name/contact autofill heuristics.

## Validation

- `npm run typecheck:frontend`
- `npm run lint:frontend`
- `npm run test -- CollectionModal useVideoCollections CollectionContext`
- `npm run test:frontend`
- `git diff --check`