### PR TITLE
Fix sidebar scrollbar width shift

### DIFF
--- a/frontend/src/components/AuthorsList.tsx
+++ b/frontend/src/components/AuthorsList.tsx
@@ -16,6 +16,7 @@ import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { Video } from '../types';
+import { authorAvatarFallbackSx } from '../utils/authorAvatarStyles';
 
 interface AuthorsListProps {
     videos: Video[];
@@ -37,22 +38,23 @@ const AuthorListItem: React.FC<AuthorListItemProps> = React.memo(({ author, avat
             component={Link}
             to={`/author/${encodeURIComponent(author)}`}
             onClick={onItemClick}
-            sx={{ pl: 2, borderRadius: 1 }}
+            sx={{ pl: 2, borderRadius: 1, minWidth: 0 }}
         >
             <Avatar
                 src={avatarUrl || undefined}
-                sx={{
+                sx={[authorAvatarFallbackSx, {
                     width: 24,
                     height: 24,
-                    bgcolor: 'primary.main',
                     mr: 1,
+                    flexShrink: 0,
                     fontSize: '0.75rem'
-                }}
+                }]}
             >
                 {author ? author.charAt(0).toUpperCase() : 'A'}
             </Avatar>
             <ListItemText
                 primary={author}
+                sx={{ minWidth: 0 }}
                 primaryTypographyProps={{
                     variant: 'body2',
                     noWrap: true
@@ -131,8 +133,8 @@ const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1 }}>
-                <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 600 }}>
+            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+                <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('authors')}
                 </Typography>
                 <IconButton

--- a/frontend/src/components/Collections.tsx
+++ b/frontend/src/components/Collections.tsx
@@ -78,8 +78,8 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1 }}>
-                <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 600 }}>
+            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+                <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('collections')}
                 </Typography>
                 <IconButton
@@ -106,11 +106,12 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
                             component={Link}
                             to={`/collection/${collection.id}`}
                             onClick={onItemClick}
-                            sx={{ pl: 2, borderRadius: 1 }}
+                            sx={{ pl: 2, borderRadius: 1, minWidth: 0 }}
                         >
-                            <Folder fontSize="small" sx={{ mr: 1, color: 'secondary.main' }} />
+                            <Folder fontSize="small" sx={{ mr: 1, flexShrink: 0, color: 'secondary.main' }} />
                             <ListItemText
                                 primary={collection.name}
