### PR TITLE
feat: add subscribe-only playlist subscriptions

### DIFF
--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -20,7 +20,11 @@ import {
 } from "../../controllers/subscriptionController";
 import { ValidationError } from "../../errors/DownloadErrors";
 import { continuousDownloadService } from "../../services/continuousDownloadService";
-import { checkPlaylist } from "../../services/downloadService";
+import {
+  checkPlaylist,
+  getBilibiliCollectionVideos,
+  getBilibiliSeriesVideos,
+} from "../../services/downloadService";
 import * as storageService from "../../services/storageService";
 import { subscriptionService } from "../../services/subscriptionService";
 import { logger } from "../../utils/logger";
@@ -60,6 +64,9 @@ vi.mock("../../services/continuousDownloadService", () => ({
 
 vi.mock("../../services/downloadService", () => ({
   checkPlaylist: vi.fn(),
+  checkBilibiliCollectionOrSeries: vi.fn(),
+  getBilibiliCollectionVideos: vi.fn(),
+  getBilibiliSeriesVideos: vi.fn(),
 }));
 
 vi.mock("../../services/storageService", () => ({
@@ -75,6 +82,10 @@ vi.mock("../../utils/helpers", () => ({
   isBilibiliUrl: vi.fn((url: string) => url.includes("bilibili")),
   isTwitchChannelUrl: vi.fn((url: string) => url.includes("twitch.tv")),
   isYouTubeUrl: vi.fn((url: string) => url.includes("youtube")),
+  extractBilibiliVideoId: vi.fn((url: string) => {
+    const match = url.match(/\/video\/([^/?#]+)/);
+    return match?.[1] ?? null;
+  }),
   normalizeTwitchChannelUrl: vi.fn((url: string) => url.replace(/\/+$/, "").toLowerCase()),
   normalizeYouTubeAuthorUrl: vi.fn((url: string) => url.replace(/\/+$/, "")),
 }));
@@ -112,6 +123,7 @@ describe("SubscriptionController", () => {
       .mockReturnValue({ json } as unknown as Response);
     req = { body: {}, params: {} };
     res = { json, status };
+    (subscriptionService.listSubscriptions as any).mockResolvedValue([]);
   });
 
   describe("createSubscription", () => {
@@ -725,14 +737,15 @@ describe("SubscriptionController", () => {
       );
     });
 
-    it("uses Bilibili collectionInfo for title/count and still probes the head baseline", async () => {
+    it("uses Bilibili collectionInfo and API videos for a video URL baseline", async () => {
       req.body = {
-        playlistUrl: "https://www.bilibili.com/list/ml123",
+        playlistUrl: "https://www.bilibili.com/video/BV1xx",
         interval: 30,
         collectionName: "Bili List",
         collectionInfo: {
           type: "collection",
           id: 9988,
+          mid: 12345,
           title: "合集标题",
           count: 88,
         },
@@ -741,15 +754,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "Bili List",
       });
-      (executeYtDlpJson as any).mockResolvedValue({
-        _type: "playlist",
-        entries: [
-          {
-            id: "BV1xx",
-            webpage_url: "https://www.bilibili.com/video/BV1xx",
-            uploader: "UP Name",
-          },
-        ],
+      (getBilibiliCollectionVideos as any).mockResolvedValue({
+        success: true,
+        videos: [{ bvid: "BV1head", title: "Head", aid: 1 }],
       });
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
         id: "sub-bili-1",
@@ -759,16 +766,18 @@ describe("SubscriptionController", () => {
 
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
         expect.objectContaining({
-          playlistUrl: "https://www.bilibili.com/list/ml123",
+          playlistUrl: "https://www.bilibili.com/video/BV1xx",
           interval: 30,
           playlistTitle: "合集标题",
           playlistId: "9988",
-          author: "UP Name",
+          author: "Bilibili 12345",
           platform: "Bilibili",
           collectionId: "existing-col",
-          initialHeadVideoUrl: "https://www.bilibili.com/video/BV1xx",
+          initialHeadVideoUrl: "https://www.bilibili.com/video/BV1head",
         })
       );
+      expect(executeYtDlpJson).not.toHaveBeenCalled();
+      expect(getBilibiliSeriesVideos).not.toHaveBeenCalled();
     });
 
     it("returns backfillStatus not_needed_empty for a verified empty playlist with downloadAll", async () => {
@@ -935,6 +944,10 @@ describe("SubscriptionController", () => {
         .mockResolvedValueOnce({
           _type: "playlist",
           entries: [{ id: "headOne" }],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "headTwo" }],
         });
       (storageService.getSettings as any).mockReturnValue({ saveAuthorFilesToCollection: false });
       (storageService.getCollectionByName as any).mockReturnValue({
@@ -943,7 +956,11 @@ describe("SubscriptionController", () => {
       });
       // Single listSubscriptions call; PL_TWO is already in the set.
       (subscriptionService.listSubscriptions as any).mockResolvedValue([
-        { id: "existing-sub-two", authorUrl: "https://www.youtube.com/playlist?list=PL_TWO" },
+        {
+          id: "existing-sub-two",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_TWO",
+          collectionId: "existing-col-two",
+        },
       ]);
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
         id: "new-sub-one",
@@ -993,6 +1010,54 @@ describe("SubscriptionController", () => {
       expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ subscribedCount: 1, skippedCount: 1, errorCount: 0 })
+      );
+    });
+
+    it("creates a backfill task for an already subscribed playlist when requested", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        downloadAllPrevious: true,
+      };
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            {
+              id: "PL_EXISTING",
+              url: "https://www.youtube.com/playlist?list=PL_EXISTING",
+              title: "Existing Playlist",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "existingHead" }],
+        });
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        {
+          id: "existing-sub",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_EXISTING",
+          collectionId: "existing-col",
+        },
+      ]);
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "backfill-task",
+      });
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_EXISTING",
+        "My Channel",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ subscribedCount: 0, skippedCount: 1 })
       );
     });
 

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -926,6 +926,7 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "task-existing",
       });
@@ -934,6 +935,9 @@ describe("SubscriptionController", () => {
 
       expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
       expect(storageService.getCollectionByName).not.toHaveBeenCalled();
+      expect(continuousDownloadService.getTaskByAuthorUrl).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123"
+      );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL123",
         "Uploader Name",
@@ -949,6 +953,51 @@ describe("SubscriptionController", () => {
           taskId: "task-existing",
           downloadAll: true,
           backfillStatus: "started",
+        })
+      );
+    });
+
+    it("does not queue a duplicate direct backfill task when one already exists", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      const existingSubscription = {
+        id: "existing-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: "existing-col",
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: "existing-col",
+        name: "My Playlist",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
+        id: "existing-task",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(continuousDownloadService.createPlaylistTask).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription: existingSubscription,
+          collectionId: "existing-col",
+          taskId: "existing-task",
+          downloadAll: true,
+          backfillStatus: "already_exists",
         })
       );
     });

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -780,6 +780,52 @@ describe("SubscriptionController", () => {
       expect(getBilibiliSeriesVideos).not.toHaveBeenCalled();
     });
 
+    it("starts Bilibili collection backfill when API inspection finds videos despite a zero client count", async () => {
+      req.body = {
+        playlistUrl: "https://www.bilibili.com/video/BV1xx",
+        interval: 30,
+        collectionName: "Bili List",
+        downloadAll: true,
+        collectionInfo: {
+          type: "collection",
+          id: 9988,
+          mid: 12345,
+          title: "合集标题",
+          count: 0,
+        },
+      };
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "existing-col",
+        name: "Bili List",
+      });
+      (getBilibiliCollectionVideos as any).mockResolvedValue({
+        success: true,
+        videos: [{ bvid: "BV1head", title: "Head", aid: 1 }],
+      });
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "sub-bili-1",
+      });
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "task-bili",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.bilibili.com/video/BV1xx",
+        "Bilibili 12345",
+        "Bilibili",
+        "existing-col",
+        "sub-bili-1"
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: "task-bili",
+          backfillStatus: "started",
+        })
+      );
+    });
+
     it("returns backfillStatus not_needed_empty for a verified empty playlist with downloadAll", async () => {
       req.body = {
         playlistUrl: "https://www.youtube.com/playlist?list=PL123",

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -30,6 +30,7 @@ import { subscriptionService } from "../../services/subscriptionService";
 import { logger } from "../../utils/logger";
 import {
     executeYtDlpJson,
+    getEffectiveUserYtDlpConfig,
     getNetworkConfigFromUserConfig,
     getUserYtDlpConfig,
 } from "../../utils/ytDlpUtils";
@@ -45,6 +46,7 @@ vi.mock("../../services/subscriptionService", () => ({
     getSubscriptionById: vi.fn(),
     subscribePlaylist: vi.fn(),
     updatePlaylistSubscriptionCollection: vi.fn(),
+    updatePlaylistSubscriptionCursor: vi.fn(),
     subscribeChannelPlaylistsWatcher: vi.fn(),
   },
 }));
@@ -60,6 +62,7 @@ vi.mock("../../services/continuousDownloadService", () => ({
     clearFinishedTasks: vi.fn(),
     createPlaylistTask: vi.fn(),
     getTaskByAuthorUrl: vi.fn(),
+    getBlockingPlaylistTaskByDestination: vi.fn(),
   },
 }));
 
@@ -969,6 +972,7 @@ describe("SubscriptionController", () => {
         id: "existing-sub",
         authorUrl: "https://www.youtube.com/playlist?list=PL123",
         collectionId: "existing-col",
+        ytdlpConfig: "--cookies /config/cookies.txt",
       };
       (subscriptionService.listSubscriptions as any).mockResolvedValue([
         existingSubscription,
@@ -984,9 +988,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(
-        null
-      );
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "task-existing",
       });
@@ -995,8 +999,16 @@ describe("SubscriptionController", () => {
 
       expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
       expect(storageService.getCollectionByName).not.toHaveBeenCalled();
-      expect(continuousDownloadService.getTaskByAuthorUrl).toHaveBeenCalledWith(
-        "https://www.youtube.com/playlist?list=PL123"
+      expect(getEffectiveUserYtDlpConfig).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "--cookies /config/cookies.txt"
+      );
+      expect(
+        continuousDownloadService.getBlockingPlaylistTaskByDestination
+      ).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "existing-sub",
+        "existing-col"
       );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL123",
@@ -1005,10 +1017,21 @@ describe("SubscriptionController", () => {
         "existing-col",
         "existing-sub"
       );
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCursor
+      ).toHaveBeenCalledWith(
+        "existing-sub",
+        "https://www.youtube.com/watch?v=vidA",
+        expect.any(Number)
+      );
       expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({
-          subscription: existingSubscription,
+          subscription: expect.objectContaining({
+            id: "existing-sub",
+            lastVideoLink: "https://www.youtube.com/watch?v=vidA",
+            lastCheck: expect.any(Number),
+          }),
           collectionId: "existing-col",
           taskId: "task-existing",
           downloadAll: true,
@@ -1043,9 +1066,9 @@ describe("SubscriptionController", () => {
         id: "resolved-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(
-        null
-      );
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "task-legacy",
       });
@@ -1055,6 +1078,13 @@ describe("SubscriptionController", () => {
       expect(
         subscriptionService.updatePlaylistSubscriptionCollection
       ).toHaveBeenCalledWith("legacy-sub", "resolved-col");
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCursor
+      ).toHaveBeenCalledWith(
+        "legacy-sub",
+        "https://www.youtube.com/watch?v=vidA",
+        expect.any(Number)
+      );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL123",
         "Uploader Name",
@@ -1067,6 +1097,8 @@ describe("SubscriptionController", () => {
           subscription: expect.objectContaining({
             id: "legacy-sub",
             collectionId: "resolved-col",
+            lastVideoLink: "https://www.youtube.com/watch?v=vidA",
+            lastCheck: expect.any(Number),
           }),
           collectionId: "resolved-col",
           taskId: "task-legacy",
@@ -1101,7 +1133,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue({
         id: "existing-task",
         status: "active",
         subscriptionId: "existing-sub",
@@ -1112,6 +1146,9 @@ describe("SubscriptionController", () => {
 
       expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
       expect(continuousDownloadService.createPlaylistTask).not.toHaveBeenCalled();
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCursor
+      ).not.toHaveBeenCalled();
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({
           subscription: existingSubscription,
@@ -1123,7 +1160,7 @@ describe("SubscriptionController", () => {
       );
     });
 
-    it("queues a replacement direct backfill when an active task belongs to another destination", async () => {
+    it("queues a replacement direct backfill when no blocking task belongs to the same destination", async () => {
       req.body = {
         playlistUrl: "https://www.youtube.com/playlist?list=PL123",
         interval: 60,
@@ -1149,11 +1186,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
-        id: "standalone-task",
-        status: "active",
-        collectionId: "other-col",
-      });
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "replacement-task",
       });
@@ -1201,10 +1236,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
-        id: "completed-task",
-        status: "completed",
-      });
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "replacement-task",
       });
@@ -1337,7 +1371,9 @@ describe("SubscriptionController", () => {
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
         id: "new-sub-one",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "created-task-1",
       });
@@ -1411,9 +1447,12 @@ describe("SubscriptionController", () => {
           id: "existing-sub",
           authorUrl: "https://www.youtube.com/playlist?list=PL_EXISTING",
           collectionId: "existing-col",
+          ytdlpConfig: "--cookies /bulk-cookies.txt",
         },
       ]);
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "backfill-task",
       });
@@ -1421,12 +1460,23 @@ describe("SubscriptionController", () => {
       await subscribeChannelPlaylists(req as Request, res as Response);
 
       expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(getEffectiveUserYtDlpConfig).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_EXISTING",
+        "--cookies /bulk-cookies.txt"
+      );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL_EXISTING",
         "My Channel",
         "YouTube",
         "existing-col",
         "existing-sub"
+      );
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCursor
+      ).toHaveBeenCalledWith(
+        "existing-sub",
+        "https://www.youtube.com/watch?v=existingHead",
+        expect.any(Number)
       );
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ subscribedCount: 0, skippedCount: 1 })
@@ -1465,7 +1515,9 @@ describe("SubscriptionController", () => {
         id: "resolved-legacy-col",
         name: "Legacy Playlist - My Channel",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "legacy-backfill-task",
       });
@@ -1479,6 +1531,13 @@ describe("SubscriptionController", () => {
       expect(
         subscriptionService.updatePlaylistSubscriptionCollection
       ).toHaveBeenCalledWith("legacy-sub", "resolved-legacy-col");
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCursor
+      ).toHaveBeenCalledWith(
+        "legacy-sub",
+        "https://www.youtube.com/watch?v=legacyHead",
+        expect.any(Number)
+      );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL_LEGACY",
         "My Channel",

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -73,6 +73,7 @@ vi.mock("../../services/downloadService", () => ({
 vi.mock("../../services/storageService", () => ({
   getCollectionByName: vi.fn(),
   getCollectionById: vi.fn(),
+  getCollectionBySourceKey: vi.fn(),
   generateUniqueCollectionName: vi.fn((name: string) => `${name}-unique`),
   saveCollection: vi.fn(),
   deleteCollection: vi.fn(),
@@ -781,6 +782,62 @@ describe("SubscriptionController", () => {
       expect(getBilibiliSeriesVideos).not.toHaveBeenCalled();
     });
 
+    it("creates a separate collection when a Bilibili name matches another source key", async () => {
+      req.body = {
+        playlistUrl: "https://www.bilibili.com/video/BV1xx",
+        interval: 30,
+        collectionName: "Bili List",
+        collectionInfo: {
+          type: "collection",
+          id: 9988,
+          mid: 12345,
+          title: "合集标题",
+          count: 88,
+        },
+      };
+      (storageService.getCollectionBySourceKey as any).mockReturnValue(
+        undefined
+      );
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "other-source-col",
+        name: "Bili List",
+        videos: [],
+        sourcePlatform: "bilibili",
+        sourceType: "collection",
+        sourceMid: "999",
+        sourceId: "111",
+      });
+      (storageService.generateUniqueCollectionName as any).mockReturnValue(
+        "Bili List (2)"
+      );
+      (getBilibiliCollectionVideos as any).mockResolvedValue({
+        success: true,
+        videos: [{ bvid: "BV1head", title: "Head", aid: 1 }],
+      });
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "sub-bili-1",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      const savedCollection = (storageService.saveCollection as Mock).mock
+        .calls[0][0];
+      expect(savedCollection).toEqual(
+        expect.objectContaining({
+          name: "Bili List (2)",
+          sourcePlatform: "bilibili",
+          sourceType: "collection",
+          sourceMid: "12345",
+          sourceId: "9988",
+        })
+      );
+      expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
+        expect.objectContaining({
+          collectionId: savedCollection.id,
+        })
+      );
+    });
+
     it("starts Bilibili collection backfill when API inspection finds videos despite a zero client count", async () => {
       req.body = {
         playlistUrl: "https://www.bilibili.com/video/BV1xx",
@@ -1047,6 +1104,8 @@ describe("SubscriptionController", () => {
       (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
         id: "existing-task",
         status: "active",
+        subscriptionId: "existing-sub",
+        collectionId: "existing-col",
       });
 
       await createPlaylistSubscription(req as Request, res as Response);
@@ -1060,6 +1119,58 @@ describe("SubscriptionController", () => {
           taskId: "existing-task",
           downloadAll: true,
           backfillStatus: "already_exists",
+        })
+      );
+    });
+
+    it("queues a replacement direct backfill when an active task belongs to another destination", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      const existingSubscription = {
+        id: "existing-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: "existing-col",
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: "existing-col",
+        name: "My Playlist",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
+        id: "standalone-task",
+        status: "active",
+        collectionId: "other-col",
+      });
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "replacement-task",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "Uploader Name",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: "replacement-task",
+          backfillStatus: "started",
         })
       );
     });
@@ -1365,6 +1476,9 @@ describe("SubscriptionController", () => {
       expect(storageService.getCollectionByName).toHaveBeenCalledWith(
         "Legacy Playlist - My Channel"
       );
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCollection
+      ).toHaveBeenCalledWith("legacy-sub", "resolved-legacy-col");
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL_LEGACY",
         "My Channel",

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -64,8 +64,10 @@ vi.mock("../../services/downloadService", () => ({
 
 vi.mock("../../services/storageService", () => ({
   getCollectionByName: vi.fn(),
+  getCollectionById: vi.fn(),
   generateUniqueCollectionName: vi.fn((name: string) => `${name}-unique`),
   saveCollection: vi.fn(),
+  deleteCollection: vi.fn(),
   getSettings: vi.fn(() => ({})),
 }));
 
@@ -81,6 +83,7 @@ vi.mock("../../utils/ytDlpUtils", () => ({
   executeYtDlpJson: vi.fn(),
   getNetworkConfigFromUserConfig: vi.fn(() => ({})),
   getUserYtDlpConfig: vi.fn(() => ({})),
+  getEffectiveUserYtDlpConfig: vi.fn(() => ({})),
 }));
 
 vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
@@ -589,22 +592,75 @@ describe("SubscriptionController", () => {
       ).rejects.toThrow("playlist parameter");
     });
 
-    it("should create playlist subscription for youtube and create task when downloadAll is true", async () => {
+    it("rejects non-boolean downloadAll values (strings/numbers/objects)", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: "false",
+      };
+      await expect(
+        createPlaylistSubscription(req as Request, res as Response)
+      ).rejects.toThrow(ValidationError);
+    });
+
+    it("creates subscribe-only subscription with baseline and no task when downloadAll is false", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: false,
+      };
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "sub-playlist-1",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      // No historical task created in subscribe-only mode.
+      expect(continuousDownloadService.createPlaylistTask).not.toHaveBeenCalled();
+      expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
+        expect.objectContaining({
+          playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+          interval: 60,
+          initialHeadVideoUrl: "https://www.youtube.com/watch?v=vidA",
+          baselineObservedAt: expect.any(Number),
+        })
+      );
+      expect(status).toHaveBeenCalledWith(201);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription: { id: "sub-playlist-1" },
+          taskId: null,
+          downloadAll: false,
+          backfillStatus: "not_requested",
+        })
+      );
+    });
+
+    it("creates subscription and a linked task when downloadAll is true", async () => {
       req.body = {
         playlistUrl: "https://www.youtube.com/playlist?list=PL123",
         interval: 60,
         collectionName: "My Playlist",
         downloadAll: true,
       };
-      (checkPlaylist as any).mockResolvedValue({
-        success: true,
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
         title: "Playlist Title",
-        videoCount: 12,
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
       });
       (storageService.getCollectionByName as any).mockReturnValue(null);
-      (executeYtDlpJson as any).mockResolvedValue({
-        entries: [{ uploader: "Uploader Name" }],
-      });
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
         id: "sub-playlist-1",
       });
@@ -614,29 +670,62 @@ describe("SubscriptionController", () => {
 
       await createPlaylistSubscription(req as Request, res as Response);
 
-      expect(checkPlaylist).toHaveBeenCalledWith(
-        "https://www.youtube.com/playlist?list=PL123"
-      );
-      expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
+      // The historical task is linked to the subscription id (design §7.4).
+      expect(
+        continuousDownloadService.createPlaylistTask
+      ).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL123",
-        60,
-        "Playlist Title",
-        "PL123",
         "Uploader Name",
         "YouTube",
-        expect.any(String)
+        expect.any(String),
+        "sub-playlist-1"
       );
-      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalled();
       expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({
           subscription: { id: "sub-playlist-1" },
           taskId: "task-123",
+          downloadAll: true,
+          backfillStatus: "started",
         })
       );
     });
 
-    it("should use bilibili collectionInfo without calling checkPlaylist", async () => {
+    it("returns backfillStatus failed (taskId null) when task creation errors", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "sub-playlist-1",
+      });
+      (continuousDownloadService.createPlaylistTask as any).mockRejectedValue(
+        new Error("task create failed")
+      );
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(logger.error).toHaveBeenCalled();
+      expect(status).toHaveBeenCalledWith(201);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: null,
+          backfillStatus: "failed",
+        })
+      );
+    });
+
+    it("uses Bilibili collectionInfo for title/count and still probes the head baseline", async () => {
       req.body = {
         playlistUrl: "https://www.bilibili.com/list/ml123",
         interval: 30,
@@ -652,86 +741,160 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "Bili List",
       });
-      (executeYtDlpJson as any).mockResolvedValue({ uploader: "UP Name" });
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        entries: [
+          {
+            id: "BV1xx",
+            webpage_url: "https://www.bilibili.com/video/BV1xx",
+            uploader: "UP Name",
+          },
+        ],
+      });
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
         id: "sub-bili-1",
       });
 
       await createPlaylistSubscription(req as Request, res as Response);
 
-      expect(checkPlaylist).not.toHaveBeenCalled();
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
-        "https://www.bilibili.com/list/ml123",
-        30,
-        "合集标题",
-        "9988",
-        "UP Name",
-        "Bilibili",
-        "existing-col"
+        expect.objectContaining({
+          playlistUrl: "https://www.bilibili.com/list/ml123",
+          interval: 30,
+          playlistTitle: "合集标题",
+          playlistId: "9988",
+          author: "UP Name",
+          platform: "Bilibili",
+          collectionId: "existing-col",
+          initialHeadVideoUrl: "https://www.bilibili.com/video/BV1xx",
+        })
       );
     });
 
-    it("should continue with default author when yt-dlp extraction fails", async () => {
-      req.body = {
-        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
-        interval: 60,
-        collectionName: "My Playlist",
-      };
-      (checkPlaylist as any).mockResolvedValue({
-        success: true,
-        title: "Playlist Title",
-        videoCount: 12,
-      });
-      (storageService.getCollectionByName as any).mockReturnValue(null);
-      (executeYtDlpJson as any).mockRejectedValue(new Error("yt-dlp error"));
-      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
-        id: "sub-playlist-1",
-      });
-
-      await createPlaylistSubscription(req as Request, res as Response);
-      expect(logger.warn).toHaveBeenCalled();
-      expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
-        "https://www.youtube.com/playlist?list=PL123",
-        60,
-        "Playlist Title",
-        "PL123",
-        "Playlist Author",
-        "YouTube",
-        expect.any(String)
-      );
-    });
-
-    it("should not fail when creating backfill task errors", async () => {
+    it("returns backfillStatus not_needed_empty for a verified empty playlist with downloadAll", async () => {
       req.body = {
         playlistUrl: "https://www.youtube.com/playlist?list=PL123",
         interval: 60,
         collectionName: "My Playlist",
         downloadAll: true,
       };
-      (checkPlaylist as any).mockResolvedValue({
-        success: true,
-        title: "Playlist Title",
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Empty",
+        id: "PL123",
+        entries: [],
       });
       (storageService.getCollectionByName as any).mockReturnValue(null);
-      (executeYtDlpJson as any).mockResolvedValue({ uploader: "Uploader Name" });
       (subscriptionService.subscribePlaylist as any).mockResolvedValue({
-        id: "sub-playlist-1",
+        id: "sub-empty",
       });
-      (continuousDownloadService.createPlaylistTask as any).mockRejectedValue(
-        new Error("task create failed")
-      );
 
       await createPlaylistSubscription(req as Request, res as Response);
 
-      expect(logger.error).toHaveBeenCalled();
-      expect(status).toHaveBeenCalledWith(201);
+      // Empty playlist omits the zero-length task (design §4.5).
+      expect(
+        continuousDownloadService.createPlaylistTask
+      ).not.toHaveBeenCalled();
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({
-          taskId: undefined,
+          taskId: null,
+          backfillStatus: "not_needed_empty",
         })
       );
     });
+
+    it("creates no subscription/collection/task when the baseline probe fails (fail-closed)", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: false,
+      };
+      (executeYtDlpJson as any).mockRejectedValue(new Error("probe failed"));
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+
+      await expect(
+        createPlaylistSubscription(req as Request, res as Response)
+      ).rejects.toThrow("probe failed");
+
+      // No persistent side effects created before the baseline (design §7.5).
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(storageService.saveCollection).not.toHaveBeenCalled();
+      expect(
+        continuousDownloadService.createPlaylistTask
+      ).not.toHaveBeenCalled();
+    });
+
+    it("rejects a direct duplicate before creating a collection/task", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        { authorUrl: "https://www.youtube.com/playlist?list=PL123" },
+      ]);
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+
+      await expect(
+        createPlaylistSubscription(req as Request, res as Response)
+      ).rejects.toThrow(/already exists/);
+
+      // Duplicate is rejected before any probe or collection creation.
+      expect(executeYtDlpJson).not.toHaveBeenCalled();
+      expect(storageService.saveCollection).not.toHaveBeenCalled();
+    });
+
+    it("removes a fresh empty collection when subscription insertion fails", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+      };
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+      (storageService.getCollectionById as any).mockImplementation((id: string) => ({
+        id,
+        name: "My Playlist-unique",
+        videos: [],
+      }));
+      (subscriptionService.subscribePlaylist as any).mockRejectedValue(
+        new Error("insert failed")
+      );
+      (subscriptionService.listSubscriptions as any)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      (storageService.deleteCollection as any).mockReturnValue(true);
+
+      await expect(
+        createPlaylistSubscription(req as Request, res as Response)
+      ).rejects.toThrow("insert failed");
+
+      expect(storageService.deleteCollection).toHaveBeenCalledWith(
+        expect.any(String)
+      );
+    });
+
+    it("rejects malformed Bilibili collectionInfo instead of silently ignoring it", async () => {
+      req.body = {
+        playlistUrl: "https://www.bilibili.com/list/ml123",
+        interval: 60,
+        collectionName: "Bili List",
+        collectionInfo: { type: "unknown", id: "123" },
+      };
+
+      await expect(
+        createPlaylistSubscription(req as Request, res as Response)
+      ).rejects.toThrow(ValidationError);
+      expect(executeYtDlpJson).not.toHaveBeenCalled();
+    });
   });
+
 
   describe("subscribeChannelPlaylists", () => {
     it("should throw when required fields are missing", async () => {
@@ -750,47 +913,74 @@ describe("SubscriptionController", () => {
       ).rejects.toThrow("No playlists found");
     });
 
+    // Models the new two-phase flow (design §8.1): one listing call feeds the
+    // candidate list and the duplicate set, then each new candidate gets a
+    // head-snapshot probe before a sequential collection+subscription insert.
     function setupChannelPlaylistsMocks() {
       req.body = {
         url: "https://www.youtube.com/@channel",
         interval: 60,
         downloadAllPrevious: true,
       };
-      (executeYtDlpJson as any).mockResolvedValue({
-        uploader: "My Channel",
-        entries: [
-          { id: "PL_ONE", url: "https://www.youtube.com/playlist?list=PL_ONE", title: "Playlist One" },
-          { id: "PL_TWO", url: "https://www.youtube.com/playlist?list=PL_TWO", title: "Playlist Two" },
-        ],
-      });
+      // 1st call: channel listing. PL_TWO is already subscribed (in the set).
+      // Then one head probe for PL_ONE.
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            { id: "PL_ONE", url: "https://www.youtube.com/playlist?list=PL_ONE", title: "Playlist One" },
+            { id: "PL_TWO", url: "https://www.youtube.com/playlist?list=PL_TWO", title: "Playlist Two" },
+          ],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "headOne" }],
+        });
       (storageService.getSettings as any).mockReturnValue({ saveAuthorFilesToCollection: false });
-      (storageService.getCollectionByName as any)
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce({ id: "existing-col-2", name: "Playlist Two" });
-      (subscriptionService.listSubscriptions as any)
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([
-          { authorUrl: "https://www.youtube.com/playlist?list=PL_TWO" },
-        ]);
-      (continuousDownloadService.getTaskByAuthorUrl as any)
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: "existing-task" });
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "col-one",
+        name: "Playlist One",
+      });
+      // Single listSubscriptions call; PL_TWO is already in the set.
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        { id: "existing-sub-two", authorUrl: "https://www.youtube.com/playlist?list=PL_TWO" },
+      ]);
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "new-sub-one",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "created-task-1",
       });
     }
 
-    it("should subscribe new playlists and skip duplicates", async () => {
+    it("should subscribe new playlists with a baseline and skip duplicates", async () => {
       setupChannelPlaylistsMocks();
       await subscribeChannelPlaylists(req as Request, res as Response);
 
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledTimes(1);
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
-        "https://www.youtube.com/playlist?list=PL_ONE",
-        60, "Playlist One", "PL_ONE", "My Channel", "YouTube",
-        expect.any(String)
+        expect.objectContaining({
+          playlistUrl: "https://www.youtube.com/playlist?list=PL_ONE",
+          interval: 60,
+          playlistTitle: "Playlist One",
+          playlistId: "PL_ONE",
+          author: "My Channel",
+          platform: "YouTube",
+          initialHeadVideoUrl: "https://www.youtube.com/watch?v=headOne",
+          baselineObservedAt: expect.any(Number),
+        })
       );
-      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledTimes(1);
+      // Backfill task linked to the newly created subscription (design §7.4).
+      expect(
+        continuousDownloadService.createPlaylistTask
+      ).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_ONE",
+        "My Channel",
+        "YouTube",
+        "col-one",
+        "new-sub-one"
+      );
     });
 
     it("should create watcher and respond with counts", async () => {
@@ -806,27 +996,56 @@ describe("SubscriptionController", () => {
       );
     });
 
+    it("counts a failed baseline probe as an error, not a skip", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+      };
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            { id: "PL_BAD", url: "https://www.youtube.com/playlist?list=PL_BAD", title: "Bad" },
+          ],
+        })
+        // Head probe fails.
+        .mockRejectedValueOnce(new Error("probe failed"));
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([]);
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      // Failed baseline => error, no subscription created.
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ subscribedCount: 0, errorCount: 1 })
+      );
+    });
+
     it("should fallback channel name from url when uploader is missing", async () => {
       req.body = {
         url: "https://www.youtube.com/@MyChannel",
         interval: 60,
       };
-      (executeYtDlpJson as any).mockResolvedValue({
-        channel_id: "id-1",
-        entries: [{ id: "PL1", title: "P1" }],
-      });
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          channel_id: "id-1",
+          entries: [{ id: "PL1", title: "P1" }],
+        })
+        .mockResolvedValueOnce({ _type: "playlist", entries: [{ id: "h1" }] });
       (subscriptionService.listSubscriptions as any).mockResolvedValue([]);
