### PR TITLE
Fix channel subscription URL being cleared

### DIFF
--- a/frontend/src/components/ChannelSubscribeChoiceModal.tsx
+++ b/frontend/src/components/ChannelSubscribeChoiceModal.tsx
@@ -36,7 +36,9 @@ const ChannelSubscribeChoiceModal: React.FC<ChannelSubscribeChoiceModalProps> = 
         setPendingAction(action);
         try {
             await (action === 'playlists' ? onChoosePlaylists() : onChooseVideos());
-            onClose();
+            // The selected handler owns the modal transition. Calling onClose
+            // here would also run the parent's cancellation cleanup, clearing
+            // the channel URL before the subscription modal can use it.
         } catch {
             // Keep the modal open so the action can be retried.
         } finally {

--- a/frontend/src/components/__tests__/ChannelSubscribeChoiceModal.test.tsx
+++ b/frontend/src/components/__tests__/ChannelSubscribeChoiceModal.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ChannelSubscribeChoiceModal from '../ChannelSubscribeChoiceModal';
+
+vi.mock('../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+describe('ChannelSubscribeChoiceModal', () => {
+    const onClose = vi.fn();
+    const onChooseVideos = vi.fn();
+    const onChoosePlaylists = vi.fn();
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('leaves closing to the selected subscription flow', async () => {
+        const user = userEvent.setup();
+        render(
+            <ChannelSubscribeChoiceModal
+                open
+                onClose={onClose}
+                onChooseVideos={onChooseVideos}
+                onChoosePlaylists={onChoosePlaylists}
+            />
+        );
+
+        await user.click(screen.getByRole('button', { name: 'subscribeAllVideos' }));
+
+        expect(onChooseVideos).toHaveBeenCalledOnce();
+        expect(onClose).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- preserve the selected YouTube channel URL when moving from the channel-choice dialog to the subscription dialog
- add regression coverage for the dialog handoff

## Root cause

After choosing “Subscribe all videos,” the choice dialog ran its cancellation close handler. That handler cleared `subscribeUrl`, causing the subsequent subscription request to send `url: ""`.

## Validation

- `npm --prefix frontend test -- --run src/components/__tests__/ChannelSubscribeChoiceModal.test.tsx src/contexts/__tests__/DownloadContext.test.tsx`
- `npm --prefix frontend run typecheck`