+                                sx={{ minWidth: 0 }}
                                 slotProps={{
                                     primary: {
                                         variant: 'body2',

--- a/frontend/src/components/Header/HeaderContainer.tsx
+++ b/frontend/src/components/Header/HeaderContainer.tsx
@@ -3,7 +3,6 @@ import {
     alpha,
     AppBar,
     Box,
-    ClickAwayListener,
     Fab,
     Slide,
     Toolbar,
@@ -88,6 +87,14 @@ const HeaderContainer: React.FC<HeaderProps> = ({
     const handleCloseMobileMenu = () => {
         setMobileMenuOpen(false);
     };
+    const handleBackdropPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+    };
+    const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        handleCloseMobileMenu();
+    };
     const handleToggleMobileMenu = () => {
         setMobileMenuOpen((open) => !open);
     };
@@ -146,85 +153,85 @@ const HeaderContainer: React.FC<HeaderProps> = ({
 
     return (
         <>
-            <ClickAwayListener onClickAway={handleCloseMobileMenu}>
-                <AppBar
-                    position="fixed"
-                    color="default"
-                    elevation={0}
+            <AppBar
+                position="fixed"
+                color="default"
+                elevation={0}
+                sx={{
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    width: '100%',
+                    maxWidth: '100%',
+                    zIndex: (muiTheme) => muiTheme.zIndex.appBar + 1,
+                    bgcolor: collapsedMobileHeader ? 'transparent' : desktopBackgroundColor,
+                    backgroundImage: collapsedMobileHeader ? gradientBackground : 'none',
+                    borderBottom: collapsedMobileHeader ? 0 : 1,
+                    borderColor: 'divider',
+                    transition: 'background-color 0.3s ease-in-out, background-image 0.3s ease-in-out, border-bottom 0.3s ease-in-out, backdrop-filter 0.3s ease-in-out, height 0.3s ease-in-out',
+                    backdropFilter: collapsedMobileHeader ? 'none' : 'blur(10px)',
+                    boxSizing: 'border-box'
+                }}
+            >
+                <Toolbar
                     sx={{
-                        top: 0,
-                        left: 0,
-                        right: 0,
+                        flexDirection: isMobile ? 'column' : 'row',
+                        alignItems: isMobile ? 'stretch' : 'center',
+                        py: toolbarPaddingY,
+                        minHeight: toolbarMinHeight,
+                        transition: 'min-height 0.3s ease-in-out, padding 0.3s ease-in-out',
                         width: '100%',
                         maxWidth: '100%',
-                        zIndex: (muiTheme) => muiTheme.zIndex.appBar,
-                        bgcolor: collapsedMobileHeader ? 'transparent' : desktopBackgroundColor,
-                        backgroundImage: collapsedMobileHeader ? gradientBackground : 'none',
-                        borderBottom: collapsedMobileHeader ? 0 : 1,
-                        borderColor: 'divider',
-                        transition: 'background-color 0.3s ease-in-out, background-image 0.3s ease-in-out, border-bottom 0.3s ease-in-out, backdrop-filter 0.3s ease-in-out, height 0.3s ease-in-out',
-                        backdropFilter: collapsedMobileHeader ? 'none' : 'blur(10px)',
                         boxSizing: 'border-box'
                     }}
                 >
-                    <Toolbar
-                        sx={{
-                            flexDirection: isMobile ? 'column' : 'row',
-                            alignItems: isMobile ? 'stretch' : 'center',
-                            py: toolbarPaddingY,
-                            minHeight: toolbarMinHeight,
-                            transition: 'min-height 0.3s ease-in-out, padding 0.3s ease-in-out',
-                            width: '100%',
-                            maxWidth: '100%',
-                            boxSizing: 'border-box'
-                        }}
-                    >
-                        <HeaderToolbarContent
-                            isMobile={isMobile}
-                            isScrolled={isScrolled}
-                            isVisitor={isVisitor}
-                            websiteName={websiteName}
-                            onResetSearch={onResetSearch}
-                            activeDownloads={activeDownloads}
-                            queuedDownloads={queuedDownloads}
-                            downloadsAnchorEl={anchorEl}
-                            manageAnchorEl={manageAnchorEl}
-                            onDownloadsClick={handleDownloadsClick}
-                            onDownloadsClose={handleDownloadsClose}
-                            onManageClick={handleManageClick}
-                            onManageClose={handleManageClose}
-                            hasActiveSubscriptions={hasActiveSubscriptions}
-                            showThemeButton={showThemeButton}
-                            showAudioDownloadButton={showAudioDownloadButton}
-                            mobileMenuOpen={mobileMenuOpen}
-                            onToggleMobileMenu={handleToggleMobileMenu}
-                            onCloseMobileMenu={handleCloseMobileMenu}
-                            videoUrl={videoUrl}
-                            setVideoUrl={setVideoUrl}
-                            isSubmitting={isSubmitting}
-                            error={error}
-                            isSearchMode={isSearchMode}
-                            onSubmit={handleToolbarSubmit}
-                            onAudioOnlySubmit={handleAudioSubmit}
-                            collections={collections}
-                            videos={videos}
-                            showTagsInMobileMenu={showTagsInMobileMenu}
-                            linkToAllTagsInMobileMenu={linkToAllTagsInMobileMenu}
-                            effectiveTags={mobileEffectiveTags}
-                        />
-                    </Toolbar>
-                </AppBar>
-            </ClickAwayListener>
+                    <HeaderToolbarContent
+                        isMobile={isMobile}
+                        isScrolled={isScrolled}
+                        isVisitor={isVisitor}
+                        websiteName={websiteName}
+                        onResetSearch={onResetSearch}
+                        activeDownloads={activeDownloads}
+                        queuedDownloads={queuedDownloads}
+                        downloadsAnchorEl={anchorEl}
+                        manageAnchorEl={manageAnchorEl}
+                        onDownloadsClick={handleDownloadsClick}
+                        onDownloadsClose={handleDownloadsClose}
+                        onManageClick={handleManageClick}
+                        onManageClose={handleManageClose}
+                        hasActiveSubscriptions={hasActiveSubscriptions}
+                        showThemeButton={showThemeButton}
+                        showAudioDownloadButton={showAudioDownloadButton}
+                        mobileMenuOpen={mobileMenuOpen}
+                        onToggleMobileMenu={handleToggleMobileMenu}
+                        onCloseMobileMenu={handleCloseMobileMenu}
+                        videoUrl={videoUrl}
+                        setVideoUrl={setVideoUrl}
+                        isSubmitting={isSubmitting}
+                        error={error}
+                        isSearchMode={isSearchMode}
+                        onSubmit={handleToolbarSubmit}
+                        onAudioOnlySubmit={handleAudioSubmit}
+                        collections={collections}
+                        videos={videos}
+                        showTagsInMobileMenu={showTagsInMobileMenu}
+                        linkToAllTagsInMobileMenu={linkToAllTagsInMobileMenu}
+                        effectiveTags={mobileEffectiveTags}
+                    />
+                </Toolbar>
+            </AppBar>
 
             {isMobile && (
                 <Box
-                    onClick={handleCloseMobileMenu}
+                    data-testid="mobile-menu-backdrop"
+                    onPointerDown={handleBackdropPointerDown}
+                    onClick={handleBackdropClick}
                     aria-hidden
                     sx={{
                         position: 'fixed',
                         inset: 0,
                         bgcolor: alpha(theme.palette.common.black, 0.4),
-                        zIndex: (muiTheme) => muiTheme.zIndex.appBar - 1,
+                        zIndex: (muiTheme) => muiTheme.zIndex.appBar,
                         opacity: mobileMenuOpen ? 1 : 0,
                         pointerEvents: mobileMenuOpen ? 'auto' : 'none',
                         transition: 'opacity 0.3s ease-in-out',

--- a/frontend/src/components/Header/__tests__/HeaderContainer.test.tsx
+++ b/frontend/src/components/Header/__tests__/HeaderContainer.test.tsx
@@ -6,6 +6,15 @@ const mockNavigate = vi.fn();
 const mockHandleTagToggle = vi.fn();
 const mockRequestHomeViewMode = vi.fn();
 let mockPathname = '/';
+let mockIsMobile = true;
+
+vi.mock('@mui/material', async () => {
+    const actual = await vi.importActual<typeof import('@mui/material')>('@mui/material');
+    return {
+        ...actual,
+        useMediaQuery: () => mockIsMobile,
+    };
+});
 
 vi.mock('react-router-dom', async () => {
     const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
@@ -88,6 +97,7 @@ vi.mock('../HeaderToolbarContent', () => ({
             <button onClick={props.onToggleMobileMenu}>toggle-mobile-menu</button>
             <button onClick={props.onCloseMobileMenu}>close-mobile-menu</button>
             <button onClick={() => props.effectiveTags.onTagToggle('tag1')}>toggle-tag</button>
+            <span data-testid="mobile-menu-open">{String(props.mobileMenuOpen)}</span>
             <span data-testid="show-tags-in-mobile-menu">{String(props.showTagsInMobileMenu)}</span>
             <span data-testid="link-to-all-tags-in-mobile-menu">{String(props.linkToAllTagsInMobileMenu)}</span>
         </div>
@@ -110,6 +120,7 @@ const renderHeader = () =>
 describe('HeaderContainer', () => {
     afterEach(() => {
         mockPathname = '/';
+        mockIsMobile = true;
         vi.clearAllMocks();
     });
 
@@ -163,6 +174,36 @@ describe('HeaderContainer', () => {
         expect(scrollSpy).toHaveBeenCalled();
 
         scrollSpy.mockRestore();
+    });
+
+    it('uses the mobile backdrop to close the menu without clicking through to page content', () => {
+        const pageClick = vi.fn();
+
+        render(
+            <div onClick={pageClick}>
+                <HeaderContainer
+                    onSubmit={vi.fn()}
+                    onSearch={vi.fn()}
+                    activeDownloads={[]}
+                    queuedDownloads={[]}
+                    isSearchMode={false}
+                    collections={[]}
+                    videos={[]}
+                />
+                <button>underlying-page-action</button>
+            </div>
+        );
+
+        fireEvent.click(screen.getByText('toggle-mobile-menu'));
+        expect(screen.getByTestId('mobile-menu-open')).toHaveTextContent('true');
+
+        const backdrop = screen.getByTestId('mobile-menu-backdrop');
+        pageClick.mockClear();
+        fireEvent.pointerDown(backdrop);
+        fireEvent.click(backdrop);
+
+        expect(screen.getByTestId('mobile-menu-open')).toHaveTextContent('false');
+        expect(pageClick).not.toHaveBeenCalled();
     });
 
     it('requests All Videos when a mobile header tag is toggled on a home route', () => {

--- a/frontend/src/components/HomeLoadingSkeleton.tsx
+++ b/frontend/src/components/HomeLoadingSkeleton.tsx
@@ -28,15 +28,15 @@ export const HomeLoadingSkeleton: FC<HomeLoadingSkeletonProps> = ({
         <Container
             maxWidth={false}
             data-testid="home-loading-skeleton"
-            sx={{ py: 4, px: { xs: 0, sm: 3 } }}
+            sx={{ py: 4, px: { xs: 0, sm: 3 }, overflowX: 'hidden' }}
         >
-            <Box sx={{ display: 'flex', alignItems: 'stretch' }}>
+            <Box sx={{ display: 'flex', alignItems: 'stretch', minWidth: 0 }}>
                 {!isMobile && isSidebarOpen && (
                     <Box
                         sx={{
-                            width: { md: 240, lg: 280 },
+                            width: { md: 260, lg: 280 },
                             flexShrink: 0,
-                            px: 2,
+                            mr: { md: 3, lg: 4 },
                             display: 'flex',
                             flexDirection: 'column',
                             gap: 2

--- a/frontend/src/components/HomeSidebar.tsx
+++ b/frontend/src/components/HomeSidebar.tsx
@@ -13,6 +13,7 @@ interface HomeSidebarProps {
     selectedTags: string[];
     onTagToggle: (tag: string) => void;
     videos: Video[];
+    maxPanelHeight?: number | null;
 }
 
 export const HomeSidebar: React.FC<HomeSidebarProps> = ({
@@ -21,42 +22,46 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
     availableTags,
     selectedTags,
     onTagToggle,
-    videos
+    videos,
+    maxPanelHeight
 }) => {
     return (
-        // The flex item itself is sticky and self-scrolling. Because it stays
-        // in normal flow (no absolute positioning), a long list contributes to
-        // the row height and can never overlap the footer, while its own
-        // overflow caps it to the viewport. `alignSelf: flex-start` keeps it
-        // from stretching to the video column so it retains room to stick while
-        // the grid scrolls.
+        // Keep the flex item itself free of vertical scrollbars. Otherwise the
+        // 6px custom scrollbar can appear after first layout and shrink the
+        // main video column.
         <Box sx={{
             display: { xs: 'none', md: 'block' },
             alignSelf: 'flex-start',
-            position: 'sticky',
-            top: 16,
-            maxHeight: 'calc(100vh - 32px)',
-            overflowY: 'auto',
-            '&::-webkit-scrollbar': {
-                width: '6px',
-            },
-            '&::-webkit-scrollbar-track': {
-                background: 'transparent',
-            },
-            '&::-webkit-scrollbar-thumb': {
-                background: overlay.sidebarTrack,
-                borderRadius: '3px',
-            },
-            '&:hover::-webkit-scrollbar-thumb': {
-                background: overlay.sidebarThumb,
-            },
+            overflowX: 'hidden',
+            flexShrink: 0,
         }}>
             <Collapse
                 in={isSidebarOpen}
                 orientation="horizontal"
                 timeout={300}
             >
-                <Box sx={{ width: 280, mr: 4, flexShrink: 0 }}>
+                <Box sx={{
+                    width: { md: 260, lg: 280 },
+                    mr: { md: 3, lg: 4 },
+                    flexShrink: 0,
+                    minWidth: 0,
+                    maxHeight: maxPanelHeight ? `${maxPanelHeight}px` : undefined,
+                    overflowY: isSidebarOpen ? 'auto' : 'hidden',
+                    overflowX: 'hidden',
+                    '&::-webkit-scrollbar': {
+                        width: '6px',
+                    },
+                    '&::-webkit-scrollbar-track': {
+                        background: 'transparent',
+                    },
+                    '&::-webkit-scrollbar-thumb': {
+                        background: overlay.sidebarTrack,
+                        borderRadius: '3px',
+                    },
+                    '&:hover::-webkit-scrollbar-thumb': {
+                        background: overlay.sidebarThumb,
+                    },
+                }}>
                     <Collections collections={collections} />
                     <Box sx={{ mt: 2 }}>
                         <TagsList

--- a/frontend/src/components/HomeSidebar.tsx
+++ b/frontend/src/components/HomeSidebar.tsx
@@ -34,8 +34,6 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
             alignSelf: 'flex-start',
             position: 'sticky',
             top: 16,
-            maxHeight: 'calc(100vh - 32px)',
-            overflowX: 'hidden',
             flexShrink: 0,
         }} data-testid="home-sidebar">
             <Collapse
@@ -48,7 +46,7 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
                     mr: { md: 3, lg: 4 },
                     flexShrink: 0,
                     minWidth: 0,
-                    maxHeight: maxPanelHeight ? `min(${maxPanelHeight}px, calc(100vh - 32px))` : 'calc(100vh - 32px)',
+                    maxHeight: maxPanelHeight ? `${maxPanelHeight}px` : undefined,
                     overflowY: isSidebarOpen ? 'auto' : 'hidden',
                     overflowX: 'hidden',
                     '&::-webkit-scrollbar': {

--- a/frontend/src/components/HomeSidebar.tsx
+++ b/frontend/src/components/HomeSidebar.tsx
@@ -32,9 +32,12 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
         <Box sx={{
             display: { xs: 'none', md: 'block' },
             alignSelf: 'flex-start',
+            position: 'sticky',
+            top: 16,
+            maxHeight: 'calc(100vh - 32px)',
             overflowX: 'hidden',
             flexShrink: 0,
-        }}>
+        }} data-testid="home-sidebar">
             <Collapse
                 in={isSidebarOpen}
                 orientation="horizontal"
@@ -45,7 +48,7 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
                     mr: { md: 3, lg: 4 },
                     flexShrink: 0,
                     minWidth: 0,
-                    maxHeight: maxPanelHeight ? `${maxPanelHeight}px` : undefined,
+                    maxHeight: maxPanelHeight ? `min(${maxPanelHeight}px, calc(100vh - 32px))` : 'calc(100vh - 32px)',
                     overflowY: isSidebarOpen ? 'auto' : 'hidden',
                     overflowX: 'hidden',
                     '&::-webkit-scrollbar': {
@@ -61,7 +64,7 @@ export const HomeSidebar: React.FC<HomeSidebarProps> = ({
                     '&:hover::-webkit-scrollbar-thumb': {
                         background: overlay.sidebarThumb,
                     },
-                }}>
+                }} data-testid="home-sidebar-panel">
                     <Collections collections={collections} />
                     <Box sx={{ mt: 2 }}>
                         <TagsList

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -101,8 +101,8 @@ const TagsList: React.FC<TagsListProps> = ({
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, mb: 1 }}>
-                <Typography variant="h6" component="div" sx={{ flexGrow: 1, fontWeight: 600 }}>
+            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, mb: 1, minWidth: 0 }}>
+                <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('tags') || 'Tags'}
                 </Typography>
                 {linkToAllTags && (
@@ -136,8 +136,13 @@ const TagsList: React.FC<TagsListProps> = ({
                                 variant={isSelected ? "filled" : "outlined"}
                                 icon={isSelected ? <LocalOffer sx={{ fontSize: '1rem !important' }} /> : undefined}
                                 sx={{
+                                    maxWidth: '100%',
                                     cursor: 'pointer',
                                     transition: 'background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s',
+                                    '& .MuiChip-label': {
+                                        overflow: 'hidden',
+                                        textOverflow: 'ellipsis'
+                                    },
                                     '&:hover': {
                                         bgcolor: isSelected ? 'primary.dark' : 'action.hover'
                                     }

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { Video } from '../../types';
+import { authorAvatarFallbackSx } from '../../utils/authorAvatarStyles';
 import { formatRelativeDownloadTime } from '../../utils/formatUtils';
 import { VideoCardCollectionInfo } from '../../utils/videoCardUtils';
 
@@ -172,14 +173,13 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
                     <Avatar
                         src={avatarUrl || undefined}
                         onClick={onAuthorClick}
-                        sx={{
+                        sx={[authorAvatarFallbackSx, {
                             width: 24,
                             height: 24,
-                            bgcolor: 'primary.main',
                             mr: 0.75,
                             fontSize: '0.75rem',
                             cursor: 'pointer'
-                        }}
+                        }]}
                     >
                         {video.author ? video.author.charAt(0).toUpperCase() : 'A'}
                     </Avatar>

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoAuthorInfo.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoAuthorInfo.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../../hooks/useCloudStorageUrl';
+import { authorAvatarFallbackSx } from '../../../utils/authorAvatarStyles';
 
 interface VideoAuthorInfoProps {
     author: string;
@@ -63,12 +64,11 @@ const VideoAuthorInfo: React.FC<VideoAuthorInfoProps> = ({
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <Avatar 
                 src={avatarUrl || undefined}
-                sx={{ 
-                    bgcolor: 'primary.main', 
+                sx={[authorAvatarFallbackSx, {
                     mr: { xs: 1, sm: 2 },
                     cursor: 'pointer',
                     '&:hover': { opacity: 0.8 }
-                }}
+                }]}
                 onClick={onAvatarClick || onAuthorClick}
             >
                 {author ? author.charAt(0).toUpperCase() : 'A'}

--- a/frontend/src/components/__tests__/HomeSidebar.test.tsx
+++ b/frontend/src/components/__tests__/HomeSidebar.test.tsx
@@ -47,8 +47,11 @@ describe('HomeSidebar', () => {
             position: 'sticky',
             top: '16px',
         });
+        expect(screen.getByTestId('home-sidebar')).not.toHaveStyle({
+            maxHeight: 'calc(100vh - 32px)',
+        });
         expect(screen.getByTestId('home-sidebar-panel')).toHaveStyle({
-            maxHeight: 'min(720px, calc(100vh - 32px))',
+            maxHeight: '720px',
             overflowY: 'auto',
         });
     });

--- a/frontend/src/components/__tests__/HomeSidebar.test.tsx
+++ b/frontend/src/components/__tests__/HomeSidebar.test.tsx
@@ -39,4 +39,17 @@ describe('HomeSidebar', () => {
         // We can't easily query by style with testing-library, but we can check if it renders without crashing.
         expect(container).toBeInTheDocument();
     });
+
+    it('keeps the outer wrapper sticky while the inner panel scrolls', () => {
+        render(<HomeSidebar {...defaultProps} maxPanelHeight={720} />);
+
+        expect(screen.getByTestId('home-sidebar')).toHaveStyle({
+            position: 'sticky',
+            top: '16px',
+        });
+        expect(screen.getByTestId('home-sidebar-panel')).toHaveStyle({
+            maxHeight: 'min(720px, calc(100vh - 32px))',
+            overflowY: 'auto',
+        });
+    });
 });

--- a/frontend/src/pages/AllAuthorsPage.tsx
+++ b/frontend/src/pages/AllAuthorsPage.tsx
@@ -7,6 +7,7 @@ import { useVideo } from '../contexts/VideoContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { brand, modeColors } from '../theme/colors';
 import { Video } from '../types';
+import { authorAvatarFallbackSx } from '../utils/authorAvatarStyles';
 
 interface AuthorSummary {
     author: string;
@@ -50,7 +51,7 @@ const AuthorCard: React.FC<{ summary: AuthorSummary; videosLabel: string }> = ({
                     <Avatar
                         src={avatarUrl || undefined}
                         alt={summary.author}
-                        sx={{ width: '100%', height: '100%' }}
+                        sx={[authorAvatarFallbackSx, { width: '100%', height: '100%' }]}
                     >
                         {summary.author ? summary.author.charAt(0).toUpperCase() : <Person />}
                     </Avatar>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { Alert, Box, Container, Pagination, Typography, useMediaQuery, useTheme } from '@mui/material';
-import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { HomeHeader } from '../components/HomeHeader';
 import { HomeLoadingSkeleton } from '../components/HomeLoadingSkeleton';
@@ -53,6 +53,8 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
     const location = useLocation();
     const navigate = useNavigate();
     const [isDeleteFilteredOpen, setIsDeleteFilteredOpen] = useState(false);
+    const [mainContentHeight, setMainContentHeight] = useState<number | null>(null);
+    const mainContentRef = useRef<HTMLDivElement | null>(null);
     const homeViewModeRequest = useHomeViewModeRequestOptional();
 
     // Custom hooks
@@ -154,6 +156,31 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
     const loadingSkeletonCount = Math.min(Math.max(itemsPerPage, 6), 12);
     const priorityVideos = infiniteScroll ? sortedVideos : displayedVideos;
 
+    useLayoutEffect(() => {
+        const mainContent = mainContentRef.current;
+        if (!mainContent) {
+            return undefined;
+        }
+
+        const updateMainContentHeight = () => {
+            const nextHeight = Math.ceil(mainContent.getBoundingClientRect().height);
+            setMainContentHeight((currentHeight) => (
+                currentHeight === nextHeight ? currentHeight : nextHeight
+            ));
+        };
+
+        updateMainContentHeight();
+
+        if (typeof ResizeObserver === 'undefined') {
+            window.addEventListener('resize', updateMainContentHeight);
+            return () => window.removeEventListener('resize', updateMainContentHeight);
+        }
+
+        const observer = new ResizeObserver(updateMainContentHeight);
+        observer.observe(mainContent);
+        return () => observer.disconnect();
+    }, [loading, settingsLoaded, videoArray.length, viewMode]);
+
     if (!settingsLoaded || (loading && videoArray.length === 0)) {
         return <HomeLoadingSkeleton gridProps={gridProps} isSidebarOpen={isSidebarOpen} cardsCount={loadingSkeletonCount} />;
     }
@@ -171,7 +198,7 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
 
     // Regular home view (not in search mode)
     return (
-        <Container maxWidth={false} sx={{ py: 4, px: { xs: 0, sm: 3 } }}>
+        <Container maxWidth={false} sx={{ py: 4, px: { xs: 0, sm: 3 }, overflowX: 'hidden' }}>
             {/* Preload first video thumbnail for better LCP */}
             {priorityVideos.length > 0 && <LCPImagePreloader videos={priorityVideos} />}
 
@@ -204,7 +231,7 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                     </Typography>
                 </Box>
             ) : (
-                <Box sx={{ display: 'flex', alignItems: 'stretch' }}>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', minWidth: 0 }}>
                     <HomeSidebar
                         isSidebarOpen={isSidebarOpen}
                         collections={collections}
@@ -212,10 +239,11 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                         selectedTags={selectedTags}
                         onTagToggle={handleHomeTagToggle}
                         videos={videoArray}
+                        maxPanelHeight={mainContentHeight}
                     />
 
                     {/* Videos grid */}
-                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Box ref={mainContentRef} sx={{ flex: 1, minWidth: 0, alignSelf: 'flex-start' }}>
                         <HomeHeader
                             viewMode={viewMode}
                             onViewModeChange={handleHomeViewModeChange}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -53,8 +53,8 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
     const location = useLocation();
     const navigate = useNavigate();
     const [isDeleteFilteredOpen, setIsDeleteFilteredOpen] = useState(false);
-    const [mainContentHeight, setMainContentHeight] = useState<number | null>(null);
-    const mainContentRef = useRef<HTMLDivElement | null>(null);
+    const [videoGridHeight, setVideoGridHeight] = useState<number | null>(null);
+    const videoGridRef = useRef<HTMLDivElement | null>(null);
     const homeViewModeRequest = useHomeViewModeRequestOptional();
 
     // Custom hooks
@@ -157,29 +157,30 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
     const priorityVideos = infiniteScroll ? sortedVideos : displayedVideos;
 
     useLayoutEffect(() => {
-        const mainContent = mainContentRef.current;
-        if (!mainContent) {
+        const videoGrid = videoGridRef.current;
+        if (!videoGrid) {
+            setVideoGridHeight(null);
             return undefined;
         }
 
-        const updateMainContentHeight = () => {
-            const nextHeight = Math.ceil(mainContent.getBoundingClientRect().height);
-            setMainContentHeight((currentHeight) => (
+        const updateVideoGridHeight = () => {
+            const nextHeight = Math.ceil(videoGrid.getBoundingClientRect().height);
+            setVideoGridHeight((currentHeight) => (
                 currentHeight === nextHeight ? currentHeight : nextHeight
             ));
         };
 
-        updateMainContentHeight();
+        updateVideoGridHeight();
 
         if (typeof ResizeObserver === 'undefined') {
-            window.addEventListener('resize', updateMainContentHeight);
-            return () => window.removeEventListener('resize', updateMainContentHeight);
+            window.addEventListener('resize', updateVideoGridHeight);
+            return () => window.removeEventListener('resize', updateVideoGridHeight);
         }
 
-        const observer = new ResizeObserver(updateMainContentHeight);
-        observer.observe(mainContent);
+        const observer = new ResizeObserver(updateVideoGridHeight);
+        observer.observe(videoGrid);
         return () => observer.disconnect();
-    }, [loading, settingsLoaded, videoArray.length, viewMode]);
+    }, [displayedVideos.length, infiniteScroll, isSidebarOpen, loading, settingsLoaded, sortedVideos.length, videoArray.length, videoColumns, viewMode]);
 
     if (!settingsLoaded || (loading && videoArray.length === 0)) {
         return <HomeLoadingSkeleton gridProps={gridProps} isSidebarOpen={isSidebarOpen} cardsCount={loadingSkeletonCount} />;
@@ -239,11 +240,11 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                         selectedTags={selectedTags}
                         onTagToggle={handleHomeTagToggle}
                         videos={videoArray}
-                        maxPanelHeight={mainContentHeight}
+                        maxPanelHeight={videoGridHeight}
                     />
 
                     {/* Videos grid */}
-                    <Box ref={mainContentRef} sx={{ flex: 1, minWidth: 0, alignSelf: 'flex-start' }}>
+                    <Box sx={{ flex: 1, minWidth: 0, alignSelf: 'flex-start' }}>
                         <HomeHeader
                             viewMode={viewMode}
                             onViewModeChange={handleHomeViewModeChange}
@@ -268,18 +269,20 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                                 </Typography>
                             </Box>
                         ) : (
-                            <VideoGrid
-                                videos={videoArray}
-                                sortedVideos={sortedVideos}
-                                displayedVideos={displayedVideos}
-                                collections={collections}
-                                viewMode={viewMode}
-                                infiniteScroll={infiniteScroll}
-                                gridProps={gridProps}
-                                onDeleteVideo={deleteVideo}
-                                showTagsOnThumbnail={showTagsOnThumbnail}
-                                onTagToggle={handleHomeTagToggle}
-                            />
+                            <Box ref={videoGridRef}>
+                                <VideoGrid
+                                    videos={videoArray}
+                                    sortedVideos={sortedVideos}
+                                    displayedVideos={displayedVideos}
+                                    collections={collections}
+                                    viewMode={viewMode}
+                                    infiniteScroll={infiniteScroll}
+                                    gridProps={gridProps}
+                                    onDeleteVideo={deleteVideo}
+                                    showTagsOnThumbnail={showTagsOnThumbnail}
+                                    onTagToggle={handleHomeTagToggle}
+                                />
+                            </Box>
                         )}
 
                         {viewMode !== 'favorite' && !infiniteScroll && totalPages > 1 && (

--- a/frontend/src/pages/authorVideos/AuthorVideosHeader.tsx
+++ b/frontend/src/pages/authorVideos/AuthorVideosHeader.tsx
@@ -3,6 +3,7 @@ import { Avatar, Box, Button, IconButton, Tooltip, Typography } from '@mui/mater
 
 import FavoriteToggle from '../../components/FavoriteToggle';
 import SortControl from '../../components/SortControl';
+import { authorAvatarFallbackSx } from '../../utils/authorAvatarStyles';
 
 interface AuthorVideosHeaderProps {
     authorDisplayName: string;
@@ -78,15 +79,14 @@ const AuthorVideosHeader: React.FC<AuthorVideosHeaderProps> = ({
 
                 <Avatar
                     src={avatarUrl || undefined}
-                    sx={{
+                    sx={[authorAvatarFallbackSx, {
                         display: { xs: 'none', md: 'flex' },
                         width: 56,
                         height: 56,
-                        bgcolor: 'primary.main',
                         mr: 2,
                         fontSize: '1.5rem',
                         flexShrink: 0,
-                    }}
+                    }]}
                 >
                     {initial}
                 </Avatar>
@@ -108,15 +108,14 @@ const AuthorVideosHeader: React.FC<AuthorVideosHeaderProps> = ({
                                 component="span"
                                 src={avatarUrl || undefined}
                                 aria-hidden
-                                sx={{
+                                sx={[authorAvatarFallbackSx, {
                                     display: { xs: 'inline-flex', md: 'none' },
                                     width: 40,
                                     height: 40,
                                     mr: 1,
                                     verticalAlign: 'middle',
-                                    bgcolor: 'primary.main',
                                     fontSize: '1.1rem',
-                                }}
+                                }]}
                             >
                                 {initial}
                             </Avatar>

--- a/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
+++ b/frontend/src/pages/favorite/FavoriteAuthorRail.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
 import { brand, modeColors } from '../../theme/colors';
 import type { FavoriteAuthorItem } from '../../types';
+import { authorAvatarFallbackSx } from '../../utils/authorAvatarStyles';
 import FavoriteToggle from '../../components/FavoriteToggle';
 import FavoriteRailCarousel from './FavoriteRailCarousel';
 import FavoriteSectionHeader from './FavoriteSectionHeader';
@@ -70,7 +71,7 @@ const FavoriteAuthorCard: React.FC<{
                         className="favorite-author-avatar"
                         src={avatarUrl}
                         alt={favorite.displayName}
-                        sx={{ width: '100%', height: '100%', transition: 'box-shadow 0.2s' }}
+                        sx={[authorAvatarFallbackSx, { width: '100%', height: '100%', transition: 'box-shadow 0.2s' }]}
                     >
                         {isUnavailable ? <WarningAmber /> : <Person />}
                     </Avatar>

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -1,5 +1,5 @@
 import { Star } from '@mui/icons-material';
-import { Box, Button, Card, CardMedia, Chip, Typography, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Card, CardMedia, Chip, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -17,7 +17,7 @@ interface FavoriteHeroProps {
     carouselControls?: ReactNode;
 }
 
-const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant = 'featured', carouselControls }) => {
+const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, variant = 'featured', carouselControls }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const theme = useTheme();
@@ -191,17 +191,15 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                         )}
                     </Box>
 
-                    <Box sx={{ color: theme.palette.mode === 'dark' ? neutral.white : 'text.primary', maxWidth: 620, width: { xs: '100%', md: 'auto' } }}>
-                        <Box
-                            sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'space-between',
-                                gap: 1.5,
-                                mb: 1.25,
-                                flexWrap: 'nowrap',
-                            }}
-                        >
+                    <Box
+                        sx={{
+                            position: 'relative',
+                            color: theme.palette.mode === 'dark' ? neutral.white : 'text.primary',
+                            maxWidth: 620,
+                            width: { xs: '100%', md: 'auto' },
+                        }}
+                    >
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.25, flexWrap: 'wrap', pr: carouselControls ? { xs: 22, md: 0 } : 0 }}>
                             <Typography
                                 sx={{
                                     color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary',
@@ -214,12 +212,19 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                             >
                                 {video.author || t('unknownAuthor')}
                             </Typography>
-                            {carouselControls && (
-                                <Box sx={{ display: { xs: 'flex', md: 'none' }, flexShrink: 0, ml: 'auto' }}>
-                                    {carouselControls}
-                                </Box>
-                            )}
                         </Box>
+                        {carouselControls && (
+                            <Box
+                                sx={{
+                                    position: 'absolute',
+                                    top: -0.5,
+                                    right: 0,
+                                    display: { xs: 'flex', md: 'none' },
+                                }}
+                            >
+                                {carouselControls}
+                            </Box>
+                        )}
                         <Typography
                             variant="h5"
                             component="h2"
@@ -262,19 +267,6 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                             >
                                 {description}
                             </Typography>
-                        )}
-                        {collection && (
-                            <Box sx={{ display: 'flex', gap: 1.5, mt: 2.5, flexWrap: 'wrap' }}>
-                                <Button
-                                    variant="outlined"
-                                    sx={theme.palette.mode === 'dark'
-                                        ? { color: neutral.white, borderColor: overlay.white70, '&:hover': { borderColor: neutral.white, bgcolor: overlay.white10 } }
-                                        : undefined}
-                                    onClick={() => navigate(`/collection/${encodeURIComponent(collection.collectionId)}`)}
-                                >
-                                    {t('openCollection')}
-                                </Button>
-                            </Box>
                         )}
                     </Box>
                 </Box>

--- a/frontend/src/pages/favorite/FavoriteHero.tsx
+++ b/frontend/src/pages/favorite/FavoriteHero.tsx
@@ -1,6 +1,7 @@
 import { Star } from '@mui/icons-material';
 import { Box, Button, Card, CardMedia, Chip, Typography, useMediaQuery, useTheme } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { brand, modeColors, neutral, overlay } from '../../theme/colors';
@@ -13,9 +14,10 @@ interface FavoriteHeroProps {
     video: Video;
     collection?: FavoriteCollectionItem;
     variant?: 'continue' | 'featured';
+    carouselControls?: ReactNode;
 }
 
-const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant = 'featured' }) => {
+const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant = 'featured', carouselControls }) => {
     const { t } = useLanguage();
     const navigate = useNavigate();
     const theme = useTheme();
@@ -190,15 +192,33 @@ const FavoriteHero: React.FC<FavoriteHeroProps> = ({ video, collection, variant 
                     </Box>
 
                     <Box sx={{ color: theme.palette.mode === 'dark' ? neutral.white : 'text.primary', maxWidth: 620, width: { xs: '100%', md: 'auto' } }}>
-                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.25, flexWrap: 'wrap' }}>
+                        <Box
+                            sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'space-between',
+                                gap: 1.5,
+                                mb: 1.25,
+                                flexWrap: 'nowrap',
+                            }}
+                        >
                             <Typography
                                 sx={{
                                     color: theme.palette.mode === 'dark' ? overlay.white80 : 'text.secondary',
                                     fontWeight: 500,
+                                    minWidth: 0,
+                                    overflow: 'hidden',
+                                    textOverflow: 'ellipsis',
+                                    whiteSpace: 'nowrap',
                                 }}
                             >
                                 {video.author || t('unknownAuthor')}
                             </Typography>
+                            {carouselControls && (
+                                <Box sx={{ display: { xs: 'flex', md: 'none' }, flexShrink: 0, ml: 'auto' }}>
+                                    {carouselControls}
+                                </Box>
+                            )}
                         </Box>
                         <Typography
                             variant="h5"

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -105,7 +105,10 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         event.stopPropagation();
         navigate(`/collection/${encodeURIComponent(current.collection.collectionId)}`);
     };
-    const renderControls = (sx?: SxProps<Theme>) => (
+    const renderControls = (
+        sx?: SxProps<Theme>,
+        { showCarouselNavigation = true }: { showCarouselNavigation?: boolean } = {},
+    ) => (
         <Box
             sx={{
                 zIndex: 2,
@@ -135,47 +138,54 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                     <CollectionsBookmark fontSize="small" />
                 </IconButton>
             )}
-            <IconButton
-                size="small"
-                aria-label={t('previous')}
-                onClick={() => go(safeIndex - 1, -1)}
-                sx={{ color: neutral.white, p: 0.5 }}
-            >
-                <ChevronLeft fontSize="small" />
-            </IconButton>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 0.25 }}>
-                {items.map((item, dotIndex) => (
-                    <Box
-                        key={item.video.id}
-                        component="button"
-                        type="button"
-                        aria-label={`${t('featured')} ${dotIndex + 1}`}
-                        aria-current={dotIndex === safeIndex}
-                        onClick={() => go(dotIndex, dotIndex >= safeIndex ? 1 : -1)}
-                        sx={{
-                            p: 0,
-                            border: 'none',
-                            cursor: 'pointer',
-                            width: dotIndex === safeIndex ? 18 : 7,
-                            height: 7,
-                            borderRadius: 999,
-                            transition: 'width 0.25s ease, background-color 0.25s ease',
-                            bgcolor: dotIndex === safeIndex ? neutral.white : overlay.white32,
-                        }}
-                    />
-                ))}
-            </Box>
-            <IconButton
-                size="small"
-                aria-label={t('next')}
-                onClick={() => go(safeIndex + 1, 1)}
-                sx={{ color: neutral.white, p: 0.5 }}
-            >
-                <ChevronRight fontSize="small" />
-            </IconButton>
+            {showCarouselNavigation && (
+                <>
+                    <IconButton
+                        size="small"
+                        aria-label={t('previous')}
+                        onClick={() => go(safeIndex - 1, -1)}
+                        sx={{ color: neutral.white, p: 0.5 }}
+                    >
+                        <ChevronLeft fontSize="small" />
+                    </IconButton>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 0.25 }}>
+                        {items.map((item, dotIndex) => (
+                            <Box
+                                key={item.video.id}
+                                component="button"
+                                type="button"
+                                aria-label={`${t('featured')} ${dotIndex + 1}`}
+                                aria-current={dotIndex === safeIndex}
+                                onClick={() => go(dotIndex, dotIndex >= safeIndex ? 1 : -1)}
+                                sx={{
+                                    p: 0,
+                                    border: 'none',
+                                    cursor: 'pointer',
+                                    width: dotIndex === safeIndex ? 18 : 7,
+                                    height: 7,
+                                    borderRadius: 999,
+                                    transition: 'width 0.25s ease, background-color 0.25s ease',
+                                    bgcolor: dotIndex === safeIndex ? neutral.white : overlay.white32,
+                                }}
+                            />
+                        ))}
+                    </Box>
+                    <IconButton
+                        size="small"
+                        aria-label={t('next')}
+                        onClick={() => go(safeIndex + 1, 1)}
+                        sx={{ color: neutral.white, p: 0.5 }}
+                    >
+                        <ChevronRight fontSize="small" />
+                    </IconButton>
+                </>
+            )}
         </Box>
     );
-    const carouselControls = count > 1 && isMobile ? renderControls() : undefined;
+    const shouldShowControls = count > 1 || Boolean(current.collection);
+    const carouselControls = shouldShowControls && isMobile
+        ? renderControls(undefined, { showCarouselNavigation: count > 1 })
+        : undefined;
 
     return (
         <Box
@@ -225,11 +235,13 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                 />
             </motion.div>
 
-            {count > 1 && !isMobile && (
+            {shouldShowControls && !isMobile && (
                 renderControls({
                     position: 'absolute',
                     top: 12,
                     right: 12,
+                }, {
+                    showCarouselNavigation: count > 1,
                 })
             )}
         </Box>

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from '@mui/icons-material';
 import { Box, IconButton, useMediaQuery, useTheme } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 import { motion } from 'framer-motion';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -96,6 +97,62 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
 
     const safeIndex = Math.min(index, count - 1);
     const current = items[safeIndex];
+    const renderControls = (sx?: SxProps<Theme>) => (
+        <Box
+            sx={{
+                zIndex: 2,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                px: 0.5,
+                py: 0.25,
+                borderRadius: 999,
+                bgcolor: overlay.black55,
+                backdropFilter: 'blur(6px)',
+                ...sx,
+            }}
+        >
+            <IconButton
+                size="small"
+                aria-label={t('previous')}
+                onClick={() => go(safeIndex - 1, -1)}
+                sx={{ color: neutral.white, p: 0.5 }}
+            >
+                <ChevronLeft fontSize="small" />
+            </IconButton>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 0.25 }}>
+                {items.map((item, dotIndex) => (
+                    <Box
+                        key={item.video.id}
+                        component="button"
+                        type="button"
+                        aria-label={`${t('featured')} ${dotIndex + 1}`}
+                        aria-current={dotIndex === safeIndex}
+                        onClick={() => go(dotIndex, dotIndex >= safeIndex ? 1 : -1)}
+                        sx={{
+                            p: 0,
+                            border: 'none',
+                            cursor: 'pointer',
+                            width: dotIndex === safeIndex ? 18 : 7,
+                            height: 7,
+                            borderRadius: 999,
+                            transition: 'width 0.25s ease, background-color 0.25s ease',
+                            bgcolor: dotIndex === safeIndex ? neutral.white : overlay.white32,
+                        }}
+                    />
+                ))}
+            </Box>
+            <IconButton
+                size="small"
+                aria-label={t('next')}
+                onClick={() => go(safeIndex + 1, 1)}
+                sx={{ color: neutral.white, p: 0.5 }}
+            >
+                <ChevronRight fontSize="small" />
+            </IconButton>
+        </Box>
+    );
+    const carouselControls = count > 1 && isMobile ? renderControls() : undefined;
 
     return (
         <Box
@@ -137,65 +194,20 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                 animate={{ opacity: 1, x: 0 }}
                 transition={isReducedMotion ? { duration: 0 } : { duration: 0.3, ease: 'easeOut' }}
             >
-                <FavoriteHero video={current.video} collection={current.collection} variant={current.variant} />
+                <FavoriteHero
+                    video={current.video}
+                    collection={current.collection}
+                    variant={current.variant}
+                    carouselControls={carouselControls}
+                />
             </motion.div>
 
-            {count > 1 && (
-                <Box
-                    sx={{
-                        position: 'absolute',
-                        top: 12,
-                        right: 12,
-                        zIndex: 2,
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 0.5,
-                        px: 0.5,
-                        py: 0.25,
-                        borderRadius: 999,
-                        bgcolor: overlay.black55,
-                        backdropFilter: 'blur(6px)',
-                    }}
-                >
-                    <IconButton
-                        size="small"
-                        aria-label={t('previous')}
-                        onClick={() => go(safeIndex - 1, -1)}
-                        sx={{ color: neutral.white, p: 0.5 }}
-                    >
-                        <ChevronLeft fontSize="small" />
-                    </IconButton>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 0.25 }}>
-                        {items.map((item, dotIndex) => (
-                            <Box
-                                key={item.video.id}
-                                component="button"
-                                type="button"
-                                aria-label={`${t('featured')} ${dotIndex + 1}`}
-                                aria-current={dotIndex === safeIndex}
-                                onClick={() => go(dotIndex, dotIndex >= safeIndex ? 1 : -1)}
-                                sx={{
-                                    p: 0,
-                                    border: 'none',
-                                    cursor: 'pointer',
-                                    width: dotIndex === safeIndex ? 18 : 7,
-                                    height: 7,
-                                    borderRadius: 999,
-                                    transition: 'width 0.25s ease, background-color 0.25s ease',
-                                    bgcolor: dotIndex === safeIndex ? neutral.white : overlay.white32,
-                                }}
-                            />
-                        ))}
-                    </Box>
-                    <IconButton
-                        size="small"
-                        aria-label={t('next')}
-                        onClick={() => go(safeIndex + 1, 1)}
-                        sx={{ color: neutral.white, p: 0.5 }}
-                    >
-                        <ChevronRight fontSize="small" />
-                    </IconButton>
-                </Box>
+            {count > 1 && !isMobile && (
+                renderControls({
+                    position: 'absolute',
+                    top: 12,
+                    right: 12,
+                })
             )}
         </Box>
     );

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -1,8 +1,10 @@
-import { ChevronLeft, ChevronRight } from '@mui/icons-material';
+import { ChevronLeft, ChevronRight, CollectionsBookmark } from '@mui/icons-material';
 import { Box, IconButton, useMediaQuery, useTheme } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 import { motion } from 'framer-motion';
+import type { MouseEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { neutral, overlay } from '../../theme/colors';
 import type { FavoriteCollectionItem, Video } from '../../types';
@@ -30,6 +32,7 @@ const AUTO_ADVANCE_MS = 7000;
  */
 const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) => {
     const { t } = useLanguage();
+    const navigate = useNavigate();
     const theme = useTheme();
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -97,6 +100,11 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
 
     const safeIndex = Math.min(index, count - 1);
     const current = items[safeIndex];
+    const openCollection = (event: MouseEvent<HTMLButtonElement>) => {
+        if (!current.collection) return;
+        event.stopPropagation();
+        navigate(`/collection/${encodeURIComponent(current.collection.collectionId)}`);
+    };
     const renderControls = (sx?: SxProps<Theme>) => (
         <Box
             sx={{
@@ -112,6 +120,21 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
                 ...sx,
             }}
         >
+            {current.collection && (
+                <IconButton
+                    size="small"
+                    aria-label={t('openCollection')}
+                    onClick={openCollection}
+                    sx={{
+                        color: neutral.white,
+                        p: 0.5,
+                        borderRight: `1px solid ${overlay.white32}`,
+                        borderRadius: 0,
+                    }}
+                >
+                    <CollectionsBookmark fontSize="small" />
+                </IconButton>
+            )}
             <IconButton
                 size="small"
                 aria-label={t('previous')}
@@ -190,9 +213,9 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         >
             <motion.div
                 key={current.video.id}
-                initial={isReducedMotion ? false : { opacity: 0, x: slideDirection * 24 }}
+                initial={isReducedMotion ? false : { opacity: 0, x: slideDirection * 6 }}
                 animate={{ opacity: 1, x: 0 }}
-                transition={isReducedMotion ? { duration: 0 } : { duration: 0.3, ease: 'easeOut' }}
+                transition={isReducedMotion ? { duration: 0 } : { duration: 0.22, ease: 'easeOut' }}
             >
                 <FavoriteHero
                     video={current.video}

--- a/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
+++ b/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
@@ -1,5 +1,6 @@
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { fireEvent, render, screen, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import FavoriteHeroCarousel, { type FavoriteHeroItem } from '../FavoriteHeroCarousel';
 
@@ -19,9 +20,11 @@ const makeItems = (titles: string[]): FavoriteHeroItem[] =>
 
 const renderCarousel = (items: FavoriteHeroItem[]) =>
     render(
-        <ThemeProvider theme={createTheme()}>
-            <FavoriteHeroCarousel items={items} />
-        </ThemeProvider>,
+        <MemoryRouter>
+            <ThemeProvider theme={createTheme()}>
+                <FavoriteHeroCarousel items={items} />
+            </ThemeProvider>
+        </MemoryRouter>,
     );
 
 beforeEach(() => {
@@ -55,6 +58,15 @@ describe('FavoriteHeroCarousel', () => {
         expect(screen.getByRole('button', { name: 'previous' })).toBeInTheDocument();
         // Three dots (aria-label "featured N").
         expect(screen.getAllByRole('button', { name: /^featured \d$/ })).toHaveLength(3);
+    });
+
+    it('shows a collection action before the carousel controls when the active slide has a collection', () => {
+        const items = makeItems(['A', 'B']);
+        items[0].collection = { collectionId: 'collection-1', name: 'Saved collection' } as never;
+
+        renderCarousel(items);
+
+        expect(screen.getByRole('button', { name: 'openCollection' })).toBeInTheDocument();
     });
 
     it('advances to the next slide when the next arrow is clicked', () => {

--- a/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
+++ b/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
@@ -52,6 +52,17 @@ describe('FavoriteHeroCarousel', () => {
         expect(screen.queryByRole('button', { name: 'previous' })).not.toBeInTheDocument();
     });
 
+    it('keeps the collection action for a single collection-backed hero', () => {
+        const items = makeItems(['Only One']);
+        items[0].collection = { collectionId: 'collection-1', name: 'Saved collection' } as never;
+
+        renderCarousel(items);
+
+        expect(screen.getByRole('button', { name: 'openCollection' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'next' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'previous' })).not.toBeInTheDocument();
+    });
+
     it('renders one dot per slide and arrows when there are multiple', () => {
         renderCarousel(makeItems(['A', 'B', 'C']));
         expect(screen.getByRole('button', { name: 'next' })).toBeInTheDocument();

--- a/frontend/src/utils/authorAvatarStyles.ts
+++ b/frontend/src/utils/authorAvatarStyles.ts
@@ -1,0 +1,8 @@
+import type { Theme } from '@mui/material/styles';
+import type { SystemStyleObject } from '@mui/system';
+import { neutral } from '../theme/colors';
+
+export const authorAvatarFallbackSx = (theme: Theme): SystemStyleObject<Theme> => ({
+    bgcolor: theme.palette.mode === 'dark' ? neutral.grey550 : neutral.grey300,
+    color: theme.palette.mode === 'dark' ? neutral.grey200 : neutral.grey700,
+});


### PR DESCRIPTION
## Summary

- Moves the home sidebar's vertical scrolling from the outer flex item to the fixed-width inner panel.
- Measures the main content height and passes it to the sidebar so the sidebar can remain internally scrollable without changing the right-panel width.
- Adds overflow constraints to the home layout to keep the main grid stable when the sidebar becomes scrollable.

## Root Cause

The sidebar's custom 6px scrollbar could appear on the outer flex item after the first layout. Because that outer item participates in the same row as the video grid, the scrollbar could steal width from the right panel and make the grid appear to shrink once during early interaction.

## Validation

- `npm run typecheck:frontend`