### PR TITLE
Soften frontend color scheme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
     />
-    <meta name="theme-color" content="#ff3e3e" />
+    <meta name="theme-color" content="#0f766e" />
     <title>MyTube - My Videos, My Rules.</title>
   </head>
   <body>

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#0f766e",
+  "background_color": "#f8fafc",
   "display": "standalone"
 }

--- a/frontend/src/pages/AllAuthorsPage.tsx
+++ b/frontend/src/pages/AllAuthorsPage.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useVideo } from '../contexts/VideoContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
-import { brand } from '../theme/colors';
+import { brand, modeColors } from '../theme/colors';
 import { Video } from '../types';
 
 interface AuthorSummary {
@@ -43,7 +43,7 @@ const AuthorCard: React.FC<{ summary: AuthorSummary; videosLabel: string }> = ({
                         mx: 'auto',
                         borderRadius: '50%',
                         p: '3px',
-                        background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                        background: (theme) => `linear-gradient(135deg, ${brand.primaryDark}, ${modeColors(theme.palette.mode).secondary})`,
                         transition: 'transform 0.2s ease',
                     }}
                 >

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -3,7 +3,7 @@ import { Avatar, Box, Card, CardActionArea, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
-import { brand } from '../../theme/colors';
+import { brand, modeColors } from '../../theme/colors';
 import type { FavoriteAuthorItem } from '../../types';
 import FavoriteToggle from '../../components/FavoriteToggle';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
@@ -62,7 +62,7 @@ const FavoriteAuthorCard: React.FC<{
                         p: '3px',
                         background: isUnavailable
                             ? 'transparent'
-                            : `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                            : (theme) => `linear-gradient(135deg, ${brand.primaryDark}, ${modeColors(theme.palette.mode).secondary})`,
                         transition: 'transform 0.2s ease',
                     }}
                 >

--- a/frontend/src/pages/favorite/FavoriteCollectionRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteCollectionRail.tsx
@@ -2,7 +2,7 @@ import { VideoLibrary } from '@mui/icons-material';
 import { Box, Card, CardActionArea, CardMedia, Chip, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
-import { neutral, overlay } from '../../theme/colors';
+import { brand, modeColors, neutral, overlay, type ThemeMode } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
 import FavoriteSectionHeader from './FavoriteSectionHeader';
@@ -15,19 +15,24 @@ interface FavoriteCollectionRailProps {
 }
 
 /** Deterministic branded gradient so cover-less collections still look intentional. */
-const COVER_GRADIENTS = [
-    'linear-gradient(140deg, #00e5ff 0%, #651fff 100%)',
-    'linear-gradient(140deg, #FF7eb3 0%, #651fff 100%)',
-    'linear-gradient(140deg, #00bfff 0%, #00727d 100%)',
-    'linear-gradient(140deg, #f857a6 0%, #ff5858 100%)',
-    'linear-gradient(140deg, #7028e4 0%, #00e5ff 100%)',
-    'linear-gradient(140deg, #f7971e 0%, #ff3e3e 100%)',
-] as const;
+const coverGradientsForMode = (mode: ThemeMode) => {
+    const secondary = modeColors(mode).secondary;
 
-const gradientForName = (name: string): string => {
+    return [
+        `linear-gradient(140deg, ${brand.primaryDark} 0%, ${secondary} 100%)`,
+        `linear-gradient(140deg, ${brand.accentPink} 0%, ${secondary} 100%)`,
+        `linear-gradient(140deg, ${brand.accentBlue} 0%, ${brand.primaryLight} 100%)`,
+        `linear-gradient(140deg, ${brand.primaryLight} 0%, ${brand.accentBlue} 100%)`,
+        `linear-gradient(140deg, ${secondary} 0%, ${brand.primaryDark} 100%)`,
+        `linear-gradient(140deg, ${brand.accentRed} 0%, ${secondary} 100%)`,
+    ] as const;
+};
+
+const gradientForName = (name: string, mode: ThemeMode): string => {
+    const gradients = coverGradientsForMode(mode);
     let hash = 0;
-    for (let i = 0; i < name.length; i += 1) hash = (hash + name.charCodeAt(i)) % COVER_GRADIENTS.length;
-    return COVER_GRADIENTS[hash];
+    for (let i = 0; i < name.length; i += 1) hash = (hash + name.charCodeAt(i)) % gradients.length;
+    return gradients[hash];
 };
 
 const FavoriteCollectionCard: React.FC<{
@@ -67,7 +72,7 @@ const FavoriteCollectionCard: React.FC<{
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
-                                background: gradientForName(favorite.name),
+                                background: (theme) => gradientForName(favorite.name, theme.palette.mode),
                             }}
                         >
                             <VideoLibrary sx={{ fontSize: 72, color: overlay.white32 }} />

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Card, CardMedia, Chip, Typography, useMediaQuery, useTheme
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
-import { brand, neutral, overlay } from '../../theme/colors';
+import { brand, modeColors, neutral, overlay } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
 import { api } from '../../utils/apiClient';
 import { formatDuration, parseDuration } from '../../utils/formatUtils';
@@ -19,6 +19,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
     const { t } = useLanguage();
     const navigate = useNavigate();
     const theme = useTheme();
+    const secondary = modeColors(theme.palette.mode).secondary;
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
     const thumbnail = useFavoriteThumbnail(video);
 
@@ -160,7 +161,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                                 letterSpacing: 0.6,
                                 textTransform: 'uppercase',
                                 color: neutral.white,
-                                background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                                background: `linear-gradient(135deg, ${brand.primaryDark}, ${secondary})`,
                                 '& .MuiChip-icon': { color: neutral.white },
                             }}
                         />
@@ -181,7 +182,7 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                                     sx={{
                                         height: '100%',
                                         width: `${progressRatio * 100}%`,
-                                        background: `linear-gradient(135deg, ${brand.primaryDark}, ${brand.secondary})`,
+                                        background: `linear-gradient(135deg, ${brand.primaryDark}, ${secondary})`,
                                     }}
                                 />
                             </Box>

--- a/frontend/src/pages/favorite/FavoriteSectionHeader.tsx
+++ b/frontend/src/pages/favorite/FavoriteSectionHeader.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, Typography } from '@mui/material';
 import type { ReactNode } from 'react';
-import { brand } from '../../theme/colors';
+import { brand, modeColors } from '../../theme/colors';
 
 interface FavoriteSectionHeaderProps {
     id: string;
@@ -9,8 +9,6 @@ interface FavoriteSectionHeaderProps {
     count?: number;
     icon?: ReactNode;
 }
-
-const accentGradient = `linear-gradient(180deg, ${brand.primaryDark}, ${brand.secondary})`;
 
 /**
  * Shared rail heading: a gradient accent bar, the section title, an optional
@@ -28,7 +26,13 @@ const FavoriteSectionHeader: React.FC<FavoriteSectionHeaderProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25 }}>
             <Box
                 aria-hidden
-                sx={{ width: 4, height: 22, borderRadius: 2, background: accentGradient, flexShrink: 0 }}
+                sx={{
+                    width: 4,
+                    height: 22,
+                    borderRadius: 2,
+                    background: (theme) => `linear-gradient(180deg, ${brand.primaryDark}, ${modeColors(theme.palette.mode).secondary})`,
+                    flexShrink: 0,
+                }}
             />
             {icon}
             <Typography id={id} variant="h6" component="h2" fontWeight={700} sx={{ letterSpacing: 0.2 }}>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,6 +1,5 @@
 import { createTheme } from "@mui/material/styles";
 import {
-  brand,
   modeColors,
   shadow,
   type ThemeMode,
@@ -16,7 +15,7 @@ const getTheme = (mode: ThemeMode) => {
         main: colors.primary,
       },
       secondary: {
-        main: brand.secondary,
+        main: colors.secondary,
       },
       background: {
         default: colors.backgroundDefault,

--- a/frontend/src/theme/colors.ts
+++ b/frontend/src/theme/colors.ts
@@ -7,13 +7,14 @@ export type ThemeMode = "light" | "dark";
 
 /** Core brand palette (also used in logo.svg / favicon.svg gradients). */
 export const brand = {
-  primaryDark: "#00e5ff",
-  primaryLight: "#00727d",
-  secondary: "#651fff",
-  accentPink: "#FF7eb3",
-  accentBlue: "#00bfff",
-  accentRed: "#ff3333",
-  metaTheme: "#ff3e3e",
+  primaryDark: "#2dd4bf",
+  primaryLight: "#0f766e",
+  secondary: "#7c3aed",
+  secondaryLight: "#8b5cf6",
+  accentPink: "#a855f7",
+  accentBlue: "#2563eb",
+  accentRed: "#dc2626",
+  metaTheme: "#0f766e",
 } as const;
 
 /** Neutral grayscale ramp. */
@@ -45,7 +46,7 @@ export const platform = {
 /** Semantic status colors. */
 export const status = {
   success: "#4caf50",
-  error: "#d32f2f",
+  error: brand.accentRed,
 } as const;
 
 /** Semi-transparent overlays used on thumbnails, video controls, badges, etc. */
@@ -130,6 +131,7 @@ export const scrollbar = {
 /** Mode-aware semantic color resolver for components and MUI theme. */
 export const modeColors = (mode: ThemeMode) => ({
   primary: mode === "dark" ? brand.primaryDark : brand.primaryLight,
+  secondary: mode === "dark" ? brand.secondary : brand.secondaryLight,
   backgroundDefault: mode === "dark" ? neutral.grey950 : neutral.grey200,
   backgroundPaper: mode === "dark" ? neutral.grey800 : neutral.white,
   backgroundElevated: mode === "dark" ? neutral.grey850 : neutral.white,


### PR DESCRIPTION
## Summary

- Replaces the high-saturation cyan/red UI palette with a calmer teal-led color scheme.
- Adds mode-aware secondary purple so light mode uses a softer violet while dark mode keeps stronger contrast.
- Updates favorite page gradient accents, browser theme color, and web manifest colors without changing the logo assets.

## Validation

- `npm run typecheck`
- `npm run build`