+      (storageService.getCollectionByName as any).mockReturnValue(null);
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({ id: "s1" });
 
       await subscribeChannelPlaylists(req as Request, res as Response);
 
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
-        "https://www.youtube.com/playlist?list=PL1",
-        60,
-        "P1",
-        "PL1",
-        "@MyChannel",
-        "YouTube",
-        expect.any(String)
+        expect.objectContaining({
+          playlistUrl: "https://www.youtube.com/playlist?list=PL1",
+          playlistTitle: "P1",
+          playlistId: "PL1",
+          author: "@MyChannel",
+          platform: "YouTube",
+        })
       );
       expect(storageService.saveCollection).toHaveBeenCalled();
     });

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -44,6 +44,7 @@ vi.mock("../../services/subscriptionService", () => ({
     updateSubscriptionSettings: vi.fn(),
     getSubscriptionById: vi.fn(),
     subscribePlaylist: vi.fn(),
+    updatePlaylistSubscriptionCollection: vi.fn(),
     subscribeChannelPlaylistsWatcher: vi.fn(),
   },
 }));
@@ -926,7 +927,9 @@ describe("SubscriptionController", () => {
         id: "existing-col",
         name: "My Playlist",
       });
-      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(
+        null
+      );
       (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
         id: "task-existing",
       });
@@ -952,6 +955,64 @@ describe("SubscriptionController", () => {
           collectionId: "existing-col",
           taskId: "task-existing",
           downloadAll: true,
+          backfillStatus: "started",
+        })
+      );
+    });
+
+    it("links a resolved collection to a legacy direct duplicate before backfill", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      const existingSubscription = {
+        id: "legacy-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: null,
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "resolved-col",
+        name: "My Playlist",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(
+        null
+      );
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "task-legacy",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(
+        subscriptionService.updatePlaylistSubscriptionCollection
+      ).toHaveBeenCalledWith("legacy-sub", "resolved-col");
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "Uploader Name",
+        "YouTube",
+        "resolved-col",
+        "legacy-sub"
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription: expect.objectContaining({
+            id: "legacy-sub",
+            collectionId: "resolved-col",
+          }),
+          collectionId: "resolved-col",
+          taskId: "task-legacy",
           backfillStatus: "started",
         })
       );
@@ -985,6 +1046,7 @@ describe("SubscriptionController", () => {
       });
       (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
         id: "existing-task",
+        status: "active",
       });
 
       await createPlaylistSubscription(req as Request, res as Response);
@@ -998,6 +1060,57 @@ describe("SubscriptionController", () => {
           taskId: "existing-task",
           downloadAll: true,
           backfillStatus: "already_exists",
+        })
+      );
+    });
+
+    it("queues a replacement direct backfill when the previous task is terminal", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      const existingSubscription = {
+        id: "existing-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: "existing-col",
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: "existing-col",
+        name: "My Playlist",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue({
+        id: "completed-task",
+        status: "completed",
+      });
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "replacement-task",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "Uploader Name",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskId: "replacement-task",
+          backfillStatus: "started",
         })
       );
     });

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -1107,6 +1107,58 @@ describe("SubscriptionController", () => {
       );
     });
 
