### PR TITLE
fix: address remaining subscription override review feedback

### DIFF
--- a/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
+++ b/backend/src/__tests__/services/subscription/channelPlaylists.test.ts
@@ -95,20 +95,34 @@ describe("subscription channelPlaylists", () => {
         collectionId: expect.any(String),
         initialHeadVideoUrl: "https://www.youtube.com/watch?v=vid-new-head",
         baselineObservedAt: expect.any(Number),
+        ytdlpConfig: null,
         filenameTemplate: null,
       })
     );
   });
 
-  it("threads the per-subscription yt-dlp override into the playlist listing", async () => {
+  it("threads the per-subscription yt-dlp override through discovered playlists", async () => {
     const { executeYtDlpJson, getEffectiveUserYtDlpConfig } = await import(
       "../../../utils/ytDlpUtils"
     );
-    vi.mocked(executeYtDlpJson).mockResolvedValueOnce({ entries: [] } as any);
+    vi.mocked(executeYtDlpJson)
+      .mockResolvedValueOnce({
+        entries: [
+          {
+            id: "PL_override",
+            title: "Override Playlist",
+            url: "https://youtube.com/playlist?list=PL_override",
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        _type: "playlist",
+        entries: [{ id: "override-head" }],
+      } as any);
 
     const deps = {
       listSubscriptions: vi.fn().mockResolvedValue([]),
-      subscribePlaylist: vi.fn(),
+      subscribePlaylist: vi.fn().mockResolvedValue(undefined),
     };
 
     await checkChannelPlaylistsForWatcher(
@@ -119,6 +133,12 @@ describe("subscription channelPlaylists", () => {
     expect(getEffectiveUserYtDlpConfig).toHaveBeenCalledWith(
       "https://youtube.com/@channel/playlists",
       "--format bestaudio"
+    );
+    expect(deps.subscribePlaylist).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playlistUrl: "https://youtube.com/playlist?list=PL_override",
+        ytdlpConfig: "--format bestaudio",
+      })
     );
   });
 

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -642,6 +642,7 @@ describe('SubscriptionService', () => {
         collectionId: 'col-1',
         initialHeadVideoUrl: 'https://www.youtube.com/watch?v=headA',
         baselineObservedAt: 1700000000000,
+        ytdlpConfig: '--proxy http://playlist-proxy:8080',
       });
 
       expect(result).toMatchObject({
@@ -650,6 +651,7 @@ describe('SubscriptionService', () => {
         collectionId: 'col-1',
         lastVideoLink: 'https://www.youtube.com/watch?v=headA',
         lastCheck: 1700000000000,
+        ytdlpConfig: '--proxy http://playlist-proxy:8080',
       });
       expect(db.insert).toHaveBeenCalled();
     });

--- a/backend/src/__tests__/utils/getEffectiveUserYtDlpConfig.test.ts
+++ b/backend/src/__tests__/utils/getEffectiveUserYtDlpConfig.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as storageService from "../../services/storageService";
+import { logger } from "../../utils/logger";
 import { getEffectiveUserYtDlpConfig } from "../../utils/ytdlp/config";
 
 vi.mock("../../services/storageService", () => ({
@@ -43,15 +44,26 @@ describe("getEffectiveUserYtDlpConfig (issue #345)", () => {
   });
 
   it("merges the override on top of the global config (override wins per-key)", () => {
+    const logSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
     const effective = getEffectiveUserYtDlpConfig(
       "https://example.com/v",
-      "--format bestaudio"
+      "--proxy http://user:secret@override-proxy:8080\n--format bestaudio"
     );
-    // Override supplies format; proxy is inherited from the global config.
+    // The override supplies both values, but its parsed contents must not be
+    // passed to the logger because configs may contain credentials or headers.
     expect(effective).toEqual({
-      proxy: "http://global-proxy:8080",
+      proxy: "http://user:secret@override-proxy:8080",
       format: "bestaudio",
     });
+    expect(logSpy).toHaveBeenCalledWith(
+      "Applying per-subscription yt-dlp override"
+    );
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        proxy: "http://user:secret@override-proxy:8080",
+      })
+    );
   });
 
   it("lets a long-form override replace the same long-form global key", () => {

--- a/backend/src/services/subscription/channelPlaylists.ts
+++ b/backend/src/services/subscription/channelPlaylists.ts
@@ -140,6 +140,7 @@ export async function checkChannelPlaylistsForWatcher(
             collectionId,
             initialHeadVideoUrl: snapshot.headVideoUrl,
             baselineObservedAt: snapshot.observedAt,
+            ytdlpConfig: sub.ytdlpConfig ?? null,
             filenameTemplate: sub.filenameTemplate ?? null,
           });
         } catch (error) {

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -73,6 +73,7 @@ export interface SubscribePlaylistOptions {
   collectionId: string | null;
   initialHeadVideoUrl: string | null;
   baselineObservedAt: number;
+  ytdlpConfig?: string | null;
   filenameTemplate?: string | null;
 }
 
@@ -263,6 +264,7 @@ export class SubscriptionService {
       collectionId,
       initialHeadVideoUrl,
       baselineObservedAt,
+      ytdlpConfig,
       filenameTemplate,
     } = options;
 
@@ -299,6 +301,7 @@ export class SubscriptionService {
       channelName: author,
       subscriptionType: "playlist",
       collectionId: collectionId || undefined,
+      ytdlpConfig: ytdlpConfig ?? null,
       filenameTemplate: filenameTemplate ?? null,
     };
 

--- a/backend/src/utils/ytdlp/config.ts
+++ b/backend/src/utils/ytdlp/config.ts
@@ -168,7 +168,7 @@ export function getEffectiveUserYtDlpConfig(
     isAdminTrustLevelAtLeast("container")
   ) {
     const overrideConfig = parseYtDlpConfig(subscriptionOverride);
-    logger.info("Applying per-subscription yt-dlp override:", overrideConfig);
+    logger.info("Applying per-subscription yt-dlp override");
 
     // Start from the global config, then drop any global key that the override
     // supersedes via an *alias* (short/long form of the same option) so the


### PR DESCRIPTION
## Summary

- inherit a channel-playlist watcher's per-subscription yt-dlp override when creating discovered playlist subscriptions
- persist the inherited override on the child playlist subscription
- stop logging parsed per-subscription yt-dlp override values that may contain credentials, cookies, or headers
- add regression coverage for propagation, persistence, and safe logging

## Why

This follows up on the two remaining review threads from #362. Discovered playlists previously lost the watcher override, and effective-config resolution logged the parsed override object.

## Impact

Discovered playlist subscriptions now retain the network/auth/format settings required by their watcher, while sensitive override contents no longer appear in that log entry.

## Validation

- `npm test` in `backend` — 2,431 tests passed
- `npm run build` in `backend` — passed
- `git diff --check` — passed