### PR TITLE
Polish collection cards and mobile navigation

### DIFF
--- a/frontend/src/components/CollectionCard.tsx
+++ b/frontend/src/components/CollectionCard.tsx
@@ -1,4 +1,4 @@
-import { Folder } from '@mui/icons-material';
+import { Folder, Star } from '@mui/icons-material';
 import {
     Box,
     Card,
@@ -7,12 +7,13 @@ import {
     CardMedia,
     Chip,
     Typography,
+    useMediaQuery,
     useTheme
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { overlay } from '../theme/colors';
-import { useLanguage } from '../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
+import { useFavoriteCollections } from '../hooks/useFavoriteCollections';
 import { Collection, Video } from '../types';
 import { getBackendUrl } from '../utils/apiUrl';
 import { formatDisplayDate } from '../utils/formatUtils';
@@ -25,9 +26,11 @@ interface CollectionCardProps {
 }
 
 const CollectionCard: React.FC<CollectionCardProps> = ({ collection, videos }) => {
-    const { t } = useLanguage();
     const navigate = useNavigate();
     const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const { isFavorite } = useFavoriteCollections();
+    const favorited = isFavorite(collection.id);
 
     // Get the first 4 videos in the collection
     const collectionVideos = collection.videos
@@ -41,20 +44,46 @@ const CollectionCard: React.FC<CollectionCardProps> = ({ collection, videos }) =
 
     return (
         <Card
+            elevation={0}
             sx={{
                 height: '100%',
                 display: 'flex',
                 flexDirection: 'column',
                 position: 'relative',
-                transition: 'transform 0.2s, box-shadow 0.2s, background-color 0.3s, color 0.3s',
-                '&:hover': {
-                    transform: 'translateY(-4px)',
-                    boxShadow: theme.shadows[8],
-                }
+                bgcolor: 'transparent',
+                backgroundImage: 'none',
+                boxShadow: 'none',
+                borderRadius: 2,
+                overflow: 'visible',
+                border: 'none',
+                transition: 'background-color 0.15s ease, color 0.3s, border-color 0.3s',
+                ...(!isMobile && {
+                    '&:hover': {
+                        bgcolor: 'action.hover',
+                        boxShadow: 'none'
+                    }
+                })
             }}
         >
-            <CardActionArea onClick={handleClick} sx={{ flexGrow: 1, display: 'flex', flexDirection: 'column', alignItems: 'stretch' }}>
-                <Box sx={{ position: 'relative', paddingTop: '56.25%' /* 16:9 aspect ratio */, bgcolor: 'action.hover' }}>
+            <CardActionArea
+                onClick={handleClick}
+                sx={{
+                    flexGrow: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    borderRadius: 2,
+                    color: 'inherit',
+                    '& .MuiCardActionArea-focusHighlight': {
+                        bgcolor: 'transparent'
+                    },
+                    '&.Mui-focusVisible': {
+                        outline: `2px solid ${theme.palette.primary.main}`,
+                        outlineOffset: 2
+                    }
+                }}
+            >
+                <Box sx={{ position: 'relative', paddingTop: '56.25%' /* 16:9 aspect ratio */, bgcolor: 'action.hover', borderRadius: isMobile ? 0 : 2, overflow: 'hidden' }}>
                     {/* 2x2 Grid for Thumbnails */}
                     <Box
                         sx={{
@@ -85,11 +114,48 @@ const CollectionCard: React.FC<CollectionCardProps> = ({ collection, videos }) =
                         size="small"
                         sx={{ position: 'absolute', bottom: 8, right: 8 }}
                     />
+
+                    {favorited && (
+                        <Box
+                            component="span"
+                            aria-label="favorited"
+                            sx={{
+                                position: 'absolute',
+                                top: 8,
+                                right: 8,
+                                width: 28,
+                                height: 28,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                bgcolor: overlay.black60,
+                                color: 'warning.main',
+                                borderRadius: '50%',
+                                zIndex: 3,
+                                pointerEvents: 'none'
+                            }}
+                        >
+                            <Star sx={{ fontSize: 18 }} />
+                        </Box>
+                    )}
                 </Box>
 
-                <CardContent sx={{ flexGrow: 1, p: 2 }}>
-                    <Typography gutterBottom variant="subtitle1" component="div" sx={{ fontWeight: 600, lineHeight: 1.2, mb: 1 }}>
-                        {collection.name} {t('collection')}
+                <CardContent sx={{ flexGrow: 1, px: 1, py: isMobile ? 1.5 : 1, display: 'flex', flexDirection: 'column' }}>
+                    <Typography
+                        gutterBottom
+                        variant="subtitle1"
+                        component="div"
+                        sx={{
+                            fontWeight: 600,
+                            lineHeight: 1.2,
+                            mb: 1,
+                            display: '-webkit-box',
+                            WebkitLineClamp: 2,
+                            WebkitBoxOrient: 'vertical',
+                            overflow: 'hidden'
+                        }}
+                    >
+                        {collection.name}
                     </Typography>
 
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 'auto' }}>

--- a/frontend/src/components/Header/HeaderContainer.tsx
+++ b/frontend/src/components/Header/HeaderContainer.tsx
@@ -216,6 +216,22 @@ const HeaderContainer: React.FC<HeaderProps> = ({
                 </AppBar>
             </ClickAwayListener>
 
+            {isMobile && (
+                <Box
+                    onClick={handleCloseMobileMenu}
+                    aria-hidden
+                    sx={{
+                        position: 'fixed',
+                        inset: 0,
+                        bgcolor: alpha(theme.palette.common.black, 0.4),
+                        zIndex: (muiTheme) => muiTheme.zIndex.appBar - 1,
+                        opacity: mobileMenuOpen ? 1 : 0,
+                        pointerEvents: mobileMenuOpen ? 'auto' : 'none',
+                        transition: 'opacity 0.3s ease-in-out',
+                    }}
+                />
+            )}
+
             <Box
                 sx={{
                     height: spacerHeight,

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -1,10 +1,11 @@
-import { Group, Logout, Settings, VideoLibrary } from '@mui/icons-material';
+import { Logout, Settings, VideoLibrary } from '@mui/icons-material';
 import { Box, Button, Collapse, Divider, Stack } from '@mui/material';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useSettings } from '../../hooks/useSettings';
-import { Collection } from '../../types';
+import { Collection, Video } from '../../types';
+import AuthorsList from '../AuthorsList';
 import Collections from '../Collections';
 import TagsList from '../TagsList';
 import SearchInput from './SearchInput';
@@ -26,7 +27,7 @@ interface MobileMenuProps {
     availableTags?: string[];
     selectedTags?: string[];
     onTagToggle?: (tag: string) => void;
-    videos?: Array<{ tags?: string[] }>;
+    videos?: Video[];
     /** Home only: cap tags and link to /tags. Author/collection keep full local lists. */
     linkToAllTags?: boolean;
 }
@@ -132,16 +133,10 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
                             onItemClick={onClose}
                         />
                         <Box sx={{ mt: 2 }}>
-                            <Button
-                                component={Link}
-                                to="/authors"
-                                variant="outlined"
-                                fullWidth
-                                onClick={onClose}
-                                startIcon={<Group />}
-                            >
-                                {t('authors')}
-                            </Button>
+                            <AuthorsList
+                                videos={videos ?? []}
+                                onItemClick={onClose}
+                            />
                         </Box>
                         {showTags && (
                             <Box sx={{ mt: 2 }}>

--- a/frontend/src/components/Header/__tests__/MobileMenu.test.tsx
+++ b/frontend/src/components/Header/__tests__/MobileMenu.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router-dom';
 import type { ComponentProps, FormEvent } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Video } from '../../../types';
 import MobileMenu from '../MobileMenu';
 
 const mockNavigate = vi.fn();
@@ -56,6 +58,27 @@ vi.mock('../SearchInput', () => ({
 }));
 
 describe('MobileMenu', () => {
+    const theme = createTheme();
+    const videos: Video[] = [
+        {
+            id: 'video-1',
+            title: 'Alpha video',
+            author: 'Alpha Author',
+            date: '2024-01-01',
+            source: 'youtube',
+            sourceUrl: 'https://example.com/alpha',
+            addedAt: '2024-01-01',
+        },
+        {
+            id: 'video-2',
+            title: 'Beta video',
+            author: 'Beta Author',
+            date: '2024-01-02',
+            source: 'youtube',
+            sourceUrl: 'https://example.com/beta',
+            addedAt: '2024-01-02',
+        },
+    ];
     const baseProps: ComponentProps<typeof MobileMenu> = {
         open: true,
         videoUrl: '',
@@ -71,12 +94,15 @@ describe('MobileMenu', () => {
         availableTags: [],
         selectedTags: [],
         onTagToggle: vi.fn(),
+        videos,
     };
 
     const renderMenu = (props: Partial<typeof baseProps> = {}) =>
         render(
             <MemoryRouter>
-                <MobileMenu {...baseProps} {...props} />
+                <ThemeProvider theme={theme}>
+                    <MobileMenu {...baseProps} {...props} />
+                </ThemeProvider>
             </MemoryRouter>
         );
 
@@ -98,14 +124,15 @@ describe('MobileMenu', () => {
 
         expect(screen.getByRole('link', { name: 'manageVideos' })).toBeInTheDocument();
         expect(screen.getByRole('link', { name: 'settings' })).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: 'authors' })).toHaveAttribute('href', '/authors');
+        expect(screen.getByRole('link', { name: 'all' })).toHaveAttribute('href', '/authors');
+        expect(screen.getByRole('link', { name: /Alpha Author/ })).toHaveAttribute('href', '/author/Alpha%20Author');
         expect(screen.queryByRole('button', { name: 'logout' })).not.toBeInTheDocument();
         expect(screen.queryByText('tags-item')).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByRole('link', { name: 'manageVideos' }));
         fireEvent.click(screen.getByRole('link', { name: 'settings' }));
         fireEvent.click(screen.getByText('collections-item'));
-        fireEvent.click(screen.getByRole('link', { name: 'authors' }));
+        fireEvent.click(screen.getByRole('link', { name: 'all' }));
         expect(onClose).toHaveBeenCalledTimes(4);
 
         fireEvent.click(screen.getByText('search-submit'));
@@ -124,14 +151,14 @@ describe('MobileMenu', () => {
         });
 
         const collectionsItem = screen.getByText('collections-item');
-        const authorsLink = screen.getByRole('link', { name: 'authors' });
+        const authorsHeading = screen.getByText('authors');
         const tagsItem = screen.getByText('tags-item');
 
         expect(
-            collectionsItem.compareDocumentPosition(authorsLink) & Node.DOCUMENT_POSITION_FOLLOWING
+            collectionsItem.compareDocumentPosition(authorsHeading) & Node.DOCUMENT_POSITION_FOLLOWING
         ).toBeTruthy();
         expect(
-            authorsLink.compareDocumentPosition(tagsItem) & Node.DOCUMENT_POSITION_FOLLOWING
+            authorsHeading.compareDocumentPosition(tagsItem) & Node.DOCUMENT_POSITION_FOLLOWING
         ).toBeTruthy();
 
         fireEvent.click(tagsItem);

--- a/frontend/src/components/ManagePage/CollectionsTable.tsx
+++ b/frontend/src/components/ManagePage/CollectionsTable.tsx
@@ -4,6 +4,7 @@ import {
     Alert,
     Box,
     IconButton,
+    Link,
     Pagination,
     Paper,
     Table,
@@ -19,6 +20,7 @@ import {
     useMediaQuery
 } from '@mui/material';
 import React, { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useSnackbar } from '../../contexts/SnackbarContext';
@@ -243,7 +245,19 @@ const CollectionsTable: React.FC<CollectionsTableProps> = ({
                                                         <Edit fontSize="small" />
                                                     </IconButton>
                                                 )}
-                                                {collection.name}
+                                                <Link
+                                                    component={RouterLink}
+                                                    to={`/collection/${collection.id}`}
+                                                    onClick={(e) => e.stopPropagation()}
+                                                    sx={{
+                                                        color: 'inherit',
+                                                        textDecoration: 'none',
+                                                        cursor: 'pointer',
+                                                        '&:hover': { textDecoration: 'underline' }
+                                                    }}
+                                                >
+                                                    {collection.name}
+                                                </Link>
                                             </Box>
                                         )}
                                     </TableCell>

--- a/frontend/src/components/ManagePage/__tests__/CollectionsTable.test.tsx
+++ b/frontend/src/components/ManagePage/__tests__/CollectionsTable.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { Collection } from '../../../types';
 import CollectionsTable from '../CollectionsTable'; // Import from local directory
@@ -38,19 +39,26 @@ describe('CollectionsTable', () => {
         onSort: vi.fn(),
     };
 
+    const renderTable = (props: Partial<typeof defaultProps> = {}) =>
+        render(
+            <MemoryRouter>
+                <CollectionsTable {...defaultProps} {...props} />
+            </MemoryRouter>
+        );
+
     it('should render table with collections', () => {
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
         expect(screen.getByText('Collection 1')).toBeInTheDocument();
         expect(screen.getByText('10 MB')).toBeInTheDocument();
     });
 
     it('should render empty state if no collections', () => {
-        render(<CollectionsTable {...defaultProps} totalCollectionsCount={0} displayedCollections={[]} />);
+        renderTable({ totalCollectionsCount: 0, displayedCollections: [] });
         expect(screen.getByText('noCollections')).toBeInTheDocument();
     });
 
     it('should call onDelete when delete button is clicked', () => {
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
         // Use getAllByRole to find icon buttons, then filter or use label if available
         // The delete button has tooltip title 'deleteCollection' which becomes aria-label or accessible name
         fireEvent.click(screen.getByLabelText('deleteCollection'));
@@ -60,20 +68,20 @@ describe('CollectionsTable', () => {
 
     it('should not show actions column in visitor mode', () => {
         mockUseAuth.mockReturnValue({ userRole: 'visitor' });
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
         expect(screen.queryByText('actions')).not.toBeInTheDocument();
         // Reset mock
         mockUseAuth.mockReturnValue({ userRole: 'admin' });
     });
 
     it('should render pagination if totalPages > 1', () => {
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
         expect(screen.getByRole('navigation')).toBeInTheDocument();
     });
 
     // Edit tests
     it('should show input field when edit button is clicked', () => {
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
 
         const editButton = screen.getByLabelText('edit collection');
         fireEvent.click(editButton);
@@ -83,7 +91,7 @@ describe('CollectionsTable', () => {
     });
 
     it('should call onUpdate when save is clicked', async () => {
-        render(<CollectionsTable {...defaultProps} />);
+        renderTable();
 
         const editButton = screen.getByLabelText('edit collection');
         fireEvent.click(editButton);
@@ -95,5 +103,11 @@ describe('CollectionsTable', () => {
         fireEvent.click(saveButton);
 
         expect(defaultProps.onUpdate).toHaveBeenCalledWith('1', 'New Name');
+    });
+
+    it('should link collection name to its collection page', () => {
+        renderTable();
+        const link = screen.getByRole('link', { name: 'Collection 1' });
+        expect(link).toHaveAttribute('href', '/collection/1');
     });
 });

--- a/frontend/src/components/__tests__/CollectionCard.test.tsx
+++ b/frontend/src/components/__tests__/CollectionCard.test.tsx
@@ -27,6 +27,16 @@ vi.mock('../../contexts/LanguageContext', () => ({
     }),
 }));
 
+// Mock useFavoriteCollections — controllable per test via mockIsFavorite
+const mockIsFavorite = vi.fn(() => false);
+vi.mock('../../hooks/useFavoriteCollections', () => ({
+    useFavoriteCollections: () => ({
+        isFavorite: mockIsFavorite,
+        toggle: vi.fn(),
+        isToggling: false,
+    }),
+}));
+
 describe('CollectionCard', () => {
     const mockVideos: Video[] = [
         {
@@ -85,6 +95,7 @@ describe('CollectionCard', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockIsFavorite.mockReturnValue(false);
     });
 
     it('renders collection name and video count', () => {
@@ -186,5 +197,29 @@ describe('CollectionCard', () => {
         fireEvent.error(image);
 
         expect(image).toHaveAttribute('src', THUMBNAIL_PLACEHOLDER_SRC);
+    });
+
+    it('does not show favorite star when collection is not favorited', () => {
+        mockIsFavorite.mockReturnValue(false);
+        const theme = createTheme();
+        render(
+            <ThemeProvider theme={theme}>
+                <CollectionCard collection={mockCollection} videos={mockVideos} />
+            </ThemeProvider>
+        );
+
+        expect(screen.queryByLabelText('favorited')).not.toBeInTheDocument();
+    });
+
+    it('shows favorite star when collection is favorited', () => {
+        mockIsFavorite.mockReturnValue(true);
+        const theme = createTheme();
+        render(
+            <ThemeProvider theme={theme}>
+                <CollectionCard collection={mockCollection} videos={mockVideos} />
+            </ThemeProvider>
+        );
+
+        expect(screen.getByLabelText('favorited')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

- Restyle collection cards to read more like video cards, including hover treatment, tighter title handling, and favorite collection indicators.
- Add mobile header backdrop behavior and replace the mobile authors shortcut with the real authors list.
- Link collection names from the manage table directly to their collection pages.
- Update tests for favorite markers, collection links, and real mobile authors-list integration.

## Validation

- `npm run test -- MobileMenu.test.tsx AuthorsList.test.tsx`
- `npm run typecheck`
- Previously reviewed with full frontend test suite passing: `173 passed`, `1658 tests passed`.