+    it("resolves a collection for already subscribed playlist backfill when the row has none", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        downloadAllPrevious: true,
+      };
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            {
+              id: "PL_LEGACY",
+              url: "https://www.youtube.com/playlist?list=PL_LEGACY",
+              title: "Legacy Playlist",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "legacyHead" }],
+        });
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        {
+          id: "legacy-sub",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_LEGACY",
+          collectionId: null,
+        },
+      ]);
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "resolved-legacy-col",
+        name: "Legacy Playlist - My Channel",
+      });
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "legacy-backfill-task",
+      });
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(storageService.getCollectionByName).toHaveBeenCalledWith(
+        "Legacy Playlist - My Channel"
+      );
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_LEGACY",
+        "My Channel",
+        "YouTube",
+        "resolved-legacy-col",
+        "legacy-sub"
+      );
+    });
+
     it("counts a failed baseline probe as an error, not a skip", async () => {
       req.body = {
         url: "https://www.youtube.com/@channel",

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -900,6 +900,59 @@ describe("SubscriptionController", () => {
       expect(storageService.saveCollection).not.toHaveBeenCalled();
     });
 
+    it("queues backfill for a direct duplicate when downloadAll is true", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+      };
+      const existingSubscription = {
+        id: "existing-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: "existing-col",
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: "existing-col",
+        name: "My Playlist",
+      });
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "task-existing",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(storageService.getCollectionByName).not.toHaveBeenCalled();
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "Uploader Name",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      expect(status).toHaveBeenCalledWith(201);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription: existingSubscription,
+          collectionId: "existing-col",
+          taskId: "task-existing",
+          downloadAll: true,
+          backfillStatus: "started",
+        })
+      );
+    });
+
     it("removes a fresh empty collection when subscription insertion fails", async () => {
       req.body = {
         playlistUrl: "https://www.youtube.com/playlist?list=PL123",

--- a/backend/src/__tests__/services/continuousDownload/taskRepository.test.ts
+++ b/backend/src/__tests__/services/continuousDownload/taskRepository.test.ts
@@ -17,8 +17,11 @@ vi.mock('../../../db', () => ({
 vi.mock('../../../db/schema', () => ({
   continuousDownloadTasks: {
     id: 'id',
+    authorUrl: 'authorUrl',
+    subscriptionId: 'subscriptionId',
     collectionId: 'collectionId',
     status: 'status',
+    createdAt: 'createdAt',
     // ... other fields for referencing
   },
   collections: {
@@ -52,6 +55,7 @@ describe('TaskRepository', () => {
       values: vi.fn().mockReturnThis(),
       set: vi.fn().mockReturnThis(),
       leftJoin: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
       then: (resolve: any) => Promise.resolve(result).then(resolve)
     };
     return builder;
@@ -157,6 +161,43 @@ describe('TaskRepository', () => {
     const status = await taskRepository.getTaskStatus('missing');
 
     expect(status).toBeNull();
+  });
+
+  it('getBlockingPlaylistTaskByDestination should return matching active task', async () => {
+    const mockData = [
+      {
+        task: {
+          id: 'active-task',
+          status: 'active',
+          author: 'A',
+          authorUrl: 'https://youtube.com/playlist?list=PL123',
+          subscriptionId: 'sub-1',
+          collectionId: 'col-1',
+          createdAt: 10,
+        },
+        playlistName: 'Playlist',
+      },
+    ];
+    mockBuilder.then = (cb: any) => Promise.resolve(mockData).then(cb);
+
+    const task = await taskRepository.getBlockingPlaylistTaskByDestination(
+      'https://youtube.com/playlist?list=PL123',
+      'sub-1',
+      'col-1'
+    );
+
+    expect(db.select).toHaveBeenCalled();
+    expect(mockBuilder.where).toHaveBeenCalled();
+    expect(mockBuilder.orderBy).toHaveBeenCalled();
+    expect(task).toEqual(
+      expect.objectContaining({
+        id: 'active-task',
+        status: 'active',
+        subscriptionId: 'sub-1',
+        collectionId: 'col-1',
+        playlistName: 'Playlist',
+      })
+    );
   });
 
   it('updateProgress should update stats', async () => {

--- a/backend/src/__tests__/services/continuousDownloadService.test.ts
+++ b/backend/src/__tests__/services/continuousDownloadService.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../services/continuousDownload/taskRepository", () => ({
       getAllTasks: vi.fn().mockResolvedValue([]),
       getTaskById: vi.fn().mockResolvedValue(null),
       getTaskByAuthorUrl: vi.fn().mockResolvedValue(null),
+      getBlockingPlaylistTaskByDestination: vi.fn().mockResolvedValue(null),
       cancelTask: vi.fn().mockResolvedValue(undefined),
       pauseTask: vi.fn().mockResolvedValue(undefined),
       resumeTask: vi.fn().mockResolvedValue(undefined),
@@ -158,10 +159,14 @@ describe("ContinuousDownloadService", () => {
       repo.getAllTasks.mockResolvedValue([{ id: "a" }]);
       repo.getTaskById.mockResolvedValue({ id: "b" });
       repo.getTaskByAuthorUrl.mockResolvedValue({ id: "c" });
+      repo.getBlockingPlaylistTaskByDestination.mockResolvedValue({ id: "d" });
 
       await expect(service.getAllTasks()).resolves.toEqual([{ id: "a" }]);
       await expect(service.getTaskById("b")).resolves.toEqual({ id: "b" });
       await expect(service.getTaskByAuthorUrl("u")).resolves.toEqual({ id: "c" });
+      await expect(
+        service.getBlockingPlaylistTaskByDestination("u", "sub", "col")
+      ).resolves.toEqual({ id: "d" });
     });
   });
 

--- a/backend/src/__tests__/services/continuousDownloadService.test.ts
+++ b/backend/src/__tests__/services/continuousDownloadService.test.ts
@@ -134,6 +134,26 @@ describe("ContinuousDownloadService", () => {
       processSpy.mockRestore();
     });
 
+    it("createPlaylistTask should persist an explicit subscription owner", async () => {
+      const processSpy = vi
+        .spyOn(service as any, "processTask")
+        .mockResolvedValue(undefined);
+
+      const task = await service.createPlaylistTask(
+        "https://youtube.com/playlist?list=PL1",
+        "Author",
+        "YouTube",
+        "col-1",
+        "sub-1"
+      );
+
+      expect(task.subscriptionId).toBe("sub-1");
+      expect(repo.createTask).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptionId: "sub-1" })
+      );
+      processSpy.mockRestore();
+    });
+
     it("getters should delegate to repository", async () => {
       repo.getAllTasks.mockResolvedValue([{ id: "a" }]);
       repo.getTaskById.mockResolvedValue({ id: "b" });

--- a/backend/src/__tests__/services/downloadService.test.ts
+++ b/backend/src/__tests__/services/downloadService.test.ts
@@ -99,8 +99,16 @@ describe("downloadService", () => {
       );
       expect(BilibiliDownloader.checkVideoParts).toHaveBeenCalledWith("bv1");
       expect(BilibiliDownloader.checkCollectionOrSeries).toHaveBeenCalledWith("bv1");
-      expect(BilibiliDownloader.getCollectionVideos).toHaveBeenCalledWith(1, 2);
-      expect(BilibiliDownloader.getSeriesVideos).toHaveBeenCalledWith(3, 4);
+      expect(BilibiliDownloader.getCollectionVideos).toHaveBeenCalledWith(
+        1,
+        2,
+        undefined
+      );
+      expect(BilibiliDownloader.getSeriesVideos).toHaveBeenCalledWith(
+        3,
+        4,
+        undefined
+      );
     });
 
     it("delegates bilibili part and collection downloads", async () => {

--- a/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCollection.test.ts
@@ -54,13 +54,18 @@ vi.mock("../../../utils/logger", () => ({
   logger: mocks.logger,
 }));
 
-import { downloadCollection } from "../../../services/downloaders/bilibili/bilibiliCollection";
+import {
+  downloadCollection,
+  getCollectionVideos,
+  getSeriesVideos,
+} from "../../../services/downloaders/bilibili/bilibiliCollection";
 
 describe("bilibiliCollection.downloadCollection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.axiosGet.mockResolvedValue({
       data: {
+        code: 0,
         data: {
           archives: [
             { bvid: "BV1", title: "Episode 1", aid: 1 },
@@ -93,6 +98,44 @@ describe("bilibiliCollection.downloadCollection", () => {
       success: true,
       videoData: { id: "video-2" },
     });
+  });
+
+  it("rejects Bilibili collection API error payloads", async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: { code: -412, message: "rate limited" },
+    });
+
+    const result = await getCollectionVideos(9, 42);
+
+    expect(result).toEqual({ success: false, videos: [] });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      "Error fetching collection videos:",
+      expect.any(Error),
+    );
+  });
+
+  it("rejects Bilibili series payloads that are missing archives", async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: { code: 0, data: { page: { total: 0 } } },
+    });
+
+    const result = await getSeriesVideos(9, 42);
+
+    expect(result).toEqual({ success: false, videos: [] });
+    expect(mocks.logger.error).toHaveBeenCalledWith(
+      "Error fetching series videos:",
+      expect.any(Error),
+    );
+  });
+
+  it("keeps verified empty Bilibili collection pages as successful", async () => {
+    mocks.axiosGet.mockResolvedValueOnce({
+      data: { code: 0, data: { archives: [], page: { total: 0 } } },
+    });
+
+    const result = await getCollectionVideos(9, 42);
+
+    expect(result).toEqual({ success: true, videos: [] });
   });
 
   it("reuses the linked collection and downloads only missing videos", async () => {
@@ -458,6 +501,7 @@ describe("bilibiliCollection.downloadCollection", () => {
     try {
       mocks.axiosGet.mockResolvedValue({
         data: {
+          code: 0,
           data: {
             archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
             page: { total: 1 },
@@ -495,6 +539,7 @@ describe("bilibiliCollection.downloadCollection", () => {
     try {
       mocks.axiosGet.mockResolvedValue({
         data: {
+          code: 0,
           data: {
             archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
             page: { total: 1 },
@@ -530,6 +575,7 @@ describe("bilibiliCollection.downloadCollection", () => {
     try {
       mocks.axiosGet.mockResolvedValue({
         data: {
+          code: 0,
           data: {
             archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
             page: { total: 1 },
@@ -569,6 +615,7 @@ describe("bilibiliCollection.downloadCollection", () => {
     try {
       mocks.axiosGet.mockResolvedValue({
         data: {
+          code: 0,
           data: {
             archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
             page: { total: 1 },
@@ -605,6 +652,7 @@ describe("bilibiliCollection.downloadCollection", () => {
   it("does not retry a generic (non-risk-control) failure", async () => {
     mocks.axiosGet.mockResolvedValue({
       data: {
+        code: 0,
         data: {
           archives: [{ bvid: "BV1", title: "Episode 1", aid: 1 }],
           page: { total: 1 },

--- a/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
+++ b/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
@@ -24,8 +24,10 @@ vi.mock("../../../db/schema", () => ({ subscriptions: { id: "id" } }));
 // storageService is used for collection lookups; mock the relevant surface.
 vi.mock("../../../services/storageService", () => ({
   getCollectionByName: vi.fn().mockReturnValue(null),
+  getCollectionById: vi.fn(),
   generateUniqueCollectionName: vi.fn().mockImplementation((name: string) => `${name}-unique`),
   saveCollection: vi.fn(),
+  deleteCollection: vi.fn(),
 }));
 
 const makeSub = (overrides: Partial<Subscription> = {}): Subscription => ({
@@ -56,12 +58,18 @@ describe("subscription channelPlaylists", () => {
 
   it("skips playlists already subscribed and subscribes to new ones", async () => {
     const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
-    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
-      entries: [
-        { id: "PL_existing", title: "Existing", url: "https://youtube.com/playlist?list=PL_existing" },
-        { id: "PL_new", title: "New Playlist", url: "https://youtube.com/playlist?list=PL_new" },
-      ],
-    } as any);
+    // 1st call: channel listing. 2nd call: head baseline probe for PL_new.
+    vi.mocked(executeYtDlpJson)
+      .mockResolvedValueOnce({
+        entries: [
+          { id: "PL_existing", title: "Existing", url: "https://youtube.com/playlist?list=PL_existing" },
+          { id: "PL_new", title: "New Playlist", url: "https://youtube.com/playlist?list=PL_new" },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        _type: "playlist",
+        entries: [{ id: "vid-new-head" }],
+      } as any);
 
     const deps = {
       listSubscriptions: vi.fn().mockResolvedValue([
@@ -74,15 +82,20 @@ describe("subscription channelPlaylists", () => {
 
     expect(count).toBe(1);
     expect(deps.subscribePlaylist).toHaveBeenCalledTimes(1);
-    // Should be called with the new playlist's details and the channel name.
+    // Watcher now passes an options object including the captured baseline
+    // (design §8.2).
     expect(deps.subscribePlaylist).toHaveBeenCalledWith(
-      "https://youtube.com/playlist?list=PL_new",
-      60,
-      "New Playlist",
-      "PL_new",
-      "ChannelName",
-      "YouTube",
-      expect.any(String),
+      expect.objectContaining({
+        playlistUrl: "https://youtube.com/playlist?list=PL_new",
+        interval: 60,
+        playlistTitle: "New Playlist",
+        playlistId: "PL_new",
+        author: "ChannelName",
+        platform: "YouTube",
+        collectionId: expect.any(String),
+        initialHeadVideoUrl: "https://www.youtube.com/watch?v=vid-new-head",
+        baselineObservedAt: expect.any(Number),
+      })
     );
   });
 
@@ -110,12 +123,16 @@ describe("subscription channelPlaylists", () => {
 
   it("continues past a subscribePlaylist failure and still counts successes", async () => {
     const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
-    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
-      entries: [
-        { id: "PL_fail", title: "Fail", url: "https://youtube.com/playlist?list=PL_fail" },
-        { id: "PL_ok", title: "Ok", url: "https://youtube.com/playlist?list=PL_ok" },
-      ],
-    } as any);
+    // Channel listing, then a head probe per new playlist (two probes).
+    vi.mocked(executeYtDlpJson)
+      .mockResolvedValueOnce({
+        entries: [
+          { id: "PL_fail", title: "Fail", url: "https://youtube.com/playlist?list=PL_fail" },
+          { id: "PL_ok", title: "Ok", url: "https://youtube.com/playlist?list=PL_ok" },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ _type: "playlist", entries: [{ id: "vf" }] } as any)
+      .mockResolvedValueOnce({ _type: "playlist", entries: [{ id: "vo" }] } as any);
 
     const deps = {
       listSubscriptions: vi.fn().mockResolvedValue([]),
@@ -124,10 +141,70 @@ describe("subscription channelPlaylists", () => {
         .mockRejectedValueOnce(new Error("boom"))
         .mockResolvedValueOnce(undefined),
     };
+    const { getCollectionById, deleteCollection } = await import(
+      "../../../services/storageService"
+    );
+    vi.mocked(getCollectionById).mockImplementation((id: string) => ({
+      id,
+      name: "Fail - ChannelName-unique",
+      videos: [],
+    }) as any);
+    vi.mocked(deleteCollection).mockReturnValue(true);
 
     const count = await checkChannelPlaylistsForWatcher(makeSub(), deps);
 
     expect(count).toBe(1);
     expect(deps.subscribePlaylist).toHaveBeenCalledTimes(2);
+    expect(deleteCollection).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not subscribe and retries next interval when the baseline probe fails", async () => {
+    // Design §8.2: a failed baseline creates no child; the URL is not added to
+    // the subscribed set so the next watcher interval retries.
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson)
+      .mockResolvedValueOnce({
+        entries: [
+          { id: "PL_probe_fail", title: "Probe Fail", url: "https://youtube.com/playlist?list=PL_probe_fail" },
+        ],
+      } as any)
+      .mockRejectedValueOnce(new Error("probe failed"));
+
+    const deps = {
+      listSubscriptions: vi.fn().mockResolvedValue([]),
+      subscribePlaylist: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const count = await checkChannelPlaylistsForWatcher(makeSub(), deps);
+
+    expect(count).toBe(0);
+    expect(deps.subscribePlaylist).not.toHaveBeenCalled();
+  });
+
+  it("captures a verified-empty baseline and still creates the child", async () => {
+    // Design §4.5 / §8.2: a verified empty playlist is a valid subscription
+    // with an empty cursor; its first future item is treated as new.
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson)
+      .mockResolvedValueOnce({
+        entries: [
+          { id: "PL_empty", title: "Empty", url: "https://youtube.com/playlist?list=PL_empty" },
+        ],
+      } as any)
+      .mockResolvedValueOnce({ _type: "playlist", entries: [] } as any);
+
+    const deps = {
+      listSubscriptions: vi.fn().mockResolvedValue([]),
+      subscribePlaylist: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const count = await checkChannelPlaylistsForWatcher(makeSub(), deps);
+
+    expect(count).toBe(1);
+    expect(deps.subscribePlaylist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialHeadVideoUrl: null,
+      })
+    );
   });
 });

--- a/backend/src/__tests__/services/subscription/playlistFeed.test.ts
+++ b/backend/src/__tests__/services/subscription/playlistFeed.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  getBilibiliCollectionHeadSnapshot,
   getPlaylistHeadSnapshot,
   inspectPlaylist,
   resolveEntryVideoUrl,
@@ -17,6 +18,10 @@ vi.mock("../../../utils/helpers", () => ({
 }));
 vi.mock("../../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
   getProviderScript: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../../../services/downloadService", () => ({
+  getBilibiliCollectionVideos: vi.fn(),
+  getBilibiliSeriesVideos: vi.fn(),
 }));
 vi.mock("../../../utils/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -198,6 +203,64 @@ describe("getPlaylistHeadSnapshot", () => {
         extractorArgs:
           "youtubepot-bgutilscript:script_path=/path/to/script.js",
       })
+    );
+  });
+});
+
+describe("getBilibiliCollectionHeadSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches only one Bilibili collection entry for head-only probes", async () => {
+    const { getBilibiliCollectionVideos } = await import(
+      "../../../services/downloadService"
+    );
+    vi.mocked(getBilibiliCollectionVideos).mockResolvedValueOnce({
+      success: true,
+      videos: [{ bvid: "BVhead", title: "Head", aid: 1 }],
+    });
+
+    const snap = await getBilibiliCollectionHeadSnapshot(
+      "https://www.bilibili.com/video/BVseed",
+      {
+        type: "collection",
+        mid: 12345,
+        id: 9988,
+      },
+      { headOnly: true }
+    );
+
+    expect(getBilibiliCollectionVideos).toHaveBeenCalledWith(
+      12345,
+      9988,
+      { pageSize: 1, maxPages: 1 }
+    );
+    expect(snap.headVideoUrl).toBe("https://www.bilibili.com/video/BVhead");
+  });
+
+  it("keeps full Bilibili collection fetches for baseline inspection", async () => {
+    const { getBilibiliSeriesVideos } = await import(
+      "../../../services/downloadService"
+    );
+    vi.mocked(getBilibiliSeriesVideos).mockResolvedValueOnce({
+      success: true,
+      videos: [{ bvid: "BVhead", title: "Head", aid: 1 }],
+    });
+
+    await getBilibiliCollectionHeadSnapshot(
+      "https://www.bilibili.com/video/BVseed",
+      {
+        type: "series",
+        mid: 12345,
+        id: 9988,
+      }
+    );
+
+    expect(getBilibiliSeriesVideos).toHaveBeenCalledWith(
+      12345,
+      9988,
+      undefined
     );
   });
 });

--- a/backend/src/__tests__/services/subscription/playlistFeed.test.ts
+++ b/backend/src/__tests__/services/subscription/playlistFeed.test.ts
@@ -263,6 +263,31 @@ describe("getBilibiliCollectionHeadSnapshot", () => {
       undefined
     );
   });
+
+  it("rejects failed Bilibili collection fetches before seeding a cursor", async () => {
+    const { getBilibiliCollectionVideos } = await import(
+      "../../../services/downloadService"
+    );
+    vi.mocked(getBilibiliCollectionVideos).mockResolvedValueOnce({
+      success: false,
+      videos: [],
+    });
+
+    await expect(
+      getBilibiliCollectionHeadSnapshot(
+        "https://www.bilibili.com/video/BVseed",
+        {
+          type: "collection",
+          mid: 12345,
+          id: 9988,
+        }
+      )
+    ).rejects.toMatchObject({
+      name: "ValidationError",
+      message: "Failed to get videos from Bilibili collection",
+      field: "collectionInfo",
+    });
+  });
 });
 
 describe("inspectPlaylist", () => {

--- a/backend/src/__tests__/services/subscription/playlistFeed.test.ts
+++ b/backend/src/__tests__/services/subscription/playlistFeed.test.ts
@@ -196,7 +196,7 @@ describe("getPlaylistHeadSnapshot", () => {
       expect.any(String),
       expect.objectContaining({
         extractorArgs:
-          "youtubepot-bgfuncscript:script_path=/path/to/script.js",
+          "youtubepot-bgutilscript:script_path=/path/to/script.js",
       })
     );
   });

--- a/backend/src/__tests__/services/subscription/playlistFeed.test.ts
+++ b/backend/src/__tests__/services/subscription/playlistFeed.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPlaylistHeadSnapshot,
+  inspectPlaylist,
+  resolveEntryVideoUrl,
+} from "../../../services/subscription/playlistFeed";
+import { ValidationError } from "../../../errors/DownloadErrors";
+
+// Mock the yt-dlp utils + helpers so no network/spawn is touched.
+vi.mock("../../../utils/ytDlpUtils", () => ({
+  executeYtDlpJson: vi.fn(),
+  getEffectiveUserYtDlpConfig: vi.fn().mockReturnValue({}),
+  getNetworkConfigFromUserConfig: vi.fn().mockReturnValue({}),
+}));
+vi.mock("../../../utils/helpers", () => ({
+  isBilibiliUrl: vi.fn((url: string) => url.includes("bilibili")),
+}));
+vi.mock("../../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderScript: vi.fn().mockReturnValue(null),
+}));
+vi.mock("../../../utils/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+describe("resolveEntryVideoUrl", () => {
+  it("prefers a valid absolute webpage_url", () => {
+    expect(
+      resolveEntryVideoUrl(
+        {
+          webpage_url: "https://www.youtube.com/watch?v=abc",
+          url: "ignored",
+          id: "ignored",
+        },
+        "YouTube"
+      )
+    ).toBe("https://www.youtube.com/watch?v=abc");
+  });
+
+  it("falls back to a valid absolute url when webpage_url is absent", () => {
+    expect(
+      resolveEntryVideoUrl(
+        { url: "https://www.bilibili.com/video/BV1xx", id: "BV1xx" },
+        "Bilibili"
+      )
+    ).toBe("https://www.bilibili.com/video/BV1xx");
+  });
+
+  it("ignores a bare-id-looking webpage_url and falls through to id", () => {
+    // A bare id is not a valid absolute URL.
+    expect(
+      resolveEntryVideoUrl(
+        { webpage_url: "dQw4w9WgXcQ", id: "dQw4w9WgXcQ" },
+        "YouTube"
+      )
+    ).toBe("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+  });
+
+  it("constructs a YouTube watch URL from a bare id", () => {
+    expect(resolveEntryVideoUrl({ id: "abc123" }, "YouTube")).toBe(
+      "https://www.youtube.com/watch?v=abc123"
+    );
+  });
+
+  it("constructs a Bilibili video URL from a bare id", () => {
+    expect(resolveEntryVideoUrl({ id: "BV1xx" }, "Bilibili")).toBe(
+      "https://www.bilibili.com/video/BV1xx"
+    );
+  });
+
+  it("returns null when nothing can be derived", () => {
+    expect(resolveEntryVideoUrl({}, "YouTube")).toBeNull();
+  });
+});
+
+describe("getPlaylistHeadSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the canonical head url for a non-empty YouTube playlist", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{ id: "vidA" }],
+    } as any);
+
+    const snap = await getPlaylistHeadSnapshot(
+      "https://www.youtube.com/playlist?list=PL1",
+      "YouTube"
+    );
+
+    expect(snap.headVideoUrl).toBe("https://www.youtube.com/watch?v=vidA");
+    expect(typeof snap.observedAt).toBe("number");
+  });
+
+  it("returns headVideoUrl null for a verified empty playlist", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [],
+    } as any);
+
+    const snap = await getPlaylistHeadSnapshot(
+      "https://www.youtube.com/playlist?list=PL1",
+      "YouTube"
+    );
+
+    expect(snap.headVideoUrl).toBeNull();
+  });
+
+  it("throws ValidationError for a non-playlist result with no entries", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      title: "some video",
+    } as any);
+
+    await expect(
+      getPlaylistHeadSnapshot(
+        "https://www.youtube.com/watch?v=abc",
+        "YouTube"
+      )
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("throws when the leading entry cannot be resolved to a URL", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{}],
+    } as any);
+
+    await expect(
+      getPlaylistHeadSnapshot(
+        "https://www.youtube.com/playlist?list=PL1",
+        "YouTube"
+      )
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("propagates network/extractor errors instead of returning null", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockRejectedValueOnce(new Error("network down"));
+
+    await expect(
+      getPlaylistHeadSnapshot(
+        "https://www.youtube.com/playlist?list=PL1",
+        "YouTube"
+      )
+    ).rejects.toThrow("network down");
+  });
+
+  it("passes the effective subscription yt-dlp config into the probe", async () => {
+    const {
+      executeYtDlpJson,
+      getEffectiveUserYtDlpConfig,
+    } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{ id: "vidA" }],
+    } as any);
+
+    await getPlaylistHeadSnapshot(
+      "https://www.youtube.com/playlist?list=PL1",
+      "YouTube",
+      { subscriptionYtdlpConfig: "--proxy socks5://127.0.0.1:1080" }
+    );
+
+    expect(getEffectiveUserYtDlpConfig).toHaveBeenCalledWith(
+      "https://www.youtube.com/playlist?list=PL1",
+      "--proxy socks5://127.0.0.1:1080"
+    );
+    // playlistEnd:1 limits the probe to the leading entry.
+    expect(executeYtDlpJson).toHaveBeenCalledWith(
+      "https://www.youtube.com/playlist?list=PL1",
+      expect.objectContaining({ flatPlaylist: true, playlistEnd: 1 })
+    );
+  });
+
+  it("retains the provider script option when present", async () => {
+    const { getProviderScript } = await import(
+      "../../../services/downloaders/ytdlp/ytdlpHelpers"
+    );
+    vi.mocked(getProviderScript).mockReturnValueOnce("/path/to/script.js");
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{ id: "vidA" }],
+    } as any);
+
+    await getPlaylistHeadSnapshot(
+      "https://www.youtube.com/playlist?list=PL1",
+      "YouTube"
+    );
+
+    expect(executeYtDlpJson).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        extractorArgs:
+          "youtubepot-bgfuncscript:script_path=/path/to/script.js",
+      })
+    );
+  });
+});
+
+describe("inspectPlaylist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns metadata plus the canonical head for a non-empty playlist", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      title: "My Playlist",
+      id: "PL1",
+      playlist_count: 5,
+      entries: [{ id: "vidA", uploader: "Uploader" }],
+    } as any);
+
+    const inspection = await inspectPlaylist(
+      "https://www.youtube.com/playlist?list=PL1"
+    );
+
+    expect(inspection.headVideoUrl).toBe(
+      "https://www.youtube.com/watch?v=vidA"
+    );
+    expect(inspection.title).toBe("My Playlist");
+    expect(inspection.videoCount).toBe(5);
+    expect(inspection.playlistId).toBe("PL1");
+    expect(inspection.author).toBe("Uploader");
+    expect(inspection.platform).toBe("YouTube");
+  });
+
+  it("returns headVideoUrl null and count 0 for a verified empty playlist", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      title: "Empty",
+      entries: [],
+      uploader: "Some Channel",
+    } as any);
+
+    const inspection = await inspectPlaylist(
+      "https://www.youtube.com/playlist?list=PL1"
+    );
+
+    expect(inspection.headVideoUrl).toBeNull();
+    expect(inspection.videoCount).toBe(0);
+    expect(inspection.author).toBe("Some Channel");
+  });
+
+  it("detects Bilibili platform", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      title: "Bili List",
+      entries: [{ id: "BV1xx", webpage_url: "https://www.bilibili.com/video/BV1xx" }],
+    } as any);
+
+    const inspection = await inspectPlaylist(
+      "https://www.bilibili.com/list/ml123"
+    );
+
+    expect(inspection.platform).toBe("Bilibili");
+    expect(inspection.headVideoUrl).toBe("https://www.bilibili.com/video/BV1xx");
+  });
+
+  it("throws ValidationError for a non-playlist result", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({ title: "a video" } as any);
+
+    await expect(
+      inspectPlaylist("https://www.youtube.com/watch?v=abc")
+    ).rejects.toThrow(ValidationError);
+  });
+
+  it("propagates extractor errors", async () => {
+    const { executeYtDlpJson } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(executeYtDlpJson).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(
+      inspectPlaylist("https://www.youtube.com/playlist?list=PL1")
+    ).rejects.toThrow("boom");
+  });
+});

--- a/backend/src/__tests__/services/subscription/playlistFeed.test.ts
+++ b/backend/src/__tests__/services/subscription/playlistFeed.test.ts
@@ -181,6 +181,74 @@ describe("getPlaylistHeadSnapshot", () => {
     );
   });
 
+  it("preserves subscription extractor args in playlist probes", async () => {
+    const {
+      executeYtDlpJson,
+      getEffectiveUserYtDlpConfig,
+      getNetworkConfigFromUserConfig,
+    } = await import("../../../utils/ytDlpUtils");
+    const userConfig = {
+      extractorArgs: "youtube:player_client=web",
+      proxy: "socks5://127.0.0.1:1080",
+    };
+    vi.mocked(getEffectiveUserYtDlpConfig).mockReturnValueOnce(userConfig);
+    vi.mocked(getNetworkConfigFromUserConfig).mockReturnValueOnce({
+      proxy: userConfig.proxy,
+    });
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{ id: "vidA" }],
+    } as any);
+
+    await getPlaylistHeadSnapshot(
+      "https://www.youtube.com/playlist?list=PL1",
+      "YouTube",
+      {
+        subscriptionYtdlpConfig:
+          "--extractor-args youtube:player_client=web",
+      }
+    );
+
+    expect(getNetworkConfigFromUserConfig).toHaveBeenCalledWith(userConfig);
+    expect(executeYtDlpJson).toHaveBeenCalledWith(
+      "https://www.youtube.com/playlist?list=PL1",
+      expect.objectContaining({
+        extractorArgs: "youtube:player_client=web",
+        proxy: "socks5://127.0.0.1:1080",
+      })
+    );
+  });
+
+  it("merges subscription extractor args with the provider script option", async () => {
+    const { getProviderScript } = await import(
+      "../../../services/downloaders/ytdlp/ytdlpHelpers"
+    );
+    vi.mocked(getProviderScript).mockReturnValueOnce("/path/to/script.js");
+    const {
+      executeYtDlpJson,
+      getEffectiveUserYtDlpConfig,
+    } = await import("../../../utils/ytDlpUtils");
+    vi.mocked(getEffectiveUserYtDlpConfig).mockReturnValueOnce({
+      extractorArgs: "youtube:max_comments=20",
+    });
+    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({
+      _type: "playlist",
+      entries: [{ id: "vidA" }],
+    } as any);
+
+    await inspectPlaylist("https://www.youtube.com/playlist?list=PL1", {
+      subscriptionYtdlpConfig: "--extractor-args youtube:max_comments=20",
+    });
+
+    expect(executeYtDlpJson).toHaveBeenCalledWith(
+      "https://www.youtube.com/playlist?list=PL1",
+      expect.objectContaining({
+        extractorArgs:
+          "youtube:max_comments=20;youtubepot-bgutilscript:script_path=/path/to/script.js",
+      })
+    );
+  });
+
   it("retains the provider script option when present", async () => {
     const { getProviderScript } = await import(
       "../../../services/downloaders/ytdlp/ytdlpHelpers"

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -28,6 +28,7 @@ vi.mock('../../db/schema', () => ({
     author: 'author',
     authorUrl: 'authorUrl',
     retentionDays: 'retentionDays',
+    collectionId: 'collectionId',
     // add other fields if needed for referencing columns
   }
 }));
@@ -367,7 +368,8 @@ describe('SubscriptionService', () => {
 
       expect(downloadService.getBilibiliCollectionVideos).toHaveBeenCalledWith(
         12345,
-        9988
+        9988,
+        { pageSize: 1, maxPages: 1 }
       );
       expect(executeYtDlpJson).not.toHaveBeenCalled();
       expect(downloadService.downloadSingleBilibiliPart).toHaveBeenCalledWith(
@@ -744,6 +746,25 @@ describe('SubscriptionService', () => {
       expect(mockBuilder.set).toHaveBeenCalledWith({
         interval: 45,
         retentionDays: 14,
+      });
+    });
+
+    it('should link a playlist subscription to a collection', async () => {
+      mockBuilder.then = (cb: any) =>
+        Promise.resolve([{ id: 'sub1', author: 'A' }]).then(cb);
+
+      await subscriptionService.updatePlaylistSubscriptionCollection(
+        'sub1',
+        'collection-1'
+      );
+
+      expect(db.update).toHaveBeenCalledTimes(1);
+      expect(mockBuilder.set).toHaveBeenCalledWith({
+        collectionId: 'collection-1',
+      });
+      expect(mockBuilder.returning).toHaveBeenCalledWith({
+        id: 'id',
+        author: 'author',
       });
     });
 

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -498,15 +498,22 @@ describe('SubscriptionService', () => {
       // Execute
       await subscriptionService.checkChannelPlaylists(sub as any);
 
-      // Verify
+      // Verify the watcher passed a captured baseline in an options object
+      // (design §8.2): playlistUrl, interval, title, playlistId, channel name,
+      // platform, collection id, the server-observed head, and an observation
+      // timestamp.
       expect(subscribeSpy).toHaveBeenCalledWith(
-        expect.any(String), // url
-        expect.any(Number), // interval
-        'My Playlist',      // title
-        'pl-1',             // playlistId
-        'User',             // channelName
-        'YouTube',          // platform
-        expect.any(String)  // playlist watchers always create a collection now
+        expect.objectContaining({
+          playlistUrl: 'https://youtube.com/playlist?list=pl-1',
+          interval: 60,
+          playlistTitle: 'My Playlist',
+          playlistId: 'pl-1',
+          author: 'User',
+          platform: 'YouTube',
+          collectionId: expect.any(String),
+          initialHeadVideoUrl: expect.any(String),
+          baselineObservedAt: expect.any(Number),
+        })
       );
 
       expect(storageService.saveCollection).toHaveBeenCalled();
@@ -518,20 +525,24 @@ describe('SubscriptionService', () => {
     it('should create playlist subscription with display name', async () => {
       mockBuilder.then = (cb: any) => Promise.resolve([]).then(cb);
 
-      const result = await subscriptionService.subscribePlaylist(
-        'https://youtube.com/playlist?list=pl1',
-        60,
-        'Playlist 1',
-        'pl1',
-        'Channel A',
-        'YouTube',
-        'col-1'
-      );
+      const result = await subscriptionService.subscribePlaylist({
+        playlistUrl: 'https://youtube.com/playlist?list=pl1',
+        interval: 60,
+        playlistTitle: 'Playlist 1',
+        playlistId: 'pl1',
+        author: 'Channel A',
+        platform: 'YouTube',
+        collectionId: 'col-1',
+        initialHeadVideoUrl: 'https://www.youtube.com/watch?v=headA',
+        baselineObservedAt: 1700000000000,
+      });
 
       expect(result).toMatchObject({
         author: 'Playlist 1 - Channel A',
         subscriptionType: 'playlist',
         collectionId: 'col-1',
+        lastVideoLink: 'https://www.youtube.com/watch?v=headA',
+        lastCheck: 1700000000000,
       });
       expect(db.insert).toHaveBeenCalled();
     });
@@ -691,33 +702,58 @@ describe('SubscriptionService', () => {
       expect(cron.schedule).toHaveBeenCalledWith('0 * * * *', expect.any(Function));
     });
 
+    // Playlist head resolution is now provided by playlistFeed.getPlaylistHeadSnapshot
+    // (design §6.5 / Step 5). The scheduler consumes its typed, fail-closed result;
+    // the resolution + empty-vs-failure rules are covered directly in
+    // playlistFeed.test.ts. The tests below exercise the scheduler's handling of
+    // that snapshot during a real checkSingleSubscription sweep.
+
     it('should resolve latest playlist URL from first entry id', async () => {
+      // The new playlist feed constructs the canonical watch URL from a bare id;
+      // the scheduler no longer owns this logic but the canonicalization contract
+      // still holds (covered in detail by playlistFeed.test.ts).
       (executeYtDlpJson as any).mockResolvedValue({
         entries: [{ id: 'abc123' }],
       });
 
-      const youtubeUrl = await (subscriptionService as any).getLatestPlaylistVideoUrl(
+      const { getPlaylistHeadSnapshot } = await import(
+        '../../services/subscription/playlistFeed'
+      );
+      const youtubeUrl = await getPlaylistHeadSnapshot(
         'https://youtube.com/playlist?list=xyz',
         'YouTube'
       );
-      const bilibiliUrl = await (subscriptionService as any).getLatestPlaylistVideoUrl(
+      const bilibiliUrl = await getPlaylistHeadSnapshot(
         'https://www.bilibili.com/medialist/play/1',
         'Bilibili'
       );
 
-      expect(youtubeUrl).toBe('https://www.youtube.com/watch?v=abc123');
-      expect(bilibiliUrl).toBe('https://www.bilibili.com/video/abc123');
+      expect(youtubeUrl.headVideoUrl).toBe(
+        'https://www.youtube.com/watch?v=abc123'
+      );
+      expect(bilibiliUrl.headVideoUrl).toBe(
+        'https://www.bilibili.com/video/abc123'
+      );
     });
 
-    it('should return null when latest playlist lookup throws', async () => {
-      (executeYtDlpJson as any).mockRejectedValue(new Error('playlist lookup failed'));
-
-      const result = await (subscriptionService as any).getLatestPlaylistVideoUrl(
-        'https://youtube.com/playlist?list=xyz',
-        'YouTube'
+    it('should propagate playlist lookup errors (fail-closed) instead of swallowing them', async () => {
+      // Design §3.4 / §9.1: the old probe swallowed errors and returned null,
+      // which let a failed probe look like an empty playlist. The new typed
+      // snapshot throws so the check is marked failed.
+      (executeYtDlpJson as any).mockRejectedValue(
+        new Error('playlist lookup failed')
       );
 
-      expect(result).toBeNull();
+      const { getPlaylistHeadSnapshot } = await import(
+        '../../services/subscription/playlistFeed'
+      );
+
+      await expect(
+        getPlaylistHeadSnapshot(
+          'https://youtube.com/playlist?list=xyz',
+          'YouTube'
+        )
+      ).rejects.toThrow('playlist lookup failed');
     });
 
     it('should return direct playlist entry URL when available', async () => {
@@ -725,23 +761,31 @@ describe('SubscriptionService', () => {
         entries: [{ url: 'https://www.youtube.com/watch?v=url-first' }],
       });
 
-      const result = await (subscriptionService as any).getLatestPlaylistVideoUrl(
+      const { getPlaylistHeadSnapshot } = await import(
+        '../../services/subscription/playlistFeed'
+      );
+      const result = await getPlaylistHeadSnapshot(
         'https://youtube.com/playlist?list=xyz',
         'YouTube'
       );
 
-      expect(result).toBe('https://www.youtube.com/watch?v=url-first');
+      expect(result.headVideoUrl).toBe(
+        'https://www.youtube.com/watch?v=url-first'
+      );
     });
 
-    it('should return null when playlist has no entries', async () => {
+    it('should return headVideoUrl null for a verified empty playlist', async () => {
       (executeYtDlpJson as any).mockResolvedValue({ entries: [] });
 
-      const result = await (subscriptionService as any).getLatestPlaylistVideoUrl(
+      const { getPlaylistHeadSnapshot } = await import(
+        '../../services/subscription/playlistFeed'
+      );
+      const result = await getPlaylistHeadSnapshot(
         'https://youtube.com/playlist?list=xyz',
         'YouTube'
       );
 
-      expect(result).toBeNull();
+      expect(result.headVideoUrl).toBeNull();
     });
 
     it('should choose latest video resolver based on platform', async () => {
@@ -862,15 +906,17 @@ describe('SubscriptionService', () => {
         Promise.resolve([{ id: 'existing-playlist' }]).then(cb);
 
       await expect(
-        subscriptionService.subscribePlaylist(
-          'https://www.youtube.com/playlist?list=dup',
-          30,
-          'Duplicate',
-          'dup',
-          'Author',
-          'YouTube',
-          null
-        )
+        subscriptionService.subscribePlaylist({
+          playlistUrl: 'https://www.youtube.com/playlist?list=dup',
+          interval: 30,
+          playlistTitle: 'Duplicate',
+          playlistId: 'dup',
+          author: 'Author',
+          platform: 'YouTube',
+          collectionId: null,
+          initialHeadVideoUrl: 'https://www.youtube.com/watch?v=baseline',
+          baselineObservedAt: Date.now(),
+        })
       ).rejects.toThrow(DuplicateError);
     });
   });
@@ -937,14 +983,20 @@ describe('SubscriptionService', () => {
       } as any);
 
       expect(storageService.saveCollection).toHaveBeenCalled();
+      // The watcher now captures a head baseline before subscribing and passes
+      // an options object (design §8.2). The entry has no id but a valid
+      // absolute url, so the baseline equals that url.
       expect(subscribeSpy).toHaveBeenCalledWith(
-        'https://www.youtube.com/playlist?list=PL123',
-        120,
-        'Playlist - One',
-        'PL123',
-        'Watcher Name',
-        'YouTube',
-        expect.any(String)
+        expect.objectContaining({
+          playlistUrl: 'https://www.youtube.com/playlist?list=PL123',
+          interval: 120,
+          playlistTitle: 'Playlist - One',
+          author: 'Watcher Name',
+          platform: 'YouTube',
+          collectionId: expect.any(String),
+          initialHeadVideoUrl: 'https://www.youtube.com/playlist?list=PL123',
+          baselineObservedAt: expect.any(Number),
+        })
       );
       subscribeSpy.mockRestore();
     });

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -390,6 +390,48 @@ describe('SubscriptionService', () => {
       );
     });
 
+    it('updates lastCheck when a playlist probe fails to back off retries', async () => {
+      const sub = {
+        id: 'playlist-probe-fail-sub',
+        author: 'Playlist Author',
+        platform: 'YouTube',
+        authorUrl: 'https://www.youtube.com/playlist?list=PLFAIL',
+        interval: 60,
+        lastCheck: 0,
+        lastVideoLink: 'https://www.youtube.com/watch?v=old',
+        subscriptionType: 'playlist',
+        collectionId: 'collection-1',
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb);
+        if (callCount === 2) return Promise.resolve([{ id: sub.id }]).then(cb);
+        return Promise.resolve([]).then(cb);
+      };
+      const recordSpy = vi
+        .spyOn(subscriptionService as any, 'recordSubscriptionCheckCompleted')
+        .mockResolvedValue(undefined);
+      (executeYtDlpJson as any).mockRejectedValue(
+        new Error('playlist lookup failed')
+      );
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(mockBuilder.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastCheck: expect.any(Number) })
+      );
+      expect(downloadService.downloadYouTubeVideo).not.toHaveBeenCalled();
+      expect(recordSpy).toHaveBeenCalledWith(
+        sub,
+        'fail',
+        expect.objectContaining({ failureReason: expect.any(String) })
+      );
+
+      recordSpy.mockRestore();
+    });
+
     it('should skip shorts when subscription is deleted before lastCheck update', async () => {
       const sub = {
         id: 'sub-deleted',

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -328,6 +328,68 @@ describe('SubscriptionService', () => {
       expect(db.update).toHaveBeenCalled();
     });
 
+    it('polls Bilibili collection playlist subscriptions through the collection API', async () => {
+      const sub = {
+        id: 'bili-playlist-sub',
+        author: '合集标题 - Bilibili 12345',
+        platform: 'Bilibili',
+        authorUrl: 'https://www.bilibili.com/video/BVseed',
+        lastCheck: 0,
+        interval: 10,
+        lastVideoLink: 'https://www.bilibili.com/video/BVold',
+        subscriptionType: 'playlist',
+        playlistId: '9988',
+        collectionId: 'existing-col',
+      };
+
+      let callCount = 0;
+      mockBuilder.then = (cb: any) => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve([sub]).then(cb);
+        return Promise.resolve([sub]).then(cb);
+      };
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: 'existing-col',
+        sourcePlatform: 'bilibili',
+        sourceType: 'collection',
+        sourceMid: '12345',
+        sourceId: '9988',
+      });
+      (downloadService.getBilibiliCollectionVideos as any).mockResolvedValue({
+        success: true,
+        videos: [{ bvid: 'BVnew', title: 'New', aid: 1 }],
+      });
+      (downloadService.downloadSingleBilibiliPart as any).mockResolvedValue({
+        videoData: { id: 'video-new', title: 'New Bili Video' },
+      });
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(downloadService.getBilibiliCollectionVideos).toHaveBeenCalledWith(
+        12345,
+        9988
+      );
+      expect(executeYtDlpJson).not.toHaveBeenCalled();
+      expect(downloadService.downloadSingleBilibiliPart).toHaveBeenCalledWith(
+        'https://www.bilibili.com/video/BVnew',
+        1,
+        1,
+        '',
+        'test-uuid',
+        expect.any(Function),
+        undefined,
+        expect.objectContaining({
+          sourceCollectionId: '9988',
+          sourceCollectionType: 'playlist',
+        }),
+        { subscriptionYtdlpConfig: undefined }
+      );
+      expect(storageService.addVideoToCollection).toHaveBeenCalledWith(
+        'existing-col',
+        'video-new'
+      );
+    });
+
     it('should skip shorts when subscription is deleted before lastCheck update', async () => {
       const sub = {
         id: 'sub-deleted',

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -564,7 +564,7 @@ export const clearFinishedTasks = async (
  * Baseline-first sequencing (design §7.1 / §7.3 / §7.5):
  *   1. Parse + validate scalar request values.
  *   2. Normalize/detect platform and playlist ID.
- *   3. Reject a duplicate subscription before any persistent side effect.
+ *   3. Reject subscribe-only duplicates before any persistent side effect.
  *   4. Inspect playlist metadata and capture the current head as baseline.
  *   5. Resolve/create the destination collection.
  *   6. Insert the subscription with the captured head + observation time.
@@ -632,9 +632,14 @@ export const createPlaylistSubscription = async (
     }
   }
 
-  // 3. Early duplicate rejection before any persistent side effect (design §7.3).
+  // 3. Early subscribe-only duplicate rejection before any persistent side
+  //    effect (design §7.3). With downloadAll=true, a duplicate request is a
+  //    request to queue historical backfill for the existing subscription.
   const preExisting = await subscriptionService.listSubscriptions();
-  if (preExisting.some((sub) => sub.authorUrl === playlistUrl)) {
+  const existingSubscription = preExisting.find(
+    (sub) => sub.authorUrl === playlistUrl
+  );
+  if (existingSubscription && !downloadAll) {
     throw DuplicateError.subscription();
   }
 
@@ -673,7 +678,22 @@ export const createPlaylistSubscription = async (
   // 5. Resolve/create the destination collection immediately before inserting
   //    the subscription (design §7.3). Subscribe-only still creates/resolves
   //    one so later scheduled downloads can be grouped (design §3.6).
-  const collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+  let collectionResolution: ReturnType<typeof resolvePlaylistCollectionWithStatus>;
+  if (existingSubscription?.collectionId) {
+    const existingCollection = storageService.getCollectionById(
+      existingSubscription.collectionId
+    );
+    if (existingCollection) {
+      collectionResolution = { collection: existingCollection, created: false };
+    } else {
+      logger.warn(
+        `Playlist subscription ${existingSubscription.id} references missing collection ${existingSubscription.collectionId}; resolving "${collectionName}" for backfill`
+      );
+      collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+    }
+  } else {
+    collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+  }
   const collection = collectionResolution.collection;
   if (
     isBilibiliCollectionOrSeries &&
@@ -697,27 +717,29 @@ export const createPlaylistSubscription = async (
     initialHeadVideoUrl: inspection.headVideoUrl,
     baselineObservedAt: inspection.observedAt,
   };
-  let subscription;
-  try {
-    subscription = await subscriptionService.subscribePlaylist(subscribeOptions);
-  } catch (error) {
-    // The collection write is outside the subscription database transaction.
-    // Clean up only a collection that this request created and can still prove
-    // is empty and unreferenced (design §7.3).
+  let subscription = existingSubscription;
+  if (!subscription) {
     try {
-      await deleteCreatedCollectionIfUnused(
-        collectionResolution,
-        () => subscriptionService.listSubscriptions()
-      );
-    } catch (cleanupError) {
-      logger.error(
-        "Failed to clean up collection after playlist subscription insertion failed",
-        cleanupError instanceof Error
-          ? cleanupError
-          : new Error(String(cleanupError))
-      );
+      subscription = await subscriptionService.subscribePlaylist(subscribeOptions);
+    } catch (error) {
+      // The collection write is outside the subscription database transaction.
+      // Clean up only a collection that this request created and can still prove
+      // is empty and unreferenced (design §7.3).
+      try {
+        await deleteCreatedCollectionIfUnused(
+          collectionResolution,
+          () => subscriptionService.listSubscriptions()
+        );
+      } catch (cleanupError) {
+        logger.error(
+          "Failed to clean up collection after playlist subscription insertion failed",
+          cleanupError instanceof Error
+            ? cleanupError
+            : new Error(String(cleanupError))
+        );
+      }
+      throw error;
     }
-    throw error;
   }
 
   // 7. Optionally create a linked historical task (design §7.1 / §7.4).

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -119,21 +119,6 @@ export type PlaylistBackfillStatus =
   | "not_needed_empty"
   | "failed";
 
-const BLOCKING_BACKFILL_TASK_STATUSES = new Set(["active", "paused"]);
-
-const isBlockingBackfillTask = (task: { status?: string }): boolean =>
-  BLOCKING_BACKFILL_TASK_STATUSES.has(task.status ?? "");
-
-const isReusableBackfillTask = (
-  task: { status?: string; subscriptionId?: string | null; collectionId?: string | null },
-  subscriptionId: string | undefined,
-  collectionId: string
-): boolean =>
-  isBlockingBackfillTask(task) &&
-  Boolean(subscriptionId) &&
-  task.subscriptionId === subscriptionId &&
-  task.collectionId === collectionId;
-
 /**
  * Strictly parse the `downloadAll` request value (design §11.1).
  *
@@ -243,6 +228,32 @@ function hasBilibiliCollectionSource(
     typeof candidate.id === "number" &&
     typeof candidate.mid === "number"
   );
+}
+
+async function refreshExistingPlaylistSubscriptionCursor(
+  subscription: Awaited<ReturnType<typeof subscriptionService.listSubscriptions>>[number],
+  headVideoUrl: string,
+  observedAt: number,
+  context: string
+): Promise<typeof subscription> {
+  try {
+    await subscriptionService.updatePlaylistSubscriptionCursor(
+      subscription.id,
+      headVideoUrl,
+      observedAt
+    );
+    return {
+      ...subscription,
+      lastVideoLink: headVideoUrl,
+      lastCheck: observedAt,
+    };
+  } catch (error) {
+    logger.error(
+      `Failed to update playlist subscription cursor after starting ${context}`,
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return subscription;
+  }
 }
 
 /**
@@ -674,7 +685,9 @@ export const createPlaylistSubscription = async (
   const inspection =
     isBilibiliCollectionOrSeries && collectionInfo
       ? await inspectBilibiliCollectionPlaylist(playlistUrl, collectionInfo)
-      : await inspectPlaylist(playlistUrl);
+      : await inspectPlaylist(playlistUrl, {
+          subscriptionYtdlpConfig: existingSubscription?.ytdlpConfig ?? null,
+        });
 
   let playlistId: string;
   let playlistTitle: string;
@@ -819,11 +832,12 @@ export const createPlaylistSubscription = async (
   } else {
     try {
       const existingTask =
-        await continuousDownloadService.getTaskByAuthorUrl(playlistUrl);
-      if (
-        existingTask &&
-        isReusableBackfillTask(existingTask, subscription.id, collection.id)
-      ) {
+        await continuousDownloadService.getBlockingPlaylistTaskByDestination(
+          playlistUrl,
+          subscription.id,
+          collection.id
+        );
+      if (existingTask) {
         task = { id: existingTask.id };
         backfillStatus = "already_exists";
         logger.info(
@@ -838,6 +852,14 @@ export const createPlaylistSubscription = async (
           subscription.id
         );
         backfillStatus = "started";
+        if (existingSubscription) {
+          subscription = await refreshExistingPlaylistSubscriptionCursor(
+            subscription,
+            inspection.headVideoUrl,
+            inspection.observedAt,
+            `playlist backfill ${task.id}`
+          );
+        }
         logger.info(
           `Created continuous download task ${task.id} for playlist subscription ${subscription.id}`
         );
@@ -936,8 +958,9 @@ export const subscribeChannelPlaylists = async (
     title: string;
     playlistId: string;
     existingSubscription?: {
-      id?: string;
+      id: string;
       collectionId?: string | null;
+      ytdlpConfig?: string | null;
     };
   };
   const candidates: Candidate[] = [];
@@ -980,7 +1003,11 @@ export const subscribeChannelPlaylists = async (
     try {
       const snapshot = await getPlaylistHeadSnapshot(
         candidate.playlistUrl,
-        platform
+        platform,
+        {
+          subscriptionYtdlpConfig:
+            candidate.existingSubscription?.ytdlpConfig ?? null,
+        }
       );
       preflight[idx] = {
         ok: true,
@@ -1010,6 +1037,7 @@ export const subscribeChannelPlaylists = async (
     const { candidate, headVideoUrl, observedAt } = result_item;
 
     let createdSubscriptionId = candidate.existingSubscription?.id;
+    let subscriptionWasCreatedByThisRequest = false;
     let taskCollectionId = candidate.existingSubscription?.collectionId;
     let taskCollectionResolution: ReturnType<
       typeof resolveChannelPlaylistCollectionWithStatus
@@ -1082,6 +1110,7 @@ export const subscribeChannelPlaylists = async (
           baselineObservedAt: observedAt,
         });
         createdSubscriptionId = subscription.id;
+        subscriptionWasCreatedByThisRequest = true;
         subscribedCount++;
         existingSubByUrl.set(candidate.playlistUrl, subscription);
       } catch (error: unknown) {
@@ -1137,17 +1166,14 @@ export const subscribeChannelPlaylists = async (
       }
       try {
         const resolvedTaskCollectionId = await ensureTaskCollectionId();
-        const existingTask = await continuousDownloadService.getTaskByAuthorUrl(
-          candidate.playlistUrl
-        );
-        if (
-          existingTask &&
-          isReusableBackfillTask(
-            existingTask,
-            createdSubscriptionId,
-            resolvedTaskCollectionId
-          )
-        ) {
+        const existingTask = createdSubscriptionId
+          ? await continuousDownloadService.getBlockingPlaylistTaskByDestination(
+              candidate.playlistUrl,
+              createdSubscriptionId,
+              resolvedTaskCollectionId
+            )
+          : null;
+        if (existingTask) {
           logger.info(
             `Skipping download task creation for playlist "${candidate.title}": task already exists`
           );
@@ -1165,6 +1191,20 @@ export const subscribeChannelPlaylists = async (
           logger.info(
             `Created continuous download task ${task.id} for playlist: ${candidate.title}`
           );
+          if (!subscriptionWasCreatedByThisRequest && createdSubscriptionId) {
+            try {
+              await subscriptionService.updatePlaylistSubscriptionCursor(
+                createdSubscriptionId,
+                headVideoUrl,
+                observedAt
+              );
+            } catch (error) {
+              logger.error(
+                `Failed to update playlist subscription cursor after starting bulk backfill for "${candidate.title}"`,
+                error instanceof Error ? error : new Error(String(error))
+              );
+            }
+          }
         }
       } catch (error) {
         logger.error(

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -114,6 +114,7 @@ function canReadYtdlpConfigOverride(req: Request): boolean {
 export type PlaylistBackfillStatus =
   | "not_requested"
   | "started"
+  | "already_exists"
   | "not_needed_empty"
   | "failed";
 
@@ -756,17 +757,27 @@ export const createPlaylistSubscription = async (
     backfillStatus = "not_needed_empty";
   } else {
     try {
-      task = await continuousDownloadService.createPlaylistTask(
-        playlistUrl,
-        author,
-        platform,
-        collection.id,
-        subscription.id
-      );
-      backfillStatus = "started";
-      logger.info(
-        `Created continuous download task ${task.id} for playlist subscription ${subscription.id}`
-      );
+      const existingTask =
+        await continuousDownloadService.getTaskByAuthorUrl(playlistUrl);
+      if (existingTask) {
+        task = { id: existingTask.id };
+        backfillStatus = "already_exists";
+        logger.info(
+          `Skipping playlist backfill for ${playlistUrl}: task ${existingTask.id} already exists`
+        );
+      } else {
+        task = await continuousDownloadService.createPlaylistTask(
+          playlistUrl,
+          author,
+          platform,
+          collection.id,
+          subscription.id
+        );
+        backfillStatus = "started";
+        logger.info(
+          `Created continuous download task ${task.id} for playlist subscription ${subscription.id}`
+        );
+      }
     } catch (error) {
       // Failure to create the historical task does NOT roll back a
       // successfully created subscription (design §7.3). Return no task id

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -118,6 +118,11 @@ export type PlaylistBackfillStatus =
   | "not_needed_empty"
   | "failed";
 
+const BLOCKING_BACKFILL_TASK_STATUSES = new Set(["active", "paused"]);
+
+const isBlockingBackfillTask = (task: { status?: string }): boolean =>
+  BLOCKING_BACKFILL_TASK_STATUSES.has(task.status ?? "");
+
 /**
  * Strictly parse the `downloadAll` request value (design §11.1).
  *
@@ -719,6 +724,30 @@ export const createPlaylistSubscription = async (
     baselineObservedAt: inspection.observedAt,
   };
   let subscription = existingSubscription;
+  if (subscription && subscription.collectionId !== collection.id) {
+    try {
+      await subscriptionService.updatePlaylistSubscriptionCollection(
+        subscription.id,
+        collection.id
+      );
+      subscription = { ...subscription, collectionId: collection.id };
+    } catch (error) {
+      try {
+        await deleteCreatedCollectionIfUnused(
+          collectionResolution,
+          () => subscriptionService.listSubscriptions()
+        );
+      } catch (cleanupError) {
+        logger.error(
+          "Failed to clean up collection after playlist subscription collection update failed",
+          cleanupError instanceof Error
+            ? cleanupError
+            : new Error(String(cleanupError))
+        );
+      }
+      throw error;
+    }
+  }
   if (!subscription) {
     try {
       subscription = await subscriptionService.subscribePlaylist(subscribeOptions);
@@ -759,7 +788,7 @@ export const createPlaylistSubscription = async (
     try {
       const existingTask =
         await continuousDownloadService.getTaskByAuthorUrl(playlistUrl);
-      if (existingTask) {
+      if (existingTask && isBlockingBackfillTask(existingTask)) {
         task = { id: existingTask.id };
         backfillStatus = "already_exists";
         logger.info(

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -31,6 +31,7 @@ import {
     deriveChannelName,
     deleteCreatedCollectionIfUnused,
     extractYouTubePlaylistId,
+    resolveBilibiliPlaylistCollectionWithStatus,
     resolveChannelPlaylistCollectionWithStatus,
     resolvePlaylistCollectionWithStatus,
     sanitizePlaylistTitle,
@@ -123,6 +124,16 @@ const BLOCKING_BACKFILL_TASK_STATUSES = new Set(["active", "paused"]);
 const isBlockingBackfillTask = (task: { status?: string }): boolean =>
   BLOCKING_BACKFILL_TASK_STATUSES.has(task.status ?? "");
 
+const isReusableBackfillTask = (
+  task: { status?: string; subscriptionId?: string | null; collectionId?: string | null },
+  subscriptionId: string | undefined,
+  collectionId: string
+): boolean =>
+  isBlockingBackfillTask(task) &&
+  Boolean(subscriptionId) &&
+  task.subscriptionId === subscriptionId &&
+  task.collectionId === collectionId;
+
 /**
  * Strictly parse the `downloadAll` request value (design §11.1).
  *
@@ -191,7 +202,7 @@ function parseBilibiliCollectionInfo(
 function saveBilibiliCollectionSourceIfCompatible(
   collection: storageService.Collection,
   source: { type: "collection" | "series"; id: number; mid: number }
-): void {
+): storageService.Collection | null {
   const sourceKey = {
     sourcePlatform: "bilibili",
     sourceType: source.type,
@@ -210,9 +221,15 @@ function saveBilibiliCollectionSourceIfCompatible(
     collection.sourceMid === sourceKey.sourceMid &&
     collection.sourceId === sourceKey.sourceId;
 
-  if (!hasSourceKey || matchesSourceKey) {
-    storageService.saveCollection({ ...collection, ...sourceKey });
+  if (matchesSourceKey) {
+    return collection;
   }
+  if (!hasSourceKey) {
+    const updatedCollection = { ...collection, ...sourceKey };
+    storageService.saveCollection(updatedCollection);
+    return updatedCollection;
+  }
+  return null;
 }
 
 function hasBilibiliCollectionSource(
@@ -684,32 +701,47 @@ export const createPlaylistSubscription = async (
   // 5. Resolve/create the destination collection immediately before inserting
   //    the subscription (design §7.3). Subscribe-only still creates/resolves
   //    one so later scheduled downloads can be grouped (design §3.6).
+  const bilibiliSource =
+    isBilibiliCollectionOrSeries && hasBilibiliCollectionSource(inspection)
+      ? inspection.bilibiliSource
+      : null;
+  const resolveRequestedCollection = (): ReturnType<
+    typeof resolvePlaylistCollectionWithStatus
+  > =>
+    bilibiliSource
+      ? resolveBilibiliPlaylistCollectionWithStatus(
+          collectionName,
+          bilibiliSource
+        )
+      : resolvePlaylistCollectionWithStatus(collectionName);
+
   let collectionResolution: ReturnType<typeof resolvePlaylistCollectionWithStatus>;
   if (existingSubscription?.collectionId) {
     const existingCollection = storageService.getCollectionById(
       existingSubscription.collectionId
     );
     if (existingCollection) {
-      collectionResolution = { collection: existingCollection, created: false };
+      if (bilibiliSource) {
+        const compatibleCollection = saveBilibiliCollectionSourceIfCompatible(
+          existingCollection,
+          bilibiliSource
+        );
+        collectionResolution = compatibleCollection
+          ? { collection: compatibleCollection, created: false }
+          : resolveRequestedCollection();
+      } else {
+        collectionResolution = { collection: existingCollection, created: false };
+      }
     } else {
       logger.warn(
         `Playlist subscription ${existingSubscription.id} references missing collection ${existingSubscription.collectionId}; resolving "${collectionName}" for backfill`
       );
-      collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+      collectionResolution = resolveRequestedCollection();
     }
   } else {
-    collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+    collectionResolution = resolveRequestedCollection();
   }
   const collection = collectionResolution.collection;
-  if (
-    isBilibiliCollectionOrSeries &&
-    hasBilibiliCollectionSource(inspection)
-  ) {
-    saveBilibiliCollectionSourceIfCompatible(
-      collection,
-      inspection.bilibiliSource
-    );
-  }
 
   // 6. Insert the subscription with the captured baseline (design §7.2).
   const subscribeOptions: SubscribePlaylistOptions = {
@@ -788,7 +820,10 @@ export const createPlaylistSubscription = async (
     try {
       const existingTask =
         await continuousDownloadService.getTaskByAuthorUrl(playlistUrl);
-      if (existingTask && isBlockingBackfillTask(existingTask)) {
+      if (
+        existingTask &&
+        isReusableBackfillTask(existingTask, subscription.id, collection.id)
+      ) {
         task = { id: existingTask.id };
         backfillStatus = "already_exists";
         logger.info(
@@ -976,12 +1011,52 @@ export const subscribeChannelPlaylists = async (
 
     let createdSubscriptionId = candidate.existingSubscription?.id;
     let taskCollectionId = candidate.existingSubscription?.collectionId;
-    const resolveTaskCollectionId = (): string => {
-      const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
+    let taskCollectionResolution: ReturnType<
+      typeof resolveChannelPlaylistCollectionWithStatus
+    > | null = null;
+    const resolveTaskCollection = (): ReturnType<
+      typeof resolveChannelPlaylistCollectionWithStatus
+    > => {
+      taskCollectionResolution ??= resolveChannelPlaylistCollectionWithStatus(
         candidate.title,
         channelName
       );
-      return collectionResolution.collection.id;
+      return taskCollectionResolution;
+    };
+    const ensureTaskCollectionId = async (): Promise<string> => {
+      if (taskCollectionId) {
+        return taskCollectionId;
+      }
+
+      const collectionResolution = resolveTaskCollection();
+      taskCollectionId = collectionResolution.collection.id;
+
+      if (candidate.existingSubscription?.id) {
+        try {
+          await subscriptionService.updatePlaylistSubscriptionCollection(
+            candidate.existingSubscription.id,
+            taskCollectionId
+          );
+          candidate.existingSubscription.collectionId = taskCollectionId;
+        } catch (error) {
+          try {
+            await deleteCreatedCollectionIfUnused(
+              collectionResolution,
+              () => subscriptionService.listSubscriptions()
+            );
+          } catch (cleanupError) {
+            logger.error(
+              `Failed to clean up collection for playlist "${candidate.title}" after subscription collection update failed:`,
+              cleanupError instanceof Error
+                ? cleanupError
+                : new Error(String(cleanupError))
+            );
+          }
+          throw error;
+        }
+      }
+
+      return taskCollectionId;
     };
 
     if (!candidate.existingSubscription) {
@@ -1061,17 +1136,22 @@ export const subscribeChannelPlaylists = async (
         continue;
       }
       try {
+        const resolvedTaskCollectionId = await ensureTaskCollectionId();
         const existingTask = await continuousDownloadService.getTaskByAuthorUrl(
           candidate.playlistUrl
         );
-        if (existingTask) {
+        if (
+          existingTask &&
+          isReusableBackfillTask(
+            existingTask,
+            createdSubscriptionId,
+            resolvedTaskCollectionId
+          )
+        ) {
           logger.info(
             `Skipping download task creation for playlist "${candidate.title}": task already exists`
           );
         } else {
-          if (!taskCollectionId) {
-            taskCollectionId = resolveTaskCollectionId();
-          }
           // Link to the subscription created/known by this request. An existing
           // candidate came from phase one, and a raced duplicate above resolved
           // its exact current row.
@@ -1079,7 +1159,7 @@ export const subscribeChannelPlaylists = async (
             candidate.playlistUrl,
             channelName,
             platform,
-            taskCollectionId,
+            resolvedTaskCollectionId,
             createdSubscriptionId
           );
           logger.info(

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -4,7 +4,7 @@ import {
     isAdminTrustLevelAtLeast,
 } from "../config/adminTrust";
 import { getErrorMessage } from "../utils/errors";
-import { ValidationError } from "../errors/DownloadErrors";
+import { DuplicateError, ValidationError } from "../errors/DownloadErrors";
 import { continuousDownloadService } from "../services/continuousDownloadService";
 import { DownloadOrder } from "../services/continuousDownload/types";
 import { checkPlaylist } from "../services/downloadService";
@@ -25,17 +25,22 @@ import {
     getUserYtDlpConfig,
 } from "../utils/ytDlpUtils";
 import { getPositiveIntegerParam, getStringParam } from "../utils/paramUtils";
+import { runWithConcurrencyLimit } from "../utils/concurrency";
 import {
     detectPlaylistPlatform,
     deriveChannelName,
-    extractBilibiliPlaylistId,
-    extractPlaylistAuthor,
+    deleteCreatedCollectionIfUnused,
     extractYouTubePlaylistId,
-    resolveChannelPlaylistCollection,
-    resolvePlaylistCollection,
+    resolveChannelPlaylistCollectionWithStatus,
+    resolvePlaylistCollectionWithStatus,
     sanitizePlaylistTitle,
     toPlaylistsTabUrl,
 } from "../services/subscription/playlistResolution";
+import {
+    getPlaylistHeadSnapshot,
+    inspectPlaylist,
+} from "../services/subscription/playlistFeed";
+import type { SubscribePlaylistOptions } from "../services/subscriptionService";
 
 // Per-subscription yt-dlp config override (issue #345). Same free-text format
 // and trust requirement ("container") as the global ytDlpConfig setting.
@@ -96,6 +101,83 @@ function canReadYtdlpConfigOverride(req: Request): boolean {
     return false;
   }
   return req.user?.role !== "visitor";
+}
+
+/**
+ * Backfill outcome for a playlist subscription response (design §7.1).
+ * `taskId` alone cannot distinguish an intentionally omitted zero-length
+ * backfill from a task-creation failure, so this explicit status lets the UI
+ * report each outcome accurately.
+ */
+export type PlaylistBackfillStatus =
+  | "not_requested"
+  | "started"
+  | "not_needed_empty"
+  | "failed";
+
+/**
+ * Strictly parse the `downloadAll` request value (design §11.1).
+ *
+ * The existing boolean already has the exact required API meaning: whether to
+ * create a historical task. Normalize once here so:
+ * - missing `downloadAll` normalizes to `false` (subscribe-only) for
+ *   compatibility (F10);
+ * - a non-boolean value (string "false", 0, object, null) is rejected rather
+ *   than treated as truthy/falsy.
+ */
+function parseDownloadAll(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new ValidationError("downloadAll must be a boolean", "downloadAll");
+  }
+  return value;
+}
+
+/**
+ * Validate the trusted-looking `collectionInfo` shape for Bilibili
+ * collections/series (design §7.1 / §12.2). Returns a normalized object or
+ * null. The server uses this for title/count/IDs only; baseline capture still
+ * requires a real source probe.
+ */
+function parseBilibiliCollectionInfo(
+  value: unknown
+): {
+  type: "collection" | "series";
+  id: string | number;
+  mid?: string | number;
+  title: string;
+  count: number;
+} | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "object") {
+    throw new ValidationError(
+      "collectionInfo must be an object",
+      "collectionInfo"
+    );
+  }
+  const info = value as Record<string, unknown>;
+  if (info.type !== "collection" && info.type !== "series") {
+    throw new ValidationError(
+      "collectionInfo.type must be collection or series",
+      "collectionInfo"
+    );
+  }
+  if (info.id === undefined) {
+    throw new ValidationError(
+      "collectionInfo.id is required for collection/series",
+      "collectionInfo"
+    );
+  }
+  return {
+    type: info.type,
+    id: info.id as string | number,
+    mid: info.mid as string | number | undefined,
+    title: typeof info.title === "string" ? info.title : String(info.title ?? ""),
+    count:
+      typeof info.count === "number"
+        ? info.count
+        : parseInt(String(info.count ?? "0"), 10) || 0,
+  };
 }
 
 /**
@@ -435,15 +517,51 @@ export const clearFinishedTasks = async (
 };
 
 /**
- * Create a playlist subscription (and optionally download all videos)
- * Errors are automatically handled by asyncHandler middleware
+ * Create a playlist subscription (and optionally download all videos).
+ *
+ * Baseline-first sequencing (design §7.1 / §7.3 / §7.5):
+ *   1. Parse + validate scalar request values.
+ *   2. Normalize/detect platform and playlist ID.
+ *   3. Reject a duplicate subscription before any persistent side effect.
+ *   4. Inspect playlist metadata and capture the current head as baseline.
+ *   5. Resolve/create the destination collection.
+ *   6. Insert the subscription with the captured head + observation time.
+ *   7. Optionally create a linked historical task.
+ *   8. Return a typed, self-describing response.
+ *
+ * If the baseline probe fails, no subscription/collection/task is created
+ * (fail-closed, design §7.5 / F9).
+ *
+ * Errors are automatically handled by asyncHandler middleware.
  */
 export const createPlaylistSubscription = async (
   req: Request,
   res: Response
 ): Promise<void> => {
-  const { playlistUrl, interval, collectionName, downloadAll, collectionInfo } =
+  const { playlistUrl, collectionName, collectionInfo: rawCollectionInfo } =
     req.body;
+
+  // 1a. Strict interval validation: positive safe integer (design §7.1).
+  const interval = getPositiveIntegerParam(req.body.interval);
+  if (interval === undefined) {
+    throw new ValidationError(
+      "Playlist URL, interval, and collection name are required",
+      "body"
+    );
+  }
+  if (!playlistUrl || !collectionName) {
+    throw new ValidationError(
+      "Playlist URL, interval, and collection name are required",
+      "body"
+    );
+  }
+
+  // 1b. Strict downloadAll parsing (design §11.1). Missing => subscribe-only.
+  const downloadAll = parseDownloadAll(req.body.downloadAll);
+
+  // Validate Bilibili collectionInfo shape when provided (design §7.1 / §12.2).
+  const collectionInfo = parseBilibiliCollectionInfo(rawCollectionInfo);
+
   logger.info("Creating playlist subscription:", {
     playlistUrl,
     interval,
@@ -452,44 +570,19 @@ export const createPlaylistSubscription = async (
     collectionInfo,
   });
 
-  if (!playlistUrl || !interval || !collectionName) {
-    throw new ValidationError(
-      "Playlist URL, interval, and collection name are required",
-      "body"
-    );
-  }
-
-  // Detect platform
+  // 2. Detect platform and playlist ID.
   const isBilibili = isBilibiliUrl(playlistUrl);
   const platform = detectPlaylistPlatform(playlistUrl);
 
-  // Validate playlist URL format based on platform
-  let playlistId: string | null = null;
-  let playlistTitle: string = collectionName;
-  let videoCount: number = 0;
-
-  // For Bilibili collection/series, use collectionInfo if provided
-  if (
+  // For Bilibili collection/series, a trusted collectionInfo may supply the ID.
+  const isBilibiliCollectionOrSeries =
     isBilibili &&
-    collectionInfo &&
-    (collectionInfo.type === "collection" || collectionInfo.type === "series")
-  ) {
-    // Skip checkPlaylist validation for Bilibili collections/series
-    // Use the collectionInfo directly
-    playlistId = collectionInfo.id?.toString() || null;
-    playlistTitle = collectionInfo.title || collectionName;
-    videoCount = collectionInfo.count || 0;
-    logger.info(
-      `Using Bilibili ${collectionInfo.type} info: ${playlistTitle} (${videoCount} videos)`
-    );
-  } else if (isBilibili) {
-    // For Bilibili playlists (not collections), try to validate with checkPlaylist
-    // For Bilibili, yt-dlp handles playlist URLs differently
-    playlistId = null; // Will be extracted from playlist info if available
-  } else {
-    // For YouTube, check for list parameter
-    playlistId = extractYouTubePlaylistId(playlistUrl);
-    if (!playlistId) {
+    !!collectionInfo &&
+    (collectionInfo.type === "collection" || collectionInfo.type === "series");
+
+  if (!isBilibili) {
+    // YouTube requires a list= parameter.
+    if (!extractYouTubePlaylistId(playlistUrl)) {
       throw new ValidationError(
         "YouTube URL must contain a playlist parameter (list=)",
         "playlistUrl"
@@ -497,88 +590,127 @@ export const createPlaylistSubscription = async (
     }
   }
 
-  // Get playlist info (skip if we already have collectionInfo for Bilibili)
-  let playlistInfo: {
-    success: boolean;
-    title?: string;
-    videoCount?: number;
-    error?: string;
-  };
+  // 3. Early duplicate rejection before any persistent side effect (design §7.3).
+  const preExisting = await subscriptionService.listSubscriptions();
+  if (preExisting.some((sub) => sub.authorUrl === playlistUrl)) {
+    throw DuplicateError.subscription();
+  }
 
-  if (
-    isBilibili &&
-    collectionInfo &&
-    (collectionInfo.type === "collection" || collectionInfo.type === "series")
-  ) {
-    // Use collectionInfo instead of calling checkPlaylist
-    playlistInfo = {
-      success: true,
-      title: playlistTitle,
-      videoCount: videoCount,
-    };
+  // 4. Inspect playlist metadata and capture the current head as the baseline
+  //    (design §6 / §7.1). This single shared probe replaces the former
+  //    repeated checkPlaylist / extractBilibiliPlaylistId / extractPlaylistAuthor
+  //    probes (design §6.5 / Step 2). Throws on operational failure => the
+  //    centralized error handler returns 400/502/500 without side effects.
+  const inspection = await inspectPlaylist(playlistUrl);
+
+  let playlistId: string;
+  let playlistTitle: string;
+  let videoCount: number;
+  let author: string;
+
+  if (isBilibiliCollectionOrSeries && collectionInfo) {
+    // Use the validated collectionInfo for title/count/IDs (design §12.2), but
+    // the head baseline still came from the real source probe above.
+    playlistId = collectionInfo.id?.toString() || inspection.playlistId || "";
+    playlistTitle = collectionInfo.title || inspection.title;
+    videoCount = collectionInfo.count;
+    author = inspection.author;
+    logger.info(
+      `Using Bilibili ${collectionInfo.type} info: ${playlistTitle} (${videoCount} videos)`
+    );
   } else {
-    // Get playlist info (this validates the playlist for both platforms)
-    playlistInfo = await checkPlaylist(playlistUrl);
-
-    if (!playlistInfo.success) {
-      throw new ValidationError(
-        playlistInfo.error || "Failed to get playlist information",
-        "playlistUrl"
-      );
-    }
-
-    playlistTitle = playlistInfo.title || collectionName;
-    videoCount = playlistInfo.videoCount || 0;
+    playlistId = inspection.playlistId || "";
+    playlistTitle = inspection.title || collectionName;
+    videoCount = inspection.videoCount;
+    author = inspection.author;
   }
 
-  // Extract playlist ID from yt-dlp info if not already extracted (for Bilibili)
-  if (!playlistId && isBilibili) {
-    playlistId = await extractBilibiliPlaylistId(playlistUrl);
-  }
+  // 5. Resolve/create the destination collection immediately before inserting
+  //    the subscription (design §7.3). Subscribe-only still creates/resolves
+  //    one so later scheduled downloads can be grouped (design §3.6).
+  const collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
+  const collection = collectionResolution.collection;
 
-  // Create or find collection
-  const collection = resolvePlaylistCollection(collectionName);
-
-  // Extract author from playlist
-  const author = await extractPlaylistAuthor(playlistUrl);
-
-  // Create subscription
-  const subscription = await subscriptionService.subscribePlaylist(
+  // 6. Insert the subscription with the captured baseline (design §7.2).
+  const subscribeOptions: SubscribePlaylistOptions = {
     playlistUrl,
-    parseInt(interval),
+    interval,
     playlistTitle,
-    playlistId || "",
+    playlistId,
     author,
     platform,
-    collection.id
-  );
+    collectionId: collection.id,
+    initialHeadVideoUrl: inspection.headVideoUrl,
+    baselineObservedAt: inspection.observedAt,
+  };
+  let subscription;
+  try {
+    subscription = await subscriptionService.subscribePlaylist(subscribeOptions);
+  } catch (error) {
+    // The collection write is outside the subscription database transaction.
+    // Clean up only a collection that this request created and can still prove
+    // is empty and unreferenced (design §7.3).
+    try {
+      await deleteCreatedCollectionIfUnused(
+        collectionResolution,
+        () => subscriptionService.listSubscriptions()
+      );
+    } catch (cleanupError) {
+      logger.error(
+        "Failed to clean up collection after playlist subscription insertion failed",
+        cleanupError instanceof Error
+          ? cleanupError
+          : new Error(String(cleanupError))
+      );
+    }
+    throw error;
+  }
 
-  // If user wants to download all videos, create a continuous download task
-  let task = null;
-  if (downloadAll) {
+  // 7. Optionally create a linked historical task (design §7.1 / §7.4).
+  //    Capturing the baseline here is intentional: it prevents the scheduler
+  //    from enqueuing the same latest item while the task processes history
+  //    (design §4.4). A verified empty playlist needs no backfill task
+  //    (design §4.5).
+  let task: { id: string } | null = null;
+  let backfillStatus: PlaylistBackfillStatus;
+  if (!downloadAll) {
+    backfillStatus = "not_requested";
+  } else if (videoCount === 0 || inspection.headVideoUrl === null) {
+    // Empty playlist: omit the zero-length task (design §4.5).
+    backfillStatus = "not_needed_empty";
+  } else {
     try {
       task = await continuousDownloadService.createPlaylistTask(
         playlistUrl,
         author,
         platform,
-        collection.id
+        collection.id,
+        subscription.id
       );
+      backfillStatus = "started";
       logger.info(
         `Created continuous download task ${task.id} for playlist subscription ${subscription.id}`
       );
     } catch (error) {
+      // Failure to create the historical task does NOT roll back a
+      // successfully created subscription (design §7.3). Return no task id
+      // with a "failed" status so the UI can warn rather than claim history
+      // was queued.
+      backfillStatus = "failed";
       logger.error(
         "Error creating continuous download task for playlist:",
         error instanceof Error ? error : new Error(String(error))
       );
-      // Don't fail the subscription creation if task creation fails
     }
   }
 
+  // 8. Typed, self-describing response (design §7.1).
   res.status(201).json({
     subscription,
     collectionId: collection.id,
-    taskId: task?.id,
+    taskId: task?.id ?? null,
+    downloadAll,
+    backfillStatus,
   });
 };
 
@@ -641,85 +773,176 @@ export const subscribeChannelPlaylists = async (
   let skippedCount = 0;
   const errors: string[] = [];
 
-  // Process each playlist
-  for (const entry of result.entries) {
-    // Must be a playlist type or have a title and url/id
-    if (!entry.url && !entry.id) continue;
+  // --- Phase 1 (design §8.1): build the candidate list and drop already-
+  // subscribed URLs. A single listSubscriptions call feeds every candidate's
+  // duplicate check rather than one query per playlist.
+  const existingSubs = await subscriptionService.listSubscriptions();
+  const subscribedUrlSet = new Set(existingSubs.map((s) => s.authorUrl));
 
+  type Candidate = {
+    playlistUrl: string;
+    title: string;
+    playlistId: string;
+  };
+  const candidates: Candidate[] = [];
+  for (const entry of result.entries) {
+    if (!entry.url && !entry.id) continue;
     const playlistUrl =
       entry.url || `https://www.youtube.com/playlist?list=${entry.id}`;
     const title = sanitizePlaylistTitle(entry.title);
+    const playlistId = entry.id ?? extractYouTubePlaylistId(playlistUrl) ?? "";
 
-    logger.info(`Processing playlist subscription: ${title} (${playlistUrl})`);
-
-    // Check if already subscribed to this playlist
-    const existing = await subscriptionService.listSubscriptions();
-    const alreadySubscribed = existing.some(
-      (sub) => sub.authorUrl === playlistUrl
-    );
-
-    // Get or create collection for this playlist
-    const collection = resolveChannelPlaylistCollection(title, channelName);
-    const collectionId = collection.id;
-
-    // Extract playlist ID
-    const playlistId = entry.id ?? extractYouTubePlaylistId(playlistUrl);
-
-    // Create subscription if not already subscribed
-    if (!alreadySubscribed) {
-      try {
-        // Create subscription for this playlist
-        await subscriptionService.subscribePlaylist(
-          playlistUrl,
-          parseInt(interval),
-          title,
-          playlistId || "",
-          channelName,
-          platform,
-          collectionId
-        );
-        subscribedCount++;
-      } catch (error: unknown) {
-        logger.error(`Error subscribing to playlist "${title}":`, error);
-        if (error instanceof Error && error.name === "DuplicateError") {
-          skippedCount++;
-        } else {
-          errors.push(`${title}: ${getErrorMessage(error, "Unknown error")}`);
-        }
-        // Continue to check if we should create download task even if subscription failed
-      }
-    } else {
+    if (subscribedUrlSet.has(playlistUrl)) {
       logger.info(`Skipping playlist "${title}": already subscribed`);
       skippedCount++;
+      continue;
+    }
+    candidates.push({ playlistUrl, title, playlistId });
+  }
+
+  // --- Phase 2: resolve head snapshots concurrently with a conservative
+  // limit of 3 (design §8.1). Each worker catches internally and writes an
+  // indexed preflight result so one failed probe does not abort the remaining
+  // candidates. A failed baseline counts as an error, not a skip.
+  type Preflight =
+    | { ok: true; candidate: Candidate; headVideoUrl: string | null; observedAt: number }
+    | { ok: false; candidate: Candidate; error: string };
+  const preflight: Preflight[] = new Array(candidates.length);
+
+  await runWithConcurrencyLimit(candidates, 3, async (candidate) => {
+    const idx = candidates.indexOf(candidate);
+    try {
+      const snapshot = await getPlaylistHeadSnapshot(
+        candidate.playlistUrl,
+        platform
+      );
+      preflight[idx] = {
+        ok: true,
+        candidate,
+        headVideoUrl: snapshot.headVideoUrl,
+        observedAt: snapshot.observedAt,
+      };
+    } catch (error) {
+      const message = getErrorMessage(error, "Unknown error");
+      errors.push(`${candidate.title}: ${message}`);
+      preflight[idx] = { ok: false, candidate, error: message };
+      logger.error(
+        `Baseline probe failed for playlist "${candidate.title}":`,
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  });
+
+  // --- Phase 3: sequentially resolve collections and insert subscriptions
+  // for successful snapshots (design §8.1). Sequential mutation avoids
+  // Date.now() collection-ID collisions and keeps counters deterministic.
+  const wantBackfill = downloadAllPrevious === true;
+
+  for (const result_item of preflight) {
+    if (!result_item || !result_item.ok) continue;
+    const { candidate, headVideoUrl, observedAt } = result_item;
+
+    // Resolve/create collection only after a successful baseline.
+    const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
+      candidate.title,
+      channelName
+    );
+    const collection = collectionResolution.collection;
+    const collectionId = collection.id;
+
+    let createdSubscriptionId: string | undefined;
+    let taskCollectionId: string | null | undefined = collectionId;
+    try {
+      const subscription = await subscriptionService.subscribePlaylist({
+        playlistUrl: candidate.playlistUrl,
+        interval: parseInt(interval),
+        playlistTitle: candidate.title,
+        playlistId: candidate.playlistId,
+        author: channelName,
+        platform,
+        collectionId,
+        initialHeadVideoUrl: headVideoUrl,
+        baselineObservedAt: observedAt,
+      });
+      createdSubscriptionId = subscription.id;
+      subscribedCount++;
+      subscribedUrlSet.add(candidate.playlistUrl);
+    } catch (error: unknown) {
+      logger.error(`Error subscribing to playlist "${candidate.title}":`, error);
+      try {
+        await deleteCreatedCollectionIfUnused(
+          collectionResolution,
+          () => subscriptionService.listSubscriptions()
+        );
+      } catch (cleanupError) {
+        logger.error(
+          `Failed to clean up collection for playlist "${candidate.title}" after subscription insertion failed:`,
+          cleanupError instanceof Error
+            ? cleanupError
+            : new Error(String(cleanupError))
+        );
+      }
+      if (error instanceof Error && error.name === "DuplicateError") {
+        skippedCount++;
+        // A concurrent request may have inserted the subscription after the
+        // phase-one list. Resolve that exact row before creating a requested
+        // backfill task; never attach the task to this request's now-cleaned
+        // collection (design §11.3).
+        const concurrentSub = (await subscriptionService.listSubscriptions()).find(
+          (sub) => sub.authorUrl === candidate.playlistUrl
+        );
+        if (!concurrentSub) {
+          errors.push(
+            `${candidate.title}: concurrent subscription could not be resolved`
+          );
+          continue;
+        }
+        createdSubscriptionId = concurrentSub.id;
+        taskCollectionId = concurrentSub.collectionId;
+      } else {
+        errors.push(
+          `${candidate.title}: ${getErrorMessage(error, "Unknown error")}`
+        );
+        // A real insertion failure must not turn into an unlinked historical
+        // task. The next bulk request can retry the subscription cleanly.
+        continue;
+      }
     }
 
-    // If user wants to download all previous videos, create a continuous download task
-    // This should happen even if the playlist was already subscribed
-    if (downloadAllPrevious) {
+    // Historical task only when requested. For a bulk duplicate (already
+    // subscribed), link the task to the existing subscription id when
+    // available (design §11.3).
+    if (wantBackfill) {
+      // A verified empty playlist needs no backfill task (design §4.5).
+      if (headVideoUrl === null) {
+        continue;
+      }
       try {
-        // Check if task already exists
         const existingTask = await continuousDownloadService.getTaskByAuthorUrl(
-          playlistUrl
+          candidate.playlistUrl
         );
-
         if (existingTask) {
           logger.info(
-            `Skipping download task creation for playlist "${title}": task already exists`
+            `Skipping download task creation for playlist "${candidate.title}": task already exists`
           );
         } else {
-          await continuousDownloadService.createPlaylistTask(
-            playlistUrl,
+          // Link to the subscription created/known by this request. A
+          // pre-existing candidate was removed in phase one, and a raced
+          // duplicate above resolved its exact current row.
+          const task = await continuousDownloadService.createPlaylistTask(
+            candidate.playlistUrl,
             channelName,
             platform,
-            collectionId
+            taskCollectionId,
+            createdSubscriptionId
           );
           logger.info(
-            `Created continuous download task for playlist: ${title}`
+            `Created continuous download task ${task.id} for playlist: ${candidate.title}`
           );
         }
       } catch (error) {
         logger.error(
-          `Error creating continuous download task for playlist "${title}":`,
+          `Error creating continuous download task for playlist "${candidate.title}":`,
           error instanceof Error ? error : new Error(String(error))
         );
         // Don't fail the subscription if task creation fails

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -914,6 +914,13 @@ export const subscribeChannelPlaylists = async (
 
     let createdSubscriptionId = candidate.existingSubscription?.id;
     let taskCollectionId = candidate.existingSubscription?.collectionId;
+    const resolveTaskCollectionId = (): string => {
+      const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
+        candidate.title,
+        channelName
+      );
+      return collectionResolution.collection.id;
+    };
 
     if (!candidate.existingSubscription) {
       // Resolve/create collection only after a successful baseline.
@@ -1000,6 +1007,9 @@ export const subscribeChannelPlaylists = async (
             `Skipping download task creation for playlist "${candidate.title}": task already exists`
           );
         } else {
+          if (!taskCollectionId) {
+            taskCollectionId = resolveTaskCollectionId();
+          }
           // Link to the subscription created/known by this request. An existing
           // candidate came from phase one, and a raced duplicate above resolved
           // its exact current row.

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -41,6 +41,7 @@ import {
     inspectBilibiliCollectionPlaylist,
     inspectPlaylist,
 } from "../services/subscription/playlistFeed";
+import type { BilibiliCollectionSource } from "../services/subscription/playlistFeed";
 import type { SubscribePlaylistOptions } from "../services/subscriptionService";
 
 // Per-subscription yt-dlp config override (issue #345). Same free-text format
@@ -179,6 +180,46 @@ function parseBilibiliCollectionInfo(
         ? info.count
         : parseInt(String(info.count ?? "0"), 10) || 0,
   };
+}
+
+function saveBilibiliCollectionSourceIfCompatible(
+  collection: storageService.Collection,
+  source: { type: "collection" | "series"; id: number; mid: number }
+): void {
+  const sourceKey = {
+    sourcePlatform: "bilibili",
+    sourceType: source.type,
+    sourceMid: String(source.mid),
+    sourceId: String(source.id),
+  };
+  const hasSourceKey = Boolean(
+    collection.sourcePlatform ||
+      collection.sourceType ||
+      collection.sourceMid ||
+      collection.sourceId
+  );
+  const matchesSourceKey =
+    collection.sourcePlatform === sourceKey.sourcePlatform &&
+    collection.sourceType === sourceKey.sourceType &&
+    collection.sourceMid === sourceKey.sourceMid &&
+    collection.sourceId === sourceKey.sourceId;
+
+  if (!hasSourceKey || matchesSourceKey) {
+    storageService.saveCollection({ ...collection, ...sourceKey });
+  }
+}
+
+function hasBilibiliCollectionSource(
+  inspection: object
+): inspection is { bilibiliSource: BilibiliCollectionSource } {
+  const source = (inspection as { bilibiliSource?: unknown }).bilibiliSource;
+  if (!source || typeof source !== "object") return false;
+  const candidate = source as Partial<BilibiliCollectionSource>;
+  return (
+    (candidate.type === "collection" || candidate.type === "series") &&
+    typeof candidate.id === "number" &&
+    typeof candidate.mid === "number"
+  );
 }
 
 /**
@@ -617,7 +658,7 @@ export const createPlaylistSubscription = async (
     // the head baseline resolved through the Bilibili collection API.
     playlistId = collectionInfo.id?.toString() || inspection.playlistId || "";
     playlistTitle = collectionInfo.title || inspection.title;
-    videoCount = collectionInfo.count;
+    videoCount = inspection.videoCount;
     author = inspection.author;
     logger.info(
       `Using Bilibili ${collectionInfo.type} info: ${playlistTitle} (${videoCount} videos)`
@@ -634,6 +675,15 @@ export const createPlaylistSubscription = async (
   //    one so later scheduled downloads can be grouped (design §3.6).
   const collectionResolution = resolvePlaylistCollectionWithStatus(collectionName);
   const collection = collectionResolution.collection;
+  if (
+    isBilibiliCollectionOrSeries &&
+    hasBilibiliCollectionSource(inspection)
+  ) {
+    saveBilibiliCollectionSourceIfCompatible(
+      collection,
+      inspection.bilibiliSource
+    );
+  }
 
   // 6. Insert the subscription with the captured baseline (design §7.2).
   const subscribeOptions: SubscribePlaylistOptions = {

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -38,6 +38,7 @@ import {
 } from "../services/subscription/playlistResolution";
 import {
     getPlaylistHeadSnapshot,
+    inspectBilibiliCollectionPlaylist,
     inspectPlaylist,
 } from "../services/subscription/playlistFeed";
 import type { SubscribePlaylistOptions } from "../services/subscriptionService";
@@ -601,7 +602,10 @@ export const createPlaylistSubscription = async (
   //    repeated checkPlaylist / extractBilibiliPlaylistId / extractPlaylistAuthor
   //    probes (design §6.5 / Step 2). Throws on operational failure => the
   //    centralized error handler returns 400/502/500 without side effects.
-  const inspection = await inspectPlaylist(playlistUrl);
+  const inspection =
+    isBilibiliCollectionOrSeries && collectionInfo
+      ? await inspectBilibiliCollectionPlaylist(playlistUrl, collectionInfo)
+      : await inspectPlaylist(playlistUrl);
 
   let playlistId: string;
   let playlistTitle: string;
@@ -609,8 +613,8 @@ export const createPlaylistSubscription = async (
   let author: string;
 
   if (isBilibiliCollectionOrSeries && collectionInfo) {
-    // Use the validated collectionInfo for title/count/IDs (design §12.2), but
-    // the head baseline still came from the real source probe above.
+    // Use the validated collectionInfo for title/count/IDs (design §12.2), with
+    // the head baseline resolved through the Bilibili collection API.
     playlistId = collectionInfo.id?.toString() || inspection.playlistId || "";
     playlistTitle = collectionInfo.title || inspection.title;
     videoCount = collectionInfo.count;
@@ -773,16 +777,21 @@ export const subscribeChannelPlaylists = async (
   let skippedCount = 0;
   const errors: string[] = [];
 
-  // --- Phase 1 (design §8.1): build the candidate list and drop already-
-  // subscribed URLs. A single listSubscriptions call feeds every candidate's
-  // duplicate check rather than one query per playlist.
+  // --- Phase 1 (design §8.1): build the candidate list. Already-subscribed
+  // playlists are skipped for insertion, but remain candidates when the caller
+  // requested historical backfill so subscribe-only rows can be backfilled later.
+  // A single listSubscriptions call feeds every candidate's duplicate check.
   const existingSubs = await subscriptionService.listSubscriptions();
-  const subscribedUrlSet = new Set(existingSubs.map((s) => s.authorUrl));
+  const existingSubByUrl = new Map(existingSubs.map((sub) => [sub.authorUrl, sub]));
 
   type Candidate = {
     playlistUrl: string;
     title: string;
     playlistId: string;
+    existingSubscription?: {
+      id?: string;
+      collectionId?: string | null;
+    };
   };
   const candidates: Candidate[] = [];
   for (const entry of result.entries) {
@@ -792,9 +801,19 @@ export const subscribeChannelPlaylists = async (
     const title = sanitizePlaylistTitle(entry.title);
     const playlistId = entry.id ?? extractYouTubePlaylistId(playlistUrl) ?? "";
 
-    if (subscribedUrlSet.has(playlistUrl)) {
+    const existingSubscription = existingSubByUrl.get(playlistUrl);
+
+    if (existingSubscription) {
       logger.info(`Skipping playlist "${title}": already subscribed`);
       skippedCount++;
+      if (downloadAllPrevious === true) {
+        candidates.push({
+          playlistUrl,
+          title,
+          playlistId,
+          existingSubscription,
+        });
+      }
       continue;
     }
     candidates.push({ playlistUrl, title, playlistId });
@@ -833,79 +852,84 @@ export const subscribeChannelPlaylists = async (
     }
   });
 
-  // --- Phase 3: sequentially resolve collections and insert subscriptions
-  // for successful snapshots (design §8.1). Sequential mutation avoids
-  // Date.now() collection-ID collisions and keeps counters deterministic.
+  // --- Phase 3: sequentially resolve collections, insert new subscriptions,
+  // and create requested backfill tasks for successful snapshots (design §8.1).
+  // Sequential mutation avoids Date.now() collection-ID collisions and keeps
+  // counters deterministic.
   const wantBackfill = downloadAllPrevious === true;
 
   for (const result_item of preflight) {
     if (!result_item || !result_item.ok) continue;
     const { candidate, headVideoUrl, observedAt } = result_item;
 
-    // Resolve/create collection only after a successful baseline.
-    const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
-      candidate.title,
-      channelName
-    );
-    const collection = collectionResolution.collection;
-    const collectionId = collection.id;
+    let createdSubscriptionId = candidate.existingSubscription?.id;
+    let taskCollectionId = candidate.existingSubscription?.collectionId;
 
-    let createdSubscriptionId: string | undefined;
-    let taskCollectionId: string | null | undefined = collectionId;
-    try {
-      const subscription = await subscriptionService.subscribePlaylist({
-        playlistUrl: candidate.playlistUrl,
-        interval: parseInt(interval),
-        playlistTitle: candidate.title,
-        playlistId: candidate.playlistId,
-        author: channelName,
-        platform,
-        collectionId,
-        initialHeadVideoUrl: headVideoUrl,
-        baselineObservedAt: observedAt,
-      });
-      createdSubscriptionId = subscription.id;
-      subscribedCount++;
-      subscribedUrlSet.add(candidate.playlistUrl);
-    } catch (error: unknown) {
-      logger.error(`Error subscribing to playlist "${candidate.title}":`, error);
+    if (!candidate.existingSubscription) {
+      // Resolve/create collection only after a successful baseline.
+      const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
+        candidate.title,
+        channelName
+      );
+      const collection = collectionResolution.collection;
+      const collectionId = collection.id;
+      taskCollectionId = collectionId;
+
       try {
-        await deleteCreatedCollectionIfUnused(
-          collectionResolution,
-          () => subscriptionService.listSubscriptions()
-        );
-      } catch (cleanupError) {
-        logger.error(
-          `Failed to clean up collection for playlist "${candidate.title}" after subscription insertion failed:`,
-          cleanupError instanceof Error
-            ? cleanupError
-            : new Error(String(cleanupError))
-        );
-      }
-      if (error instanceof Error && error.name === "DuplicateError") {
-        skippedCount++;
-        // A concurrent request may have inserted the subscription after the
-        // phase-one list. Resolve that exact row before creating a requested
-        // backfill task; never attach the task to this request's now-cleaned
-        // collection (design §11.3).
-        const concurrentSub = (await subscriptionService.listSubscriptions()).find(
-          (sub) => sub.authorUrl === candidate.playlistUrl
-        );
-        if (!concurrentSub) {
-          errors.push(
-            `${candidate.title}: concurrent subscription could not be resolved`
+        const subscription = await subscriptionService.subscribePlaylist({
+          playlistUrl: candidate.playlistUrl,
+          interval: parseInt(interval),
+          playlistTitle: candidate.title,
+          playlistId: candidate.playlistId,
+          author: channelName,
+          platform,
+          collectionId,
+          initialHeadVideoUrl: headVideoUrl,
+          baselineObservedAt: observedAt,
+        });
+        createdSubscriptionId = subscription.id;
+        subscribedCount++;
+        existingSubByUrl.set(candidate.playlistUrl, subscription);
+      } catch (error: unknown) {
+        logger.error(`Error subscribing to playlist "${candidate.title}":`, error);
+        try {
+          await deleteCreatedCollectionIfUnused(
+            collectionResolution,
+            () => subscriptionService.listSubscriptions()
           );
+        } catch (cleanupError) {
+          logger.error(
+            `Failed to clean up collection for playlist "${candidate.title}" after subscription insertion failed:`,
+            cleanupError instanceof Error
+              ? cleanupError
+              : new Error(String(cleanupError))
+          );
+        }
+        if (error instanceof Error && error.name === "DuplicateError") {
+          skippedCount++;
+          // A concurrent request may have inserted the subscription after the
+          // phase-one list. Resolve that exact row before creating a requested
+          // backfill task; never attach the task to this request's now-cleaned
+          // collection (design §11.3).
+          const concurrentSub = (await subscriptionService.listSubscriptions()).find(
+            (sub) => sub.authorUrl === candidate.playlistUrl
+          );
+          if (!concurrentSub) {
+            errors.push(
+              `${candidate.title}: concurrent subscription could not be resolved`
+            );
+            continue;
+          }
+          createdSubscriptionId = concurrentSub.id;
+          taskCollectionId = concurrentSub.collectionId;
+        } else {
+          errors.push(
+            `${candidate.title}: ${getErrorMessage(error, "Unknown error")}`
+          );
+          // A real insertion failure must not turn into an unlinked historical
+          // task. The next bulk request can retry the subscription cleanly.
           continue;
         }
-        createdSubscriptionId = concurrentSub.id;
-        taskCollectionId = concurrentSub.collectionId;
-      } else {
-        errors.push(
-          `${candidate.title}: ${getErrorMessage(error, "Unknown error")}`
-        );
-        // A real insertion failure must not turn into an unlinked historical
-        // task. The next bulk request can retry the subscription cleanly.
-        continue;
       }
     }
 
@@ -926,9 +950,9 @@ export const subscribeChannelPlaylists = async (
             `Skipping download task creation for playlist "${candidate.title}": task already exists`
           );
         } else {
-          // Link to the subscription created/known by this request. A
-          // pre-existing candidate was removed in phase one, and a raced
-          // duplicate above resolved its exact current row.
+          // Link to the subscription created/known by this request. An existing
+          // candidate came from phase one, and a raced duplicate above resolved
+          // its exact current row.
           const task = await continuousDownloadService.createPlaylistTask(
             candidate.playlistUrl,
             channelName,

--- a/backend/src/services/continuousDownload/taskRepository.ts
+++ b/backend/src/services/continuousDownload/taskRepository.ts
@@ -1,4 +1,4 @@
-import { eq, type InferSelectModel } from "drizzle-orm";
+import { and, desc, eq, inArray, type InferSelectModel } from "drizzle-orm";
 import { db } from "../../db";
 import { continuousDownloadTasks, subscriptions } from "../../db/schema";
 import { logger } from "../../utils/logger";
@@ -271,6 +271,44 @@ export class TaskRepository {
 
     const { task, playlistName } = result[0];
 
+    return mapTaskRowToEntity(task, playlistName);
+  }
+
+  /**
+   * Find an active/paused playlist task for the exact subscription destination.
+   * This avoids treating an arbitrary terminal or standalone same-URL task as
+   * the linked subscription backfill.
+   */
+  async getBlockingPlaylistTaskByDestination(
+    authorUrl: string,
+    subscriptionId: string,
+    collectionId: string
+  ): Promise<ContinuousDownloadTask | null> {
+    const { collections } = await import("../../db/schema");
+    const result = await db
+      .select({
+        task: continuousDownloadTasks,
+        playlistName: collections.name,
+      })
+      .from(continuousDownloadTasks)
+      .leftJoin(
+        collections,
+        eq(continuousDownloadTasks.collectionId, collections.id)
+      )
+      .where(
+        and(
+          eq(continuousDownloadTasks.authorUrl, authorUrl),
+          eq(continuousDownloadTasks.subscriptionId, subscriptionId),
+          eq(continuousDownloadTasks.collectionId, collectionId),
+          inArray(continuousDownloadTasks.status, ["active", "paused"])
+        )
+      )
+      .orderBy(desc(continuousDownloadTasks.createdAt))
+      .limit(1);
+
+    if (result.length === 0) return null;
+
+    const { task, playlistName } = result[0];
     return mapTaskRowToEntity(task, playlistName);
   }
 

--- a/backend/src/services/continuousDownloadService.ts
+++ b/backend/src/services/continuousDownloadService.ts
@@ -211,6 +211,18 @@ export class ContinuousDownloadService {
     return this.taskRepository.getTaskByAuthorUrl(authorUrl);
   }
 
+  async getBlockingPlaylistTaskByDestination(
+    authorUrl: string,
+    subscriptionId: string,
+    collectionId: string
+  ): Promise<ContinuousDownloadTask | null> {
+    return this.taskRepository.getBlockingPlaylistTaskByDestination(
+      authorUrl,
+      subscriptionId,
+      collectionId
+    );
+  }
+
   /**
    * Cancel a task
    */

--- a/backend/src/services/continuousDownloadService.ts
+++ b/backend/src/services/continuousDownloadService.ts
@@ -142,17 +142,24 @@ export class ContinuousDownloadService {
   }
 
   /**
-   * Create a new continuous download task for a playlist
+   * Create a new continuous download task for a playlist.
+   *
+   * `subscriptionId` (design §7.4) is persisted when provided so a historical
+   * backfill task created alongside a subscription is linked to the exact
+   * subscription whose metadata (e.g. filename template / yt-dlp override) it
+   * must use. Existing standalone callers that omit it remain valid.
    */
   async createPlaylistTask(
     playlistUrl: string,
     author: string,
     platform: string,
-    collectionId: string | null | undefined
+    collectionId: string | null | undefined,
+    subscriptionId?: string
   ): Promise<ContinuousDownloadTask> {
     const task: ContinuousDownloadTask = {
       id: uuidv4(),
       collectionId: collectionId || undefined,
+      subscriptionId,
       authorUrl: playlistUrl,
       author,
       platform,
@@ -170,7 +177,7 @@ export class ContinuousDownloadService {
     logger.info(
       `Created playlist download task ${task.id}${
         collectionId ? ` for collection ${collectionId}` : ""
-      } (${platform})`
+      } (${platform})${subscriptionId ? ` linked to subscription ${subscriptionId}` : ""}`
     );
 
     // Start processing the task asynchronously

--- a/backend/src/services/downloadService.ts
+++ b/backend/src/services/downloadService.ts
@@ -135,16 +135,18 @@ export async function checkBilibiliCollectionOrSeries(
 export async function getBilibiliCollectionVideos(
   mid: number,
   seasonId: number,
+  options?: { pageSize?: number; maxPages?: number },
 ): Promise<BilibiliVideosResult> {
-  return BilibiliDownloader.getCollectionVideos(mid, seasonId);
+  return BilibiliDownloader.getCollectionVideos(mid, seasonId, options);
 }
 
 // Helper function to get all videos from a Bilibili series
 export async function getBilibiliSeriesVideos(
   mid: number,
   seriesId: number,
+  options?: { pageSize?: number; maxPages?: number },
 ): Promise<BilibiliVideosResult> {
-  return BilibiliDownloader.getSeriesVideos(mid, seriesId);
+  return BilibiliDownloader.getSeriesVideos(mid, seriesId, options);
 }
 
 // Helper function to download a single Bilibili part

--- a/backend/src/services/downloaders/BilibiliDownloader.ts
+++ b/backend/src/services/downloaders/BilibiliDownloader.ts
@@ -18,6 +18,7 @@ import {
   CollectionDownloadResult,
   DownloadResult,
 } from "./bilibili/types";
+import type { BilibiliVideoFetchOptions as CollectionFetchOptions } from "./bilibili/bilibiliCollection";
 
 // Re-export all types for backward compatibility
 export type {
@@ -122,17 +123,19 @@ export class BilibiliDownloader extends BaseDownloader {
   // Helper function to get all videos from a Bilibili collection
   static async getCollectionVideos(
     mid: number,
-    seasonId: number
+    seasonId: number,
+    options?: CollectionFetchOptions
   ): Promise<BilibiliVideosResult> {
-    return bilibiliCollection.getCollectionVideos(mid, seasonId);
+    return bilibiliCollection.getCollectionVideos(mid, seasonId, options);
   }
 
   // Helper function to get all videos from a Bilibili series
   static async getSeriesVideos(
     mid: number,
-    seriesId: number
+    seriesId: number,
+    options?: CollectionFetchOptions
   ): Promise<BilibiliVideosResult> {
-    return bilibiliCollection.getSeriesVideos(mid, seriesId);
+    return bilibiliCollection.getSeriesVideos(mid, seriesId, options);
   }
 
   // Helper function to download a single Bilibili part

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -170,6 +170,65 @@ function normalizeFetchOptions(
   return { pageSize, maxPages };
 }
 
+function formatBilibiliApiError(responseBody: Record<string, unknown>): string {
+  const message =
+    typeof responseBody.message === "string"
+      ? responseBody.message
+      : typeof responseBody.msg === "string"
+        ? responseBody.msg
+        : null;
+
+  if (message && message.trim() !== "") {
+    return message;
+  }
+
+  return `code ${String(responseBody.code)}`;
+}
+
+function readBilibiliArchivePage(
+  responseBody: unknown,
+  label: "collection" | "series",
+  pageNum: number,
+): { archives: any[]; total: number } {
+  if (!responseBody || typeof responseBody !== "object") {
+    throw new Error(
+      `Bilibili ${label} API returned an invalid response on page ${pageNum}`,
+    );
+  }
+
+  const body = responseBody as Record<string, unknown>;
+  if (body.code !== 0) {
+    throw new Error(
+      `Bilibili ${label} API returned ${formatBilibiliApiError(body)} on page ${pageNum}`,
+    );
+  }
+
+  const data = body.data;
+  if (!data || typeof data !== "object") {
+    throw new Error(
+      `Bilibili ${label} API returned missing data on page ${pageNum}`,
+    );
+  }
+
+  const archiveData = data as {
+    archives?: unknown;
+    page?: { total?: unknown };
+  };
+  if (!Array.isArray(archiveData.archives)) {
+    throw new Error(
+      `Bilibili ${label} API returned missing archives on page ${pageNum}`,
+    );
+  }
+
+  const total =
+    typeof archiveData.page?.total === "number" &&
+    Number.isFinite(archiveData.page.total)
+      ? archiveData.page.total
+      : archiveData.archives.length;
+
+  return { archives: archiveData.archives, total };
+}
+
 const getCollectionCleanupNames = (
   collection: Collection,
   fallbackName: string,
@@ -302,29 +361,27 @@ export async function getCollectionVideos(
         },
       });
 
-      if (response.data && response.data.data) {
-        const data = response.data.data;
-        const archives = data.archives || [];
+      const { archives, total } = readBilibiliArchivePage(
+        response.data,
+        "collection",
+        pageNum,
+      );
 
-        logger.info(`Got ${archives.length} videos from page ${pageNum}`);
+      logger.info(`Got ${archives.length} videos from page ${pageNum}`);
 
-        archives.forEach((video: any) => {
-          allVideos.push({
-            bvid: video.bvid,
-            title: video.title,
-            aid: video.aid,
-            uploadDate: normalizeUploadDate(video.pubdate ?? video.ctime ?? video.created),
-            viewCount: normalizeViewCount(video.stat?.view ?? video.play),
-          });
+      archives.forEach((video: any) => {
+        allVideos.push({
+          bvid: video.bvid,
+          title: video.title,
+          aid: video.aid,
+          uploadDate: normalizeUploadDate(video.pubdate ?? video.ctime ?? video.created),
+          viewCount: normalizeViewCount(video.stat?.view ?? video.play),
         });
+      });
 
-        // Check if there are more pages
-        const total = data.page?.total || 0;
-        hasMore = allVideos.length < total;
-        pageNum++;
-      } else {
-        hasMore = false;
-      }
+      // Check if there are more pages
+      hasMore = allVideos.length < total;
+      pageNum++;
     }
 
     logger.info(`Total videos in collection: ${allVideos.length}`);
@@ -371,30 +428,27 @@ export async function getSeriesVideos(
         },
       });
 
-      if (response.data && response.data.data) {
-        const data = response.data.data;
-        const archives = data.archives || [];
+      const { archives, total } = readBilibiliArchivePage(
+        response.data,
+        "series",
+        pageNum,
+      );
 
-        logger.info(`Got ${archives.length} videos from page ${pageNum}`);
+      logger.info(`Got ${archives.length} videos from page ${pageNum}`);
 
-        archives.forEach((video: any) => {
-          allVideos.push({
-            bvid: video.bvid,
-            title: video.title,
-            aid: video.aid,
-            uploadDate: normalizeUploadDate(video.pubdate ?? video.ctime ?? video.created),
-            viewCount: normalizeViewCount(video.stat?.view ?? video.play),
-          });
+      archives.forEach((video: any) => {
+        allVideos.push({
+          bvid: video.bvid,
+          title: video.title,
+          aid: video.aid,
+          uploadDate: normalizeUploadDate(video.pubdate ?? video.ctime ?? video.created),
+          viewCount: normalizeViewCount(video.stat?.view ?? video.play),
         });
+      });
 
-        // Check if there are more pages
-        const page = data.page || {};
-        hasMore =
-          archives.length === pageSize && allVideos.length < (page.total || 0);
-        pageNum++;
-      } else {
-        hasMore = false;
-      }
+      // Check if there are more pages
+      hasMore = archives.length === pageSize && allVideos.length < total;
+      pageNum++;
     }
 
     logger.info(`Total videos in series: ${allVideos.length}`);

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -148,6 +148,28 @@ const canReuseCollectionForSource = (
   !hasBilibiliSourceKey(collection) ||
   (sourceKey != null && matchesBilibiliSourceKey(collection, sourceKey));
 
+export interface BilibiliVideoFetchOptions {
+  pageSize?: number;
+  maxPages?: number;
+}
+
+const DEFAULT_BILIBILI_PAGE_SIZE = 30;
+
+function normalizeFetchOptions(
+  options?: BilibiliVideoFetchOptions,
+): { pageSize: number; maxPages: number | null } {
+  const pageSize =
+    Number.isSafeInteger(options?.pageSize) && (options?.pageSize ?? 0) > 0
+      ? options!.pageSize!
+      : DEFAULT_BILIBILI_PAGE_SIZE;
+  const maxPages =
+    Number.isSafeInteger(options?.maxPages) && (options?.maxPages ?? 0) > 0
+      ? options!.maxPages!
+      : null;
+
+  return { pageSize, maxPages };
+}
+
 const getCollectionCleanupNames = (
   collection: Collection,
   fallbackName: string,
@@ -246,19 +268,20 @@ function resolveExistingBilibiliCollection(
  */
 export async function getCollectionVideos(
   mid: number,
-  seasonId: number
+  seasonId: number,
+  options?: BilibiliVideoFetchOptions,
 ): Promise<BilibiliVideosResult> {
   try {
     const allVideos: BilibiliVideoItem[] = [];
     let pageNum = 1;
-    const pageSize = 30;
+    const { pageSize, maxPages } = normalizeFetchOptions(options);
     let hasMore = true;
 
     logger.info(
       `Fetching collection videos for mid=${mid}, season_id=${seasonId}`
     );
 
-    while (hasMore) {
+    while (hasMore && (maxPages === null || pageNum <= maxPages)) {
       const apiUrl = `https://api.bilibili.com/x/polymer/web-space/seasons_archives_list`;
       const params = {
         mid: mid,
@@ -317,17 +340,18 @@ export async function getCollectionVideos(
  */
 export async function getSeriesVideos(
   mid: number,
-  seriesId: number
+  seriesId: number,
+  options?: BilibiliVideoFetchOptions,
 ): Promise<BilibiliVideosResult> {
   try {
     const allVideos: BilibiliVideoItem[] = [];
     let pageNum = 1;
-    const pageSize = 30;
+    const { pageSize, maxPages } = normalizeFetchOptions(options);
     let hasMore = true;
 
     logger.info(`Fetching series videos for mid=${mid}, series_id=${seriesId}`);
 
-    while (hasMore) {
+    while (hasMore && (maxPages === null || pageNum <= maxPages)) {
       const apiUrl = `https://api.bilibili.com/x/series/archives`;
       const params = {
         mid: mid,

--- a/backend/src/services/subscription/channelPlaylists.ts
+++ b/backend/src/services/subscription/channelPlaylists.ts
@@ -4,11 +4,14 @@ import { subscriptions } from "../../db/schema";
 import { logger } from "../../utils/logger";
 import { getSubscriptionLogContext } from "./helpers";
 import {
+  deleteCreatedCollectionIfUnused,
   extractYouTubePlaylistId,
-  resolveChannelPlaylistCollection,
+  resolveChannelPlaylistCollectionWithStatus,
   sanitizePlaylistTitle,
 } from "./playlistResolution";
 import type { Subscription } from "./types";
+import type { SubscribePlaylistOptions } from "../subscriptionService";
+import { getPlaylistHeadSnapshot } from "./playlistFeed";
 
 /**
  * Dependencies the extracted watcher logic needs from the service. Kept
@@ -16,15 +19,7 @@ import type { Subscription } from "./types";
  */
 export interface ChannelPlaylistDeps {
   listSubscriptions: () => Promise<Subscription[]>;
-  subscribePlaylist: (
-    playlistUrl: string,
-    interval: number,
-    title: string,
-    playlistId: string,
-    channelName: string,
-    platform: string,
-    collectionId: string | null,
-  ) => Promise<unknown>;
+  subscribePlaylist: (options: SubscribePlaylistOptions) => Promise<unknown>;
 }
 
 /**
@@ -110,27 +105,70 @@ export async function checkChannelPlaylistsForWatcher(
       // For channel_playlists subscriptions, author is already the clean channel name
       const channelName = sub.author;
 
-      // Get or create collection
-      const collectionId = resolveChannelPlaylistCollection(title, channelName).id;
-
       // Extract playlist ID
       const playlistId = entry.id ?? extractYouTubePlaylistId(playlistUrl);
 
       try {
-        // Subscribe to the new playlist
-        await deps.subscribePlaylist(
+        // Capture the head baseline BEFORE creating any persistent side effect
+        // (design §8.2 / F7). The watcher is always subscribe-only (no
+        // historical task); the baseline ensures existing entries in a newly
+        // discovered playlist are not implicitly downloaded on the first poll.
+        // Capture the head with the watcher's effective yt-dlp config.
+        const snapshot = await getPlaylistHeadSnapshot(
           playlistUrl,
-          sub.interval, // Use same interval as watcher
-          title,
-          playlistId || "",
-          channelName,
           sub.platform,
-          collectionId
+          { subscriptionYtdlpConfig: sub.ytdlpConfig }
         );
+
+        // Resolve the destination collection only after a successful snapshot
+        // (design §8.2) so a failed probe leaves no orphan collection.
+        const collectionResolution = resolveChannelPlaylistCollectionWithStatus(
+          title,
+          channelName
+        );
+        const collectionId = collectionResolution.collection.id;
+
+        // Create the child subscription with the head and observation timestamp.
+        try {
+          await deps.subscribePlaylist({
+            playlistUrl,
+            interval: sub.interval, // Use same interval as watcher
+            playlistTitle: title,
+            playlistId: playlistId || "",
+            author: channelName,
+            platform: sub.platform,
+            collectionId,
+            initialHeadVideoUrl: snapshot.headVideoUrl,
+            baselineObservedAt: snapshot.observedAt,
+          });
+        } catch (error) {
+          // The watcher has no task-creation path, so a freshly-created,
+          // empty, unreferenced collection is safe to remove on an insertion
+          // failure (design §7.3 / §8.2).
+          try {
+            await deleteCreatedCollectionIfUnused(
+              collectionResolution,
+              deps.listSubscriptions
+            );
+          } catch (cleanupError) {
+            logger.error(
+              `Failed to clean up collection for playlist ${title}:`,
+              cleanupError
+            );
+          }
+          throw error;
+        }
+        // Add the URL only after insertion succeeds (design §8.2).
         subscribedUrls.add(playlistUrl);
         newSubscriptionsCount++;
       } catch (error) {
-        logger.error(`Error auto-subscribing to playlist ${title}:`, error);
+        // A failed baseline probe (or insert) does not subscribe and does not
+        // add the URL to the set; the next watcher interval will retry
+        // (design §8.2).
+        logger.error(
+          `Error auto-subscribing to playlist ${title}:`,
+          error
+        );
       }
     }
 

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -1,0 +1,243 @@
+import { isBilibiliUrl } from "../../utils/helpers";
+import {
+  executeYtDlpJson,
+  getEffectiveUserYtDlpConfig,
+  getNetworkConfigFromUserConfig,
+} from "../../utils/ytDlpUtils";
+import { logger } from "../../utils/logger";
+import { ValidationError } from "../../errors/DownloadErrors";
+
+/**
+ * Playlist source inspection boundary (design §6).
+ *
+ * This module is the single place that turns a playlist URL into either a
+ * typed "current head" snapshot or a richer metadata inspection. It exists so
+ * the baseline captured at subscription-creation time and the head observed at
+ * scheduled poll time use the *same* normalization, so equality between the
+ * stored cursor and a later probe is stable.
+ *
+ * Failure model (design §6.4):
+ * - A successful playlist result with an empty `entries` array returns
+ *   `headVideoUrl: null` (a *verified empty* playlist).
+ * - Network / extractor / authentication errors propagate (throw). They are
+ *   NOT converted to `null`, because that ambiguity previously allowed a
+ *   failed probe to look like an empty playlist and seed an empty cursor.
+ * - A non-playlist result or a non-empty first entry that cannot be converted
+ *   to a playable URL is an error, not an empty playlist.
+ */
+
+export interface PlaylistHeadSnapshot {
+  /** The current leading/latest playlist entry as a canonical URL, or null when the playlist is verified empty. */
+  headVideoUrl: string | null;
+  /** Timestamp (ms) at which the head was observed. */
+  observedAt: number;
+}
+
+export interface PlaylistInspection extends PlaylistHeadSnapshot {
+  title: string;
+  videoCount: number;
+  playlistId: string | null;
+  author: string;
+  platform: "YouTube" | "Bilibili";
+}
+
+export interface PlaylistFeedOptions {
+  /** Optional per-subscription yt-dlp override layered on top of global config (issue #345). */
+  subscriptionYtdlpConfig?: string | null;
+}
+
+/**
+ * Normalize a flat-playlist entry into a canonical playable video URL
+ * (design §6.3). Precedence:
+ *   1. valid absolute `webpage_url`;
+ *   2. valid absolute `url`;
+ *   3. construct from `id` using the platform's canonical watch URL.
+ *
+ * Returns null only when no value can be derived. Exported so unit tests can
+ * cover each branch without a network probe.
+ */
+export function resolveEntryVideoUrl(
+  entry: { url?: string; webpage_url?: string; id?: string },
+  platform: string
+): string | null {
+  const isValidAbsolute = (value: string | undefined): boolean => {
+    if (!value) return false;
+    try {
+      const parsed = new URL(value);
+      // A bare video id like "dQw4w9WgXcQ" is not a valid absolute URL.
+      return parsed.protocol === "http:" || parsed.protocol === "https:";
+    } catch {
+      return false;
+    }
+  };
+
+  if (isValidAbsolute(entry.webpage_url)) {
+    return entry.webpage_url as string;
+  }
+  if (isValidAbsolute(entry.url)) {
+    return entry.url as string;
+  }
+  if (entry.id) {
+    if (platform === "Bilibili") {
+      return `https://www.bilibili.com/video/${entry.id}`;
+    }
+    // Default to YouTube canonical watch URL. Never store a bare video ID
+    // because scheduled comparisons use full URLs (design §6.3).
+    return `https://www.youtube.com/watch?v=${entry.id}`;
+  }
+  return null;
+}
+
+function detectPlatform(playlistUrl: string): "YouTube" | "Bilibili" {
+  return isBilibiliUrl(playlistUrl) ? "Bilibili" : "YouTube";
+}
+
+/**
+ * Build the yt-dlp flag set for a playlist probe, applying the effective
+ * per-subscription yt-dlp override on top of the global network config and the
+ * provider script, exactly as the existing channel/playlist probes do.
+ */
+async function buildProbeFlags(
+  playlistUrl: string,
+  options: PlaylistFeedOptions | undefined,
+  probeEnd: number | null
+): Promise<Record<string, any>> {
+  const { getProviderScript } = await import(
+    "../downloaders/ytdlp/ytdlpHelpers"
+  );
+  const userConfig = getEffectiveUserYtDlpConfig(
+    playlistUrl,
+    options?.subscriptionYtdlpConfig ?? null
+  );
+  const networkConfig = getNetworkConfigFromUserConfig(userConfig);
+  const PROVIDER_SCRIPT = getProviderScript();
+  return {
+    ...networkConfig,
+    noWarnings: true,
+    flatPlaylist: true,
+    ...(probeEnd !== null ? { playlistEnd: probeEnd } : {}),
+    ...(PROVIDER_SCRIPT
+      ? {
+          extractorArgs: `youtubepot-bgfuncscript:script_path=${PROVIDER_SCRIPT}`,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Lightweight head snapshot: probe only the leading entry
+ * (`playlistEnd: 1`). Used by the scheduler poll, channel-playlists preflight,
+ * and watcher discovery (design §6.1).
+ *
+ * Throws on operational failure. Returns `headVideoUrl: null` for a verified
+ * empty playlist.
+ */
+export async function getPlaylistHeadSnapshot(
+  playlistUrl: string,
+  platform: string,
+  options?: PlaylistFeedOptions
+): Promise<PlaylistHeadSnapshot> {
+  const resolvedPlatform = platform || detectPlatform(playlistUrl);
+  const flags = await buildProbeFlags(playlistUrl, options, 1);
+
+  const info = await executeYtDlpJson(playlistUrl, flags);
+
+  // Verified empty playlist: an explicit empty entries array. Check this
+  // before the non-playlist rejection so a valid `_type: "playlist"` result
+  // with zero entries is treated as empty rather than an error.
+  if (Array.isArray(info?.entries) && info.entries.length === 0) {
+    return { headVideoUrl: null, observedAt: Date.now() };
+  }
+
+  // A playlist result must either declare itself a playlist or carry entries.
+  const isPlaylistResult =
+    info?._type === "playlist" ||
+    (Array.isArray(info?.entries) && info.entries.length > 0);
+
+  if (!isPlaylistResult) {
+    throw new ValidationError(
+      "Source is not a valid playlist",
+      "playlistUrl"
+    );
+  }
+
+  const firstEntry = info.entries[0];
+  const headVideoUrl = resolveEntryVideoUrl(firstEntry, resolvedPlatform);
+  if (!headVideoUrl) {
+    // Non-empty entry that cannot be converted to a playable URL is an error,
+    // not an empty playlist (design §6.4).
+    throw new ValidationError(
+      "Could not resolve a playable URL for the latest playlist entry",
+      "playlistUrl"
+    );
+  }
+  return { headVideoUrl, observedAt: Date.now() };
+}
+
+/**
+ * Rich inspection used at direct playlist-creation time, where title, count,
+ * author and id are also needed (design §6.1). Throws on failure; returns
+ * `headVideoUrl: null` for a verified empty playlist.
+ */
+export async function inspectPlaylist(
+  playlistUrl: string,
+  options?: PlaylistFeedOptions
+): Promise<PlaylistInspection> {
+  const platform = detectPlatform(playlistUrl);
+  // Full flat playlist enumeration (no playlistEnd) so the reported
+  // videoCount/title reflect the whole playlist, not just the head.
+  const flags = await buildProbeFlags(playlistUrl, options, null);
+
+  const info = await executeYtDlpJson(playlistUrl, flags);
+
+  const isPlaylistResult =
+    info?._type === "playlist" || Array.isArray(info?.entries);
+
+  if (!isPlaylistResult) {
+    throw new ValidationError("Source is not a valid playlist", "playlistUrl");
+  }
+
+  const entries = Array.isArray(info?.entries) ? info.entries : [];
+  const videoCount =
+    (typeof info?.playlist_count === "number" && info.playlist_count) ||
+    entries.length;
+  const title = info?.title || info?.playlist || "Playlist";
+  const playlistId =
+    (info?.id && String(info.id)) || info?.playlist_id || null;
+
+  let author = "Playlist Author";
+  if (entries.length > 0) {
+    const first = entries[0];
+    author = first?.uploader || first?.channel || info?.uploader || info?.channel || author;
+  } else if (info?.uploader || info?.channel) {
+    author = info.uploader || info.channel;
+  }
+
+  let headVideoUrl: string | null = null;
+  if (entries.length > 0) {
+    headVideoUrl = resolveEntryVideoUrl(entries[0], platform);
+    if (!headVideoUrl) {
+      throw new ValidationError(
+        "Could not resolve a playable URL for the latest playlist entry",
+        "playlistUrl"
+      );
+    }
+  }
+  // entries.length === 0 => verified empty => headVideoUrl stays null.
+
+  logger.info("Inspected playlist for subscription baseline", {
+    platform,
+    videoCount,
+    baselineState: headVideoUrl ? "item" : "empty",
+  });
+
+  return {
+    headVideoUrl,
+    observedAt: Date.now(),
+    title,
+    videoCount,
+    playlistId,
+    author,
+    platform,
+  };
+}

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -60,6 +60,10 @@ export interface BilibiliCollectionHeadSnapshot extends PlaylistHeadSnapshot {
   bilibiliSource: BilibiliCollectionSource;
 }
 
+export interface BilibiliCollectionHeadSnapshotOptions {
+  headOnly?: boolean;
+}
+
 export interface BilibiliCollectionPlaylistInspection
   extends PlaylistInspection {
   bilibiliSource: BilibiliCollectionSource;
@@ -324,7 +328,8 @@ async function resolveBilibiliCollectionSource(
 
 export async function getBilibiliCollectionHeadSnapshot(
   playlistUrl: string,
-  collectionInfo: BilibiliCollectionInspectionInput
+  collectionInfo: BilibiliCollectionInspectionInput,
+  options?: BilibiliCollectionHeadSnapshotOptions
 ): Promise<BilibiliCollectionHeadSnapshot> {
   const source = await resolveBilibiliCollectionSource(
     playlistUrl,
@@ -340,10 +345,13 @@ export async function getBilibiliCollectionHeadSnapshot(
   const { getBilibiliCollectionVideos, getBilibiliSeriesVideos } = await import(
     "../downloadService"
   );
+  const fetchOptions = options?.headOnly
+    ? { pageSize: 1, maxPages: 1 }
+    : undefined;
   const videosResult =
     source.type === "collection"
-      ? await getBilibiliCollectionVideos(source.mid, source.id)
-      : await getBilibiliSeriesVideos(source.mid, source.id);
+      ? await getBilibiliCollectionVideos(source.mid, source.id, fetchOptions)
+      : await getBilibiliSeriesVideos(source.mid, source.id, fetchOptions);
 
   if (!videosResult.success) {
     throw new ValidationError(

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -1,4 +1,4 @@
-import { isBilibiliUrl } from "../../utils/helpers";
+import { extractBilibiliVideoId, isBilibiliUrl } from "../../utils/helpers";
 import {
   executeYtDlpJson,
   getEffectiveUserYtDlpConfig,
@@ -39,6 +39,14 @@ export interface PlaylistInspection extends PlaylistHeadSnapshot {
   playlistId: string | null;
   author: string;
   platform: "YouTube" | "Bilibili";
+}
+
+export interface BilibiliCollectionInspectionInput {
+  type: "collection" | "series";
+  id: string | number;
+  mid?: string | number;
+  title: string;
+  count: number;
 }
 
 export interface PlaylistFeedOptions {
@@ -239,5 +247,93 @@ export async function inspectPlaylist(
     playlistId,
     author,
     platform,
+  };
+}
+
+function toFiniteNumber(value: string | number | undefined): number | null {
+  if (value === undefined) return null;
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Inspect a Bilibili collection/series using Bilibili's collection API when the
+ * frontend already supplied collection metadata for a normal video URL. This
+ * avoids probing the video URL as a generic yt-dlp playlist before the metadata
+ * branch can run.
+ */
+export async function inspectBilibiliCollectionPlaylist(
+  playlistUrl: string,
+  collectionInfo: BilibiliCollectionInspectionInput,
+  options?: PlaylistFeedOptions
+): Promise<PlaylistInspection> {
+  let mid = toFiniteNumber(collectionInfo.mid);
+  let collectionId = toFiniteNumber(collectionInfo.id);
+
+  if (mid === null || collectionId === null) {
+    const videoId = extractBilibiliVideoId(playlistUrl);
+    if (!videoId) {
+      return inspectPlaylist(playlistUrl, options);
+    }
+
+    const { checkBilibiliCollectionOrSeries } = await import(
+      "../downloadService"
+    );
+    const detected = await checkBilibiliCollectionOrSeries(videoId);
+    if (
+      !detected.success ||
+      detected.type !== collectionInfo.type ||
+      detected.mid === undefined ||
+      detected.id === undefined
+    ) {
+      throw new ValidationError(
+        "Could not resolve Bilibili collection metadata",
+        "collectionInfo"
+      );
+    }
+    mid = detected.mid;
+    collectionId = detected.id;
+  }
+  if (mid === null || collectionId === null) {
+    throw new ValidationError(
+      "Could not resolve Bilibili collection metadata",
+      "collectionInfo"
+    );
+  }
+
+  const { getBilibiliCollectionVideos, getBilibiliSeriesVideos } = await import(
+    "../downloadService"
+  );
+  const videosResult =
+    collectionInfo.type === "collection"
+      ? await getBilibiliCollectionVideos(mid, collectionId)
+      : await getBilibiliSeriesVideos(mid, collectionId);
+
+  if (!videosResult.success) {
+    throw new ValidationError(
+      `Failed to get videos from Bilibili ${collectionInfo.type}`,
+      "collectionInfo"
+    );
+  }
+
+  const firstVideo = videosResult.videos[0];
+  const headVideoUrl = firstVideo?.bvid
+    ? `https://www.bilibili.com/video/${firstVideo.bvid}`
+    : null;
+
+  logger.info("Inspected Bilibili collection for subscription baseline", {
+    type: collectionInfo.type,
+    videoCount: collectionInfo.count || videosResult.videos.length,
+    baselineState: headVideoUrl ? "item" : "empty",
+  });
+
+  return {
+    headVideoUrl,
+    observedAt: Date.now(),
+    title: collectionInfo.title || "Bilibili Playlist",
+    videoCount: collectionInfo.count || videosResult.videos.length,
+    playlistId: String(collectionId),
+    author: mid ? `Bilibili ${mid}` : "Bilibili Author",
+    platform: "Bilibili",
   };
 }

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -142,7 +142,7 @@ async function buildProbeFlags(
     ...(probeEnd !== null ? { playlistEnd: probeEnd } : {}),
     ...(PROVIDER_SCRIPT
       ? {
-          extractorArgs: `youtubepot-bgfuncscript:script_path=${PROVIDER_SCRIPT}`,
+          extractorArgs: `youtubepot-bgutilscript:script_path=${PROVIDER_SCRIPT}`,
         }
       : {}),
   };

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -42,11 +42,27 @@ export interface PlaylistInspection extends PlaylistHeadSnapshot {
 }
 
 export interface BilibiliCollectionInspectionInput {
-  type: "collection" | "series";
-  id: string | number;
+  type?: "collection" | "series";
+  id?: string | number;
   mid?: string | number;
-  title: string;
-  count: number;
+  title?: string;
+  count?: number;
+}
+
+export interface BilibiliCollectionSource {
+  type: "collection" | "series";
+  id: number;
+  mid: number;
+}
+
+export interface BilibiliCollectionHeadSnapshot extends PlaylistHeadSnapshot {
+  videoCount: number;
+  bilibiliSource: BilibiliCollectionSource;
+}
+
+export interface BilibiliCollectionPlaylistInspection
+  extends PlaylistInspection {
+  bilibiliSource: BilibiliCollectionSource;
 }
 
 export interface PlaylistFeedOptions {
@@ -256,45 +272,65 @@ function toFiniteNumber(value: string | number | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-/**
- * Inspect a Bilibili collection/series using Bilibili's collection API when the
- * frontend already supplied collection metadata for a normal video URL. This
- * avoids probing the video URL as a generic yt-dlp playlist before the metadata
- * branch can run.
- */
-export async function inspectBilibiliCollectionPlaylist(
+async function resolveBilibiliCollectionSource(
   playlistUrl: string,
-  collectionInfo: BilibiliCollectionInspectionInput,
-  options?: PlaylistFeedOptions
-): Promise<PlaylistInspection> {
+  collectionInfo: BilibiliCollectionInspectionInput
+): Promise<BilibiliCollectionSource | null> {
+  const requestedType = collectionInfo.type;
   let mid = toFiniteNumber(collectionInfo.mid);
   let collectionId = toFiniteNumber(collectionInfo.id);
 
-  if (mid === null || collectionId === null) {
-    const videoId = extractBilibiliVideoId(playlistUrl);
-    if (!videoId) {
-      return inspectPlaylist(playlistUrl, options);
-    }
-
-    const { checkBilibiliCollectionOrSeries } = await import(
-      "../downloadService"
-    );
-    const detected = await checkBilibiliCollectionOrSeries(videoId);
-    if (
-      !detected.success ||
-      detected.type !== collectionInfo.type ||
-      detected.mid === undefined ||
-      detected.id === undefined
-    ) {
-      throw new ValidationError(
-        "Could not resolve Bilibili collection metadata",
-        "collectionInfo"
-      );
-    }
-    mid = detected.mid;
-    collectionId = detected.id;
+  if (requestedType && mid !== null && collectionId !== null) {
+    return { type: requestedType, mid, id: collectionId };
   }
-  if (mid === null || collectionId === null) {
+
+  const videoId = extractBilibiliVideoId(playlistUrl);
+  if (!videoId) {
+    return null;
+  }
+
+  const { checkBilibiliCollectionOrSeries } = await import(
+    "../downloadService"
+  );
+  const detected = await checkBilibiliCollectionOrSeries(videoId);
+  if (
+    !detected.success ||
+    detected.type === "none" ||
+    detected.mid === undefined ||
+    detected.id === undefined
+  ) {
+    throw new ValidationError(
+      "Could not resolve Bilibili collection metadata",
+      "collectionInfo"
+    );
+  }
+  if (requestedType && detected.type !== requestedType) {
+    throw new ValidationError(
+      "Could not resolve Bilibili collection metadata",
+      "collectionInfo"
+    );
+  }
+  if (collectionId !== null && collectionId !== detected.id) {
+    throw new ValidationError(
+      "Could not resolve Bilibili collection metadata",
+      "collectionInfo"
+    );
+  }
+
+  mid = detected.mid;
+  collectionId = detected.id;
+  return { type: detected.type, mid, id: collectionId };
+}
+
+export async function getBilibiliCollectionHeadSnapshot(
+  playlistUrl: string,
+  collectionInfo: BilibiliCollectionInspectionInput
+): Promise<BilibiliCollectionHeadSnapshot> {
+  const source = await resolveBilibiliCollectionSource(
+    playlistUrl,
+    collectionInfo
+  );
+  if (!source) {
     throw new ValidationError(
       "Could not resolve Bilibili collection metadata",
       "collectionInfo"
@@ -305,13 +341,13 @@ export async function inspectBilibiliCollectionPlaylist(
     "../downloadService"
   );
   const videosResult =
-    collectionInfo.type === "collection"
-      ? await getBilibiliCollectionVideos(mid, collectionId)
-      : await getBilibiliSeriesVideos(mid, collectionId);
+    source.type === "collection"
+      ? await getBilibiliCollectionVideos(source.mid, source.id)
+      : await getBilibiliSeriesVideos(source.mid, source.id);
 
   if (!videosResult.success) {
     throw new ValidationError(
-      `Failed to get videos from Bilibili ${collectionInfo.type}`,
+      `Failed to get videos from Bilibili ${source.type}`,
       "collectionInfo"
     );
   }
@@ -321,19 +357,56 @@ export async function inspectBilibiliCollectionPlaylist(
     ? `https://www.bilibili.com/video/${firstVideo.bvid}`
     : null;
 
-  logger.info("Inspected Bilibili collection for subscription baseline", {
-    type: collectionInfo.type,
-    videoCount: collectionInfo.count || videosResult.videos.length,
-    baselineState: headVideoUrl ? "item" : "empty",
-  });
-
   return {
     headVideoUrl,
     observedAt: Date.now(),
+    videoCount:
+      collectionInfo.count && collectionInfo.count > 0
+        ? collectionInfo.count
+        : videosResult.videos.length,
+    bilibiliSource: source,
+  };
+}
+
+/**
+ * Inspect a Bilibili collection/series using Bilibili's collection API when the
+ * frontend already supplied collection metadata for a normal video URL. This
+ * avoids probing the video URL as a generic yt-dlp playlist before the metadata
+ * branch can run.
+ */
+export async function inspectBilibiliCollectionPlaylist(
+  playlistUrl: string,
+  collectionInfo: BilibiliCollectionInspectionInput,
+  options?: PlaylistFeedOptions
+): Promise<BilibiliCollectionPlaylistInspection | PlaylistInspection> {
+  const snapshot = await getBilibiliCollectionHeadSnapshot(
+    playlistUrl,
+    collectionInfo
+  ).catch((error) => {
+    if (extractBilibiliVideoId(playlistUrl)) {
+      throw error;
+    }
+    return null;
+  });
+
+  if (!snapshot) {
+    return inspectPlaylist(playlistUrl, options);
+  }
+
+  logger.info("Inspected Bilibili collection for subscription baseline", {
+    type: snapshot.bilibiliSource.type,
+    videoCount: snapshot.videoCount,
+    baselineState: snapshot.headVideoUrl ? "item" : "empty",
+  });
+
+  return {
+    headVideoUrl: snapshot.headVideoUrl,
+    observedAt: snapshot.observedAt,
     title: collectionInfo.title || "Bilibili Playlist",
-    videoCount: collectionInfo.count || videosResult.videos.length,
-    playlistId: String(collectionId),
-    author: mid ? `Bilibili ${mid}` : "Bilibili Author",
+    videoCount: snapshot.videoCount,
+    playlistId: String(snapshot.bilibiliSource.id),
+    author: `Bilibili ${snapshot.bilibiliSource.mid}`,
     platform: "Bilibili",
+    bilibiliSource: snapshot.bilibiliSource,
   };
 }

--- a/backend/src/services/subscription/playlistFeed.ts
+++ b/backend/src/services/subscription/playlistFeed.ts
@@ -120,6 +120,27 @@ function detectPlatform(playlistUrl: string): "YouTube" | "Bilibili" {
   return isBilibiliUrl(playlistUrl) ? "Bilibili" : "YouTube";
 }
 
+function parseExtractorArgParts(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => parseExtractorArgParts(entry));
+  }
+
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function mergeExtractorArgs(...values: unknown[]): string | undefined {
+  const parts = values.flatMap((value) => parseExtractorArgParts(value));
+  const uniqueParts = Array.from(new Set(parts));
+  return uniqueParts.length > 0 ? uniqueParts.join(";") : undefined;
+}
+
 /**
  * Build the yt-dlp flag set for a playlist probe, applying the effective
  * per-subscription yt-dlp override on top of the global network config and the
@@ -139,16 +160,18 @@ async function buildProbeFlags(
   );
   const networkConfig = getNetworkConfigFromUserConfig(userConfig);
   const PROVIDER_SCRIPT = getProviderScript();
+  const extractorArgs = mergeExtractorArgs(
+    userConfig.extractorArgs,
+    PROVIDER_SCRIPT
+      ? `youtubepot-bgutilscript:script_path=${PROVIDER_SCRIPT}`
+      : undefined
+  );
   return {
     ...networkConfig,
     noWarnings: true,
     flatPlaylist: true,
     ...(probeEnd !== null ? { playlistEnd: probeEnd } : {}),
-    ...(PROVIDER_SCRIPT
-      ? {
-          extractorArgs: `youtubepot-bgutilscript:script_path=${PROVIDER_SCRIPT}`,
-        }
-      : {}),
+    ...(extractorArgs ? { extractorArgs } : {}),
   };
 }
 

--- a/backend/src/services/subscription/playlistResolution.ts
+++ b/backend/src/services/subscription/playlistResolution.ts
@@ -14,6 +14,77 @@ export interface ResolvedPlaylistCollection {
   created: boolean;
 }
 
+export type BilibiliPlaylistCollectionSource = {
+  type: "collection" | "series";
+  id: number;
+  mid: number;
+};
+
+type BilibiliSourceKey = {
+  sourcePlatform: "bilibili";
+  sourceType: "collection" | "series";
+  sourceMid: string;
+  sourceId: string;
+};
+
+function toBilibiliSourceKey(
+  source: BilibiliPlaylistCollectionSource
+): BilibiliSourceKey {
+  return {
+    sourcePlatform: "bilibili",
+    sourceType: source.type,
+    sourceMid: String(source.mid),
+    sourceId: String(source.id),
+  };
+}
+
+const collectionHasSourceKey = (collection: Collection): boolean =>
+  Boolean(
+    collection.sourcePlatform ||
+      collection.sourceType ||
+      collection.sourceMid ||
+      collection.sourceId
+  );
+
+const collectionMatchesSourceKey = (
+  collection: Collection,
+  sourceKey: BilibiliSourceKey
+): boolean =>
+  collection.sourcePlatform === sourceKey.sourcePlatform &&
+  collection.sourceType === sourceKey.sourceType &&
+  collection.sourceMid === sourceKey.sourceMid &&
+  collection.sourceId === sourceKey.sourceId;
+
+function createEmptyCollection(
+  collectionName: string,
+  extra: Partial<Collection> = {}
+): Collection {
+  const uniqueCollectionName =
+    storageService.generateUniqueCollectionName(collectionName);
+  const collection = {
+    id: uuidv4(),
+    name: uniqueCollectionName,
+    videos: [],
+    createdAt: new Date().toISOString(),
+    title: uniqueCollectionName,
+    ...extra,
+  };
+  storageService.saveCollection(collection);
+  logger.info(
+    `Created collection "${uniqueCollectionName}" with ID ${collection.id}`
+  );
+  return collection;
+}
+
+function saveCollectionSourceKey(
+  collection: Collection,
+  sourceKey: BilibiliSourceKey
+): Collection {
+  const updatedCollection = { ...collection, ...sourceKey };
+  storageService.saveCollection(updatedCollection);
+  return updatedCollection;
+}
+
 /**
  * Extract a YouTube playlist id (`list=` param) from a URL, or null if absent.
  */
@@ -40,22 +111,7 @@ export function resolvePlaylistCollectionWithStatus(
   let collection = storageService.getCollectionByName(collectionName);
 
   if (!collection) {
-    const uniqueCollectionName =
-      storageService.generateUniqueCollectionName(collectionName);
-    collection = {
-      // Channel-playlist bulk creation can create several collections inside
-      // the same millisecond. A UUID keeps those sequential storage writes
-      // collision-free instead of relying on Date.now() uniqueness.
-      id: uuidv4(),
-      name: uniqueCollectionName,
-      videos: [],
-      createdAt: new Date().toISOString(),
-      title: uniqueCollectionName,
-    };
-    storageService.saveCollection(collection);
-    logger.info(
-      `Created collection "${uniqueCollectionName}" with ID ${collection.id}`
-    );
+    collection = createEmptyCollection(collectionName);
     return { collection, created: true };
   } else {
     logger.info(
@@ -63,6 +119,55 @@ export function resolvePlaylistCollectionWithStatus(
     );
     return { collection, created: false };
   }
+}
+
+/**
+ * Resolve a Bilibili collection/series destination without linking the
+ * subscription to a same-named collection that belongs to another source key.
+ */
+export function resolveBilibiliPlaylistCollectionWithStatus(
+  collectionName: string,
+  source: BilibiliPlaylistCollectionSource
+): ResolvedPlaylistCollection {
+  const sourceKey = toBilibiliSourceKey(source);
+  const sourceMatchedCollection = storageService.getCollectionBySourceKey(
+    sourceKey.sourcePlatform,
+    sourceKey.sourceType,
+    sourceKey.sourceMid,
+    sourceKey.sourceId
+  );
+
+  if (sourceMatchedCollection) {
+    logger.info(
+      `Using existing Bilibili collection "${sourceMatchedCollection.name}" with ID ${sourceMatchedCollection.id}`
+    );
+    return { collection: sourceMatchedCollection, created: false };
+  }
+
+  const namedCollection = storageService.getCollectionByName(collectionName);
+  if (!namedCollection) {
+    const collection = createEmptyCollection(collectionName, sourceKey);
+    return { collection, created: true };
+  }
+
+  if (
+    !collectionHasSourceKey(namedCollection) ||
+    collectionMatchesSourceKey(namedCollection, sourceKey)
+  ) {
+    const collection = collectionMatchesSourceKey(namedCollection, sourceKey)
+      ? namedCollection
+      : saveCollectionSourceKey(namedCollection, sourceKey);
+    logger.info(
+      `Using existing Bilibili collection "${collection.name}" with ID ${collection.id}`
+    );
+    return { collection, created: false };
+  }
+
+  logger.warn(
+    `Collection "${collectionName}" already belongs to another Bilibili source; creating a separate destination`
+  );
+  const collection = createEmptyCollection(collectionName, sourceKey);
+  return { collection, created: true };
 }
 
 /**

--- a/backend/src/services/subscription/playlistResolution.ts
+++ b/backend/src/services/subscription/playlistResolution.ts
@@ -1,8 +1,18 @@
 import { isBilibiliUrl } from "../../utils/helpers";
-import { executeYtDlpJson, getNetworkConfigFromUserConfig, getUserYtDlpConfig } from "../../utils/ytDlpUtils";
+import { v4 as uuidv4 } from "uuid";
 import { logger } from "../../utils/logger";
 import * as storageService from "../storageService";
 import type { Collection } from "../storageService";
+
+/**
+ * A collection resolved for a playlist subscription, including whether this
+ * request created it. Callers use that fact to safely clean up a fresh empty
+ * collection when subscription insertion fails after the collection write.
+ */
+export interface ResolvedPlaylistCollection {
+  collection: Collection;
+  created: boolean;
+}
 
 /**
  * Extract a YouTube playlist id (`list=` param) from a URL, or null if absent.
@@ -24,14 +34,19 @@ export function detectPlaylistPlatform(playlistUrl: string): "Bilibili" | "YouTu
  * sequence used by createPlaylistSubscription. Returns the resolved
  * collection (existing or newly created).
  */
-export function resolvePlaylistCollection(collectionName: string): Collection {
+export function resolvePlaylistCollectionWithStatus(
+  collectionName: string
+): ResolvedPlaylistCollection {
   let collection = storageService.getCollectionByName(collectionName);
 
   if (!collection) {
     const uniqueCollectionName =
       storageService.generateUniqueCollectionName(collectionName);
     collection = {
-      id: Date.now().toString(),
+      // Channel-playlist bulk creation can create several collections inside
+      // the same millisecond. A UUID keeps those sequential storage writes
+      // collision-free instead of relying on Date.now() uniqueness.
+      id: uuidv4(),
       name: uniqueCollectionName,
       videos: [],
       createdAt: new Date().toISOString(),
@@ -41,13 +56,22 @@ export function resolvePlaylistCollection(collectionName: string): Collection {
     logger.info(
       `Created collection "${uniqueCollectionName}" with ID ${collection.id}`
     );
+    return { collection, created: true };
   } else {
     logger.info(
       `Using existing collection "${collection.name}" with ID ${collection.id}`
     );
+    return { collection, created: false };
   }
+}
 
-  return collection;
+/**
+ * Backward-compatible collection resolver for callers that only need the
+ * collection. New subscription flows should use the status-aware variant so
+ * they can avoid orphaning a collection on a later insert failure.
+ */
+export function resolvePlaylistCollection(collectionName: string): Collection {
+  return resolvePlaylistCollectionWithStatus(collectionName).collection;
 }
 
 /**
@@ -55,10 +79,10 @@ export function resolvePlaylistCollection(collectionName: string): Collection {
  * title plus an optional cleaned channel name (the variant used by the
  * channel-playlists loop).
  */
-export function resolveChannelPlaylistCollection(
+export function resolveChannelPlaylistCollectionWithStatus(
   playlistTitle: string,
   channelName: string | null,
-): Collection {
+): ResolvedPlaylistCollection {
   const cleanChannelName =
     channelName && channelName !== "Unknown"
       ? channelName.replace(/[\/\\:*?"<>|]/g, "-").trim()
@@ -76,7 +100,7 @@ export function resolveChannelPlaylistCollection(
     const uniqueCollectionName =
       storageService.generateUniqueCollectionName(collectionName);
     collection = {
-      id: Date.now().toString(),
+      id: uuidv4(),
       name: uniqueCollectionName,
       videos: [],
       createdAt: new Date().toISOString(),
@@ -86,86 +110,50 @@ export function resolveChannelPlaylistCollection(
     logger.info(
       `Created collection "${uniqueCollectionName}" for playlist: ${playlistTitle}`
     );
+    return { collection, created: true };
   }
 
-  return collection;
+  return { collection, created: false };
 }
 
 /**
- * Extract a playlist ID from Bilibili playlist info via yt-dlp, when it
- * wasn't already available from the request. Best-effort: returns null on
- * failure (the caller logs and continues).
+ * Backward-compatible channel-playlist resolver. Prefer the status-aware
+ * variant while creating a subscription so a fresh collection can be cleaned
+ * up if that creation fails.
  */
-export async function extractBilibiliPlaylistId(
-  playlistUrl: string,
-): Promise<string | null> {
-  try {
-    const userConfig = getUserYtDlpConfig(playlistUrl);
-    const networkConfig = getNetworkConfigFromUserConfig(userConfig);
-
-    const info = await executeYtDlpJson(playlistUrl, {
-      ...networkConfig,
-      noWarnings: true,
-      flatPlaylist: true,
-      playlistEnd: 1,
-    });
-
-    if (info.id) {
-      return info.id;
-    } else if (info.extractor_key === "bilibili:playlist") {
-      // For Bilibili playlists, the ID might be in the URL or extractor info
-      return info.playlist_id || info.id || null;
-    }
-  } catch (error) {
-    logger.warn(
-      "Could not extract playlist ID, continuing without it:",
-      error
-    );
-  }
-  return null;
+export function resolveChannelPlaylistCollection(
+  playlistTitle: string,
+  channelName: string | null,
+): Collection {
+  return resolveChannelPlaylistCollectionWithStatus(
+    playlistTitle,
+    channelName
+  ).collection;
 }
 
 /**
- * Best-effort extraction of an author name from a playlist's first entry /
- * uploader / channel metadata via yt-dlp. Returns "Playlist Author" when no
- * author can be determined or the probe fails.
+ * Remove a collection created by the current request only when it is still
+ * provably unused. This is intentionally conservative: an existing
+ * collection, one with videos, or one referenced by any subscription is never
+ * deleted. Call only before a task can be created for the collection.
  */
-export async function extractPlaylistAuthor(
-  playlistUrl: string,
-): Promise<string> {
-  let author = "Playlist Author";
+export async function deleteCreatedCollectionIfUnused(
+  resolution: ResolvedPlaylistCollection,
+  listSubscriptions: () => Promise<Array<{ collectionId?: string | null }>>
+): Promise<void> {
+  if (!resolution.created) return;
 
-  try {
-    const userConfig = getUserYtDlpConfig(playlistUrl);
-    const networkConfig = getNetworkConfigFromUserConfig(userConfig);
+  const current = storageService.getCollectionById(resolution.collection.id);
+  if (!current || (current.videos?.length ?? 0) > 0) return;
 
-    const info = await executeYtDlpJson(playlistUrl, {
-      ...networkConfig,
-      noWarnings: true,
-      flatPlaylist: true,
-      playlistEnd: 1,
-    });
+  const subscriptions = await listSubscriptions();
+  if (subscriptions.some((sub) => sub.collectionId === current.id)) return;
 
-    if (info.entries && info.entries.length > 0) {
-      const firstEntry = info.entries[0];
-      if (firstEntry.uploader) {
-        author = firstEntry.uploader;
-      } else if (firstEntry.channel) {
-        author = firstEntry.channel;
-      }
-    } else if (info.uploader) {
-      author = info.uploader;
-    } else if (info.channel) {
-      author = info.channel;
-    }
-  } catch (error) {
-    logger.warn(
-      "Could not extract author from playlist, using default:",
-      error
+  if (storageService.deleteCollection(current.id)) {
+    logger.info(
+      `Deleted unused collection "${current.name}" after playlist subscription creation failed`
     );
   }
-
-  return author;
 }
 
 /**

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -660,7 +660,20 @@ export class SubscriptionService {
               ? probeError.message
               : String(probeError)
           );
-          // Leave cursor unchanged; the finally block records the failed check.
+          // Leave the cursor unchanged, but advance lastCheck so persistent
+          // extractor/network failures back off to the configured interval.
+          const updateResult = await db
+            .update(subscriptions)
+            .set({ lastCheck: now })
+            .where(eq(subscriptions.id, sub.id))
+            .returning({ id: subscriptions.id });
+
+          if (updateResult.length === 0) {
+            logger.warn(
+              "Subscription was deleted before failed playlist probe backoff update",
+              getSubscriptionLogContext(sub)
+            );
+          }
           return;
         }
       } else {

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -491,6 +491,32 @@ export class SubscriptionService {
     });
   }
 
+  async updatePlaylistSubscriptionCursor(
+    id: string,
+    lastVideoLink: string,
+    lastCheck: number
+  ): Promise<void> {
+    const updated = await db
+      .update(subscriptions)
+      .set({ lastVideoLink, lastCheck })
+      .where(eq(subscriptions.id, id))
+      .returning({
+        id: subscriptions.id,
+        author: subscriptions.author,
+      });
+
+    if (updated.length === 0) {
+      throw NotFoundError.subscription(id);
+    }
+
+    logger.info("Updated playlist subscription cursor", {
+      subscriptionId: updated[0].id,
+      author: updated[0].author,
+      lastVideoLink,
+      lastCheck,
+    });
+  }
+
   async resumeSubscription(id: string): Promise<void> {
     const existing = await db
       .select()

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -42,6 +42,7 @@ import {
   stopSubscriptionSchedulerTasks,
 } from "./subscription/scheduler";
 import { checkChannelPlaylistsForWatcher } from "./subscription/channelPlaylists";
+import { getPlaylistHeadSnapshot } from "./subscription/playlistFeed";
 import { resolveYouTubeAuthorName } from "./subscription/youtubeAuthor";
 import {
   checkTwitchSubscription as checkTwitchSubscriptionImpl,
@@ -50,6 +51,26 @@ import {
 } from "./subscription/twitchSubscription";
 
 export type { Subscription } from "./subscription/types";
+
+/**
+ * Options for creating a playlist subscription (design §7.2 / §18).
+ *
+ * `initialHeadVideoUrl` + `baselineObservedAt` form the required server-side
+ * baseline; `filenameTemplate` is a forward-compatible seam shared with the
+ * companion filename-template design and is omitted until that feature lands.
+ */
+export interface SubscribePlaylistOptions {
+  playlistUrl: string;
+  interval: number;
+  playlistTitle: string;
+  playlistId: string;
+  author: string;
+  platform: string;
+  collectionId: string | null;
+  initialHeadVideoUrl: string | null;
+  baselineObservedAt: number;
+  filenameTemplate?: string | null;
+}
 
 export class SubscriptionService {
   private static instance: SubscriptionService;
@@ -212,18 +233,36 @@ export class SubscriptionService {
   }
 
   /**
-   * Subscribe to a playlist to automatically download new videos
+   * Subscribe to a playlist to automatically download new videos.
+   *
+   * Requires an explicit baseline (design §7.2): the server-observed current
+   * playlist head (or null for a verified empty playlist) plus the observation
+   * timestamp. The baseline is captured by the caller via playlistFeed before
+   * any persistent side effect, so the scheduler's first poll has a real
+   * comparison cursor and an item that already existed at subscription time is
+   * not treated as new. Requiring the value at the type boundary prevents
+   * future callers from accidentally reintroducing `lastVideoLink: ""` for a
+   * non-empty playlist.
    */
   async subscribePlaylist(
-    playlistUrl: string,
-    interval: number,
-    playlistTitle: string,
-    playlistId: string,
-    author: string,
-    platform: string,
-    collectionId: string | null
+    options: SubscribePlaylistOptions
   ): Promise<Subscription> {
-    // Check if already subscribed to this playlist
+    const {
+      playlistUrl,
+      interval,
+      playlistTitle,
+      playlistId,
+      author,
+      platform,
+      collectionId,
+      initialHeadVideoUrl,
+      baselineObservedAt,
+      filenameTemplate,
+    } = options;
+
+    // Check if already subscribed to this playlist. Kept in the service as the
+    // final race-safe guard even when the controller performs an early duplicate
+    // check for user experience (design §7.2).
     const existing = await db
       .select()
       .from(subscriptions)
@@ -240,8 +279,11 @@ export class SubscriptionService {
       author: displayName,
       authorUrl: playlistUrl,
       interval,
-      lastVideoLink: "",
-      lastCheck: Date.now(),
+      // Store the captured head (or "" for a verified empty playlist) as the
+      // scheduler cursor. lastCheck is the observation timestamp, not an
+      // unrelated earlier time (design §4.3 / §7.2).
+      lastVideoLink: initialHeadVideoUrl ?? "",
+      lastCheck: baselineObservedAt,
       downloadCount: 0,
       createdAt: Date.now(),
       platform,
@@ -251,10 +293,20 @@ export class SubscriptionService {
       channelName: author,
       subscriptionType: "playlist",
       collectionId: collectionId || undefined,
+      // filenameTemplate is a forward-compatible seam shared with the
+      // companion filename-template design (§18). It is accepted here so the
+      // options contract is stable, but not persisted until that design adds
+      // the column.
     };
 
     await db.insert(subscriptions).values(newSubscription);
-    logger.info("Created playlist subscription", getSubscriptionLogContext(newSubscription));
+    logger.info(
+      "Created playlist subscription",
+      getSubscriptionLogContext(newSubscription, {
+        baselineState: initialHeadVideoUrl ? "item" : "empty",
+        baselineObservedAt,
+      })
+    );
     return newSubscription;
   }
 
@@ -310,16 +362,7 @@ export class SubscriptionService {
   async checkChannelPlaylists(sub: Subscription): Promise<number> {
     return checkChannelPlaylistsForWatcher(sub, {
       listSubscriptions: () => this.listSubscriptions(),
-      subscribePlaylist: (playlistUrl, interval, title, playlistId, channelName, platform, collectionId) =>
-        this.subscribePlaylist(
-          playlistUrl,
-          interval,
-          title,
-          playlistId,
-          channelName,
-          platform,
-          collectionId
-        ),
+      subscribePlaylist: (options) => this.subscribePlaylist(options),
     });
   }
 
@@ -586,17 +629,47 @@ export class SubscriptionService {
       }
 
       const isPlaylistSubscription = sub.subscriptionType === "playlist";
-      const latestVideoUrl = isPlaylistSubscription
-        ? await this.getLatestPlaylistVideoUrl(
+
+      // Playlist polls use the typed, fail-closed head snapshot (design §9.1).
+      // The old nullable/error-swallowing probe could not distinguish a valid
+      // empty playlist from an extraction/network failure, which let a failed
+      // probe look like an empty playlist and update lastCheck as if it
+      // succeeded. Now a probe throw marks the check failed and leaves the
+      // cursor unchanged; a verified-empty result updates only lastCheck
+      // (design §9.2) and never clears a previously non-empty cursor.
+      let latestVideoUrl: string | null = null;
+      if (isPlaylistSubscription) {
+        try {
+          const snapshot = await getPlaylistHeadSnapshot(
             sub.authorUrl,
             sub.platform,
-            sub.ytdlpConfig
-          )
-        : await this.getLatestVideoUrl(
-            sub.authorUrl,
-            sub.platform,
-            sub.ytdlpConfig
+            { subscriptionYtdlpConfig: sub.ytdlpConfig }
           );
+          latestVideoUrl = snapshot.headVideoUrl;
+        } catch (probeError) {
+          logger.error(
+            "Playlist probe failed during subscription check",
+            probeError instanceof Error
+              ? probeError
+              : new Error(String(probeError)),
+            getSubscriptionLogContext(sub)
+          );
+          checkStatus = "fail";
+          checkFailureReason = bucketDownloadError(
+            probeError instanceof Error
+              ? probeError.message
+              : String(probeError)
+          );
+          // Leave cursor unchanged; the finally block records the failed check.
+          return;
+        }
+      } else {
+        latestVideoUrl = await this.getLatestVideoUrl(
+          sub.authorUrl,
+          sub.platform,
+          sub.ytdlpConfig
+        );
+      }
 
       if (latestVideoUrl && latestVideoUrl !== sub.lastVideoLink) {
         logger.info(
@@ -1070,61 +1143,6 @@ export class SubscriptionService {
       channelUrl,
       subscriptionYtdlpConfig
     );
-  }
-
-  /**
-   * Get the latest video URL from a playlist
-   * For playlists, we check the first video (newest) in the playlist
-   */
-  private async getLatestPlaylistVideoUrl(
-    playlistUrl: string,
-    platform?: string,
-    subscriptionYtdlpConfig?: string | null
-  ): Promise<string | null> {
-    try {
-      const {
-        executeYtDlpJson,
-        getNetworkConfigFromUserConfig,
-        getEffectiveUserYtDlpConfig,
-      } = await import("../utils/ytDlpUtils");
-      // Layer any per-subscription override on top of the global config (#345)
-      // so proxy/rate-limit overrides needed to enumerate the playlist apply to
-      // the scheduled probe, not just the eventual download.
-      const userConfig = getEffectiveUserYtDlpConfig(
-        playlistUrl,
-        subscriptionYtdlpConfig
-      );
-      const networkConfig = getNetworkConfigFromUserConfig(userConfig);
-
-      // Get the first video from the playlist
-      const info = await executeYtDlpJson(playlistUrl, {
-        ...networkConfig,
-        noWarnings: true,
-        flatPlaylist: true,
-        playlistEnd: 1,
-      });
-
-      if (info.entries && info.entries.length > 0) {
-        const firstVideo = info.entries[0];
-        if (firstVideo.url) {
-          return firstVideo.url;
-        }
-        if (firstVideo.id) {
-          // Construct URL from ID
-          if (platform === "YouTube") {
-            return `https://www.youtube.com/watch?v=${firstVideo.id}`;
-          }
-          if (platform === "Bilibili") {
-            return `https://www.bilibili.com/video/${firstVideo.id}`;
-          }
-        }
-      }
-
-      return null;
-    } catch (error) {
-      logger.error("Error getting latest playlist video:", error);
-      return null;
-    }
   }
 }
 

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -9,6 +9,7 @@ import {
   ValidationError,
 } from "../errors/DownloadErrors";
 import {
+    extractBilibiliVideoId,
     extractBilibiliMid,
     extractTwitchChannelLogin,
     isBilibiliSpaceUrl,
@@ -42,7 +43,10 @@ import {
   stopSubscriptionSchedulerTasks,
 } from "./subscription/scheduler";
 import { checkChannelPlaylistsForWatcher } from "./subscription/channelPlaylists";
-import { getPlaylistHeadSnapshot } from "./subscription/playlistFeed";
+import {
+  getBilibiliCollectionHeadSnapshot,
+  getPlaylistHeadSnapshot,
+} from "./subscription/playlistFeed";
 import { resolveYouTubeAuthorName } from "./subscription/youtubeAuthor";
 import {
   checkTwitchSubscription as checkTwitchSubscriptionImpl,
@@ -640,11 +644,7 @@ export class SubscriptionService {
       let latestVideoUrl: string | null = null;
       if (isPlaylistSubscription) {
         try {
-          const snapshot = await getPlaylistHeadSnapshot(
-            sub.authorUrl,
-            sub.platform,
-            { subscriptionYtdlpConfig: sub.ytdlpConfig }
-          );
+          const snapshot = await this.getPlaylistSubscriptionHeadSnapshot(sub);
           latestVideoUrl = snapshot.headVideoUrl;
         } catch (probeError) {
           logger.error(
@@ -1090,6 +1090,37 @@ export class SubscriptionService {
         disableAutoRetry: true,
       }
     );
+  }
+
+  private async getPlaylistSubscriptionHeadSnapshot(
+    sub: Subscription
+  ): Promise<{ headVideoUrl: string | null }> {
+    if (sub.platform === "Bilibili") {
+      const collection = sub.collectionId
+        ? storageService.getCollectionById(sub.collectionId)
+        : undefined;
+      const sourceType =
+        collection?.sourcePlatform === "bilibili" &&
+        (collection.sourceType === "collection" ||
+          collection.sourceType === "series")
+          ? collection.sourceType
+          : undefined;
+      const hasCollectionSource =
+        Boolean(sourceType && collection?.sourceMid) &&
+        Boolean(collection?.sourceId || sub.playlistId);
+
+      if (hasCollectionSource || extractBilibiliVideoId(sub.authorUrl)) {
+        return getBilibiliCollectionHeadSnapshot(sub.authorUrl, {
+          type: sourceType,
+          mid: collection?.sourceMid,
+          id: collection?.sourceId ?? sub.playlistId,
+        });
+      }
+    }
+
+    return getPlaylistHeadSnapshot(sub.authorUrl, sub.platform, {
+      subscriptionYtdlpConfig: sub.ytdlpConfig,
+    });
   }
 
   /**

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -467,6 +467,30 @@ export class SubscriptionService {
     });
   }
 
+  async updatePlaylistSubscriptionCollection(
+    id: string,
+    collectionId: string
+  ): Promise<void> {
+    const updated = await db
+      .update(subscriptions)
+      .set({ collectionId })
+      .where(eq(subscriptions.id, id))
+      .returning({
+        id: subscriptions.id,
+        author: subscriptions.author,
+      });
+
+    if (updated.length === 0) {
+      throw NotFoundError.subscription(id);
+    }
+
+    logger.info("Linked playlist subscription to collection", {
+      subscriptionId: updated[0].id,
+      author: updated[0].author,
+      collectionId,
+    });
+  }
+
   async resumeSubscription(id: string): Promise<void> {
     const existing = await db
       .select()
@@ -1123,11 +1147,15 @@ export class SubscriptionService {
         Boolean(collection?.sourceId || sub.playlistId);
 
       if (hasCollectionSource || extractBilibiliVideoId(sub.authorUrl)) {
-        return getBilibiliCollectionHeadSnapshot(sub.authorUrl, {
-          type: sourceType,
-          mid: collection?.sourceMid,
-          id: collection?.sourceId ?? sub.playlistId,
-        });
+        return getBilibiliCollectionHeadSnapshot(
+          sub.authorUrl,
+          {
+            type: sourceType,
+            mid: collection?.sourceMid,
+            id: collection?.sourceId ?? sub.playlistId,
+          },
+          { headOnly: true }
+        );
       }
     }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,7 +70,7 @@ function AppContent() {
         setShowBilibiliPartsModal,
         bilibiliPartsInfo,
         isCheckingParts,
-        handleDownloadAllBilibiliParts,
+        handlePlaylistDialogConfirm,
         handleDownloadCurrentBilibiliPart
     } = useDownload();
 
@@ -145,7 +145,7 @@ function AppContent() {
                                             onClose={() => setShowBilibiliPartsModal(false)}
                                             videosNumber={bilibiliPartsInfo.videosNumber}
                                             videoTitle={bilibiliPartsInfo.title}
-                                            onDownloadAll={handleDownloadAllBilibiliParts}
+                                            onConfirm={handlePlaylistDialogConfirm}
                                             onDownloadCurrent={handleDownloadCurrentBilibiliPart}
                                             isLoading={loading || isCheckingParts}
                                             type={bilibiliPartsInfo.type}

--- a/frontend/src/components/BilibiliPartsModal.tsx
+++ b/frontend/src/components/BilibiliPartsModal.tsx
@@ -10,27 +10,51 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
+
+/**
+ * Structured modal action (design §10.1). Replaces the previous
+ * `(collectionName, subscribeInfo?)` callback so subscribe-only and the
+ * companion filename-template feature can share one callback shape without
+ * boolean/positional ambiguity.
+ *
+ * `filenameTemplate` is a forward-compatible seam for the companion design and
+ * is omitted (null) until that feature lands.
+ */
+export interface PlaylistSubscribeInfo {
+    interval: number;
+    downloadAll: boolean;
+    filenameTemplate: string | null;
+}
+
+export interface PlaylistDialogAction {
+    collectionName: string;
+    subscribe?: PlaylistSubscribeInfo;
+}
 
 interface BilibiliPartsModalProps {
     isOpen: boolean;
     onClose: () => void;
     videosNumber: number;
     videoTitle: string;
-    onDownloadAll: (collectionName: string, subscribeInfo?: { interval: number }) => void;
+    /** Structured confirm callback (design §10.1). */
+    onConfirm: (action: PlaylistDialogAction) => void | Promise<void>;
     onDownloadCurrent: () => void;
     isLoading: boolean;
     type?: 'parts' | 'collection' | 'series' | 'playlist';
 }
+
+const isSubscribableType = (type: string) =>
+    type === 'playlist' || type === 'collection' || type === 'series';
 
 const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     isOpen,
     onClose,
     videosNumber,
     videoTitle,
-    onDownloadAll,
+    onConfirm,
     onDownloadCurrent,
     isLoading,
     type = 'parts'
@@ -38,19 +62,77 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const { t } = useLanguage();
     const [collectionName, setCollectionName] = useState<string>('');
     const [subscribeToPlaylist, setSubscribeToPlaylist] = useState<boolean>(false);
-    const [subscriptionInterval, setSubscriptionInterval] = useState<number>(60);
+    // Keep the raw interval string so invalid input doesn't get coerced to 60
+    // on every keystroke (design §10.2). Submit stays disabled until valid.
+    const [intervalInput, setIntervalInput] = useState<string>('60');
+    // Historical opt-in. Off by default every time a new source opens; do not
+    // persist globally because that makes a high-volume action sticky.
+    const [downloadExistingVideos, setDownloadExistingVideos] = useState<boolean>(false);
+    // The surrounding download context does not own a loading state for a
+    // playlist subscription request. Keep the dialog locked until its async
+    // callback settles so users cannot close it or submit a second action.
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
-    const handleDownloadAll = () => {
-        const subscribeInfo = subscribeToPlaylist ? { interval: subscriptionInterval } : undefined;
-        onDownloadAll(collectionName || videoTitle, subscribeInfo);
+    // The successful submission path closes this controlled dialog from the
+    // parent, bypassing handleClose. Reset the destructive choice whenever
+    // that happens so it cannot be carried to the next detected playlist.
+    useEffect(() => {
+        if (!isOpen) {
+            setSubscribeToPlaylist(false);
+            setDownloadExistingVideos(false);
+            setIntervalInput('60');
+        }
+    }, [isOpen]);
+
+    const subscribable = isSubscribableType(type);
+
+    const parsedInterval = Number(intervalInput);
+    const intervalValid =
+        Number.isSafeInteger(parsedInterval) && parsedInterval > 0;
+    const interval = intervalValid ? parsedInterval : 0;
+
+    const handleConfirm = async () => {
+        if (subscribable && subscribeToPlaylist && !intervalValid) {
+            return;
+        }
+        const action: PlaylistDialogAction = {
+            collectionName: collectionName || videoTitle,
+        };
+        if (subscribable && subscribeToPlaylist) {
+            action.subscribe = {
+                interval,
+                downloadAll: downloadExistingVideos,
+                filenameTemplate: null, // companion design seam; omitted until implemented
+            };
+        }
+        setIsSubmitting(true);
+        try {
+            await onConfirm(action);
+        } catch {
+            // DownloadContext displays the actionable error. Keep this dialog
+            // open with its current selection so the user can retry.
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
-    // Reset state when modal closes
+    // Reset state when modal closes. The historical opt-in and subscription
+    // toggle reset on close/reopen so a destructive choice never leaks across
+    // sources (design §10.2).
     const handleClose = () => {
-        if (isLoading) return;
+        if (isLoading || isSubmitting) return;
         setSubscribeToPlaylist(false);
-        setSubscriptionInterval(60);
+        setDownloadExistingVideos(false);
+        setIntervalInput('60');
         onClose();
+    };
+
+    const toggleSubscription = (checked: boolean) => {
+        setSubscribeToPlaylist(checked);
+        // Toggling subscription off resets the destructive history opt-in.
+        if (!checked) {
+            setDownloadExistingVideos(false);
+        }
     };
 
     // Dynamic text based on type
@@ -83,9 +165,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const getDownloadAllButtonText = () => {
         switch (type) {
             case 'collection':
-                return t('downloadAllVideos', { count: videosNumber });
             case 'series':
-                return t('downloadAllVideos', { count: videosNumber });
             case 'playlist':
                 return t('downloadAllVideos', { count: videosNumber });
             default:
@@ -96,9 +176,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const getCurrentButtonText = () => {
         switch (type) {
             case 'collection':
-                return t('downloadThisVideoOnly');
             case 'series':
-                return t('downloadThisVideoOnly');
             case 'playlist':
                 return t('downloadThisVideoOnly');
             default:
@@ -106,11 +184,28 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
         }
     };
 
+    // Primary action text is state-dependent (design §4.1).
+    const getPrimaryButtonText = () => {
+        if (subscribable && subscribeToPlaylist) {
+            // Subscribe on, history off => "Subscribe"; history on => download+subscribe.
+            return downloadExistingVideos
+                ? (t('downloadAndSubscribe') || 'Download All & Subscribe')
+                : (t('subscribe') || 'Subscribe');
+        }
+        return getDownloadAllButtonText();
+    };
+
+    // Submit is disabled while loading or when subscription is on with an
+    // invalid interval (design §10.2).
+    const busy = isLoading || isSubmitting;
+    const submitDisabled =
+        busy || (subscribable && subscribeToPlaylist && !intervalValid);
+
     return (
         <Dialog
             open={isOpen}
             onClose={handleClose}
-            disableEscapeKeyDown={isLoading}
+            disableEscapeKeyDown={busy}
             maxWidth="sm"
             fullWidth
             slotProps={{
@@ -119,7 +214,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                 }
             }}
         >
-            <DialogHeader title={getHeaderText()} onClose={handleClose} closeDisabled={isLoading} closeLabel={t('close')} />
+            <DialogHeader title={getHeaderText()} onClose={handleClose} closeDisabled={busy} closeLabel={t('close')} />
             <DialogContent dividers>
                 <DialogContentText sx={{ mb: 2 }}>
                     {getDescriptionText()}
@@ -139,20 +234,20 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                         value={collectionName}
                         onChange={(e) => setCollectionName(e.target.value)}
                         placeholder={videoTitle}
-                        disabled={isLoading}
+                        disabled={busy}
                         helperText={type === 'parts' ? t('allPartsAddedToCollection') : type === 'playlist' ? t('allVideosAddedToCollection') : t('allVideosAddedToCollection')}
                     />
                 </Box>
 
                 {/* Subscription option - show for playlist, collection, and series types */}
-                {(type === 'playlist' || type === 'collection' || type === 'series') && (
+                {subscribable && (
                     <Box sx={{ mt: 3 }}>
                         <FormControlLabel
                             control={
                                 <Checkbox
                                     checked={subscribeToPlaylist}
-                                    onChange={(e) => setSubscribeToPlaylist(e.target.checked)}
-                                    disabled={isLoading}
+                                    onChange={(e) => toggleSubscription(e.target.checked)}
+                                    disabled={busy}
                                 />
                             }
                             label={t('subscribeToPlaylist')}
@@ -162,42 +257,65 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                                 <TextField
                                     type="number"
                                     label={t('checkIntervalMinutes')}
-                                    value={subscriptionInterval}
-                                    onChange={(e) => setSubscriptionInterval(Math.max(1, parseInt(e.target.value) || 60))}
-                                    disabled={isLoading}
+                                    value={intervalInput}
+                                    onChange={(e) => setIntervalInput(e.target.value)}
+                                    disabled={busy}
                                     size="small"
                                     slotProps={{ htmlInput: { min: 1 } }}
                                     helperText={t('subscribePlaylistDescription')}
+                                    error={subscribeToPlaylist && !intervalValid}
                                     sx={{ width: 200 }}
                                 />
+                                {/* Subscribe-only / history choice (design §4.1 / §10.2).
+                                    Download existing is OFF by default. */}
+                                <FormControlLabel
+                                    sx={{ display: 'flex', mt: 1 }}
+                                    control={
+                                        <Checkbox
+                                            checked={downloadExistingVideos}
+                                            onChange={(e) => setDownloadExistingVideos(e.target.checked)}
+                                            disabled={busy}
+                                            inputProps={downloadExistingVideos
+                                                ? undefined
+                                                : { 'aria-describedby': 'playlist-subscribe-only-help' }}
+                                        />
+                                    }
+                                    label={t('downloadExistingPlaylistVideos') || 'Download existing videos now'}
+                                />
+                                {!downloadExistingVideos && (
+                                    <Typography id="playlist-subscribe-only-help" variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                                        {t('subscribeOnlyNewPlaylistVideosHelp') || 'Existing playlist videos will not be queued. MyTube will download newly detected videos after this subscription is created.'}
+                                    </Typography>
+                                )}
                             </Box>
                         )}
                     </Box>
                 )}
             </DialogContent>
             <DialogActions sx={{ p: 2 }}>
+                {/* Secondary "download this video only" action never creates a
+                    subscription, even if the checkbox had been selected (design §4.1). */}
                 <Button
                     onClick={() => {
                         handleClose();
                         onDownloadCurrent();
                     }}
-                    disabled={isLoading}
-                    loading={isLoading}
+                    disabled={busy}
+                    loading={busy}
                     loadingPosition="start"
                     color="inherit"
                 >
                     {getCurrentButtonText()}
                 </Button>
                 <Button
-                    onClick={handleDownloadAll}
-                    loading={isLoading}
+                    onClick={() => { void handleConfirm(); }}
+                    loading={busy}
                     loadingPosition="start"
                     variant="contained"
                     color="primary"
+                    disabled={submitDisabled}
                 >
-                    {subscribeToPlaylist && (type === 'playlist' || type === 'collection' || type === 'series')
-                        ? t('downloadAndSubscribe') 
-                        : getDownloadAllButtonText()}
+                    {getPrimaryButtonText()}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -31,6 +31,13 @@ interface SubscribeModalProps {
     title?: string;
     description?: string;
     enableDownloadOrder?: boolean;
+    /**
+     * Optional playlist-specific overrides for the "download previous" checkbox
+     * (design §10.4). When supplied they replace the author-oriented default
+     * copy so the channel "subscribe to all playlists" dialog reads correctly.
+     */
+    downloadPreviousLabel?: string;
+    downloadPreviousHelp?: string;
 }
 
 const SubscribeModal: React.FC<SubscribeModalProps> = ({
@@ -43,6 +50,8 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     title,
     description,
     enableDownloadOrder = true,
+    downloadPreviousLabel,
+    downloadPreviousHelp,
 }) => {
     const { t } = useLanguage();
     const [interval, setInterval] = useState<number>(60); // Default 60 minutes
@@ -139,8 +148,13 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                             disabled={isSubmitting}
                         />
                     }
-                    label={t('downloadAllPreviousVideos')}
+                    label={downloadPreviousLabel || t('downloadAllPreviousVideos')}
                 />
+                {downloadAllPrevious && downloadPreviousHelp && (
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5, ml: 4 }}>
+                        {downloadPreviousHelp}
+                    </Typography>
+                )}
                 {showOrderDropdown && (
                     <FormControl fullWidth sx={{ mt: 2 }}>
                         <InputLabel id="download-order-label">{t('downloadOrder') || 'Download Order'}</InputLabel>

--- a/frontend/src/components/__tests__/BilibiliPartsModal.test.tsx
+++ b/frontend/src/components/__tests__/BilibiliPartsModal.test.tsx
@@ -1,5 +1,5 @@
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import BilibiliPartsModal from '../BilibiliPartsModal';
 
@@ -21,7 +21,7 @@ describe('BilibiliPartsModal', () => {
         onClose: vi.fn(),
         videosNumber: 10,
         videoTitle: 'Test Video',
-        onDownloadAll: vi.fn(),
+        onConfirm: vi.fn(),
         onDownloadCurrent: vi.fn(),
         isLoading: false,
     };
@@ -32,7 +32,7 @@ describe('BilibiliPartsModal', () => {
 
     const renderModal = (props = {}) => {
         const theme = createTheme();
-        render(
+        return render(
             <ThemeProvider theme={theme}>
                 <BilibiliPartsModal {...defaultProps} {...props} />
             </ThemeProvider>
@@ -51,9 +51,6 @@ describe('BilibiliPartsModal', () => {
         // Download all text description: should use 'downloadPlaylistAndCreateCollection' key
         expect(screen.getByText('downloadPlaylistAndCreateCollection')).toBeInTheDocument();
 
-        // Helper text for collection name input: should use 'allVideosAddedToCollection' key
-        // TextField helper text sometimes can be tricky to find by exact text if it's broken up, but getByText usually works.
-        // There might be multiple instances if I'm not careful, but here it should be unique or just exist.
         expect(screen.getByText('allVideosAddedToCollection')).toBeInTheDocument();
     });
 
@@ -64,5 +61,116 @@ describe('BilibiliPartsModal', () => {
         expect(screen.getByText('videoHasParts_10')).toBeInTheDocument();
         expect(screen.getByText('wouldYouLikeToDownloadAllParts')).toBeInTheDocument();
         expect(screen.getByText('allPartsAddedToCollection')).toBeInTheDocument();
+    });
+
+    it('does not show subscribe/history controls for non-subscribable multi-part videos', () => {
+        renderModal({ type: 'parts' });
+        expect(screen.queryByText('subscribeToPlaylist')).not.toBeInTheDocument();
+    });
+
+    it('defaults subscription off and primary action to Download All for playlists', () => {
+        renderModal({ type: 'playlist' });
+        // Subscription checkbox present but unchecked; primary button is Download All.
+        const subscribeLabel = screen.getByText('subscribeToPlaylist');
+        expect(subscribeLabel).toBeInTheDocument();
+        // downloadAllVideos_{count} is the primary text when subscription is off.
+        expect(screen.getByText('downloadAllVideos_10')).toBeInTheDocument();
+    });
+
+    it('enabling subscription defaults downloadAll to false and changes primary label to Subscribe', () => {
+        renderModal({ type: 'playlist' });
+        // Click the "subscribe to this playlist" checkbox by its label.
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist'));
+
+        // Primary button becomes "subscribe".
+        expect(screen.getByText('subscribe')).toBeInTheDocument();
+        // The "download existing" checkbox is now visible and unchecked.
+        expect(screen.getByLabelText('downloadExistingPlaylistVideos')).not.toBeChecked();
+    });
+
+    it('sends downloadAll:false by default when confirming a subscribe-only playlist', async () => {
+        const onConfirm = vi.fn().mockResolvedValue(undefined);
+        renderModal({ type: 'playlist', onConfirm });
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist')); // enable subscription
+
+        const primaryButton = screen.getByText('subscribe').closest('button')!;
+        await fireEvent.click(primaryButton);
+
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        const action = onConfirm.mock.calls[0][0];
+        expect(action.subscribe).toEqual(
+            expect.objectContaining({ downloadAll: false })
+        );
+    });
+
+    it('opts into history and returns downloadAll:true with a changed label', async () => {
+        const onConfirm = vi.fn().mockResolvedValue(undefined);
+        renderModal({ type: 'playlist', onConfirm });
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist')); // enable subscription
+        fireEvent.click(screen.getByLabelText('downloadExistingPlaylistVideos')); // enable history
+
+        // Label becomes downloadAndSubscribe.
+        expect(screen.getByText('downloadAndSubscribe')).toBeInTheDocument();
+        expect(screen.queryByText('subscribeOnlyNewPlaylistVideosHelp')).not.toBeInTheDocument();
+        const primaryButton = screen.getByText('downloadAndSubscribe').closest('button')!;
+        await fireEvent.click(primaryButton);
+
+        const action = onConfirm.mock.calls[0][0];
+        expect(action.subscribe).toEqual(
+            expect.objectContaining({ downloadAll: true })
+        );
+    });
+
+    it('toggling subscription off resets the history opt-in', () => {
+        renderModal({ type: 'playlist' });
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist')); // subscription on
+        fireEvent.click(screen.getByLabelText('downloadExistingPlaylistVideos')); // history on
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist')); // subscription off -> history hidden
+
+        expect(screen.queryByText('downloadExistingPlaylistVideos')).not.toBeInTheDocument();
+    });
+
+    it('resets subscription and history state when the controlled dialog closes and reopens', async () => {
+        const rendered = renderModal({ type: 'playlist' });
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist'));
+        fireEvent.click(screen.getByLabelText('downloadExistingPlaylistVideos'));
+        expect(screen.getByLabelText('downloadExistingPlaylistVideos')).toBeChecked();
+
+        rendered.rerender(
+            <ThemeProvider theme={createTheme()}>
+                <BilibiliPartsModal {...defaultProps} type="playlist" isOpen={false} />
+            </ThemeProvider>
+        );
+        rendered.rerender(
+            <ThemeProvider theme={createTheme()}>
+                <BilibiliPartsModal {...defaultProps} type="playlist" isOpen />
+            </ThemeProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByLabelText('subscribeToPlaylist')).not.toBeChecked();
+        });
+        expect(screen.queryByText('downloadExistingPlaylistVideos')).not.toBeInTheDocument();
+    });
+
+    it('locks every action while the subscription request is pending and keeps state after failure', async () => {
+        let rejectConfirm!: (reason?: unknown) => void;
+        const onConfirm = vi.fn(() => new Promise<void>((_, reject) => {
+            rejectConfirm = reject;
+        }));
+        renderModal({ type: 'playlist', onConfirm });
+        fireEvent.click(screen.getByLabelText('subscribeToPlaylist'));
+        fireEvent.click(screen.getByText('subscribe').closest('button')!);
+
+        expect(screen.getByLabelText('subscribeToPlaylist')).toBeDisabled();
+        expect(screen.getByLabelText('downloadExistingPlaylistVideos')).toBeDisabled();
+        expect(screen.getByLabelText('checkIntervalMinutes')).toBeDisabled();
+        expect(screen.getByText('downloadThisVideoOnly').closest('button')).toBeDisabled();
+
+        rejectConfirm(new Error('backend failed'));
+        await waitFor(() => {
+            expect(screen.getByLabelText('subscribeToPlaylist')).not.toBeDisabled();
+        });
+        expect(screen.getByText('subscribe')).toBeInTheDocument();
     });
 });

--- a/frontend/src/components/__tests__/SubscribeModal.test.tsx
+++ b/frontend/src/components/__tests__/SubscribeModal.test.tsx
@@ -118,4 +118,24 @@ describe('SubscribeModal', () => {
         render(<SubscribeModal {...defaultProps} />);
         expect(screen.getByText('downloadShorts')).toBeInTheDocument();
     });
+
+    it('uses the playlist-specific label and help when provided (design §10.4)', async () => {
+        const user = userEvent.setup();
+        render(
+            <SubscribeModal
+                {...defaultProps}
+                downloadPreviousLabel="Download existing videos in these playlists"
+                downloadPreviousHelp="custom-playlist-help"
+            />
+        );
+
+        // Author-mode default label is replaced.
+        expect(screen.getByText('Download existing videos in these playlists')).toBeInTheDocument();
+        expect(screen.queryByText('downloadAllPreviousVideos')).not.toBeInTheDocument();
+
+        // Help text appears only once the checkbox is checked.
+        expect(screen.queryByText('custom-playlist-help')).not.toBeInTheDocument();
+        await user.click(screen.getByLabelText('Download existing videos in these playlists'));
+        expect(screen.getByText('custom-playlist-help')).toBeInTheDocument();
+    });
 });

--- a/frontend/src/contexts/DownloadContext.tsx
+++ b/frontend/src/contexts/DownloadContext.tsx
@@ -40,6 +40,8 @@ const SubscribeModal = lazyWithRetry(
     () => import('../components/SubscribeModal'),
     'subscribe-modal',
 );
+// Structured modal action type shared with BilibiliPartsModal (design §10.1).
+import type { PlaylistDialogAction } from '../components/BilibiliPartsModal';
 
 // Payload from GET /check-bilibili-collection, forwarded to the download API
 // when the user confirms a collection/series download.
@@ -59,10 +61,6 @@ interface BilibiliPartsInfo {
     collectionInfo: BilibiliCollectionInfo | null;
 }
 
-
-interface SubscribeInfo {
-    interval: number;
-}
 
 interface DownloadContextType {
     activeDownloads: DownloadInfo[];
@@ -84,7 +82,7 @@ interface DownloadContextType {
     setShowBilibiliPartsModal: (show: boolean) => void;
     bilibiliPartsInfo: BilibiliPartsInfo;
     isCheckingParts: boolean;
-    handleDownloadAllBilibiliParts: (collectionName: string, subscribeInfo?: SubscribeInfo) => Promise<{ success: boolean; error?: string }>;
+    handlePlaylistDialogConfirm: (action: PlaylistDialogAction) => Promise<void>;
     handleDownloadCurrentBilibiliPart: () => Promise<any>;
 }
 
@@ -509,43 +507,72 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     ]);
 
 
-    const handleDownloadAllBilibiliParts = useCallback(async (collectionName: string, subscribeInfo?: SubscribeInfo) => {
+    const handlePlaylistDialogConfirm = useCallback(async (action: PlaylistDialogAction) => {
+        const collectionName = action.collectionName || bilibiliPartsInfo.title;
+        const isCollection = bilibiliPartsInfo.type === 'collection' || bilibiliPartsInfo.type === 'series';
+        const isPlaylist = bilibiliPartsInfo.type === 'playlist';
+        const isSubscribable = isPlaylist || isCollection; // Both playlists and collections/series can be subscribed
+
         try {
-            setShowBilibiliPartsModal(false);
-
-            const isCollection = bilibiliPartsInfo.type === 'collection' || bilibiliPartsInfo.type === 'series';
-            const isPlaylist = bilibiliPartsInfo.type === 'playlist';
-            const isSubscribable = isPlaylist || isCollection; // Both playlists and collections/series can be subscribed
-
-            // Handle playlist/collection/subscription - create subscription and/or download task
-            if (isSubscribable && subscribeInfo) {
-                // If subscribing, use the subscription endpoint (works for both playlists and collections)
+            // Handle playlist/collection/subscription - create subscription and/or download task.
+            // Subscribe-only is the default: when subscription is enabled and
+            // history is not, downloadAll is false (design §4.1 / §10.3).
+            if (isSubscribable && action.subscribe) {
                 const response = await api.post('/subscriptions/playlist', {
                     playlistUrl: bilibiliPartsInfo.url,
-                    interval: subscribeInfo.interval,
-                    collectionName: collectionName || bilibiliPartsInfo.title,
-                    downloadAll: true,
+                    interval: action.subscribe.interval,
+                    collectionName,
+                    downloadAll: action.subscribe.downloadAll,
                     // Include collectionInfo for Bilibili collections/series
-                    collectionInfo: isCollection ? bilibiliPartsInfo.collectionInfo : undefined
+                    collectionInfo: isCollection ? bilibiliPartsInfo.collectionInfo : undefined,
+                    filenameTemplate: action.subscribe.filenameTemplate || undefined,
                 });
 
-                // Trigger immediate status check
-                checkBackendDownloadStatus();
+                const backfillStatus = response.data.backfillStatus as
+                    | 'not_requested'
+                    | 'started'
+                    | 'not_needed_empty'
+                    | 'failed'
+                    | undefined;
+                const taskId = response.data.taskId as string | null | undefined;
 
-                // If a collection was created, refresh collections
+                // Subscribe-only still creates/resolves a collection, so refresh
+                // collections regardless of backfill outcome (design §10.3).
                 if (response.data.collectionId) {
                     await fetchCollections();
                 }
+                // Refresh the shared subscriptions list (design §10.5).
+                queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_QUERY_KEY });
 
-                showSnackbar(t('playlistSubscribedSuccessfully'));
-                return { success: true };
+                // Only trigger active-download polling when a backfill task was
+                // actually started (design §10.3 / §10.5). A null task must not
+                // imply work is queued.
+                if (backfillStatus === 'started' && taskId) {
+                    checkBackendDownloadStatus();
+                }
+
+                // Accurate snackbar feedback per backfill outcome (design §10.3).
+                if (backfillStatus === 'started' && taskId) {
+                    showSnackbar(t('playlistDownloadAndSubscriptionStarted') || t('playlistSubscribedSuccessfully'));
+                } else if (backfillStatus === 'failed') {
+                    // Subscription was created, but history failed to queue.
+                    showSnackbar(t('playlistBaselineFailed') || t('playlistSubscribedSuccessfully'), 'warning');
+                } else {
+                    // not_requested, not_needed_empty, or absent => subscribe-only success.
+                    showSnackbar(t('playlistSubscribedNewOnly') || t('playlistSubscribedSuccessfully'));
+                }
+                // Close the modal only after a successful response (design §10.7).
+                setShowBilibiliPartsModal(false);
+                return;
             }
+
+            // No subscription: preserve the standalone download paths.
 
             // Handle playlist without subscription - create continuous download task
             if (isPlaylist) {
                 const response = await api.post('/subscriptions/tasks/playlist', {
                     playlistUrl: bilibiliPartsInfo.url,
-                    collectionName: collectionName || bilibiliPartsInfo.title
+                    collectionName,
                 });
 
                 // Trigger immediate status check
@@ -557,7 +584,8 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 }
 
                 showSnackbar(t('playlistDownloadStarted'));
-                return { success: true };
+                setShowBilibiliPartsModal(false);
+                return;
             }
 
             // Handle collection/series without subscription - regular download
@@ -579,16 +607,15 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             }
 
             showSnackbar(t('downloadStartedSuccessfully'));
-            return { success: true };
+            setShowBilibiliPartsModal(false);
         } catch (err: unknown) {
             console.error('Error downloading Bilibili parts/collection:', err);
-
-            return {
-                success: false,
-                error: getApiErrorMessage(err) || t('failedToDownload')
-            };
+            // Re-throw so the modal keeps the dialog open with the user's
+            // selection intact for retry (design §10.7). Surface the message.
+            showSnackbar(getApiErrorMessage(err) || t('failedToDownload'), 'error');
+            throw err;
         }
-    }, [bilibiliPartsInfo, checkBackendDownloadStatus, fetchCollections, showSnackbar, t]);
+    }, [bilibiliPartsInfo, checkBackendDownloadStatus, fetchCollections, showSnackbar, t, queryClient]);
 
     const handleDownloadCurrentBilibiliPart = useCallback(async () => {
         setShowBilibiliPartsModal(false);
@@ -759,11 +786,11 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         setShowBilibiliPartsModal,
         bilibiliPartsInfo,
         isCheckingParts,
-        handleDownloadAllBilibiliParts,
+        handlePlaylistDialogConfirm,
         handleDownloadCurrentBilibiliPart,
     }), [
         activeDownloads, queuedDownloads, handleVideoSubmit, handleAudioOnlyDownload, showBilibiliPartsModal,
-        bilibiliPartsInfo, isCheckingParts, handleDownloadAllBilibiliParts,
+        bilibiliPartsInfo, isCheckingParts, handlePlaylistDialogConfirm,
         handleDownloadCurrentBilibiliPart,
     ]);
 
@@ -796,6 +823,8 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                         title={subscribeMode === 'playlist' ? (t('subscribeAllPlaylists') || 'Subscribe All Playlists') : undefined}
                         description={subscribeMode === 'playlist' ? (t('subscribeAllPlaylistsDescription') || 'This will subscribe to all playlists in this channel.') : undefined}
                         enableDownloadOrder={subscribeMode !== 'playlist'}
+                        downloadPreviousLabel={subscribeMode === 'playlist' ? (t('downloadExistingPlaylistVideos') || 'Download existing videos in these playlists') : undefined}
+                        downloadPreviousHelp={subscribeMode === 'playlist' ? (t('downloadAllPlaylistsWarning') || undefined) : undefined}
                     />
                 )}
                 {showDuplicateModal && (

--- a/frontend/src/contexts/DownloadContext.tsx
+++ b/frontend/src/contexts/DownloadContext.tsx
@@ -531,6 +531,7 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 const backfillStatus = response.data.backfillStatus as
                     | 'not_requested'
                     | 'started'
+                    | 'already_exists'
                     | 'not_needed_empty'
                     | 'failed'
                     | undefined;
@@ -547,18 +548,20 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 // Only trigger active-download polling when a backfill task was
                 // actually started (design §10.3 / §10.5). A null task must not
                 // imply work is queued.
-                if (backfillStatus === 'started' && taskId) {
+                if ((backfillStatus === 'started' || backfillStatus === 'already_exists') && taskId) {
                     checkBackendDownloadStatus();
                 }
 
                 // Accurate snackbar feedback per backfill outcome (design §10.3).
                 if (backfillStatus === 'started' && taskId) {
                     showSnackbar(t('playlistDownloadAndSubscriptionStarted') || t('playlistSubscribedSuccessfully'));
+                } else if (backfillStatus === 'already_exists' && taskId) {
+                    showSnackbar(t('playlistDownloadAndSubscriptionStarted') || t('playlistSubscribedSuccessfully'));
                 } else if (backfillStatus === 'failed') {
                     // Subscription was created, but history failed to queue.
                     showSnackbar(t('playlistBaselineFailed') || t('playlistSubscribedSuccessfully'), 'warning');
                 } else {
-                    // not_requested, not_needed_empty, or absent => subscribe-only success.
+                    // not_requested, not_needed_empty, already_exists without taskId, or absent => subscribe-only success.
                     showSnackbar(t('playlistSubscribedNewOnly') || t('playlistSubscribedSuccessfully'));
                 }
                 // Close the modal only after a successful response (design §10.7).

--- a/frontend/src/contexts/__tests__/DownloadContext.test.tsx
+++ b/frontend/src/contexts/__tests__/DownloadContext.test.tsx
@@ -729,6 +729,48 @@ describe('DownloadContext', () => {
     });
   });
 
+  it('already-existing backfill response triggers status polling for the returned task', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownload(), { wrapper });
+
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/download-status') {
+        return Promise.resolve({ data: { activeDownloads: [], queuedDownloads: [] } });
+      }
+      if (url === '/check-playlist') {
+        return Promise.resolve({ data: { success: true, title: 'PL', videoCount: 8 } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    await act(async () => {
+      await result.current.handleVideoSubmit('https://youtube.com/playlist?list=PL-existing');
+    });
+
+    mockApiPost.mockResolvedValueOnce({
+      data: {
+        subscription: { id: 'sub-3' },
+        collectionId: 'col-3',
+        taskId: 'task-3',
+        downloadAll: true,
+        backfillStatus: 'already_exists',
+      },
+    });
+    mockApiGet.mockClear();
+
+    await act(async () => {
+      await result.current.handlePlaylistDialogConfirm({
+        collectionName: 'My PL',
+        subscribe: { interval: 60, downloadAll: true, filenameTemplate: null },
+      });
+    });
+
+    await waitFor(() => {
+      const getCalls = mockApiGet.mock.calls.map((c: any[]) => c[0]);
+      expect(getCalls).toContain('/download-status');
+    });
+  });
+
   it('opens subscribe modal directly for Bilibili space URLs', async () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useDownload(), { wrapper });

--- a/frontend/src/contexts/__tests__/DownloadContext.test.tsx
+++ b/frontend/src/contexts/__tests__/DownloadContext.test.tsx
@@ -536,13 +536,16 @@ describe('DownloadContext', () => {
       expect(result.current.bilibiliPartsInfo.type).toBe('collection');
     });
 
-    const subscribeResult = await result.current.handleDownloadAllBilibiliParts('My B Collection', { interval: 60 });
-    expect(subscribeResult).toEqual({ success: true });
+    const subscribeResult = await result.current.handlePlaylistDialogConfirm({
+      collectionName: 'My B Collection',
+      subscribe: { interval: 60, downloadAll: false, filenameTemplate: null },
+    });
+    expect(subscribeResult).toBeUndefined();
     expect(mockApiPost).toHaveBeenCalledWith('/subscriptions/playlist', {
       playlistUrl: 'https://www.bilibili.com/video/BV1abc',
       interval: 60,
       collectionName: 'My B Collection',
-      downloadAll: true,
+      downloadAll: false,
       collectionInfo: {
         type: 'collection',
         id: 'cid',
@@ -550,6 +553,7 @@ describe('DownloadContext', () => {
         title: 'B Collection',
         count: 12,
       },
+      filenameTemplate: undefined,
     });
     expect(mockFetchCollections).toHaveBeenCalled();
 
@@ -573,8 +577,8 @@ describe('DownloadContext', () => {
     expect(result.current.bilibiliPartsInfo.type).toBe('parts');
 
     mockApiPost.mockResolvedValueOnce({ data: { success: true } });
-    const partsDownloadResult = await result.current.handleDownloadAllBilibiliParts('My parts');
-    expect(partsDownloadResult).toEqual({ success: true });
+    const partsDownloadResult = await result.current.handlePlaylistDialogConfirm({ collectionName: 'My parts' });
+    expect(partsDownloadResult).toBeUndefined();
     expect(mockApiPost).toHaveBeenCalledWith('/download', {
       youtubeUrl: 'https://www.bilibili.com/video/BV2xyz',
       downloadAllParts: true,
@@ -597,7 +601,7 @@ describe('DownloadContext', () => {
     expect(getCalls).not.toContain('/check-bilibili-parts');
   });
 
-  it('returns error object when handleDownloadAllBilibiliParts fails', async () => {
+  it('throws and shows an error snackbar when handlePlaylistDialogConfirm fails', async () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useDownload(), { wrapper });
 
@@ -616,9 +620,113 @@ describe('DownloadContext', () => {
     });
 
     mockApiPost.mockRejectedValueOnce({ response: { data: { error: 'bilibili flow failed' } } });
-    const errorResult = await result.current.handleDownloadAllBilibiliParts('broken');
+    // On backend failure the handler re-throws so the modal stays retryable,
+    // and surfaces an error snackbar (design §10.6 / §10.7).
+    await expect(
+      result.current.handlePlaylistDialogConfirm({
+        collectionName: 'broken',
+        subscribe: { interval: 60, downloadAll: false, filenameTemplate: null },
+      })
+    ).rejects.toBeDefined();
+    expect(mockShowSnackbar).toHaveBeenCalledWith(
+      expect.any(String),
+      'error'
+    );
+  });
 
-    expect(errorResult).toEqual({ success: false, error: 'bilibili flow failed' });
+  it('direct subscribe-only sends downloadAll:false and does not trigger active-download polling (design §10.3/§10.5)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownload(), { wrapper });
+
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/download-status') {
+        return Promise.resolve({ data: { activeDownloads: [], queuedDownloads: [] } });
+      }
+      if (url === '/check-playlist') {
+        return Promise.resolve({ data: { success: true, title: 'PL', videoCount: 8 } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    await act(async () => {
+      await result.current.handleVideoSubmit('https://youtube.com/playlist?list=PL-only');
+    });
+    expect(result.current.bilibiliPartsInfo.type).toBe('playlist');
+
+    // Backend reports subscribe-only: no task, backfillStatus not_requested.
+    mockApiPost.mockResolvedValueOnce({
+      data: {
+        subscription: { id: 'sub-1' },
+        collectionId: 'col-1',
+        taskId: null,
+        downloadAll: false,
+        backfillStatus: 'not_requested',
+      },
+    });
+    mockApiGet.mockClear();
+
+    await act(async () => {
+      await result.current.handlePlaylistDialogConfirm({
+        collectionName: 'My PL',
+        subscribe: { interval: 60, downloadAll: false, filenameTemplate: null },
+      });
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith('/subscriptions/playlist', expect.objectContaining({
+      playlistUrl: 'https://youtube.com/playlist?list=PL-only',
+      downloadAll: false,
+    }));
+    // Collections + subscriptions list refresh (subscribe-only still creates a collection).
+    expect(mockFetchCollections).toHaveBeenCalled();
+    // No active-download status poll triggered when no task was created.
+    const getCalls = mockApiGet.mock.calls.map((c: any[]) => c[0]);
+    expect(getCalls).not.toContain('/download-status');
+  });
+
+  it('history opt-in sends downloadAll:true and triggers status polling only when a task id exists', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownload(), { wrapper });
+
+    mockApiGet.mockImplementation((url: string) => {
+      if (url === '/download-status') {
+        return Promise.resolve({ data: { activeDownloads: [], queuedDownloads: [] } });
+      }
+      if (url === '/check-playlist') {
+        return Promise.resolve({ data: { success: true, title: 'PL', videoCount: 8 } });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    await act(async () => {
+      await result.current.handleVideoSubmit('https://youtube.com/playlist?list=PL-backfill');
+    });
+
+    mockApiPost.mockResolvedValueOnce({
+      data: {
+        subscription: { id: 'sub-2' },
+        collectionId: 'col-2',
+        taskId: 'task-2',
+        downloadAll: true,
+        backfillStatus: 'started',
+      },
+    });
+    mockApiGet.mockClear();
+
+    await act(async () => {
+      await result.current.handlePlaylistDialogConfirm({
+        collectionName: 'My PL',
+        subscribe: { interval: 60, downloadAll: true, filenameTemplate: null },
+      });
+    });
+
+    expect(mockApiPost).toHaveBeenCalledWith('/subscriptions/playlist', expect.objectContaining({
+      downloadAll: true,
+    }));
+    // Backfill started with a task id => status polling triggered.
+    await waitFor(() => {
+      const getCalls = mockApiGet.mock.calls.map((c: any[]) => c[0]);
+      expect(getCalls).toContain('/download-status');
+    });
   });
 
   it('opens subscribe modal directly for Bilibili space URLs', async () => {

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -4,7 +4,7 @@ Canonical locale key order derived from `frontend/src/utils/locales/en.ts`.
 
 This list is intentionally unnumbered. When new keys are inserted, only the local section order changes.
 
-Total keys: 1046
+Total keys: 1052
 
 ## Summary
 
@@ -34,7 +34,7 @@ Total keys: 1046
 | Batch Download | 6 | `batchDownload` | `addBatchTasks` |
 | Subscriptions | 62 | `subscribeToAuthor` | `retentionDaysUpdateFailed` |
 | Subscription Pause/Resume | 12 | `pause` | `viaContinuousDownload` |
-| Playlist Subscription | 5 | `subscribeToPlaylist` | `playlistSubscription` |
+| Playlist Subscription | 11 | `subscribeToPlaylist` | `playlistBaselineFailed` |
 | Instruction Page | 39 | `instructionSection1Title` | `instructionSection3Item3Text` |
 | Disclaimer | 3 | `disclaimerTitle` | `history` |
 | Existing Video Detection | 16 | `existingVideoDetected` | `changeSettings` |
@@ -996,6 +996,12 @@ Total keys: 1046
 | `playlistSubscribedSuccessfully` |
 | `downloadAndSubscribe` |
 | `playlistSubscription` |
+| `subscribeOnlyNewPlaylistVideos` |
+| `subscribeOnlyNewPlaylistVideosHelp` |
+| `downloadExistingPlaylistVideos` |
+| `playlistSubscribedNewOnly` |
+| `playlistDownloadAndSubscriptionStarted` |
+| `playlistBaselineFailed` |
 
 ### Instruction Page
 

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1042,6 +1042,19 @@ export const ar = {
   playlistSubscribedSuccessfully: "تم الاشتراك في قائمة التشغيل بنجاح",
   downloadAndSubscribe: "تنزيل الكل والاشتراك",
   playlistSubscription: "قائمة التشغيل",
+  // Issue #368.2 — الاشتراك في المحتوى الجديد فقط / خيار التنزيل التاريخي
+  subscribeOnlyNewPlaylistVideos:
+    "اشترك في الفيديوهات الجديدة فقط",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "لن تتم إضافة فيديوهات قائمة التشغيل الحالية إلى قائمة الانتظار. سيقوم MyTube بتنزيل الفيديوهات المكتشفة حديثًا بعد إنشاء هذا الاشتراك.",
+  downloadExistingPlaylistVideos:
+    "تنزيل الفيديوهات الحالية الآن",
+  playlistSubscribedNewOnly:
+    "تم الاشتراك في الفيديوهات الجديدة فقط. لم تتم إضافة الفيديوهات الحالية.",
+  playlistDownloadAndSubscriptionStarted:
+    "بدأ التنزيل وتم الاشتراك في قائمة التشغيل.",
+  playlistBaselineFailed:
+    "تم الاشتراك في قائمة التشغيل، لكن تعذر بدء تنزيل الفيديوهات الحالية. ستظل الفيديوهات الجديدة تُنزَّل تلقائيًا.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1085,6 +1085,19 @@ export const de = {
   playlistSubscribedSuccessfully: "Playlist erfolgreich abonniert",
   downloadAndSubscribe: "Alle herunterladen & abonnieren",
   playlistSubscription: "Playlist",
+  // Issue #368.2 — Nur neue Inhalte abonnieren / Verlauf-Download-Option
+  subscribeOnlyNewPlaylistVideos:
+    "Nur neue Videos abonnieren",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Vorhandene Playlist-Videos werden nicht in die Warteschlange aufgenommen. MyTube lädt neu erkannte Videos herunter, nachdem dieses Abonnement erstellt wurde.",
+  downloadExistingPlaylistVideos:
+    "Vorhandene Videos jetzt herunterladen",
+  playlistSubscribedNewOnly:
+    "Nur neue Videos abonniert. Vorhandene Videos wurden nicht in die Warteschlange aufgenommen.",
+  playlistDownloadAndSubscriptionStarted:
+    "Download gestartet und Playlist abonniert.",
+  playlistBaselineFailed:
+    "Playlist abonniert, aber das Herunterladen vorhandener Videos konnte nicht gestartet werden. Neue Videos werden weiterhin automatisch heruntergeladen.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1049,6 +1049,19 @@ export const en = {
   playlistSubscribedSuccessfully: "Subscribed to playlist successfully",
   downloadAndSubscribe: "Download All & Subscribe",
   playlistSubscription: "Playlist",
+  // Issue #368.2 — subscribe-only / history choice
+  subscribeOnlyNewPlaylistVideos:
+    "Subscribe only to new videos",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Existing playlist videos will not be queued. MyTube will download newly detected videos after this subscription is created.",
+  downloadExistingPlaylistVideos:
+    "Download existing videos now",
+  playlistSubscribedNewOnly:
+    "Subscribed to new videos only. Existing videos were not queued.",
+  playlistDownloadAndSubscriptionStarted:
+    "Download started and playlist subscribed.",
+  playlistBaselineFailed:
+    "Playlist subscribed, but downloading existing videos failed to start. New videos will still be downloaded automatically.",
 
   // Instruction Page
   instructionSection1Title: "1. Download & Task Management",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1081,6 +1081,19 @@ export const es = {
     "Suscrito a la lista de reproducción con éxito",
   downloadAndSubscribe: "Descargar todo y suscribirse",
   playlistSubscription: "Lista de reproducción",
+  // Issue #368.2 — Suscribirse solo a contenido nuevo / opción de descarga del historial
+  subscribeOnlyNewPlaylistVideos:
+    "Suscribirse solo a videos nuevos",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Los videos existentes de la lista de reproducción no se añadirán a la cola. MyTube descargará los videos detectados nuevamente después de crear esta suscripción.",
+  downloadExistingPlaylistVideos:
+    "Descargar videos existentes ahora",
+  playlistSubscribedNewOnly:
+    "Suscrito solo a videos nuevos. Los videos existentes no se añadieron a la cola.",
+  playlistDownloadAndSubscriptionStarted:
+    "Descarga iniciada y lista de reproducción suscrita.",
+  playlistBaselineFailed:
+    "Lista de reproducción suscrita, pero no se pudo iniciar la descarga de los videos existentes. Los videos nuevos se seguirán descargando automáticamente.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1085,6 +1085,19 @@ export const fr = {
   playlistSubscribedSuccessfully: "Abonnement à la playlist réussi",
   downloadAndSubscribe: "Tout télécharger et s'abonner",
   playlistSubscription: "Playlist",
+  // Issue #368.2 — S'abonner uniquement au nouveau contenu / option de téléchargement de l'historique
+  subscribeOnlyNewPlaylistVideos:
+    "S'abonner uniquement aux nouvelles vidéos",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Les vidéos existantes de la playlist ne seront pas mises en file d'attente. MyTube téléchargera les vidéos nouvellement détectées après la création de cet abonnement.",
+  downloadExistingPlaylistVideos:
+    "Télécharger les vidéos existantes maintenant",
+  playlistSubscribedNewOnly:
+    "Abonné uniquement aux nouvelles vidéos. Les vidéos existantes n'ont pas été mises en file d'attente.",
+  playlistDownloadAndSubscriptionStarted:
+    "Téléchargement démarré et playlist abonnée.",
+  playlistBaselineFailed:
+    "Playlist abonnée, mais le téléchargement des vidéos existantes n'a pas pu démarrer. Les nouvelles vidéos continueront d'être téléchargées automatiquement.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1068,6 +1068,19 @@ export const ja = {
   playlistSubscribedSuccessfully: "プレイリストの購読に成功しました",
   downloadAndSubscribe: "すべてダウンロードして購読",
   playlistSubscription: "プレイリスト",
+  // Issue #368.2 — 新着コンテンツのみ購読 / 履歴ダウンロードの選択
+  subscribeOnlyNewPlaylistVideos:
+    "新しい動画のみ購読",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "既存のプレイリストの動画はキューに追加されません。この購読を作成すると、MyTube は新しく検出された動画をダウンロードします。",
+  downloadExistingPlaylistVideos:
+    "今すぐ既存の動画をダウンロード",
+  playlistSubscribedNewOnly:
+    "新しい動画のみ購読しました。既存の動画はキューに追加されませんでした。",
+  playlistDownloadAndSubscriptionStarted:
+    "ダウンロードを開始し、プレイリストを購読しました。",
+  playlistBaselineFailed:
+    "プレイリストを購読しましたが、既存動画のダウンロードを開始できませんでした。新しい動画は引き続き自動的にダウンロードされます。",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1051,6 +1051,19 @@ export const ko = {
   playlistSubscribedSuccessfully: "재생목록 구독 성공",
   downloadAndSubscribe: "모두 다운로드 및 구독",
   playlistSubscription: "재생목록",
+  // Issue #368.2 — 새 콘텐츠만 구독 / 기록 다운로드 선택
+  subscribeOnlyNewPlaylistVideos:
+    "새 동영상만 구독",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "기존 재생목록 동영상은 대기열에 추가되지 않습니다. 이 구독을 생성한 후 MyTube가 새로 감지된 동영상을 다운로드합니다.",
+  downloadExistingPlaylistVideos:
+    "지금 기존 동영상 다운로드",
+  playlistSubscribedNewOnly:
+    "새 동영상만 구독했습니다. 기존 동영상은 대기열에 추가되지 않았습니다.",
+  playlistDownloadAndSubscriptionStarted:
+    "다운로드가 시작되었고 재생목록을 구독했습니다.",
+  playlistBaselineFailed:
+    "재생목록을 구독했지만 기존 동영상 다운로드를 시작하지 못했습니다. 새 동영상은 계속 자동으로 다운로드됩니다.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1072,6 +1072,19 @@ export const pt = {
   playlistSubscribedSuccessfully: "Inscrito na playlist com sucesso",
   downloadAndSubscribe: "Baixar tudo e inscrever-se",
   playlistSubscription: "Playlist",
+  // Issue #368.2 — Inscrever-se apenas em novo conteúdo / opção de download do histórico
+  subscribeOnlyNewPlaylistVideos:
+    "Inscrever-se apenas em novos vídeos",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Os vídeos existentes da playlist não serão adicionados à fila. O MyTube fará o download dos vídeos detectados recentemente após esta inscrição ser criada.",
+  downloadExistingPlaylistVideos:
+    "Baixar vídeos existentes agora",
+  playlistSubscribedNewOnly:
+    "Inscrito apenas em novos vídeos. Os vídeos existentes não foram adicionados à fila.",
+  playlistDownloadAndSubscriptionStarted:
+    "Download iniciado e playlist inscrita.",
+  playlistBaselineFailed:
+    "Playlist inscrita, mas não foi possível iniciar o download dos vídeos existentes. Os novos vídeos continuarão sendo baixados automaticamente.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1066,6 +1066,19 @@ export const ru = {
   playlistSubscribedSuccessfully: "Успешная подписка на плейлист",
   downloadAndSubscribe: "Скачать все и подписаться",
   playlistSubscription: "Плейлист",
+  // Issue #368.2 — Подписка только на новый контент / опция загрузки истории
+  subscribeOnlyNewPlaylistVideos:
+    "Подписаться только на новые видео",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "Существующие видео плейлиста не будут добавлены в очередь. MyTube будет загружать новые обнаруженные видео после создания этой подписки.",
+  downloadExistingPlaylistVideos:
+    "Загрузить существующие видео сейчас",
+  playlistSubscribedNewOnly:
+    "Подписка только на новые видео. Существующие видео не были добавлены в очередь.",
+  playlistDownloadAndSubscriptionStarted:
+    "Загрузка начата, плейлист подписан.",
+  playlistBaselineFailed:
+    "Подписка на плейлист оформлена, но не удалось начать загрузку существующих видео. Новые видео по-прежнему будут загружаться автоматически.",
 
 
   // Instruction Page

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1023,6 +1023,19 @@ export const zh = {
   playlistSubscribedSuccessfully: "成功订阅播放列表",
   downloadAndSubscribe: "下载全部并订阅",
   playlistSubscription: "播放列表",
+  // Issue #368.2 — 仅订阅新内容 / 历史下载选择
+  subscribeOnlyNewPlaylistVideos:
+    "仅订阅新视频",
+  subscribeOnlyNewPlaylistVideosHelp:
+    "不会加入现有播放列表视频。创建此订阅后，MyTube 将下载新检测到的视频。",
+  downloadExistingPlaylistVideos:
+    "立即下载现有视频",
+  playlistSubscribedNewOnly:
+    "已仅订阅新视频。未加入现有视频。",
+  playlistDownloadAndSubscriptionStarted:
+    "下载已开始并已订阅播放列表。",
+  playlistBaselineFailed:
+    "已订阅播放列表，但下载现有视频未能开始。新视频仍会自动下载。",
 
 
   // Instruction Page


### PR DESCRIPTION
## Summary
- add baseline-first playlist subscription creation for YouTube and supported Bilibili sources
- make subscribe-only the default, with an explicit historical-download opt-in
- apply the same baseline safety to channel-playlist bulk creation and watcher-created children
- add accurate backfill status feedback, task ownership, locale copy, and regression coverage

## Why
The prior playlist subscription flow immediately created a historical task and could let the first scheduled check treat existing content as new.

## Impact
Users can now subscribe to future playlist additions without queuing existing videos. Opting into history preserves the existing backfill behavior.

## Root cause
A current playlist head was not consistently captured before subscription persistence across direct, bulk, and watcher flows.

## Validation
- `npm --prefix backend run build`
- `npm --prefix backend test -- --silent --reporter=dot --maxWorkers=4` (2,483 tests)
- `npm --prefix frontend run typecheck`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test -- --silent --reporter=dot --maxWorkers=4` (1,676 tests)

Closes #368.