### PR TITLE
feat: per-subscription filename template override (#368)

### DIFF
--- a/backend/drizzle/0025_subscription_filename_template.sql
+++ b/backend/drizzle/0025_subscription_filename_template.sql
@@ -1,0 +1,2 @@
+/* tsqllint-disable */
+ALTER TABLE `subscriptions` ADD COLUMN `filename_template` text;

--- a/backend/drizzle/meta/0025_snapshot.json
+++ b/backend/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2021 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7ffe4da4-bcdb-496b-ada9-598b76985305",
+  "prevId": "8508fe5f-70c2-4521-9985-3d2da47a2caf",
+  "tables": {
+    "collection_videos": {
+      "name": "collection_videos",
+      "columns": {
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_collection_videos_video_id": {
+          "name": "idx_collection_videos_video_id",
+          "columns": [
+            "video_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "collection_videos_collection_id_collections_id_fk": {
+          "name": "collection_videos_collection_id_collections_id_fk",
+          "tableFrom": "collection_videos",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_videos_video_id_videos_id_fk": {
+          "name": "collection_videos_video_id_videos_id_fk",
+          "tableFrom": "collection_videos",
+          "tableTo": "videos",
+          "columnsFrom": [
+            "video_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collection_videos_collection_id_video_id_pk": {
+          "columns": [
+            "collection_id",
+            "video_id"
+          ],
+          "name": "collection_videos_collection_id_video_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "collections": {
+      "name": "collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_mid": {
+          "name": "source_mid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_collections_name": {
+          "name": "idx_collections_name",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "idx_collections_title": {
+          "name": "idx_collections_title",
+          "columns": [
+            "title"
+          ],
+          "isUnique": false
+        },
+        "idx_collections_source_key": {
+          "name": "idx_collections_source_key",
+          "columns": [
+            "source_platform",
+            "source_type",
+            "source_mid",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "continuous_download_tasks": {
+      "name": "continuous_download_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_url": {
+          "name": "author_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "total_videos": {
+          "name": "total_videos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "downloaded_count": {
+          "name": "downloaded_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_video_index": {
+          "name": "current_video_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_order": {
+          "name": "download_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'dateDesc'"
+        },
+        "frozen_video_list_path": {
+          "name": "frozen_video_list_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_history": {
+      "name": "download_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_size": {
+          "name": "total_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_type": {
+          "name": "download_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_limit": {
+          "name": "retry_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_interval_minutes": {
+          "name": "retry_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_metadata": {
+          "name": "retry_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "download_history_retention_subscription_idx": {
+          "name": "download_history_retention_subscription_idx",
+          "columns": [
+            "subscription_id",
+            "status",
+            "finished_at"
+          ],
+          "isUnique": false
+        },
+        "download_history_retention_video_refs_idx": {
+          "name": "download_history_retention_video_refs_idx",
+          "columns": [
+            "video_id",
+            "status",
+            "subscription_id"
+          ],
+          "isUnique": false
+        },
+        "download_history_statistics_idx": {
+          "name": "download_history_statistics_idx",
+          "columns": [
+            "finished_at",
+            "platform",
+            "source_kind",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "download_history_retry_schedule_idx": {
+          "name": "download_history_retry_schedule_idx",
+          "columns": [
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "download_history_source_url_idx": {
+          "name": "download_history_source_url_idx",
+          "columns": [
+            "source_url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "downloads": {
+      "name": "downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_size": {
+          "name": "total_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "downloaded_size": {
+          "name": "downloaded_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "speed": {
+          "name": "speed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retry_metadata": {
+          "name": "retry_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorite_authors": {
+      "name": "favorite_authors",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_favorite_authors_user": {
+          "name": "idx_favorite_authors_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_favorite_authors_author": {
+          "name": "idx_favorite_authors_author",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "favorite_authors_user_id_author_pk": {
+          "columns": [
+            "user_id",
+            "author"
+          ],
+          "name": "favorite_authors_user_id_author_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "favorite_collections": {
+      "name": "favorite_collections",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_favorite_collections_user": {
+          "name": "idx_favorite_collections_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "favorite_collections_collection_id_collections_id_fk": {
+          "name": "favorite_collections_collection_id_collections_id_fk",
+          "tableFrom": "favorite_collections",
+          "tableTo": "collections",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorite_collections_user_id_collection_id_pk": {
+          "columns": [
+            "user_id",
+            "collection_id"
+          ],
+          "name": "favorite_collections_user_id_collection_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rss_tokens": {
+      "name": "rss_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visitor'"
+        },
+        "filters": {
+          "name": "filters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "access_count": {
+          "name": "access_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "rss_tokens_role_check": {
+          "name": "rss_tokens_role_check",
+          "value": "\"rss_tokens\".\"role\" IN ('admin', 'visitor')"
+        }
+      }
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscriptions": {
+      "name": "subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_url": {
+          "name": "author_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_video_link": {
+          "name": "last_video_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_check": {
+          "name": "last_check",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'YouTube'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "playlist_title": {
+          "name": "playlist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_type": {
+          "name": "subscription_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'author'"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_shorts": {
+          "name": "download_shorts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_short_video_link": {
+          "name": "last_short_video_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitch_broadcaster_id": {
+          "name": "twitch_broadcaster_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitch_broadcaster_login": {
+          "name": "twitch_broadcaster_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_twitch_video_id": {
+          "name": "last_twitch_video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retention_days": {
+          "name": "retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consecutive_failure_count": {
+          "name": "consecutive_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_check_status": {
+          "name": "last_check_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_reason": {
+          "name": "last_failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ytdlp_config": {
+          "name": "ytdlp_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filename_template": {
+          "name": "filename_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_statistics_daily": {
+      "name": "usage_statistics_daily",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dimension_key": {
+          "name": "dimension_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dimension_value": {
+          "name": "dimension_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "dimensions_hash": {
+          "name": "dimensions_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dimensions_json": {
+          "name": "dimensions_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sum": {
+          "name": "sum",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "min": {
+          "name": "min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max": {
+          "name": "max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_usage_statistics_daily_metric_day": {
+          "name": "idx_usage_statistics_daily_metric_day",
+          "columns": [
+            "metric_key",
+            "day"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_statistics_daily_common_dims": {
+          "name": "idx_usage_statistics_daily_common_dims",
+          "columns": [
+            "metric_key",
+            "day",
+            "platform",
+            "actor_role",
+            "source_kind"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "usage_statistics_daily_day_metric_key_dimensions_hash_pk": {
+          "columns": [
+            "day",
+            "metric_key",
+            "dimensions_hash"
+          ],
+          "name": "usage_statistics_daily_day_metric_key_dimensions_hash_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_statistics_events": {
+      "name": "usage_statistics_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_occurred_at": {
+          "name": "client_occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_role": {
+          "name": "actor_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_event_id": {
+          "name": "related_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subscription_id": {
+          "name": "subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rss_token_id": {
+          "name": "rss_token_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "idx_usage_statistics_events_day": {
+          "name": "idx_usage_statistics_events_day",
+          "columns": [
+            "day",
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_statistics_events_recorded_at": {
+          "name": "idx_usage_statistics_events_recorded_at",
+          "columns": [
+            "recorded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_statistics_events_video": {
+          "name": "idx_usage_statistics_events_video",
+          "columns": [
+            "video_id",
+            "event_type",
+            "recorded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_statistics_events_subscription": {
+          "name": "idx_usage_statistics_events_subscription",
+          "columns": [
+            "subscription_id",
+            "event_type",
+            "recorded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_usage_statistics_events_related": {
+          "name": "idx_usage_statistics_events_related",
+          "columns": [
+            "related_event_id",
+            "event_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_statistics_ingestion_minutes": {
+      "name": "usage_statistics_ingestion_minutes",
+      "columns": {
+        "minute_bucket": {
+          "name": "minute_bucket",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_count": {
+          "name": "accepted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "dropped_count": {
+          "name": "dropped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sealed_day_drop_count": {
+          "name": "sealed_day_drop_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "usage_statistics_rollup_days": {
+      "name": "usage_statistics_rollup_days",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dirty": {
+          "name": "dirty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sealed": {
+          "name": "sealed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_recorded_at": {
+          "name": "last_event_recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rolled_up_at": {
+          "name": "last_rolled_up_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visitor'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_legacy_shared": {
+          "name": "is_legacy_shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "session_version": {
+          "name": "session_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_username_lower_uidx": {
+          "name": "users_username_lower_uidx",
+          "columns": [
+            "lower(\"username\")"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"users\".\"role\" IN ('visitor')"
+        }
+      }
+    },
+    "video_downloads": {
+      "name": "video_downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_video_id": {
+          "name": "source_video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'video'"
+        },
+        "video_id": {
+          "name": "video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'exists'"
+        },
+        "downloaded_at": {
+          "name": "downloaded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "video_downloads_source_video_id_platform_media_type_uidx": {
+          "name": "video_downloads_source_video_id_platform_media_type_uidx",
+          "columns": [
+            "source_video_id",
+            "platform",
+            "media_type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "videos": {
+      "name": "videos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_filename": {
+          "name": "video_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_filename": {
+          "name": "thumbnail_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "part_number": {
+          "name": "part_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_parts": {
+          "name": "total_parts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_title": {
+          "name": "series_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_updated_at": {
+          "name": "progress_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subtitles": {
+          "name": "subtitles",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_url": {
+          "name": "channel_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "author_avatar_filename": {
+          "name": "author_avatar_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_avatar_path": {
+          "name": "author_avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'video'"
+        }
+      },
+      "indexes": {
+        "idx_videos_source_url": {
+          "name": "idx_videos_source_url",
+          "columns": [
+            "source_url"
+          ],
+          "isUnique": false
+        },
+        "idx_videos_created_at": {
+          "name": "idx_videos_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_videos_visibility": {
+          "name": "idx_videos_visibility",
+          "columns": [
+            "visibility"
+          ],
+          "isUnique": false
+        },
+        "idx_videos_author": {
+          "name": "idx_videos_author",
+          "columns": [
+            "author"
+          ],
+          "isUnique": false
+        },
+        "idx_videos_channel_url": {
+          "name": "idx_videos_channel_url",
+          "columns": [
+            "channel_url"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "users_username_lower_uidx": {
+        "columns": {
+          "lower(\"username\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1783898448220,
       "tag": "0024_subscription_ytdlp_config",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1784232552045,
+      "tag": "0025_subscription_filename_template",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -1508,6 +1508,52 @@ describe("SubscriptionController", () => {
       );
     });
 
+    it("updates existing bulk playlist filenameTemplate when backfill is not requested", async () => {
+      const filenameTemplate = "{{ source_custom_name }}/{{ title }}.{{ ext }}";
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        filenameTemplate,
+      };
+      (executeYtDlpJson as any).mockResolvedValueOnce({
+        uploader: "My Channel",
+        entries: [
+          {
+            id: "PL_EXISTING",
+            url: "https://www.youtube.com/playlist?list=PL_EXISTING",
+            title: "Existing Playlist",
+          },
+        ],
+      });
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        {
+          id: "existing-sub",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_EXISTING",
+          collectionId: "existing-col",
+          filenameTemplate: null,
+        },
+      ]);
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "existing-sub",
+        { filenameTemplate }
+      );
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(continuousDownloadService.createPlaylistTask).not.toHaveBeenCalled();
+      expect(subscriptionService.subscribeChannelPlaylistsWatcher).toHaveBeenCalledWith(
+        "https://www.youtube.com/@channel/playlists",
+        60,
+        "My Channel",
+        "YouTube",
+        filenameTemplate
+      );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ subscribedCount: 0, skippedCount: 1 })
+      );
+    });
+
     it("creates a backfill task for an already subscribed playlist when requested", async () => {
       req.body = {
         url: "https://www.youtube.com/@channel",
@@ -1565,6 +1611,138 @@ describe("SubscriptionController", () => {
         "https://www.youtube.com/watch?v=existingHead",
         expect.any(Number)
       );
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ subscribedCount: 0, skippedCount: 1 })
+      );
+    });
+
+    it("updates existing bulk playlist filenameTemplate before linked backfill", async () => {
+      const filenameTemplate = "{{ source_custom_name }}/{{ title }}.{{ ext }}";
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        downloadAllPrevious: true,
+        filenameTemplate,
+      };
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            {
+              id: "PL_EXISTING",
+              url: "https://www.youtube.com/playlist?list=PL_EXISTING",
+              title: "Existing Playlist",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "existingHead" }],
+        });
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        {
+          id: "existing-sub",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_EXISTING",
+          collectionId: "existing-col",
+          filenameTemplate: null,
+        },
+      ]);
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "backfill-task",
+      });
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "existing-sub",
+        { filenameTemplate }
+      );
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_EXISTING",
+        "My Channel",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      const updateOrder = (
+        subscriptionService.updateSubscriptionSettings as Mock
+      ).mock.invocationCallOrder[0];
+      const createTaskOrder = (
+        continuousDownloadService.createPlaylistTask as Mock
+      ).mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(createTaskOrder);
+    });
+
+    it("updates concurrently discovered duplicate playlist filenameTemplate before backfill", async () => {
+      const filenameTemplate = "{{ source_custom_name }}/{{ title }}.{{ ext }}";
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        downloadAllPrevious: true,
+        filenameTemplate,
+      };
+      (executeYtDlpJson as any)
+        .mockResolvedValueOnce({
+          uploader: "My Channel",
+          entries: [
+            {
+              id: "PL_RACE",
+              url: "https://www.youtube.com/playlist?list=PL_RACE",
+              title: "Raced Playlist",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          _type: "playlist",
+          entries: [{ id: "racedHead" }],
+        });
+      (subscriptionService.listSubscriptions as any)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: "concurrent-sub",
+            authorUrl: "https://www.youtube.com/playlist?list=PL_RACE",
+            collectionId: "concurrent-col",
+            filenameTemplate: null,
+          },
+        ]);
+      (storageService.getCollectionByName as any).mockReturnValue({
+        id: "request-col",
+        name: "Raced Playlist - My Channel",
+      });
+      const duplicate = new Error("already subscribed");
+      duplicate.name = "DuplicateError";
+      (subscriptionService.subscribePlaylist as any).mockRejectedValue(duplicate);
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "raced-backfill-task",
+      });
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "concurrent-sub",
+        { filenameTemplate }
+      );
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_RACE",
+        "My Channel",
+        "YouTube",
+        "concurrent-col",
+        "concurrent-sub"
+      );
+      const updateOrder = (
+        subscriptionService.updateSubscriptionSettings as Mock
+      ).mock.invocationCallOrder[0];
+      const createTaskOrder = (
+        continuousDownloadService.createPlaylistTask as Mock
+      ).mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(createTaskOrder);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ subscribedCount: 0, skippedCount: 1 })
       );

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -974,6 +974,7 @@ describe("SubscriptionController", () => {
         authorUrl: "https://www.youtube.com/playlist?list=PL123",
         collectionId: "existing-col",
         ytdlpConfig: "--cookies /config/cookies.txt",
+        filenameTemplate: "{{ source_custom_name }}/{{ title }}.{{ ext }}",
       };
       (subscriptionService.listSubscriptions as any).mockResolvedValue([
         existingSubscription,
@@ -999,6 +1000,7 @@ describe("SubscriptionController", () => {
       await createPlaylistSubscription(req as Request, res as Response);
 
       expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(subscriptionService.updateSubscriptionSettings).not.toHaveBeenCalled();
       expect(storageService.getCollectionByName).not.toHaveBeenCalled();
       expect(getEffectiveUserYtDlpConfig).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL123",
@@ -1036,6 +1038,76 @@ describe("SubscriptionController", () => {
           collectionId: "existing-col",
           taskId: "task-existing",
           downloadAll: true,
+          backfillStatus: "started",
+        })
+      );
+    });
+
+    it("updates an existing duplicate playlist filenameTemplate before backfill", async () => {
+      const filenameTemplate = "{{ source_custom_name }}/{{ title }}.{{ ext }}";
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        downloadAll: true,
+        filenameTemplate,
+      };
+      const existingSubscription = {
+        id: "existing-sub",
+        authorUrl: "https://www.youtube.com/playlist?list=PL123",
+        collectionId: "existing-col",
+        filenameTemplate: null,
+      };
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        existingSubscription,
+      ]);
+      (executeYtDlpJson as any).mockResolvedValue({
+        _type: "playlist",
+        title: "Playlist Title",
+        id: "PL123",
+        playlist_count: 12,
+        entries: [{ id: "vidA", uploader: "Uploader Name" }],
+      });
+      (storageService.getCollectionById as any).mockReturnValue({
+        id: "existing-col",
+        name: "My Playlist",
+      });
+      (
+        continuousDownloadService.getBlockingPlaylistTaskByDestination as any
+      ).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "task-existing",
+      });
+
+      await createPlaylistSubscription(req as Request, res as Response);
+
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "existing-sub",
+        { filenameTemplate }
+      );
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        "Uploader Name",
+        "YouTube",
+        "existing-col",
+        "existing-sub"
+      );
+      const updateOrder = (
+        subscriptionService.updateSubscriptionSettings as Mock
+      ).mock.invocationCallOrder[0];
+      const createTaskOrder = (
+        continuousDownloadService.createPlaylistTask as Mock
+      ).mock.invocationCallOrder[0];
+      expect(updateOrder).toBeLessThan(createTaskOrder);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscription: expect.objectContaining({
+            id: "existing-sub",
+            filenameTemplate,
+            lastVideoLink: "https://www.youtube.com/watch?v=vidA",
+            lastCheck: expect.any(Number),
+          }),
+          taskId: "task-existing",
           backfillStatus: "started",
         })
       );

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -817,11 +817,23 @@ describe("SubscriptionController", () => {
 
       expect(subscriptionService.subscribeChannelPlaylistsWatcher).toHaveBeenCalledWith(
         "https://www.youtube.com/@channel/playlists", 60, "My Channel", "YouTube",
-        null
+        undefined
       );
       expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ subscribedCount: 1, skippedCount: 1, errorCount: 0 })
+      );
+    });
+
+    it("should pass null to the watcher when filenameTemplate is explicitly cleared", async () => {
+      setupChannelPlaylistsMocks();
+      req.body.filenameTemplate = "   ";
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.subscribeChannelPlaylistsWatcher).toHaveBeenCalledWith(
+        "https://www.youtube.com/@channel/playlists", 60, "My Channel", "YouTube",
+        null
       );
     });
 

--- a/backend/src/__tests__/controllers/subscriptionController.test.ts
+++ b/backend/src/__tests__/controllers/subscriptionController.test.ts
@@ -18,7 +18,7 @@ import {
     subscribeChannelPlaylists,
     updateSubscription,
 } from "../../controllers/subscriptionController";
-import { ValidationError } from "../../errors/DownloadErrors";
+import { NotFoundError, ValidationError } from "../../errors/DownloadErrors";
 import { continuousDownloadService } from "../../services/continuousDownloadService";
 import { checkPlaylist } from "../../services/downloadService";
 import * as storageService from "../../services/storageService";
@@ -132,6 +132,7 @@ describe("SubscriptionController", () => {
         60,
         undefined,
         true,
+        null,
         null
       );
       expect(status).toHaveBeenCalledWith(201);
@@ -624,7 +625,8 @@ describe("SubscriptionController", () => {
         "PL123",
         "Uploader Name",
         "YouTube",
-        expect.any(String)
+        expect.any(String),
+        null
       );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalled();
       expect(status).toHaveBeenCalledWith(201);
@@ -667,7 +669,8 @@ describe("SubscriptionController", () => {
         "9988",
         "UP Name",
         "Bilibili",
-        "existing-col"
+        "existing-col",
+        null
       );
     });
 
@@ -697,7 +700,8 @@ describe("SubscriptionController", () => {
         "PL123",
         "Playlist Author",
         "YouTube",
-        expect.any(String)
+        expect.any(String),
+        null
       );
     });
 
@@ -770,8 +774,14 @@ describe("SubscriptionController", () => {
       (subscriptionService.listSubscriptions as any)
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([
-          { authorUrl: "https://www.youtube.com/playlist?list=PL_TWO" },
+          {
+            id: "existing-sub-2",
+            authorUrl: "https://www.youtube.com/playlist?list=PL_TWO",
+          },
         ]);
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "created-sub-1",
+      });
       (continuousDownloadService.getTaskByAuthorUrl as any)
         .mockResolvedValueOnce(null)
         .mockResolvedValueOnce({ id: "existing-task" });
@@ -788,9 +798,17 @@ describe("SubscriptionController", () => {
       expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
         "https://www.youtube.com/playlist?list=PL_ONE",
         60, "Playlist One", "PL_ONE", "My Channel", "YouTube",
-        expect.any(String)
+        expect.any(String),
+        null
       );
       expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledTimes(1);
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_ONE",
+        "My Channel",
+        "YouTube",
+        expect.any(String),
+        "created-sub-1"
+      );
     });
 
     it("should create watcher and respond with counts", async () => {
@@ -798,11 +816,54 @@ describe("SubscriptionController", () => {
       await subscribeChannelPlaylists(req as Request, res as Response);
 
       expect(subscriptionService.subscribeChannelPlaylistsWatcher).toHaveBeenCalledWith(
-        "https://www.youtube.com/@channel/playlists", 60, "My Channel", "YouTube"
+        "https://www.youtube.com/@channel/playlists", 60, "My Channel", "YouTube",
+        null
       );
       expect(status).toHaveBeenCalledWith(201);
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({ subscribedCount: 1, skippedCount: 1, errorCount: 0 })
+      );
+    });
+
+    it("links an existing playlist subscription to its historical task", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@channel",
+        interval: 60,
+        downloadAllPrevious: true,
+      };
+      (executeYtDlpJson as any).mockResolvedValue({
+        uploader: "My Channel",
+        entries: [
+          {
+            id: "PL_EXISTING",
+            url: "https://www.youtube.com/playlist?list=PL_EXISTING",
+            title: "Existing Playlist",
+          },
+        ],
+      });
+      (subscriptionService.listSubscriptions as any).mockResolvedValue([
+        {
+          id: "existing-subscription",
+          authorUrl: "https://www.youtube.com/playlist?list=PL_EXISTING",
+        },
+      ]);
+      (continuousDownloadService.getTaskByAuthorUrl as any).mockResolvedValue(null);
+      (continuousDownloadService.createPlaylistTask as any).mockResolvedValue({
+        id: "created-task",
+      });
+      (subscriptionService.subscribeChannelPlaylistsWatcher as any).mockResolvedValue({
+        id: "watcher-1",
+      });
+
+      await subscribeChannelPlaylists(req as Request, res as Response);
+
+      expect(subscriptionService.subscribePlaylist).not.toHaveBeenCalled();
+      expect(continuousDownloadService.createPlaylistTask).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL_EXISTING",
+        "My Channel",
+        "YouTube",
+        expect.any(String),
+        "existing-subscription"
       );
     });
 
@@ -826,7 +887,8 @@ describe("SubscriptionController", () => {
         "PL1",
         "@MyChannel",
         "YouTube",
-        expect.any(String)
+        expect.any(String),
+        null
       );
       expect(storageService.saveCollection).toHaveBeenCalled();
     });
@@ -919,5 +981,126 @@ describe("SubscriptionController", () => {
   it("should keep utility mocks wired for network config helpers", () => {
     expect(getUserYtDlpConfig).toBeDefined();
     expect(getNetworkConfigFromUserConfig).toBeDefined();
+  });
+
+  describe("filename template override", () => {
+    it("createSubscription passes filenameTemplate to subscribe", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@testuser/",
+        interval: 60,
+        filenameTemplate: "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+      };
+      (subscriptionService.subscribe as any).mockResolvedValue({
+        id: "sub-123",
+        author: "@testuser",
+        platform: "YouTube",
+      });
+      await createSubscription(req as Request, res as Response);
+      expect(subscriptionService.subscribe).toHaveBeenCalledWith(
+        "https://www.youtube.com/@testuser",
+        60,
+        undefined,
+        false,
+        null,
+        "{{ source_custom_name }}/{{ title }}.{{ ext }}"
+      );
+    });
+
+    it("createSubscription rejects an invalid filenameTemplate", async () => {
+      req.body = {
+        url: "https://www.youtube.com/@testuser/",
+        interval: 60,
+        filenameTemplate: "../escape.{{ ext }}",
+      };
+      (subscriptionService.subscribe as any).mockResolvedValue({
+        id: "sub-123",
+        author: "@testuser",
+        platform: "YouTube",
+      });
+      await expect(createSubscription(req as Request, res as Response)).rejects.toThrow(
+        ValidationError
+      );
+      expect(subscriptionService.subscribe).not.toHaveBeenCalled();
+    });
+
+    it("createPlaylistSubscription passes filenameTemplate to subscribePlaylist", async () => {
+      req.body = {
+        playlistUrl: "https://www.youtube.com/playlist?list=PL123",
+        interval: 60,
+        collectionName: "My Playlist",
+        filenameTemplate: "{{ title }}.{{ ext }}",
+      };
+      (checkPlaylist as any).mockResolvedValue({ success: true, title: "My Playlist", videoCount: 5 });
+      (subscriptionService.subscribePlaylist as any).mockResolvedValue({
+        id: "sub-playlist-1",
+        author: "My Playlist - author",
+        platform: "YouTube",
+      });
+      await createPlaylistSubscription(req as Request, res as Response);
+      expect(subscriptionService.subscribePlaylist).toHaveBeenCalledWith(
+        "https://www.youtube.com/playlist?list=PL123",
+        60,
+        "My Playlist",
+        "PL123",
+        expect.any(String),
+        "YouTube",
+        expect.any(String),
+        "{{ title }}.{{ ext }}"
+      );
+    });
+
+    it("updateSubscription persists a valid filenameTemplate", async () => {
+      req.params = { id: "sub-123" };
+      req.body = { filenameTemplate: "{{ title }}.{{ ext }}" };
+      (subscriptionService.getSubscriptionById as any).mockResolvedValue({
+        id: "sub-123",
+        subscriptionType: "author",
+        filenameTemplate: null,
+      });
+      await updateSubscription(req as Request, res as Response);
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "sub-123",
+        { filenameTemplate: "{{ title }}.{{ ext }}" }
+      );
+    });
+
+    it("updateSubscription clears filenameTemplate to null", async () => {
+      req.params = { id: "sub-123" };
+      req.body = { filenameTemplate: "   " };
+      (subscriptionService.getSubscriptionById as any).mockResolvedValue({
+        id: "sub-123",
+        subscriptionType: "author",
+        filenameTemplate: "{{ title }}.{{ ext }}",
+      });
+      await updateSubscription(req as Request, res as Response);
+      expect(subscriptionService.updateSubscriptionSettings).toHaveBeenCalledWith(
+        "sub-123",
+        { filenameTemplate: null }
+      );
+    });
+
+    it("updateSubscription rejects an invalid filenameTemplate", async () => {
+      req.params = { id: "sub-123" };
+      req.body = { filenameTemplate: "no-extension-placeholder" };
+      (subscriptionService.getSubscriptionById as any).mockResolvedValue({
+        id: "sub-123",
+        subscriptionType: "author",
+        filenameTemplate: null,
+      });
+      await expect(updateSubscription(req as Request, res as Response)).rejects.toThrow(
+        ValidationError
+      );
+      expect(subscriptionService.updateSubscriptionSettings).not.toHaveBeenCalled();
+    });
+
+    it("updateSubscription keeps the normal not-found error for overrides", async () => {
+      req.params = { id: "missing-subscription" };
+      req.body = { filenameTemplate: "{{ title }}.{{ ext }}" };
+      (subscriptionService.getSubscriptionById as any).mockResolvedValue(null);
+
+      await expect(
+        updateSubscription(req as Request, res as Response)
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
   });
 });

--- a/backend/src/__tests__/services/continuousDownload/taskProcessor.test.ts
+++ b/backend/src/__tests__/services/continuousDownload/taskProcessor.test.ts
@@ -204,6 +204,102 @@ describe('TaskProcessor', () => {
     );
   });
 
+  it('passes filenameTemplate only for exactly linked subscription tasks', async () => {
+    const filenameTemplate = '{{ source_custom_name }}/{{ title }}.{{ ext }}';
+    const playlistTask: ContinuousDownloadTask = {
+      ...mockTask,
+      authorUrl: 'https://youtube.com/playlist?list=PL123',
+      collectionId: 'col-1',
+      playlistName: 'Travel Playlist - Test Author',
+      subscriptionId: 'sub-1',
+      totalVideos: 1,
+    };
+    mockTaskRepository.getSubscriptionForTask.mockResolvedValue({
+      id: 'sub-1',
+      author: 'Renamed Subscription Label',
+      authorUrl: playlistTask.authorUrl,
+      interval: 60,
+      downloadCount: 0,
+      createdAt: Date.now(),
+      platform: 'YouTube',
+      playlistId: 'PL123',
+      playlistTitle: 'Travel Playlist',
+      channelName: 'Test Author',
+      subscriptionType: 'playlist',
+      collectionId: 'col-1',
+      filenameTemplate,
+    });
+    (storageService.getVideoBySourceUrl as any).mockReturnValue(null);
+    (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+      videoData: {
+        id: 'v1',
+        title: 'Video 1',
+        videoPath: '/videos/Test Author/Travel Playlist/Video 1.mp4',
+        thumbnailPath: '/videos/Test Author/Travel Playlist/Video 1.jpg',
+      },
+    });
+
+    await taskProcessor.processTask(playlistTask, ['http://vid1']);
+
+    expect(downloadService.downloadYouTubeVideo).toHaveBeenCalledWith(
+      'http://vid1',
+      expect.objectContaining({
+        subscriptionFilenameTemplate: filenameTemplate,
+      })
+    );
+  });
+
+  it('does not apply fallback subscription filenameTemplate to standalone playlist tasks', async () => {
+    const playlistTask: ContinuousDownloadTask = {
+      ...mockTask,
+      authorUrl: 'https://youtube.com/playlist?list=PL123',
+      collectionId: 'col-1',
+      playlistName: 'Travel Playlist - Test Author',
+      totalVideos: 1,
+    };
+    mockTaskRepository.getSubscriptionForTask.mockResolvedValue({
+      id: 'sub-1',
+      author: 'Renamed Subscription Label',
+      authorUrl: playlistTask.authorUrl,
+      interval: 60,
+      downloadCount: 0,
+      createdAt: Date.now(),
+      platform: 'YouTube',
+      playlistId: 'PL123',
+      playlistTitle: 'Travel Playlist',
+      channelName: 'Test Author',
+      subscriptionType: 'playlist',
+      collectionId: 'col-1',
+      ytdlpConfig: '--cookies /tmp/cookies.txt',
+      filenameTemplate: '{{ source_custom_name }}/{{ title }}.{{ ext }}',
+    });
+    (storageService.getVideoBySourceUrl as any).mockReturnValue(null);
+    (downloadService.downloadYouTubeVideo as any).mockResolvedValue({
+      videoData: {
+        id: 'v1',
+        title: 'Video 1',
+        videoPath: '/videos/Test Author/Travel Playlist/Video 1.mp4',
+        thumbnailPath: '/videos/Test Author/Travel Playlist/Video 1.jpg',
+      },
+    });
+
+    await taskProcessor.processTask(playlistTask, ['http://vid1']);
+
+    expect(downloadService.downloadYouTubeVideo).toHaveBeenCalledWith(
+      'http://vid1',
+      expect.objectContaining({
+        subscriptionYtdlpConfig: '--cookies /tmp/cookies.txt',
+        subscriptionFilenameTemplate: null,
+        filenameTemplateSourceOptions: expect.objectContaining({
+          sourceCustomName: 'Test Author',
+          sourceCollectionName: 'Travel Playlist',
+          sourceCollectionId: 'PL123',
+          sourceCollectionType: 'playlist',
+        }),
+      })
+    );
+  });
+
   it('uses the channel subscription source options for Shorts bulk tasks', async () => {
     // Shorts tasks are created with author "<channel> (Shorts)" and a /shorts
     // authorUrl; resolving the owning subscription must give them the same

--- a/backend/src/__tests__/services/filenameTemplate/config.test.ts
+++ b/backend/src/__tests__/services/filenameTemplate/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applySubscriptionFilenameTemplateOverride,
   normalizeFilenameNamingSettings,
   resolveFilenameNamingConfig,
 } from "../../../services/filenameTemplate/config";
@@ -62,5 +63,80 @@ describe("filenameTemplate config resolver", () => {
     ).toEqual({
       downloadFilenameMode: "legacy",
     });
+  });
+});
+
+describe("applySubscriptionFilenameTemplateOverride", () => {
+  const globalSettings = {
+    downloadFilenameMode: "legacy" as const,
+    downloadFilenamePresetId: "legacy",
+    downloadFilenameTemplate: "{{ title }}-{{ uploader }}-{{ upload_year }}.{{ ext }}",
+    moveThumbnailsToVideoFolder: true,
+    moveSubtitlesToVideoFolder: false,
+    authorOrganizationMode: "flat" as const,
+  };
+
+  it("returns the original object unchanged when no override is present", () => {
+    expect(applySubscriptionFilenameTemplateOverride(globalSettings, null)).toBe(
+      globalSettings
+    );
+    expect(
+      applySubscriptionFilenameTemplateOverride(globalSettings, undefined)
+    ).toBe(globalSettings);
+    expect(applySubscriptionFilenameTemplateOverride(globalSettings, "")).toBe(
+      globalSettings
+    );
+    expect(applySubscriptionFilenameTemplateOverride(globalSettings, "  \t\n")).toBe(
+      globalSettings
+    );
+  });
+
+  it("forces template mode with the subscription template when an override is set", () => {
+    const result = applySubscriptionFilenameTemplateOverride(
+      globalSettings,
+      "{{ source_custom_name }}/{{ title }}.{{ ext }}"
+    );
+    expect(result).not.toBe(globalSettings);
+    expect(result.downloadFilenameMode).toBe("template");
+    expect(result.downloadFilenameTemplate).toBe(
+      "{{ source_custom_name }}/{{ title }}.{{ ext }}"
+    );
+    expect(result.downloadFilenamePresetId).not.toBe("legacy");
+  });
+
+  it("preserves unrelated settings such as thumbnail/subtitle placement", () => {
+    const result = applySubscriptionFilenameTemplateOverride(
+      globalSettings,
+      "{{ title }}.{{ ext }}"
+    );
+    expect(result.moveThumbnailsToVideoFolder).toBe(true);
+    expect(result.moveSubtitlesToVideoFolder).toBe(false);
+    expect(result.authorOrganizationMode).toBe("flat");
+  });
+
+  it("replaces a global template with a different subscription template", () => {
+    const templateGlobal = {
+      ...globalSettings,
+      downloadFilenameMode: "template" as const,
+      downloadFilenamePresetId: "media_center_date_index",
+      downloadFilenameTemplate:
+        "{{ source_custom_name }}/{{ upload_year }}/{{ upload_date }} - {{ title }}.{{ ext }}",
+    };
+    const result = applySubscriptionFilenameTemplateOverride(
+      templateGlobal,
+      "{{ source_custom_name }}/{{ title }}.{{ ext }}"
+    );
+    expect(result.downloadFilenameMode).toBe("template");
+    expect(result.downloadFilenameTemplate).toBe(
+      "{{ source_custom_name }}/{{ title }}.{{ ext }}"
+    );
+  });
+
+  it("derives a coherent preset id (or custom) for a preset-matching template", () => {
+    const result = applySubscriptionFilenameTemplateOverride(
+      globalSettings,
+      "{{ source_collection_name }}/{{ season_by_year__episode_by_date_and_index }} - {{ title }}.{{ ext }}"
+    );
+    expect(result.downloadFilenamePresetId).toBe("channel_year_date_index");
   });
 });

--- a/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
+++ b/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
@@ -83,6 +83,7 @@ describe("subscription channelPlaylists", () => {
       "ChannelName",
       "YouTube",
       expect.any(String),
+      null,
     );
   });
 

--- a/backend/src/__tests__/services/subscription/filenameTemplate.test.ts
+++ b/backend/src/__tests__/services/subscription/filenameTemplate.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSubscriptionFilenameTemplate } from "../../../services/subscription/filenameTemplate";
+import { ValidationError } from "../../../errors/DownloadErrors";
+
+describe("normalizeSubscriptionFilenameTemplate", () => {
+  it("returns null for null/undefined/empty/whitespace input", () => {
+    expect(normalizeSubscriptionFilenameTemplate(null)).toBeNull();
+    expect(normalizeSubscriptionFilenameTemplate(undefined)).toBeNull();
+    expect(normalizeSubscriptionFilenameTemplate("")).toBeNull();
+    expect(normalizeSubscriptionFilenameTemplate("   ")).toBeNull();
+    expect(normalizeSubscriptionFilenameTemplate("\t\n")).toBeNull();
+  });
+
+  it("accepts a valid Liquid-style template and trims it", () => {
+    expect(
+      normalizeSubscriptionFilenameTemplate(
+        "  {{ source_custom_name }}/{{ title }}.{{ ext }}  "
+      )
+    ).toBe("{{ source_custom_name }}/{{ title }}.{{ ext }}");
+  });
+
+  it("accepts a valid yt-dlp-style template", () => {
+    expect(
+      normalizeSubscriptionFilenameTemplate("%(title)s.%(ext)s")
+    ).toBe("%(title)s.%(ext)s");
+  });
+
+  it("rejects wrong types with a ValidationError on filenameTemplate", () => {
+    for (const bad of [42, {}, [], true]) {
+      expect(() => normalizeSubscriptionFilenameTemplate(bad)).toThrow(
+        ValidationError
+      );
+      try {
+        normalizeSubscriptionFilenameTemplate(bad);
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect((error as ValidationError).field).toBe("filenameTemplate");
+      }
+    }
+  });
+
+  it("rejects a template with path traversal segments", () => {
+    expect(() =>
+      normalizeSubscriptionFilenameTemplate("../{{ title }}.{{ ext }}")
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects a template missing the final extension placeholder", () => {
+    expect(() =>
+      normalizeSubscriptionFilenameTemplate("{{ source_custom_name }}/{{ title }}")
+    ).toThrow(ValidationError);
+  });
+
+  it("rejects an over-length template (2,000+ characters)", () => {
+    const tooLong = "{{ title }}" + "x".repeat(2000) + ".{{ ext }}";
+    expect(() => normalizeSubscriptionFilenameTemplate(tooLong)).toThrow(
+      ValidationError
+    );
+  });
+
+  it("attaches filenameTemplate field to validation errors", () => {
+    try {
+      normalizeSubscriptionFilenameTemplate("{{ title }}");
+      throw new Error("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ValidationError);
+      expect((error as ValidationError).field).toBe("filenameTemplate");
+    }
+  });
+});

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -542,7 +542,7 @@ describe('SubscriptionService', () => {
         id: 'existing-watcher',
         author: 'Channel',
         authorUrl: 'https://youtube.com/@channel/playlists',
-        filenameTemplate: null,
+        filenameTemplate: '{{ source_custom_name }}/{{ title }}.{{ ext }}',
       };
       mockBuilder.then = (cb: any) => Promise.resolve([existing]).then(cb);
 
@@ -556,6 +556,32 @@ describe('SubscriptionService', () => {
       expect(result).toEqual(existing);
       expect(db.insert).not.toHaveBeenCalled();
       expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('should clear an existing channel watcher filename template when null is provided', async () => {
+      const existing = {
+        id: 'existing-watcher',
+        author: 'Channel',
+        authorUrl: 'https://youtube.com/@channel/playlists',
+        filenameTemplate: '{{ source_custom_name }}/{{ title }}.{{ ext }}',
+      };
+      mockBuilder.then = (cb: any) => Promise.resolve([existing]).then(cb);
+
+      const result = await subscriptionService.subscribeChannelPlaylistsWatcher(
+        'https://youtube.com/@channel/playlists',
+        120,
+        'Channel',
+        'YouTube',
+        null
+      );
+
+      expect(result).toEqual({
+        ...existing,
+        filenameTemplate: null,
+      });
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).toHaveBeenCalled();
+      expect(mockBuilder.set).toHaveBeenCalledWith({ filenameTemplate: null });
     });
 
     it('should update an existing channel watcher filename template when provided', async () => {

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -506,7 +506,8 @@ describe('SubscriptionService', () => {
         'pl-1',             // playlistId
         'User',             // channelName
         'YouTube',          // platform
-        expect.any(String)  // playlist watchers always create a collection now
+        expect.any(String), // playlist watchers always create a collection now
+        null                // watcher filenameTemplate override (issue #368)
       );
 
       expect(storageService.saveCollection).toHaveBeenCalled();
@@ -944,7 +945,8 @@ describe('SubscriptionService', () => {
         'PL123',
         'Watcher Name',
         'YouTube',
-        expect.any(String)
+        expect.any(String),
+        null
       );
       subscribeSpy.mockRestore();
     });

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -542,6 +542,7 @@ describe('SubscriptionService', () => {
         id: 'existing-watcher',
         author: 'Channel',
         authorUrl: 'https://youtube.com/@channel/playlists',
+        filenameTemplate: null,
       };
       mockBuilder.then = (cb: any) => Promise.resolve([existing]).then(cb);
 
@@ -554,6 +555,34 @@ describe('SubscriptionService', () => {
 
       expect(result).toEqual(existing);
       expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('should update an existing channel watcher filename template when provided', async () => {
+      const existing = {
+        id: 'existing-watcher',
+        author: 'Channel',
+        authorUrl: 'https://youtube.com/@channel/playlists',
+        filenameTemplate: null,
+      };
+      const filenameTemplate = '{{ source_custom_name }}/{{ title }}.{{ ext }}';
+      mockBuilder.then = (cb: any) => Promise.resolve([existing]).then(cb);
+
+      const result = await subscriptionService.subscribeChannelPlaylistsWatcher(
+        'https://youtube.com/@channel/playlists',
+        120,
+        'Channel',
+        'YouTube',
+        filenameTemplate
+      );
+
+      expect(result).toEqual({
+        ...existing,
+        filenameTemplate,
+      });
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).toHaveBeenCalled();
+      expect(mockBuilder.set).toHaveBeenCalledWith({ filenameTemplate });
     });
 
     it('should create channel watcher subscription when missing', async () => {

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -665,10 +665,19 @@ export const subscribeChannelPlaylists = async (
   // new playlist subscription created in this request and to the watcher. Uses
   // the "playlist" source-collection type because the watcher copies its
   // template to child playlists.
-  const filenameTemplate = normalizeSubscriptionFilenameTemplate(
-    req.body.filenameTemplate,
-    "playlist"
+  const hasFilenameTemplate = Object.prototype.hasOwnProperty.call(
+    req.body,
+    "filenameTemplate"
   );
+  const filenameTemplate = hasFilenameTemplate
+    ? normalizeSubscriptionFilenameTemplate(
+        req.body.filenameTemplate,
+        "playlist"
+      )
+    : null;
+  const watcherFilenameTemplate = hasFilenameTemplate
+    ? filenameTemplate
+    : undefined;
 
   // Adjust URL to ensure we target playlists tab
   const targetUrl = toPlaylistsTabUrl(url);
@@ -840,7 +849,7 @@ export const subscribeChannelPlaylists = async (
       parseInt(interval),
       channelName,
       platform,
-      filenameTemplate
+      watcherFilenameTemplate
     );
     logger.info("Created channel playlists watcher", {
       subscriptionId: watcher.id,

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -696,11 +696,16 @@ export const createPlaylistSubscription = async (
   });
 
   // Per-subscription filename-template override (issue #368). Playlists use the
-  // "playlist" source-collection type for validation warnings.
-  const filenameTemplate = normalizeSubscriptionFilenameTemplate(
-    req.body.filenameTemplate,
-    "playlist"
+  // "playlist" source-collection type for validation warnings. Keep omitted
+  // distinct from explicit blank/null so duplicate backfill requests do not
+  // accidentally clear an existing subscription override.
+  const hasFilenameTemplate = Object.prototype.hasOwnProperty.call(
+    req.body,
+    "filenameTemplate"
   );
+  const filenameTemplate = hasFilenameTemplate
+    ? normalizeSubscriptionFilenameTemplate(req.body.filenameTemplate, "playlist")
+    : null;
 
   // 2. Detect platform and playlist ID.
   const isBilibili = isBilibiliUrl(playlistUrl);
@@ -849,6 +854,16 @@ export const createPlaylistSubscription = async (
       }
       throw error;
     }
+  }
+  if (
+    subscription &&
+    hasFilenameTemplate &&
+    (subscription.filenameTemplate ?? null) !== filenameTemplate
+  ) {
+    await subscriptionService.updateSubscriptionSettings(subscription.id, {
+      filenameTemplate,
+    });
+    subscription = { ...subscription, filenameTemplate };
   }
   if (!subscription) {
     try {

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -4,7 +4,7 @@ import {
     isAdminTrustLevelAtLeast,
 } from "../config/adminTrust";
 import { getErrorMessage } from "../utils/errors";
-import { ValidationError } from "../errors/DownloadErrors";
+import { NotFoundError, ValidationError } from "../errors/DownloadErrors";
 import { continuousDownloadService } from "../services/continuousDownloadService";
 import { DownloadOrder } from "../services/continuousDownload/types";
 import { checkPlaylist } from "../services/downloadService";
@@ -36,6 +36,7 @@ import {
     sanitizePlaylistTitle,
     toPlaylistsTabUrl,
 } from "../services/subscription/playlistResolution";
+import { normalizeSubscriptionFilenameTemplate } from "../services/subscription/filenameTemplate";
 
 // Per-subscription yt-dlp config override (issue #345). Same free-text format
 // and trust requirement ("container") as the global ytDlpConfig setting.
@@ -116,6 +117,14 @@ export const createSubscription = async (
     return;
   }
 
+  // Per-subscription filename-template override (issue #368). Not secret, not
+  // trust-gated. Blank/whitespace => null (inherit global naming). Channels and
+  // Twitch subscriptions use the "channel" source-collection type for warnings.
+  const filenameTemplate = normalizeSubscriptionFilenameTemplate(
+    req.body.filenameTemplate,
+    "channel"
+  );
+
   const validDownloadOrders: DownloadOrder[] = ["dateDesc", "dateAsc", "viewsDesc", "viewsAsc"];
   let downloadOrder: DownloadOrder = "dateDesc";
   if (downloadAllPrevious === true) {
@@ -149,7 +158,8 @@ export const createSubscription = async (
     parseInt(interval),
     authorName,
     downloadShorts,
-    ytdlpConfig
+    ytdlpConfig,
+    filenameTemplate
   );
 
   // If user wants to download all previous videos, create a continuous download task
@@ -269,8 +279,17 @@ export const updateSubscription = async (
     req.body,
     "ytdlpConfig"
   );
+  const hasFilenameTemplate = Object.prototype.hasOwnProperty.call(
+    req.body,
+    "filenameTemplate"
+  );
 
-  if (!hasInterval && !hasRetentionDays && !hasYtdlpConfig) {
+  if (
+    !hasInterval &&
+    !hasRetentionDays &&
+    !hasYtdlpConfig &&
+    !hasFilenameTemplate
+  ) {
     throw new ValidationError(
       "At least one subscription setting is required",
       "body"
@@ -310,6 +329,7 @@ export const updateSubscription = async (
     interval?: number;
     retentionDays?: number | null;
     ytdlpConfig?: string | null;
+    filenameTemplate?: string | null;
   } = {};
   if (parsedInterval !== undefined) {
     updates.interval = parsedInterval;
@@ -318,12 +338,24 @@ export const updateSubscription = async (
     updates.retentionDays = retentionDays;
   }
 
+  // Resolve the existing subscription once for the ytdlp_config trust check and
+  // the filename-template validation source type. Both are skipped when not
+  // present in the request body.
+  let existingForOverride: Awaited<
+    ReturnType<typeof subscriptionService.getSubscriptionById>
+  > | undefined;
+  if (hasYtdlpConfig || hasFilenameTemplate) {
+    existingForOverride = await subscriptionService.getSubscriptionById(id);
+    if (!existingForOverride) {
+      // Keep the same not-found behavior as updateSubscriptionSettings. The
+      // preliminary read is needed only to validate override-specific fields.
+      throw NotFoundError.subscription(id);
+    }
+  }
+
   if (hasYtdlpConfig) {
     const nextYtdlpConfig = normalizeYtdlpConfigInput(req.body.ytdlpConfig);
-    const existing = await subscriptionService.getSubscriptionById(id);
-    if (!existing) {
-      throw new ValidationError("Subscription not found", "id");
-    }
+    const existing = existingForOverride!;
     if (!ensureYtdlpConfigTrust(res, nextYtdlpConfig, existing.ytdlpConfig ?? null)) {
       return;
     }
@@ -332,6 +364,23 @@ export const updateSubscription = async (
     // just because an unchanged override was echoed back).
     if (nextYtdlpConfig !== (existing.ytdlpConfig ?? null)) {
       updates.ytdlpConfig = nextYtdlpConfig;
+    }
+  }
+
+  if (hasFilenameTemplate) {
+    // Not secret and not trust-gated. Warnings depend on the subscription type:
+    // playlists and channel-playlists watchers validate as "playlist", others as
+    // "channel".
+    const existing = existingForOverride!;
+    const isPlaylistLike =
+      existing.subscriptionType === "playlist" ||
+      existing.subscriptionType === "channel_playlists";
+    const nextFilenameTemplate = normalizeSubscriptionFilenameTemplate(
+      req.body.filenameTemplate,
+      isPlaylistLike ? "playlist" : "channel"
+    );
+    if (nextFilenameTemplate !== (existing.filenameTemplate ?? null)) {
+      updates.filenameTemplate = nextFilenameTemplate;
     }
   }
 
@@ -459,6 +508,13 @@ export const createPlaylistSubscription = async (
     );
   }
 
+  // Per-subscription filename-template override (issue #368). Playlists use the
+  // "playlist" source-collection type for validation warnings.
+  const filenameTemplate = normalizeSubscriptionFilenameTemplate(
+    req.body.filenameTemplate,
+    "playlist"
+  );
+
   // Detect platform
   const isBilibili = isBilibiliUrl(playlistUrl);
   const platform = detectPlaylistPlatform(playlistUrl);
@@ -550,10 +606,13 @@ export const createPlaylistSubscription = async (
     playlistId || "",
     author,
     platform,
-    collection.id
+    collection.id,
+    filenameTemplate
   );
 
-  // If user wants to download all videos, create a continuous download task
+  // If user wants to download all videos, create a continuous download task.
+  // Link the task to the freshly created subscription id so the task reliably
+  // inherits this subscription's filename-template override (issue #368).
   let task = null;
   if (downloadAll) {
     try {
@@ -561,7 +620,8 @@ export const createPlaylistSubscription = async (
         playlistUrl,
         author,
         platform,
-        collection.id
+        collection.id,
+        subscription.id
       );
       logger.info(
         `Created continuous download task ${task.id} for playlist subscription ${subscription.id}`
@@ -600,6 +660,15 @@ export const subscribeChannelPlaylists = async (
   if (!url || !interval) {
     throw new ValidationError("URL and interval are required", "body");
   }
+
+  // Per-subscription filename-template override (issue #368). Copied to every
+  // new playlist subscription created in this request and to the watcher. Uses
+  // the "playlist" source-collection type because the watcher copies its
+  // template to child playlists.
+  const filenameTemplate = normalizeSubscriptionFilenameTemplate(
+    req.body.filenameTemplate,
+    "playlist"
+  );
 
   // Adjust URL to ensure we target playlists tab
   const targetUrl = toPlaylistsTabUrl(url);
@@ -654,9 +723,14 @@ export const subscribeChannelPlaylists = async (
 
     // Check if already subscribed to this playlist
     const existing = await subscriptionService.listSubscriptions();
-    const alreadySubscribed = existing.some(
+    const existingSubscription = existing.find(
       (sub) => sub.authorUrl === playlistUrl
     );
+    const alreadySubscribed = Boolean(existingSubscription);
+    // Link a historical task to the exact subscription whenever one exists.
+    // This prevents the task repository's URL/collection fallbacks from
+    // selecting another subscription with a different override.
+    let playlistSubscriptionId = existingSubscription?.id;
 
     // Get or create collection for this playlist
     const collection = resolveChannelPlaylistCollection(title, channelName);
@@ -669,15 +743,17 @@ export const subscribeChannelPlaylists = async (
     if (!alreadySubscribed) {
       try {
         // Create subscription for this playlist
-        await subscriptionService.subscribePlaylist(
+        const playlistSubscription = await subscriptionService.subscribePlaylist(
           playlistUrl,
           parseInt(interval),
           title,
           playlistId || "",
           channelName,
           platform,
-          collectionId
+          collectionId,
+          filenameTemplate
         );
+        playlistSubscriptionId = playlistSubscription.id;
         subscribedCount++;
       } catch (error: unknown) {
         logger.error(`Error subscribing to playlist "${title}":`, error);
@@ -711,7 +787,8 @@ export const subscribeChannelPlaylists = async (
             playlistUrl,
             channelName,
             platform,
-            collectionId
+            collectionId,
+            playlistSubscriptionId
           );
           logger.info(
             `Created continuous download task for playlist: ${title}`
@@ -762,7 +839,8 @@ export const subscribeChannelPlaylists = async (
       targetUrl,
       parseInt(interval),
       channelName,
-      platform
+      platform,
+      filenameTemplate
     );
     logger.info("Created channel playlists watcher", {
       subscriptionId: watcher.id,

--- a/backend/src/controllers/subscriptionController.ts
+++ b/backend/src/controllers/subscriptionController.ts
@@ -1043,15 +1043,45 @@ export const subscribeChannelPlaylists = async (
   const existingSubs = await subscriptionService.listSubscriptions();
   const existingSubByUrl = new Map(existingSubs.map((sub) => [sub.authorUrl, sub]));
 
+  type ExistingPlaylistSubscription = {
+    id: string;
+    collectionId?: string | null;
+    ytdlpConfig?: string | null;
+    filenameTemplate?: string | null;
+  };
+  const applyFilenameTemplateToExistingPlaylist = async (
+    subscription: ExistingPlaylistSubscription,
+    title: string
+  ): Promise<boolean> => {
+    if (
+      !hasFilenameTemplate ||
+      (subscription.filenameTemplate ?? null) === filenameTemplate
+    ) {
+      return true;
+    }
+
+    try {
+      await subscriptionService.updateSubscriptionSettings(subscription.id, {
+        filenameTemplate,
+      });
+      subscription.filenameTemplate = filenameTemplate;
+      return true;
+    } catch (error) {
+      const message = getErrorMessage(error, "Unknown error");
+      errors.push(`${title}: ${message}`);
+      logger.error(
+        `Failed to update filename template for playlist "${title}":`,
+        error instanceof Error ? error : new Error(String(error))
+      );
+      return false;
+    }
+  };
+
   type Candidate = {
     playlistUrl: string;
     title: string;
     playlistId: string;
-    existingSubscription?: {
-      id: string;
-      collectionId?: string | null;
-      ytdlpConfig?: string | null;
-    };
+    existingSubscription?: ExistingPlaylistSubscription;
   };
   const candidates: Candidate[] = [];
   for (const entry of result.entries) {
@@ -1066,13 +1096,17 @@ export const subscribeChannelPlaylists = async (
     if (existingSubscription) {
       logger.info(`Skipping playlist "${title}": already subscribed`);
       skippedCount++;
+      const existingTemplateUpdated =
+        await applyFilenameTemplateToExistingPlaylist(existingSubscription, title);
       if (downloadAllPrevious === true) {
-        candidates.push({
-          playlistUrl,
-          title,
-          playlistId,
-          existingSubscription,
-        });
+        if (existingTemplateUpdated) {
+          candidates.push({
+            playlistUrl,
+            title,
+            playlistId,
+            existingSubscription,
+          });
+        }
       }
       continue;
     }
@@ -1234,8 +1268,17 @@ export const subscribeChannelPlaylists = async (
             );
             continue;
           }
+          const concurrentTemplateUpdated =
+            await applyFilenameTemplateToExistingPlaylist(
+              concurrentSub,
+              candidate.title
+            );
+          if (!concurrentTemplateUpdated) {
+            continue;
+          }
           createdSubscriptionId = concurrentSub.id;
           taskCollectionId = concurrentSub.collectionId;
+          existingSubByUrl.set(candidate.playlistUrl, concurrentSub);
         } else {
           errors.push(
             `${candidate.title}: ${getErrorMessage(error, "Unknown error")}`

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -301,6 +301,9 @@ export const subscriptions = sqliteTable("subscriptions", {
   // Free-text yt-dlp config snippet; null/empty = use the global ytDlpConfig.
   // Same format as the global setting. Trust-gated to "container".
   ytdlpConfig: text("ytdlp_config"),
+  // Per-subscription filename-template override (issue #368).
+  // null = inherit the current global filename naming settings.
+  filenameTemplate: text("filename_template"),
 });
 
 // Track downloaded video IDs to prevent re-downloading

--- a/backend/src/services/continuousDownload/taskProcessor.ts
+++ b/backend/src/services/continuousDownload/taskProcessor.ts
@@ -198,6 +198,11 @@ export class TaskProcessor {
       );
     }
     const subscriptionYtdlpConfig = taskSubscription?.ytdlpConfig ?? null;
+    // Per-subscription filename-template override (issue #368). Resolved once at
+    // worker start so a running task keeps its snapshot; pausing/resuming starts
+    // a new worker that picks up the current override.
+    const subscriptionFilenameTemplate =
+      taskSubscription?.filenameTemplate ?? null;
 
     // Get total count if not set
     if (task.totalVideos === 0) {
@@ -487,6 +492,9 @@ export class TaskProcessor {
     // Per-subscription yt-dlp override (issue #345). Null when the task has no
     // resolvable subscription → identical to today's behaviour (global config).
     const subscriptionYtdlpConfig = taskSubscription?.ytdlpConfig ?? null;
+    // Per-subscription filename-template override (issue #368). Null → global.
+    const subscriptionFilenameTemplate =
+      taskSubscription?.filenameTemplate ?? null;
 
     // An audio-only override (e.g. --format bestaudio) saves the item under the
     // "audio" media type. Scope the duplicate check to that media type too so a
@@ -546,7 +554,10 @@ export class TaskProcessor {
           undefined,
           undefined,
           filenameTemplateSourceOptions,
-          { subscriptionYtdlpConfig }
+          {
+            subscriptionYtdlpConfig,
+            subscriptionFilenameTemplate,
+          }
         );
 
         // Check for Bilibili download errors
@@ -561,6 +572,7 @@ export class TaskProcessor {
           downloadId,
           filenameTemplateSourceOptions,
           subscriptionYtdlpConfig,
+          subscriptionFilenameTemplate,
         });
       }
 

--- a/backend/src/services/continuousDownload/taskProcessor.ts
+++ b/backend/src/services/continuousDownload/taskProcessor.ts
@@ -93,6 +93,16 @@ export class TaskProcessor {
     private videoUrlFetcher: VideoUrlFetcher
   ) {}
 
+  private getLinkedSubscriptionFilenameTemplate(
+    task: ContinuousDownloadTask,
+    taskSubscription: Subscription | null
+  ): string | null {
+    if (!task.subscriptionId || taskSubscription?.id !== task.subscriptionId) {
+      return null;
+    }
+    return taskSubscription.filenameTemplate ?? null;
+  }
+
   /**
    * Signal that a task has been paused or cancelled. The running loop (if any)
    * observes this via isTaskInterrupted() on its next iteration.
@@ -198,11 +208,6 @@ export class TaskProcessor {
       );
     }
     const subscriptionYtdlpConfig = taskSubscription?.ytdlpConfig ?? null;
-    // Per-subscription filename-template override (issue #368). Resolved once at
-    // worker start so a running task keeps its snapshot; pausing/resuming starts
-    // a new worker that picks up the current override.
-    const subscriptionFilenameTemplate =
-      taskSubscription?.filenameTemplate ?? null;
 
     // Get total count if not set
     if (task.totalVideos === 0) {
@@ -494,7 +499,7 @@ export class TaskProcessor {
     const subscriptionYtdlpConfig = taskSubscription?.ytdlpConfig ?? null;
     // Per-subscription filename-template override (issue #368). Null → global.
     const subscriptionFilenameTemplate =
-      taskSubscription?.filenameTemplate ?? null;
+      this.getLinkedSubscriptionFilenameTemplate(task, taskSubscription);
 
     // An audio-only override (e.g. --format bestaudio) saves the item under the
     // "audio" media type. Scope the duplicate check to that media type too so a

--- a/backend/src/services/continuousDownloadService.ts
+++ b/backend/src/services/continuousDownloadService.ts
@@ -148,7 +148,8 @@ export class ContinuousDownloadService {
     playlistUrl: string,
     author: string,
     platform: string,
-    collectionId: string | null | undefined
+    collectionId: string | null | undefined,
+    subscriptionId?: string
   ): Promise<ContinuousDownloadTask> {
     const task: ContinuousDownloadTask = {
       id: uuidv4(),
@@ -164,6 +165,7 @@ export class ContinuousDownloadService {
       currentVideoIndex: 0,
       createdAt: Date.now(),
       downloadOrder: "dateDesc",
+      subscriptionId,
     };
 
     await this.taskRepository.createTask(task);

--- a/backend/src/services/downloaders/BaseDownloader.ts
+++ b/backend/src/services/downloaders/BaseDownloader.ts
@@ -37,6 +37,9 @@ export interface DownloadModeOptions {
   // Per-subscription yt-dlp config override (issue #345). Raw free-text snippet
   // from subscriptions.ytdlp_config; null/undefined = use the global config.
   subscriptionYtdlpConfig?: string | null;
+  // Validated template from subscriptions.filename_template (issue #368).
+  // null/undefined = use the global filename naming settings.
+  subscriptionFilenameTemplate?: string | null;
 }
 
 export interface DownloadOptions extends DownloadModeOptions {

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -4,6 +4,7 @@ import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 import { isCancellationError } from "../../../utils/downloadUtils";
 import { formatVideoFilename } from "../../../utils/helpers";
 import { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
+import { applySubscriptionFilenameTemplateOverride } from "../../filenameTemplate";
 import { resolveAuthorOrganizationMode } from "../../../types/settings";
 import { logger } from "../../../utils/logger";
 import {
@@ -91,7 +92,14 @@ export async function downloadSinglePart(
     const mergeOutputFormat = audioOnly
       ? audioFormat
       : resolveBilibiliMergeOutputFormat(userConfig);
-    const settings = storageService.getSettings();
+    // Overlay any per-subscription filename-template override onto the global
+    // naming settings so renameFilesWithMetadata and the legacy/template branch
+    // below use it consistently (issue #368). When no override is present the
+    // original object is returned unchanged.
+    const settings = applySubscriptionFilenameTemplateOverride(
+      storageService.getSettings(),
+      modeOptions?.subscriptionFilenameTemplate
+    );
     const moveThumbnailsToVideoFolder =
       settings.moveThumbnailsToVideoFolder || false;
     const moveSubtitlesToVideoFolder =

--- a/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
+++ b/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
@@ -11,6 +11,7 @@ import {
   isYouTubeUrl,
 } from "../../../utils/helpers";
 import { resolveManagedWebPath } from "../../filenameTemplate/pathHelpers";
+import { applySubscriptionFilenameTemplateOverride } from "../../filenameTemplate";
 import { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import { planDownloadPaths } from "./downloadPathPlanner";
 import { logger } from "../../../utils/logger";
@@ -78,6 +79,7 @@ export async function downloadVideo(
   const onStart = options.onStart;
   const filenameTemplateSourceOptions = options.filenameTemplateSourceOptions;
   const subscriptionYtdlpConfig = options.subscriptionYtdlpConfig;
+  const subscriptionFilenameTemplate = options.subscriptionFilenameTemplate;
   const effectiveUserConfig = getEffectiveUserYtDlpConfig(
     videoUrl,
     subscriptionYtdlpConfig
@@ -199,8 +201,15 @@ export async function downloadVideo(
       }
     }
 
-    // Update paths
-    const settings = storageService.getSettings();
+    // Update paths. Overlay any per-subscription filename-template override
+    // onto the global naming settings so path planning uses it consistently
+    // (issue #368). When no override is present the original object is returned
+    // unchanged, preserving existing behavior and identity.
+    const globalSettings = storageService.getSettings();
+    const settings = applySubscriptionFilenameTemplateOverride(
+      globalSettings,
+      subscriptionFilenameTemplate
+    );
     const moveThumbnailsToVideoFolder =
       settings.moveThumbnailsToVideoFolder || false;
     const moveSubtitlesToVideoFolder =
@@ -495,8 +504,13 @@ export async function downloadVideo(
     throw error;
   }
 
-  // Create metadata for the video
-  const settings = storageService.getSettings();
+  // Create metadata for the video. Re-apply the per-subscription filename
+  // override so the author-collection movement below sees the same effective
+  // naming settings as path planning did (issue #368).
+  const settings = applySubscriptionFilenameTemplateOverride(
+    storageService.getSettings(),
+    subscriptionFilenameTemplate
+  );
   const moveThumbnailsToVideoFolder =
     settings.moveThumbnailsToVideoFolder || false;
 

--- a/backend/src/services/filenameTemplate/config.ts
+++ b/backend/src/services/filenameTemplate/config.ts
@@ -335,3 +335,56 @@ export function toFilenameNamingRuntimeConfig(
     template: resolved.template,
   };
 }
+
+/**
+ * Settings shape that carries the global filename naming fields. The override
+ * helper only reads/writes the three naming fields, so any settings object with
+ * those fields (plus arbitrary others) is accepted.
+ */
+type FilenameSettingsLike = {
+  downloadFilenameMode?: unknown;
+  downloadFilenamePresetId?: unknown;
+  downloadFilenameTemplate?: unknown;
+  [key: string]: unknown;
+};
+
+/**
+ * Overlay a per-subscription filename-template override onto the global naming
+ * settings, producing one coherent effective settings object for the download
+ * pipeline (issue #368).
+ *
+ * When `subscriptionTemplate` is null/undefined/blank, the original
+ * `globalSettings` object is returned unchanged — preserving object identity
+ * and current behavior for every non-subscription path.
+ *
+ * When set, the helper returns a new object that forces template naming with
+ * the subscription's template. All three runtime naming fields are set together
+ * so the various path-planning branches (legacy-vs-template early branch,
+ * `planVideoOutputPaths`, author-collection movement, and Bilibili subtitle
+ * logic) cannot disagree:
+ *   - `downloadFilenameMode: "template"`
+ *   - `downloadFilenamePresetId`: a derived preset id (or "custom") so existing
+ *     `presetId !== "legacy"` branches still flip to template mode
+ *   - `downloadFilenameTemplate`: the subscription template
+ */
+export function applySubscriptionFilenameTemplateOverride<
+  T extends FilenameSettingsLike
+>(
+  globalSettings: T,
+  subscriptionTemplate?: string | null
+): T {
+  const normalizedTemplate = subscriptionTemplate?.trim();
+  if (!normalizedTemplate) {
+    return globalSettings;
+  }
+
+  return {
+    ...globalSettings,
+    downloadFilenameMode: "template",
+    downloadFilenamePresetId: matchPresetIdFromTemplate(
+      normalizedTemplate,
+      "template"
+    ),
+    downloadFilenameTemplate: normalizedTemplate,
+  } as T;
+}

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -317,6 +317,20 @@ function migrateCollectionsAndSubscriptionsColumns(): void {
       logger.info("Migration successful: ytdlp_config added.");
     }
 
+    // Per-subscription filename-template override (issue #368). Self-heal in
+    // case drizzle aborted its batch before applying 0025 on an existing install.
+    if (!subscriptionsColumns.includes("filename_template")) {
+      logger.info(
+        "Migrating database: Adding filename_template column to subscriptions table..."
+      );
+      sqlite
+        .prepare(
+          "ALTER TABLE subscriptions ADD COLUMN filename_template TEXT"
+        )
+        .run();
+      logger.info("Migration successful: filename_template added.");
+    }
+
     sqlite
       .prepare(
         `

--- a/backend/src/services/subscription/channelPlaylists.ts
+++ b/backend/src/services/subscription/channelPlaylists.ts
@@ -24,6 +24,7 @@ export interface ChannelPlaylistDeps {
     channelName: string,
     platform: string,
     collectionId: string | null,
+    filenameTemplate?: string | null,
   ) => Promise<unknown>;
 }
 
@@ -117,7 +118,10 @@ export async function checkChannelPlaylistsForWatcher(
       const playlistId = entry.id ?? extractYouTubePlaylistId(playlistUrl);
 
       try {
-        // Subscribe to the new playlist
+        // Subscribe to the new playlist. Copy the watcher's filename-template
+        // override onto the child subscription (issue #368). Editing the watcher
+        // later only affects playlists discovered after the edit; existing child
+        // subscriptions remain independently editable.
         await deps.subscribePlaylist(
           playlistUrl,
           sub.interval, // Use same interval as watcher
@@ -125,7 +129,8 @@ export async function checkChannelPlaylistsForWatcher(
           playlistId || "",
           channelName,
           sub.platform,
-          collectionId
+          collectionId,
+          sub.filenameTemplate ?? null,
         );
         subscribedUrls.add(playlistUrl);
         newSubscriptionsCount++;

--- a/backend/src/services/subscription/filenameTemplate.ts
+++ b/backend/src/services/subscription/filenameTemplate.ts
@@ -1,0 +1,47 @@
+import { ValidationError } from "../../errors/DownloadErrors";
+import { validateTemplate } from "../filenameTemplate/validators";
+
+/**
+ * Validate and normalize a raw filename-template override value from a request
+ * body. Accepts a string or null; treats empty/whitespace as "cleared" (null),
+ * which means "inherit the current global filename naming settings". Throws
+ * ValidationError on wrong type or an invalid/unsafe template.
+ *
+ * The existing global template validator owns the 2,000-character limit, the
+ * path-traversal rules, the required extension placeholder, and the supported
+ * variables; this helper does not duplicate those constants.
+ *
+ * @param sourceCollectionType Optional source-collection type used only to
+ *   shape non-blocking warnings. It is not required to reject a save. Use
+ *   "playlist" for playlist subscriptions and channel-playlists watchers (the
+ *   watcher copies its template to child playlists), and "channel" for channel
+ *   and Twitch subscriptions.
+ */
+export function normalizeSubscriptionFilenameTemplate(
+  raw: unknown,
+  sourceCollectionType?: "channel" | "playlist" | "single" | "unknown"
+): string | null {
+  if (raw === null || raw === undefined) {
+    return null;
+  }
+  if (typeof raw !== "string") {
+    throw new ValidationError(
+      "filenameTemplate must be a string or null",
+      "filenameTemplate"
+    );
+  }
+
+  const normalized = raw.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const result = validateTemplate(normalized, sourceCollectionType);
+  if (!result.valid) {
+    throw new ValidationError(
+      `Invalid filename template: ${result.errors.join("; ")}`,
+      "filenameTemplate"
+    );
+  }
+  return normalized;
+}

--- a/backend/src/services/subscription/twitchSubscription.ts
+++ b/backend/src/services/subscription/twitchSubscription.ts
@@ -354,6 +354,7 @@ export async function processTwitchSubscriptionVideos(
         filenameTemplateSourceOptions:
           buildFilenameTemplateSourceOptions(sub),
         subscriptionYtdlpConfig: sub.ytdlpConfig,
+        subscriptionFilenameTemplate: sub.filenameTemplate,
       });
       const videoData = downloadResult?.videoData || downloadResult || {};
       downloadedTwitchTitle = videoData.title || video.title;

--- a/backend/src/services/subscription/types.ts
+++ b/backend/src/services/subscription/types.ts
@@ -38,4 +38,7 @@ export interface Subscription {
   // Per-subscription yt-dlp config override (issue #345).
   // Free-text yt-dlp config snippet; empty/undefined = use the global config.
   ytdlpConfig?: string | null;
+
+  /** Per-subscription filename-template override. null/undefined means inherit global filename naming settings. */
+  filenameTemplate?: string | null;
 }

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -279,8 +279,24 @@ export class SubscriptionService {
       .where(eq(subscriptions.authorUrl, channelUrl));
 
     if (existing.length > 0) {
+      const existingSubscription = existing[0] as unknown as Subscription;
+      if (
+        filenameTemplate !== undefined &&
+        (existingSubscription.filenameTemplate ?? null) !== filenameTemplate
+      ) {
+        await db
+          .update(subscriptions)
+          .set({ filenameTemplate })
+          .where(eq(subscriptions.id, existingSubscription.id));
+
+        return {
+          ...existingSubscription,
+          filenameTemplate,
+        };
+      }
+
       // If it exists, just return it (idempotent)
-      return existing[0] as unknown as Subscription;
+      return existingSubscription;
     }
 
     const newSubscription: Subscription = {

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -75,7 +75,8 @@ export class SubscriptionService {
     interval: number,
     providedAuthorName?: string,
     downloadShorts: boolean = false,
-    ytdlpConfig?: string | null
+    ytdlpConfig?: string | null,
+    filenameTemplate?: string | null
   ): Promise<Subscription> {
     // Detect platform and validate URL
     let platform: string;
@@ -205,6 +206,7 @@ export class SubscriptionService {
       twitchBroadcasterLogin,
       lastTwitchVideoId,
       ytdlpConfig: ytdlpConfig ?? null,
+      filenameTemplate: filenameTemplate ?? null,
     };
 
     await db.insert(subscriptions).values(newSubscription);
@@ -221,7 +223,8 @@ export class SubscriptionService {
     playlistId: string,
     author: string,
     platform: string,
-    collectionId: string | null
+    collectionId: string | null,
+    filenameTemplate?: string | null
   ): Promise<Subscription> {
     // Check if already subscribed to this playlist
     const existing = await db
@@ -251,6 +254,7 @@ export class SubscriptionService {
       channelName: author,
       subscriptionType: "playlist",
       collectionId: collectionId || undefined,
+      filenameTemplate: filenameTemplate ?? null,
     };
 
     await db.insert(subscriptions).values(newSubscription);
@@ -265,7 +269,8 @@ export class SubscriptionService {
     channelUrl: string,
     interval: number,
     channelName: string,
-    platform: string
+    platform: string,
+    filenameTemplate?: string | null
   ): Promise<Subscription> {
     // Check if watcher already exists
     const existing = await db
@@ -290,6 +295,7 @@ export class SubscriptionService {
       platform,
       paused: 0,
       subscriptionType: "channel_playlists",
+      filenameTemplate: filenameTemplate ?? null,
     };
 
     await db.insert(subscriptions).values(newSubscription);
@@ -310,7 +316,7 @@ export class SubscriptionService {
   async checkChannelPlaylists(sub: Subscription): Promise<number> {
     return checkChannelPlaylistsForWatcher(sub, {
       listSubscriptions: () => this.listSubscriptions(),
-      subscribePlaylist: (playlistUrl, interval, title, playlistId, channelName, platform, collectionId) =>
+      subscribePlaylist: (playlistUrl, interval, title, playlistId, channelName, platform, collectionId, filenameTemplate) =>
         this.subscribePlaylist(
           playlistUrl,
           interval,
@@ -318,7 +324,8 @@ export class SubscriptionService {
           playlistId,
           channelName,
           platform,
-          collectionId
+          collectionId,
+          filenameTemplate
         ),
     });
   }
@@ -391,6 +398,7 @@ export class SubscriptionService {
       interval?: number;
       retentionDays?: number | null;
       ytdlpConfig?: string | null;
+      filenameTemplate?: string | null;
     }
   ): Promise<void> {
     if (Object.keys(updates).length === 0) {
@@ -992,7 +1000,10 @@ export class SubscriptionService {
               registerCancel,
               undefined,
               buildFilenameTemplateSourceOptions(sub),
-              { subscriptionYtdlpConfig: sub.ytdlpConfig }
+              {
+                subscriptionYtdlpConfig: sub.ytdlpConfig,
+                subscriptionFilenameTemplate: sub.filenameTemplate,
+              }
             )
           : downloadYouTubeVideo(videoUrl, {
               downloadId: downloadTaskId,
@@ -1000,6 +1011,7 @@ export class SubscriptionService {
               filenameTemplateSourceOptions:
                 buildFilenameTemplateSourceOptions(sub),
               subscriptionYtdlpConfig: sub.ytdlpConfig,
+              subscriptionFilenameTemplate: sub.filenameTemplate,
             }),
       downloadTaskId,
       initialTitle,

--- a/frontend/src/components/BilibiliPartsModal.tsx
+++ b/frontend/src/components/BilibiliPartsModal.tsx
@@ -13,13 +13,25 @@ import {
 import { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
+import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
+
+/**
+ * Structured subscribe payload shared with DownloadContext. Mirrors the
+ * companion playlist-subscribe-only design's PlaylistSubscribeInfo so both
+ * features can be carried in one object.
+ */
+export interface PlaylistSubscribeInfo {
+    interval: number;
+    downloadAll: boolean;
+    filenameTemplate: string | null;
+}
 
 interface BilibiliPartsModalProps {
     isOpen: boolean;
     onClose: () => void;
     videosNumber: number;
     videoTitle: string;
-    onDownloadAll: (collectionName: string, subscribeInfo?: { interval: number }) => void;
+    onDownloadAll: (collectionName: string, subscribeInfo?: PlaylistSubscribeInfo) => void;
     onDownloadCurrent: () => void;
     isLoading: boolean;
     type?: 'parts' | 'collection' | 'series' | 'playlist';
@@ -39,9 +51,17 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const [collectionName, setCollectionName] = useState<string>('');
     const [subscribeToPlaylist, setSubscribeToPlaylist] = useState<boolean>(false);
     const [subscriptionInterval, setSubscriptionInterval] = useState<number>(60);
+    const [filenameTemplate, setFilenameTemplate] = useState<string>('');
+    const [isTemplateValid, setIsTemplateValid] = useState<boolean>(true);
 
     const handleDownloadAll = () => {
-        const subscribeInfo = subscribeToPlaylist ? { interval: subscriptionInterval } : undefined;
+        const subscribeInfo: PlaylistSubscribeInfo | undefined = subscribeToPlaylist
+            ? {
+                  interval: subscriptionInterval,
+                  downloadAll: true,
+                  filenameTemplate: filenameTemplate.trim() || null,
+              }
+            : undefined;
         onDownloadAll(collectionName || videoTitle, subscribeInfo);
     };
 
@@ -170,6 +190,15 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                                     helperText={t('subscribePlaylistDescription')}
                                     sx={{ width: 200 }}
                                 />
+                                <Box sx={{ mt: 2 }}>
+                                    <SubscriptionFilenameTemplateField
+                                        value={filenameTemplate}
+                                        onChange={setFilenameTemplate}
+                                        sourceCollectionType="playlist"
+                                        disabled={isLoading}
+                                        onValidityChange={setIsTemplateValid}
+                                    />
+                                </Box>
                             </Box>
                         )}
                     </Box>
@@ -190,13 +219,14 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                 </Button>
                 <Button
                     onClick={handleDownloadAll}
+                    disabled={(subscribeToPlaylist && !isTemplateValid) || isLoading}
                     loading={isLoading}
                     loadingPosition="start"
                     variant="contained"
                     color="primary"
                 >
                     {subscribeToPlaylist && (type === 'playlist' || type === 'collection' || type === 'series')
-                        ? t('downloadAndSubscribe') 
+                        ? t('downloadAndSubscribe')
                         : getDownloadAllButtonText()}
                 </Button>
             </DialogActions>

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -16,7 +16,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
@@ -89,8 +89,18 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
         ? t('twitchSubscriptionVodsOnly')
         : t('subscribeDescription');
 
+    const resetFilenameTemplate = useCallback(() => {
+        setFilenameTemplate('');
+        setIsTemplateValid(true);
+    }, []);
+
+    useEffect(() => {
+        resetFilenameTemplate();
+    }, [resetFilenameTemplate, url]);
+
     const handleClose = () => {
         if (!isSubmitting) {
+            resetFilenameTemplate();
             onClose();
         }
     };
@@ -105,6 +115,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                 downloadOrder,
                 filenameTemplate: filenameTemplate.trim() || null,
             });
+            resetFilenameTemplate();
             onClose();
         } catch {
             // Keep the modal open so the action can be retried.

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -1,6 +1,7 @@
 import { Warning } from '@mui/icons-material';
 import {
     Alert,
+    Box,
     Button,
     Checkbox,
     Dialog,
@@ -18,19 +19,31 @@ import {
 import React, { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
+import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
 
 type DownloadOrder = 'dateDesc' | 'dateAsc' | 'viewsDesc' | 'viewsAsc';
+
+export interface SubscribeFormValues {
+    interval: number;
+    downloadAllPrevious: boolean;
+    downloadShorts: boolean;
+    downloadOrder: DownloadOrder;
+    filenameTemplate: string | null;
+}
 
 interface SubscribeModalProps {
     open: boolean;
     onClose: () => void;
-    onConfirm: (interval: number, downloadAllPrevious: boolean, downloadShorts: boolean, downloadOrder: DownloadOrder) => void | Promise<void>;
+    onConfirm: (values: SubscribeFormValues) => void | Promise<void>;
     authorName?: string;
     url: string;
     source?: string;
     title?: string;
     description?: string;
     enableDownloadOrder?: boolean;
+    /** When true the modal is creating channel-playlists subscriptions; the
+     *  template field validates as "playlist". */
+    playlistMode?: boolean;
 }
 
 const SubscribeModal: React.FC<SubscribeModalProps> = ({
@@ -43,12 +56,15 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     title,
     description,
     enableDownloadOrder = true,
+    playlistMode = false,
 }) => {
     const { t } = useLanguage();
     const [interval, setInterval] = useState<number>(60); // Default 60 minutes
     const [downloadAllPrevious, setDownloadAllPrevious] = useState<boolean>(false);
     const [downloadShorts, setDownloadShorts] = useState<boolean>(false);
     const [downloadOrder, setDownloadOrder] = useState<DownloadOrder>('dateDesc');
+    const [filenameTemplate, setFilenameTemplate] = useState<string>('');
+    const [isTemplateValid, setIsTemplateValid] = useState<boolean>(true);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const isTwitch = source === 'twitch';
     const showDownloadShorts = source !== 'bilibili' && source !== 'twitch';
@@ -73,7 +89,13 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     const handleConfirm = async () => {
         setIsSubmitting(true);
         try {
-            await onConfirm(interval, downloadAllPrevious, downloadShorts, downloadOrder);
+            await onConfirm({
+                interval,
+                downloadAllPrevious,
+                downloadShorts,
+                downloadOrder,
+                filenameTemplate: filenameTemplate.trim() || null,
+            });
             onClose();
         } catch {
             // Keep the modal open so the action can be retried.
@@ -83,6 +105,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     };
 
     const showOrderDropdown = downloadAllPrevious && enableDownloadOrder;
+    const canSubmit = isTemplateValid;
 
     return (
         <Dialog
@@ -179,6 +202,15 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                         )}
                     </Alert>
                 )}
+                <Box sx={{ mt: 2 }}>
+                    <SubscriptionFilenameTemplateField
+                        value={filenameTemplate}
+                        onChange={setFilenameTemplate}
+                        sourceCollectionType={playlistMode ? 'playlist' : 'channel'}
+                        disabled={isSubmitting}
+                        onValidityChange={setIsTemplateValid}
+                    />
+                </Box>
             </DialogContent>
             <DialogActions sx={{ p: 2 }}>
                 <Button onClick={handleClose} color="inherit" disabled={isSubmitting}>
@@ -188,6 +220,7 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
                     onClick={() => { void handleConfirm(); }}
                     variant="contained"
                     color="primary"
+                    disabled={!canSubmit || isSubmitting}
                     loading={isSubmitting}
                     loadingPosition="start"
                 >

--- a/frontend/src/components/SubscriptionFilenameTemplateField.tsx
+++ b/frontend/src/components/SubscriptionFilenameTemplateField.tsx
@@ -1,0 +1,224 @@
+import { Alert, Box, CircularProgress, TextField, Typography } from '@mui/material';
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { useLanguage } from '../contexts/LanguageContext';
+import { api } from '../utils/apiClient';
+import { getApiErrorMessage } from '../utils/errors';
+import {
+  getFilenameTemplateWarningMessage,
+} from './Settings/filenameTemplateShared';
+import type { TranslationKey } from '../utils/translations';
+
+/**
+ * Validation response from POST /settings/filename-template/validate. Matches
+ * the backend controller shape: { valid, errors, warnings, rendered }.
+ */
+interface ValidateResponse {
+  valid: boolean;
+  errors: string[];
+  warnings: Array<{ code: string; message: string }>;
+  rendered: {
+    videoPath: string;
+    thumbnailPath: string;
+    subtitlePath: string;
+  } | null;
+}
+
+interface ValidationState {
+  template: string;
+  sourceCollectionType: 'channel' | 'playlist';
+  response: ValidateResponse;
+}
+
+export interface SubscriptionFilenameTemplateFieldProps {
+  /** Current (untrimmed) template value. */
+  value: string;
+  onChange: (value: string) => void;
+  /** Source-collection type used to shape validation warnings and the preview. */
+  sourceCollectionType: 'channel' | 'playlist';
+  disabled?: boolean;
+  autoFocus?: boolean;
+  /**
+   * Notifies the parent when the validity of the (non-empty) input changes, so
+   * it can disable its save/subscribe action. Blank input is always considered
+   * valid (it means "inherit global"). The parent should disable its action
+   * while this is `false`.
+   */
+  onValidityChange?: (isValid: boolean) => void;
+}
+
+const DEBOUNCE_MS = 300;
+
+/**
+ * Reusable per-subscription filename-template override field. Renders a
+ * multiline monospace editor with debounced server validation, inline error and
+ * warning messages, and a rendered example when the template is valid. Blank
+ * input means "inherit the global filename naming setting".
+ *
+ * Client validation is for usability only; the backend remains authoritative.
+ */
+const SubscriptionFilenameTemplateField: React.FC<
+  SubscriptionFilenameTemplateFieldProps
+> = ({ value, onChange, sourceCollectionType, disabled, autoFocus, onValidityChange }) => {
+  const { t } = useLanguage();
+  const [validation, setValidation] = useState<ValidationState | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const requestId = useRef(0);
+  const helperTextId = useId();
+  const validationMessageId = useId();
+
+  // Blank input is always valid (inherit global). Only non-empty input is sent
+  // to the server for validation.
+  const trimmed = value.trim();
+  const hasTemplate = trimmed.length > 0;
+  const validationResponse =
+    validation?.template === trimmed &&
+    validation.sourceCollectionType === sourceCollectionType
+      ? validation.response
+      : null;
+  const hasErrors = hasTemplate && validationResponse?.valid === false;
+  const isInputValid =
+    !hasTemplate ||
+    (validationResponse?.valid === true && !isValidating);
+
+  // Report validity up to the parent whenever it changes.
+  useEffect(() => {
+    onValidityChange?.(isInputValid);
+  }, [isInputValid, onValidityChange]);
+
+  // Debounced validation request. Cancelled on unmount / value change, and
+  // stale responses are ignored via the incrementing requestId.
+  useEffect(() => {
+    if (!trimmed) {
+      // Invalidate an in-flight request before clearing the response. Without
+      // this, a late response for a value that was cleared (or retyped) could
+      // become the current validation state.
+      requestId.current += 1;
+      setValidation(null);
+      setIsValidating(false);
+      return;
+    }
+
+    setIsValidating(true);
+    const currentRequestId = requestId.current + 1;
+    requestId.current = currentRequestId;
+    const timer = setTimeout(async () => {
+      try {
+        const res = await api.post<ValidateResponse>(
+          '/settings/filename-template/validate',
+          { template: trimmed, sourceCollectionType }
+        );
+        // Ignore stale responses.
+        if (requestId.current !== currentRequestId) return;
+        setValidation({
+          template: trimmed,
+          sourceCollectionType,
+          response: res.data,
+        });
+      } catch (e: unknown) {
+        if (requestId.current !== currentRequestId) return;
+        setValidation({
+          template: trimmed,
+          sourceCollectionType,
+          response: {
+            valid: false,
+            errors: [getApiErrorMessage(e) || String(e)],
+            warnings: [],
+            rendered: null,
+          },
+        });
+      } finally {
+        if (requestId.current === currentRequestId) {
+          setIsValidating(false);
+        }
+      }
+    }, DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [trimmed, sourceCollectionType]);
+
+  return (
+    <Box>
+      <TextField
+        label={t('subscriptionFilenameTemplate')}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        autoFocus={autoFocus}
+        fullWidth
+        multiline
+        minRows={2}
+        maxRows={6}
+        spellCheck={false}
+        inputMode="text"
+        placeholder={t('subscriptionFilenameTemplatePlaceholder')}
+        error={hasErrors}
+        sx={{ fontFamily: 'monospace' }}
+        InputProps={{ style: { fontFamily: 'monospace' } }}
+        slotProps={{
+          htmlInput: {
+            'aria-describedby': hasErrors
+              ? `${helperTextId} ${validationMessageId}`
+              : helperTextId,
+          },
+        }}
+      />
+      <Typography
+        id={helperTextId}
+        variant="caption"
+        color="text.secondary"
+        sx={{ display: 'block', mt: 0.5 }}
+      >
+        {trimmed
+          ? t('subscriptionFilenameTemplateHelp')
+          : t('subscriptionFilenameTemplateInherit')}
+      </Typography>
+
+      {isValidating && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+          <CircularProgress size={12} />
+          <Typography variant="caption" color="text.secondary">
+            {t('filenameValidating')}
+          </Typography>
+        </Box>
+      )}
+
+      {hasErrors && (
+        <Alert
+          id={validationMessageId}
+          severity="error"
+          sx={{ mt: 1, whiteSpace: 'pre-wrap' }}
+        >
+          {validationResponse!.errors.join('\n') || t('filenameValidationError')}
+        </Alert>
+      )}
+
+      {!hasErrors &&
+        validationResponse?.warnings &&
+        validationResponse.warnings.length > 0 &&
+        validationResponse.warnings.map((warning) => (
+          <Alert key={warning.code} severity="warning" sx={{ mt: 1 }}>
+            {getFilenameTemplateWarningMessage(
+              warning,
+              t as (key: TranslationKey) => string
+            )}
+          </Alert>
+        ))}
+
+      {!hasErrors && trimmed && validationResponse?.rendered && (
+        <Box sx={{ mt: 1 }}>
+          <Typography variant="caption" color="text.secondary">
+            {t('subscriptionFilenameTemplatePreview')}
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ display: 'block', fontFamily: 'monospace', whiteSpace: 'break-spaces' }}
+          >
+            {validationResponse.rendered.videoPath}
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};
+
+export default SubscriptionFilenameTemplateField;

--- a/frontend/src/components/__tests__/SubscribeModal.test.tsx
+++ b/frontend/src/components/__tests__/SubscribeModal.test.tsx
@@ -3,9 +3,17 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import SubscribeModal from '../SubscribeModal';
 
+const mockApiPost = vi.fn();
+
 // Mock language context
 vi.mock('../../contexts/LanguageContext', () => ({
     useLanguage: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../../utils/apiClient', () => ({
+    api: {
+        post: (...args: any[]) => mockApiPost(...args),
+    },
 }));
 
 describe('SubscribeModal', () => {
@@ -21,6 +29,14 @@ describe('SubscribeModal', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockApiPost.mockResolvedValue({
+            data: {
+                valid: true,
+                errors: [],
+                warnings: [],
+                rendered: null,
+            },
+        });
     });
 
     it('should render strictly when open', () => {
@@ -71,6 +87,39 @@ describe('SubscribeModal', () => {
 
         await user.click(screen.getByText('subscribe'));
         expect(mockOnConfirm).toHaveBeenCalledWith({ interval: 30, downloadAllPrevious: true, downloadShorts: true, downloadOrder: 'dateDesc', filenameTemplate: null });
+    });
+
+    it('resets the filename template when the target URL changes', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(<SubscribeModal {...defaultProps} />);
+        const templateInput = screen.getByLabelText('subscriptionFilenameTemplate');
+
+        await user.type(templateInput, 'custom-template');
+        expect(templateInput).toHaveValue('custom-template');
+
+        rerender(
+            <SubscribeModal
+                {...defaultProps}
+                url="http://next.example"
+                authorName="Next Author"
+            />
+        );
+
+        expect(screen.getByLabelText('subscriptionFilenameTemplate')).toHaveValue('');
+    });
+
+    it('resets the filename template when the modal closes', async () => {
+        const user = userEvent.setup();
+        render(<SubscribeModal {...defaultProps} />);
+        const templateInput = screen.getByLabelText('subscriptionFilenameTemplate');
+
+        await user.type(templateInput, 'custom-template');
+        expect(templateInput).toHaveValue('custom-template');
+
+        await user.click(screen.getByText('cancel'));
+
+        expect(mockOnClose).toHaveBeenCalled();
+        expect(screen.getByLabelText('subscriptionFilenameTemplate')).toHaveValue('');
     });
 
     it('should show download order only when download all previous is checked', async () => {

--- a/frontend/src/components/__tests__/SubscribeModal.test.tsx
+++ b/frontend/src/components/__tests__/SubscribeModal.test.tsx
@@ -55,7 +55,7 @@ describe('SubscribeModal', () => {
 
         // Defaults: 60, false, false
         await user.click(screen.getByText('subscribe'));
-        expect(mockOnConfirm).toHaveBeenCalledWith(60, false, false, 'dateDesc');
+        expect(mockOnConfirm).toHaveBeenCalledWith({ interval: 60, downloadAllPrevious: false, downloadShorts: false, downloadOrder: 'dateDesc', filenameTemplate: null });
         expect(mockOnClose).toHaveBeenCalled();
     });
 
@@ -70,7 +70,7 @@ describe('SubscribeModal', () => {
         await user.click(screen.getByLabelText('downloadShorts'));
 
         await user.click(screen.getByText('subscribe'));
-        expect(mockOnConfirm).toHaveBeenCalledWith(30, true, true, 'dateDesc');
+        expect(mockOnConfirm).toHaveBeenCalledWith({ interval: 30, downloadAllPrevious: true, downloadShorts: true, downloadOrder: 'dateDesc', filenameTemplate: null });
     });
 
     it('should show download order only when download all previous is checked', async () => {

--- a/frontend/src/components/__tests__/SubscriptionFilenameTemplateField.test.tsx
+++ b/frontend/src/components/__tests__/SubscriptionFilenameTemplateField.test.tsx
@@ -1,0 +1,170 @@
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useState } from 'react';
+import SubscriptionFilenameTemplateField from '../SubscriptionFilenameTemplateField';
+
+// Mock LanguageContext — return the key verbatim so assertions can match keys.
+vi.mock('../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({
+        t: (key: string) => key,
+    }),
+}));
+
+const mockApiPost = vi.fn();
+
+vi.mock('../../utils/apiClient', () => ({
+    api: {
+        post: (...args: any[]) => mockApiPost(...args),
+    },
+}));
+
+/** Stateful wrapper so the controlled input actually updates on change. */
+function FieldHarness(props: {
+    initial?: string;
+    sourceCollectionType?: 'channel' | 'playlist';
+    onValidityChange?: (valid: boolean) => void;
+}) {
+    const [value, setValue] = useState(props.initial ?? '');
+    return (
+        <SubscriptionFilenameTemplateField
+            value={value}
+            onChange={setValue}
+            sourceCollectionType={props.sourceCollectionType ?? 'channel'}
+            onValidityChange={props.onValidityChange}
+        />
+    );
+}
+
+const renderField = (initial = '', sourceCollectionType: 'channel' | 'playlist' = 'channel') => {
+    const theme = createTheme();
+    return render(
+        <ThemeProvider theme={theme}>
+            <FieldHarness initial={initial} sourceCollectionType={sourceCollectionType} />
+        </ThemeProvider>
+    );
+};
+
+describe('SubscriptionFilenameTemplateField', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows the inherit helper when blank and reports validity true', () => {
+        const onValidityChange = vi.fn();
+        const theme = createTheme();
+        render(
+            <ThemeProvider theme={theme}>
+                <FieldHarness onValidityChange={onValidityChange} />
+            </ThemeProvider>
+        );
+        expect(screen.getByText('subscriptionFilenameTemplateInherit')).toBeInTheDocument();
+        expect(onValidityChange).toHaveBeenLastCalledWith(true);
+    });
+
+    it('sends a debounced validation request with the given source collection type', async () => {
+        mockApiPost.mockResolvedValue({
+            data: {
+                valid: true,
+                errors: [],
+                warnings: [],
+                rendered: {
+                    videoPath: 'Channel/Title.mp4',
+                    thumbnailPath: 'Channel/Title.jpg',
+                    subtitlePath: 'Channel/Title.en.vtt',
+                },
+            },
+        });
+
+        renderField('', 'playlist');
+        await userEvent.type(screen.getByRole('textbox'), '{{ title }}.{{ ext }}');
+
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledWith(
+                '/settings/filename-template/validate',
+                expect.objectContaining({ sourceCollectionType: 'playlist' })
+            );
+        });
+    });
+
+    it('reports a non-empty template as invalid until server validation completes', async () => {
+        let resolveValidation: ((value: unknown) => void) | undefined;
+        mockApiPost.mockReturnValue(new Promise((resolve) => {
+            resolveValidation = resolve;
+        }));
+
+        const onValidityChange = vi.fn();
+        const theme = createTheme();
+        render(
+            <ThemeProvider theme={theme}>
+                <FieldHarness onValidityChange={onValidityChange} />
+            </ThemeProvider>
+        );
+
+        await userEvent.type(screen.getByRole('textbox'), '{{ title }}.{{ ext }}');
+        await waitFor(() => {
+            expect(mockApiPost).toHaveBeenCalledTimes(1);
+        });
+        expect(onValidityChange).toHaveBeenLastCalledWith(false);
+
+        resolveValidation?.({
+            data: {
+                valid: true,
+                errors: [],
+                warnings: [],
+                rendered: null,
+            },
+        });
+        await waitFor(() => {
+            expect(onValidityChange).toHaveBeenLastCalledWith(true);
+        });
+    });
+
+    it('renders validation errors and reports validity false', async () => {
+        mockApiPost.mockResolvedValue({
+            data: {
+                valid: false,
+                errors: ['Missing extension placeholder'],
+                warnings: [],
+                rendered: null,
+            },
+        });
+
+        const onValidityChange = vi.fn();
+        const theme = createTheme();
+        render(
+            <ThemeProvider theme={theme}>
+                <FieldHarness onValidityChange={onValidityChange} />
+            </ThemeProvider>
+        );
+        await userEvent.type(screen.getByRole('textbox'), 'no-ext');
+
+        await waitFor(() => {
+            expect(screen.getByText('Missing extension placeholder')).toBeInTheDocument();
+        });
+        expect(onValidityChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('renders the preview when valid', async () => {
+        mockApiPost.mockResolvedValue({
+            data: {
+                valid: true,
+                errors: [],
+                warnings: [],
+                rendered: {
+                    videoPath: 'Channel/Title.mp4',
+                    thumbnailPath: 'Channel/Title.jpg',
+                    subtitlePath: 'Channel/Title.en.vtt',
+                },
+            },
+        });
+
+        renderField();
+        await userEvent.type(screen.getByRole('textbox'), '{{ title }}.{{ ext }}');
+
+        await waitFor(() => {
+            expect(screen.getByText('Channel/Title.mp4')).toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/src/contexts/DownloadContext.tsx
+++ b/frontend/src/contexts/DownloadContext.tsx
@@ -40,6 +40,9 @@ const SubscribeModal = lazyWithRetry(
     () => import('../components/SubscribeModal'),
     'subscribe-modal',
 );
+// Type-only import (erased at runtime) so handleSubscribeConfirm is typed
+// against the structured form values exported by SubscribeModal.
+import type { SubscribeFormValues } from '../components/SubscribeModal';
 
 // Payload from GET /check-bilibili-collection, forwarded to the download API
 // when the user confirms a collection/series download.
@@ -62,6 +65,8 @@ interface BilibiliPartsInfo {
 
 interface SubscribeInfo {
     interval: number;
+    downloadAll?: boolean;
+    filenameTemplate?: string | null;
 }
 
 interface DownloadContextType {
@@ -526,7 +531,10 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                     collectionName: collectionName || bilibiliPartsInfo.title,
                     downloadAll: true,
                     // Include collectionInfo for Bilibili collections/series
-                    collectionInfo: isCollection ? bilibiliPartsInfo.collectionInfo : undefined
+                    collectionInfo: isCollection ? bilibiliPartsInfo.collectionInfo : undefined,
+                    ...(subscribeInfo.filenameTemplate
+                        ? { filenameTemplate: subscribeInfo.filenameTemplate }
+                        : {}),
                 });
 
                 // Trigger immediate status check
@@ -610,7 +618,13 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     const [showChannelPlaylistsModal, setShowChannelPlaylistsModal] = useState(false);
     const [channelPlaylistsUrl, setChannelPlaylistsUrl] = useState('');
 
-    const handleSubscribe = async (interval: number, downloadAllPrevious: boolean, downloadShorts: boolean, downloadOrder: string) => {
+    const handleSubscribe = async (
+        interval: number,
+        downloadAllPrevious: boolean,
+        downloadShorts: boolean,
+        downloadOrder: string,
+        filenameTemplate: string | null
+    ) => {
         try {
             await api.post('/subscriptions', {
                 url: subscribeUrl,
@@ -618,6 +632,7 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                 downloadAllPrevious,
                 downloadShorts,
                 ...(downloadAllPrevious ? { downloadOrder } : {}),
+                ...(filenameTemplate ? { filenameTemplate } : {}),
             });
             showSnackbar(t('subscribedSuccessfully'));
             setShowSubscribeModal(false);
@@ -667,7 +682,11 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         setShowSubscribeModal(true);
     };
 
-    const performSubscribePlaylists = async (interval: number, downloadAllPrevious: boolean = false) => {
+    const performSubscribePlaylists = async (
+        interval: number,
+        downloadAllPrevious: boolean = false,
+        filenameTemplate: string | null = null
+    ) => {
         try {
             // Construct the playlists URL
             let playlistsUrl = subscribeUrl;
@@ -681,7 +700,8 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
             const response = await api.post('/subscriptions/channel-playlists', {
                 url: playlistsUrl,
                 interval: interval,
-                downloadAllPrevious: downloadAllPrevious
+                downloadAllPrevious: downloadAllPrevious,
+                ...(filenameTemplate ? { filenameTemplate } : {}),
             });
 
             // Construct message from translations
@@ -742,11 +762,21 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         }
     };
 
-    const handleSubscribeConfirm = async (interval: number, downloadAllPrevious: boolean, downloadShorts: boolean, downloadOrder: string) => {
+    const handleSubscribeConfirm = async (values: SubscribeFormValues) => {
         if (subscribeMode === 'video') {
-            await handleSubscribe(interval, downloadAllPrevious, downloadShorts, downloadOrder);
+            await handleSubscribe(
+                values.interval,
+                values.downloadAllPrevious,
+                values.downloadShorts,
+                values.downloadOrder,
+                values.filenameTemplate
+            );
         } else {
-            performSubscribePlaylists(interval, downloadAllPrevious);
+            performSubscribePlaylists(
+                values.interval,
+                values.downloadAllPrevious,
+                values.filenameTemplate
+            );
         }
     };
 
@@ -796,6 +826,7 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
                         title={subscribeMode === 'playlist' ? (t('subscribeAllPlaylists') || 'Subscribe All Playlists') : undefined}
                         description={subscribeMode === 'playlist' ? (t('subscribeAllPlaylistsDescription') || 'This will subscribe to all playlists in this channel.') : undefined}
                         enableDownloadOrder={subscribeMode !== 'playlist'}
+                        playlistMode={subscribeMode === 'playlist'}
                     />
                 )}
                 {showDuplicateModal && (

--- a/frontend/src/contexts/__tests__/DownloadContext.test.tsx
+++ b/frontend/src/contexts/__tests__/DownloadContext.test.tsx
@@ -84,7 +84,7 @@ vi.mock('../../components/SubscribeModal', () => ({
       <div data-testid="subscribe-modal">
         <div>{enableDownloadOrder ? 'mode-video' : 'mode-playlist'}</div>
         <div>{`source-${source || 'none'}`}</div>
-        <button onClick={() => onConfirm(30, true, false, 'viewsDesc')}>confirm-subscribe</button>
+        <button onClick={() => onConfirm({ interval: 30, downloadAllPrevious: true, downloadShorts: false, downloadOrder: 'viewsDesc', filenameTemplate: null })}>confirm-subscribe</button>
         <button onClick={onClose}>close-subscribe</button>
       </div>
     ) : null,

--- a/frontend/src/hooks/__tests__/useVideoSubscriptions.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoSubscriptions.test.tsx
@@ -115,7 +115,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(60, true, false, "viewsDesc");
+      await result.current.handleSubscribeConfirm({ interval: 60, downloadAllPrevious: true, downloadShorts: false, downloadOrder: "viewsDesc", filenameTemplate: null });
     });
 
     expect(mockApiPost).toHaveBeenCalledWith(
@@ -144,7 +144,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(30, false, true, "viewsAsc");
+      await result.current.handleSubscribeConfirm({ interval: 30, downloadAllPrevious: false, downloadShorts: true, downloadOrder: "viewsAsc", filenameTemplate: null });
     });
 
     const payload = mockApiPost.mock.calls[0][1];
@@ -353,7 +353,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(30, false, false, "viewsDesc");
+      await result.current.handleSubscribeConfirm({ interval: 30, downloadAllPrevious: false, downloadShorts: false, downloadOrder: "viewsDesc", filenameTemplate: null });
     });
 
     expect(mockShowSnackbar).toHaveBeenCalledWith(
@@ -376,7 +376,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(30, true, false, "viewsDesc");
+      await result.current.handleSubscribeConfirm({ interval: 30, downloadAllPrevious: true, downloadShorts: false, downloadOrder: "viewsDesc", filenameTemplate: null });
     });
 
     expect(mockShowSnackbar).toHaveBeenCalledWith("error", "error");
@@ -412,7 +412,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(30, false, false, "dateDesc");
+      await result.current.handleSubscribeConfirm({ interval: 30, downloadAllPrevious: false, downloadShorts: false, downloadOrder: "dateDesc", filenameTemplate: null });
     });
 
     expect(mockShowSnackbar).toHaveBeenCalledWith(
@@ -427,7 +427,7 @@ describe("useVideoSubscriptions", () => {
     });
 
     await act(async () => {
-      await result.current.handleSubscribeConfirm(30, true, true, "viewsAsc");
+      await result.current.handleSubscribeConfirm({ interval: 30, downloadAllPrevious: true, downloadShorts: true, downloadOrder: "viewsAsc", filenameTemplate: null });
     });
 
     expect(mockApiPost).not.toHaveBeenCalled();

--- a/frontend/src/hooks/useVideoSubscriptions.ts
+++ b/frontend/src/hooks/useVideoSubscriptions.ts
@@ -8,6 +8,7 @@ import { api } from "../utils/apiClient";
 import { resolveSubscriptionErrorMessage } from "../utils/subscriptionErrors";
 import { validateUrlForOpen } from "../utils/urlValidation";
 import { SUBSCRIPTIONS_QUERY_KEY, useSubscriptions } from "./useSubscriptions";
+import type { SubscribeFormValues } from "../components/SubscribeModal";
 
 interface UseVideoSubscriptionsProps {
   video: Video | undefined;
@@ -165,13 +166,11 @@ export function useVideoSubscriptions({ video }: UseVideoSubscriptionsProps) {
 
   // Handle subscribe confirmation
   const handleSubscribeConfirm = async (
-    interval: number,
-    downloadAllPrevious: boolean,
-    downloadShorts: boolean,
-    downloadOrder: string
+    values: SubscribeFormValues
   ) => {
     if (!authorChannelUrl || !video) return;
 
+    const { interval, downloadAllPrevious, downloadShorts, downloadOrder, filenameTemplate } = values;
     try {
       await api.post("/subscriptions", {
         url: authorChannelUrl,
@@ -180,6 +179,7 @@ export function useVideoSubscriptions({ video }: UseVideoSubscriptionsProps) {
         downloadAllPrevious,
         downloadShorts,
         ...(downloadAllPrevious ? { downloadOrder } : {}),
+        ...(filenameTemplate ? { filenameTemplate } : {}),
       });
       showSnackbar(t("subscribedSuccessfully"));
       void queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_QUERY_KEY });

--- a/frontend/src/pages/SubscriptionsPage.tsx
+++ b/frontend/src/pages/SubscriptionsPage.tsx
@@ -1,4 +1,4 @@
-import { AutoDelete, Cancel, Check, Close, Delete, DeleteOutline, Edit, HelpOutline, Pause, PlayArrow, Tune } from '@mui/icons-material';
+import { AutoDelete, Cancel, Check, Close, Delete, DeleteOutline, DriveFileRenameOutline, Edit, HelpOutline, Pause, PlayArrow, Tune } from '@mui/icons-material';
 import {
     Box,
     Button,
@@ -26,6 +26,7 @@ import { useTheme } from '@mui/material/styles';
 import { useQuery } from '@tanstack/react-query';
 import React, { useMemo, useState } from 'react';
 import ConfirmationModal from '../components/ConfirmationModal';
+import SubscriptionFilenameTemplateField from '../components/SubscriptionFilenameTemplateField';
 import { useAuth } from '../contexts/AuthContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
@@ -53,6 +54,7 @@ interface Subscription {
     collectionId?: string;
     retentionDays?: number | null;
     ytdlpConfig?: string | null;
+    filenameTemplate?: string | null;
 }
 
 interface ContinuousDownloadTask {
@@ -120,6 +122,13 @@ const SubscriptionsPage: React.FC = () => {
     const [ytdlpConfigSub, setYtdlpConfigSub] = useState<Subscription | null>(null);
     const [editedYtdlpConfig, setEditedYtdlpConfig] = useState<string>('');
     const [isSavingYtdlpConfig, setIsSavingYtdlpConfig] = useState(false);
+    // Per-subscription filename-template override (issue #368). Edited in a
+    // dialog. Not secret and not trust-gated, so available to all non-visitor
+    // users. null/blank means inherit the global filename naming setting.
+    const [filenameTemplateSub, setFilenameTemplateSub] = useState<Subscription | null>(null);
+    const [editedFilenameTemplate, setEditedFilenameTemplate] = useState<string>('');
+    const [isFilenameTemplateValid, setIsFilenameTemplateValid] = useState<boolean>(true);
+    const [isSavingFilenameTemplate, setIsSavingFilenameTemplate] = useState(false);
     const [subscriptionsPage, setSubscriptionsPage] = useState(0);
     const [subscriptionsRowsPerPage, setSubscriptionsRowsPerPage] = useState(DEFAULT_SUBSCRIPTIONS_ROWS_PER_PAGE);
     const [subscriptionActionId, setSubscriptionActionId] = useState<string | null>(null);
@@ -391,6 +400,36 @@ const SubscriptionsPage: React.FC = () => {
             console.error('Error updating subscription yt-dlp config:', error);
             showSnackbar(t('ytdlpConfigOverrideUpdateFailed'));
             setIsSavingYtdlpConfig(false);
+        }
+    };
+
+    const handleStartEditingFilenameTemplate = (subscription: Subscription) => {
+        setFilenameTemplateSub(subscription);
+        setEditedFilenameTemplate(subscription.filenameTemplate ?? '');
+        setIsFilenameTemplateValid(true);
+    };
+
+    const handleCancelEditingFilenameTemplate = () => {
+        setFilenameTemplateSub(null);
+        setEditedFilenameTemplate('');
+        setIsFilenameTemplateValid(true);
+        setIsSavingFilenameTemplate(false);
+    };
+
+    const handleSaveFilenameTemplate = async () => {
+        if (!filenameTemplateSub) return;
+        setIsSavingFilenameTemplate(true);
+        try {
+            await api.put(`/subscriptions/${filenameTemplateSub.id}`, {
+                filenameTemplate: editedFilenameTemplate.trim() || null,
+            });
+            showSnackbar(t('subscriptionFilenameTemplateUpdated'));
+            await refetchSubscriptions();
+            handleCancelEditingFilenameTemplate();
+        } catch (error) {
+            console.error('Error updating subscription filename template:', error);
+            showSnackbar(t('subscriptionFilenameTemplateUpdateFailed'));
+            setIsSavingFilenameTemplate(false);
         }
     };
 
@@ -696,6 +735,14 @@ const SubscriptionsPage: React.FC = () => {
                                                 </IconButton>
                                             )}
                                             <IconButton
+                                                color={sub.filenameTemplate ? 'secondary' : 'primary'}
+                                                onClick={() => handleStartEditingFilenameTemplate(sub)}
+                                                title={sub.filenameTemplate ? t('subscriptionFilenameTemplateCustom') : t('editSubscriptionFilenameTemplate')}
+                                                disabled={isEditingInterval || isEditingRetention}
+                                            >
+                                                <DriveFileRenameOutline />
+                                            </IconButton>
+                                            <IconButton
                                                 color="error"
                                                 onClick={createUnsubscribeHandler(sub)}
                                                 title={t('unsubscribe')}
@@ -951,6 +998,49 @@ const SubscriptionsPage: React.FC = () => {
                         variant="contained"
                         color="primary"
                         disabled={isSavingYtdlpConfig}
+                    >
+                        {t('save')}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+            <Dialog
+                open={filenameTemplateSub !== null}
+                onClose={handleCancelEditingFilenameTemplate}
+                maxWidth="sm"
+                fullWidth
+            >
+                <DialogTitle>{t('editSubscriptionFilenameTemplate')}</DialogTitle>
+                <DialogContent>
+                    {filenameTemplateSub && (
+                        <DialogContentText sx={{ mb: 2 }}>
+                            {filenameTemplateSub.author}
+                        </DialogContentText>
+                    )}
+                    <SubscriptionFilenameTemplateField
+                        value={editedFilenameTemplate}
+                        onChange={setEditedFilenameTemplate}
+                        sourceCollectionType={
+                            filenameTemplateSub?.subscriptionType === 'playlist' ||
+                            filenameTemplateSub?.subscriptionType === 'channel_playlists'
+                                ? 'playlist'
+                                : 'channel'
+                        }
+                        disabled={isSavingFilenameTemplate}
+                        onValidityChange={setIsFilenameTemplateValid}
+                    />
+                    <DialogContentText sx={{ mt: 2, color: 'text.secondary' }}>
+                        {t('subscriptionFilenameTemplateFutureOnly')}
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions sx={{ p: 2 }}>
+                    <Button onClick={handleCancelEditingFilenameTemplate} color="inherit" disabled={isSavingFilenameTemplate}>
+                        {t('cancel')}
+                    </Button>
+                    <Button
+                        onClick={() => void handleSaveFilenameTemplate()}
+                        variant="contained"
+                        color="primary"
+                        disabled={isSavingFilenameTemplate || !isFilenameTemplateValid}
                     >
                         {t('save')}
                     </Button>

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -4,7 +4,7 @@ Canonical locale key order derived from `frontend/src/utils/locales/en.ts`.
 
 This list is intentionally unnumbered. When new keys are inserted, only the local section order changes.
 
-Total keys: 1046
+Total keys: 1056
 
 ## Summary
 
@@ -39,7 +39,7 @@ Total keys: 1046
 | Disclaimer | 3 | `disclaimerTitle` | `history` |
 | Existing Video Detection | 16 | `existingVideoDetected` | `changeSettings` |
 | Sorting | 10 | `sort` | `random` |
-| yt-dlp Configuration | 23 | `ytDlpConfiguration` | `saveAuthorFilesToCollectionDescription` |
+| yt-dlp Configuration | 33 | `ytDlpConfiguration` | `subscriptionFilenameTemplateUpdateFailed` |
 | Cloudflare Tunnel | 16 | `cloudflaredTunnel` | `managedInDashboard` |
 | Database Export/Import | 39 | `exportImportDatabase` | `backupDatabasesCleanedUp` |
 | History Filter | 33 | `filterAll` | `browserVideoFormatNotSupported` |
@@ -1130,6 +1130,16 @@ Total keys: 1046
 | `cleanupAuthorCollectionsSuccess` |
 | `cleanupAuthorCollectionsNothingToDo` |
 | `cleanupAuthorCollectionsFailed` |
+| `subscriptionFilenameTemplate` |
+| `subscriptionFilenameTemplateHelp` |
+| `subscriptionFilenameTemplateInherit` |
+| `subscriptionFilenameTemplatePlaceholder` |
+| `subscriptionFilenameTemplatePreview` |
+| `subscriptionFilenameTemplateFutureOnly` |
+| `editSubscriptionFilenameTemplate` |
+| `subscriptionFilenameTemplateCustom` |
+| `subscriptionFilenameTemplateUpdated` |
+| `subscriptionFilenameTemplateUpdateFailed` |
 
 ### Cloudflare Tunnel
 

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1020,6 +1020,23 @@ export const ar = {
   ytdlpConfigOverrideUpdated: "تم تحديث تجاوز yt-dlp",
   ytdlpConfigOverrideUpdateFailed: "فشل تحديث تجاوز yt-dlp",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "تجاوز قالب اسم الملف",
+  subscriptionFilenameTemplateHelp:
+    "قالب اسم الملف يُطبَّق فقط على التنزيلات من هذا الاشتراك. يستخدم نفس الصيغة والمتغيرات الموجودة في الإعدادات ← تسمية الملفات. اتركه فارغًا لاستخدام إعداد تسمية الملفات العام.",
+  subscriptionFilenameTemplateInherit:
+    "اتركه فارغًا لتوريث إعداد تسمية الملفات العام.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "معاينة",
+  subscriptionFilenameTemplateFutureOnly:
+    "تؤثر التغييرات على التنزيلات المستقبلية فقط. لا تُعاد تسمية الملفات الموجودة.",
+  editSubscriptionFilenameTemplate: "تعديل تجاوز قالب اسم الملف",
+  subscriptionFilenameTemplateCustom: "قالب اسم ملف مخصص",
+  subscriptionFilenameTemplateUpdated: "تم تحديث تجاوز قالب اسم الملف",
+  subscriptionFilenameTemplateUpdateFailed:
+    "فشل تحديث تجاوز قالب اسم الملف",
+
   // Subscription Pause/Resume
   pause: "إيقاف مؤقت",
   resume: "استئناف",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1063,6 +1063,23 @@ export const de = {
   ytdlpConfigOverrideUpdateFailed:
     "yt-dlp-Überschreibung konnte nicht aktualisiert werden",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Dateinamenvorlagen-Überschreibung",
+  subscriptionFilenameTemplateHelp:
+    "Dateinamenvorlage, die nur auf Downloads dieses Abonnements angewendet wird. Verwendet dieselbe Syntax und Variablen wie Einstellungen → Dateibenennung. Leer lassen, um die globale Dateibenennungseinstellung zu verwenden.",
+  subscriptionFilenameTemplateInherit:
+    "Leer lassen, um die globale Dateibenennungseinstellung zu übernehmen.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Vorschau",
+  subscriptionFilenameTemplateFutureOnly:
+    "Änderungen wirken sich nur auf zukünftige Downloads aus. Bestehende Dateien werden nicht umbenannt.",
+  editSubscriptionFilenameTemplate: "Dateinamenvorlagen-Überschreibung bearbeiten",
+  subscriptionFilenameTemplateCustom: "Benutzerdefinierte Dateinamenvorlage",
+  subscriptionFilenameTemplateUpdated: "Dateinamenvorlagen-Überschreibung aktualisiert",
+  subscriptionFilenameTemplateUpdateFailed:
+    "Dateinamenvorlagen-Überschreibung konnte nicht aktualisiert werden",
+
   // Subscription Pause/Resume
   pause: "Pause",
   resume: "Fortsetzen",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1028,6 +1028,23 @@ export const en = {
   ytdlpConfigOverrideUpdated: "yt-dlp override updated",
   ytdlpConfigOverrideUpdateFailed: "Failed to update yt-dlp override",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Filename template override",
+  subscriptionFilenameTemplateHelp:
+    "Filename template applied only to downloads from this subscription. Uses the same syntax and variables as Settings → File Naming. Leave empty to use the global filename naming setting.",
+  subscriptionFilenameTemplateInherit:
+    "Leave empty to inherit the global filename naming setting.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Preview",
+  subscriptionFilenameTemplateFutureOnly:
+    "Changes affect future downloads. Existing files are not renamed.",
+  editSubscriptionFilenameTemplate: "Edit filename template override",
+  subscriptionFilenameTemplateCustom: "Custom filename template",
+  subscriptionFilenameTemplateUpdated: "Filename template override updated",
+  subscriptionFilenameTemplateUpdateFailed:
+    "Failed to update filename template override",
+
   // Subscription Pause/Resume
   pause: "Pause",
   resume: "Resume",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1058,6 +1058,23 @@ export const es = {
   ytdlpConfigOverrideUpdated: "Anulación de yt-dlp actualizada",
   ytdlpConfigOverrideUpdateFailed: "No se pudo actualizar la anulación de yt-dlp",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Anulación de plantilla de nombre de archivo",
+  subscriptionFilenameTemplateHelp:
+    "Plantilla de nombre de archivo aplicada solo a las descargas de esta suscripción. Usa la misma sintaxis y variables que Configuración → Nomenclatura de archivos. Déjelo vacío para usar la configuración global de nomenclatura de archivos.",
+  subscriptionFilenameTemplateInherit:
+    "Déjelo vacío para heredar la configuración global de nomenclatura de archivos.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Vista previa",
+  subscriptionFilenameTemplateFutureOnly:
+    "Los cambios afectan a las descargas futuras. Los archivos existentes no se renombran.",
+  editSubscriptionFilenameTemplate: "Editar anulación de plantilla de nombre de archivo",
+  subscriptionFilenameTemplateCustom: "Plantilla de nombre de archivo personalizada",
+  subscriptionFilenameTemplateUpdated: "Anulación de plantilla de nombre de archivo actualizada",
+  subscriptionFilenameTemplateUpdateFailed:
+    "No se pudo actualizar la anulación de plantilla de nombre de archivo",
+
   // Subscription Pause/Resume
   pause: "Pausar",
   resume: "Reanudar",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1063,6 +1063,23 @@ export const fr = {
   ytdlpConfigOverrideUpdated: "Surcharge yt-dlp mise à jour",
   ytdlpConfigOverrideUpdateFailed: "Échec de la mise à jour de la surcharge yt-dlp",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Surcharge du modèle de nom de fichier",
+  subscriptionFilenameTemplateHelp:
+    "Modèle de nom de fichier appliqué uniquement aux téléchargements de cet abonnement. Utilise la même syntaxe et les mêmes variables que Paramètres → Nommage des fichiers. Laisser vide pour utiliser le paramètre global de nommage des fichiers.",
+  subscriptionFilenameTemplateInherit:
+    "Laisser vide pour hériter du paramètre global de nommage des fichiers.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Aperçu",
+  subscriptionFilenameTemplateFutureOnly:
+    "Les modifications affectent les téléchargements futurs. Les fichiers existants ne sont pas renommés.",
+  editSubscriptionFilenameTemplate: "Modifier la surcharge du modèle de nom de fichier",
+  subscriptionFilenameTemplateCustom: "Modèle de nom de fichier personnalisé",
+  subscriptionFilenameTemplateUpdated: "Surcharge du modèle de nom de fichier mise à jour",
+  subscriptionFilenameTemplateUpdateFailed:
+    "Échec de la mise à jour de la surcharge du modèle de nom de fichier",
+
   // Subscription Pause/Resume
   pause: "Pause",
   resume: "Reprendre",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1046,6 +1046,23 @@ export const ja = {
   ytdlpConfigOverrideUpdated: "yt-dlp の上書きを更新しました",
   ytdlpConfigOverrideUpdateFailed: "yt-dlp の上書きの更新に失敗しました",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "ファイル名テンプレートの上書き",
+  subscriptionFilenameTemplateHelp:
+    "この購読からのダウンロードにのみ適用されるファイル名テンプレート。設定 → ファイル名付けと同じ構文と変数を使用します。空欄の場合はグローバルのファイル名付け設定を使用します。",
+  subscriptionFilenameTemplateInherit:
+    "空欄の場合はグローバルのファイル名付け設定を継承します。",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "プレビュー",
+  subscriptionFilenameTemplateFutureOnly:
+    "変更は今後のダウンロードにのみ適用されます。既存のファイルは名前変更されません。",
+  editSubscriptionFilenameTemplate: "ファイル名テンプレートの上書きを編集",
+  subscriptionFilenameTemplateCustom: "カスタムファイル名テンプレート",
+  subscriptionFilenameTemplateUpdated: "ファイル名テンプレートの上書きを更新しました",
+  subscriptionFilenameTemplateUpdateFailed:
+    "ファイル名テンプレートの上書きの更新に失敗しました",
+
   // Subscription Pause/Resume
   pause: "一時停止",
   resume: "再開",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1029,6 +1029,23 @@ export const ko = {
   ytdlpConfigOverrideUpdated: "yt-dlp 재정의가 업데이트되었습니다",
   ytdlpConfigOverrideUpdateFailed: "yt-dlp 재정의 업데이트에 실패했습니다",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "파일명 템플릿 재정의",
+  subscriptionFilenameTemplateHelp:
+    "이 구독의 다운로드에만 적용되는 파일명 템플릿입니다. 설정 → 파일명 지정과 동일한 문법과 변수를 사용합니다. 비워 두면 전역 파일명 지정 설정을 사용합니다.",
+  subscriptionFilenameTemplateInherit:
+    "전역 파일명 지정 설정을 상속하려면 비워 두세요.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "미리보기",
+  subscriptionFilenameTemplateFutureOnly:
+    "변경 사항은 향후 다운로드에만 적용됩니다. 기존 파일은 이름이 변경되지 않습니다.",
+  editSubscriptionFilenameTemplate: "파일명 템플릿 재정의 편집",
+  subscriptionFilenameTemplateCustom: "사용자 지정 파일명 템플릿",
+  subscriptionFilenameTemplateUpdated: "파일명 템플릿 재정의가 업데이트되었습니다",
+  subscriptionFilenameTemplateUpdateFailed:
+    "파일명 템플릿 재정의 업데이트에 실패했습니다",
+
   // Subscription Pause/Resume
   pause: "일시 중지",
   resume: "재개",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1050,6 +1050,23 @@ export const pt = {
   ytdlpConfigOverrideUpdated: "Substituição do yt-dlp atualizada",
   ytdlpConfigOverrideUpdateFailed: "Falha ao atualizar a substituição do yt-dlp",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Substituição do modelo de nome de arquivo",
+  subscriptionFilenameTemplateHelp:
+    "Modelo de nome de arquivo aplicado apenas aos downloads desta assinatura. Usa a mesma sintaxe e variáveis de Configurações → Nomenclatura de arquivos. Deixe vazio para usar a configuração global de nomenclatura de arquivos.",
+  subscriptionFilenameTemplateInherit:
+    "Deixe vazio para herdar a configuração global de nomenclatura de arquivos.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Visualização",
+  subscriptionFilenameTemplateFutureOnly:
+    "As alterações afetam apenas downloads futuros. Arquivos existentes não são renomeados.",
+  editSubscriptionFilenameTemplate: "Editar substituição do modelo de nome de arquivo",
+  subscriptionFilenameTemplateCustom: "Modelo de nome de arquivo personalizado",
+  subscriptionFilenameTemplateUpdated: "Substituição do modelo de nome de arquivo atualizada",
+  subscriptionFilenameTemplateUpdateFailed:
+    "Falha ao atualizar a substituição do modelo de nome de arquivo",
+
   // Subscription Pause/Resume
   pause: "Pausar",
   resume: "Retomar",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1044,6 +1044,23 @@ export const ru = {
   ytdlpConfigOverrideUpdated: "Переопределение yt-dlp обновлено",
   ytdlpConfigOverrideUpdateFailed: "Не удалось обновить переопределение yt-dlp",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "Переопределение шаблона имени файла",
+  subscriptionFilenameTemplateHelp:
+    "Шаблон имени файла, применяемый только к загрузкам из этой подписки. Использует тот же синтаксис и переменные, что и Настройки → Именование файлов. Оставьте пустым, чтобы использовать глобальный параметр именования файлов.",
+  subscriptionFilenameTemplateInherit:
+    "Оставьте пустым, чтобы наследовать глобальный параметр именования файлов.",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "Предпросмотр",
+  subscriptionFilenameTemplateFutureOnly:
+    "Изменения влияют только на будущие загрузки. Существующие файлы не переименовываются.",
+  editSubscriptionFilenameTemplate: "Изменить переопределение шаблона имени файла",
+  subscriptionFilenameTemplateCustom: "Пользовательский шаблон имени файла",
+  subscriptionFilenameTemplateUpdated: "Переопределение шаблона имени файла обновлено",
+  subscriptionFilenameTemplateUpdateFailed:
+    "Не удалось обновить переопределение шаблона имени файла",
+
   // Subscription Pause/Resume
   pause: "Пауза",
   resume: "Возобновить",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1002,6 +1002,23 @@ export const zh = {
   ytdlpConfigOverrideUpdated: "yt-dlp 覆盖已更新",
   ytdlpConfigOverrideUpdateFailed: "更新 yt-dlp 覆盖失败",
 
+  // Per-subscription filename-template override (issue #368)
+  subscriptionFilenameTemplate: "文件名模板覆盖",
+  subscriptionFilenameTemplateHelp:
+    "仅应用于此订阅下载的文件名模板。使用与 设置 → 文件命名 相同的语法和变量。留空则使用全局文件命名设置。",
+  subscriptionFilenameTemplateInherit:
+    "留空以继承全局文件命名设置。",
+  subscriptionFilenameTemplatePlaceholder:
+    "{{ source_custom_name }}/{{ title }}.{{ ext }}",
+  subscriptionFilenameTemplatePreview: "预览",
+  subscriptionFilenameTemplateFutureOnly:
+    "更改仅影响今后的下载。现有文件不会被重命名。",
+  editSubscriptionFilenameTemplate: "编辑文件名模板覆盖",
+  subscriptionFilenameTemplateCustom: "自定义文件名模板",
+  subscriptionFilenameTemplateUpdated: "文件名模板覆盖已更新",
+  subscriptionFilenameTemplateUpdateFailed:
+    "更新文件名模板覆盖失败",
+
   // Subscription Pause/Resume
   pause: "暂停",
   resume: "恢复",


### PR DESCRIPTION
## Summary

Implements **Issue #368 — Per-Subscription Filename Template Override**, a nullable filename-template override on each subscription so a source can use a different naming policy than the global setting.

- `null` / blank → **inherit the current global filename naming settings**
- non-empty → **force template naming** for downloads owned by that subscription

Effective naming precedence: `subscription template > global naming settings > legacy Title-Author-Year`.

Follows the implementation-ready design: `reports/issue368-subscription-filename-template-override-technical-design.md` (all 9 implementation steps + acceptance criteria marked complete there).

## What changed

**Data model**
- `subscriptions.filename_template` column + Drizzle migration `0025` + snapshot/journal + runtime self-heal guard (mirrors the `ytdlp_config` precedent)

**Backend**
- `normalizeSubscriptionFilenameTemplate()` — reuses the existing global validator (2,000-char limit, path-traversal rules, required extension placeholder); not secret, not trust-gated
- `applySubscriptionFilenameTemplateOverride()` — overlays the override onto global naming settings, setting all three runtime fields coherently so planner/legacy branches can't disagree
- Propagated through `DownloadModeOptions.subscriptionFilenameTemplate` into:
  - yt-dlp (`ytdlpVideo`) and Bilibili (`bilibiliSinglePart`) downloaders
  - scheduled channel/playlist/Twitch/Shorts checks (`enqueueSubscriptionDownload`, `twitchSubscription`)
  - continuous tasks (`taskProcessor`), with exact `subscriptionId` linkage on playlist tasks so the right override wins over URL/collection fallbacks
  - channel-playlists watcher — copy-on-create to newly discovered child playlists
- API: extended `POST/PUT /api/subscriptions`, `POST /api/subscriptions/playlist`, `POST /api/subscriptions/channel-playlists`

**Frontend**
- Reusable `SubscriptionFilenameTemplateField` (debounced validation, error/warning/preview states, validity callback that disables the parent action)
- Integrated into `SubscribeModal`, `BilibiliPartsModal`, `DownloadContext`, `useVideoSubscriptions`
- New edit dialog + row action on `SubscriptionsPage` (icon: primary when inheriting, secondary when overriding)
- 10 i18n keys across all 10 locales + `KEY_LIST.md`

## Notes
- Manual downloads and non-subscription continuous tasks are unchanged.
- Existing files are not renamed; changes affect future downloads only.
- Visitors cannot edit the value (write routes are role-protected).
- `KEY_LIST.md` had pre-existing catalog drift (unrelated to this feature) — left for a separate cleanup.

## Verification

| Check | Result |
|---|---|
| `npm --prefix backend run build` | ✅ |
| `npm --prefix backend test` | ✅ 2474 passed |
| `npm --prefix frontend run typecheck` | ✅ |
| `npm --prefix frontend run lint` | ✅ 0 errors / 0 warnings |
| `npm --prefix frontend test` | ✅ 1669 passed |

Draft for now — open to review feedback, especially on the structured `onConfirm` callback refactor in `SubscribeModal` and the watcher copy-on-create semantics.