### PR TITLE
fix(frontend): satisfy React Hooks 7 lint rules

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "react-virtuoso": "^4.18.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.21.0",
+        "@eslint/js": "^10.0.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -36,7 +36,7 @@
         "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "0.28.1",
         "eslint": "^10.7.0",
-        "eslint-plugin-react-hooks": "^5.1.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^15.15.0",
         "jsdom": "^27.3.0",
@@ -132,6 +132,57 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -146,6 +197,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -170,6 +248,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -184,6 +280,30 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1117,16 +1237,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1226,6 +1354,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -2622,6 +2761,19 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -2645,6 +2797,40 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2666,6 +2852,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2914,6 +3121,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3030,6 +3244,16 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3102,16 +3326,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -3423,6 +3654,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3545,6 +3786,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -3850,6 +4108,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4170,6 +4441,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -4328,6 +4609,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5120,6 +5411,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5440,6 +5762,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5451,6 +5780,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "react-virtuoso": "^4.18.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
@@ -44,7 +44,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.7.0",
-    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
     "jsdom": "^27.3.0",

--- a/frontend/src/components/AuthorsList.tsx
+++ b/frontend/src/components/AuthorsList.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
@@ -76,9 +76,13 @@ const TOP_AUTHORS_LIMIT = 20;
 
 const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    const [openState, setOpenState] = useState(() => ({
+        isMobile,
+        isOpen: !isMobile,
+    }));
+    const isOpen = openState.isMobile === isMobile ? openState.isOpen : !isMobile;
 
     // Count videos per author, then show only the most prolific authors.
     // "Show all" (and the full /authors page) only matters when the list is
@@ -118,22 +122,13 @@ const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
         return map;
     }, [videos]);
 
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
-
     if (!topAuthors.length) {
         return null;
     }
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setOpenState({ isMobile, isOpen: !isOpen })} sx={{ borderRadius: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('authors')}
                 </Typography>

--- a/frontend/src/components/BilibiliPartsModal.tsx
+++ b/frontend/src/components/BilibiliPartsModal.tsx
@@ -10,7 +10,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
@@ -47,7 +47,7 @@ interface BilibiliPartsModalProps {
 const isSubscribableType = (type: string) =>
     type === 'playlist' || type === 'collection' || type === 'series';
 
-const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
+const BilibiliPartsModalContent: React.FC<BilibiliPartsModalProps> = ({
     isOpen,
     onClose,
     videosNumber,
@@ -72,19 +72,6 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [filenameTemplate, setFilenameTemplate] = useState<string>('');
     const [isTemplateValid, setIsTemplateValid] = useState<boolean>(true);
-
-    // The successful submission path closes this controlled dialog from the
-    // parent, bypassing handleClose. Reset the destructive choice whenever
-    // that happens so it cannot be carried to the next detected playlist.
-    useEffect(() => {
-        if (!isOpen) {
-            setSubscribeToPlaylist(false);
-            setDownloadExistingVideos(false);
-            setIntervalInput('60');
-            setFilenameTemplate('');
-            setIsTemplateValid(true);
-        }
-    }, [isOpen]);
 
     const subscribable = isSubscribableType(type);
 
@@ -341,5 +328,8 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
         </Dialog>
     );
 };
+
+const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = (props) =>
+    props.isOpen ? <BilibiliPartsModalContent {...props} /> : null;
 
 export default BilibiliPartsModal;

--- a/frontend/src/components/Collections.tsx
+++ b/frontend/src/components/Collections.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
@@ -25,9 +25,13 @@ const TOP_COLLECTIONS_LIMIT = 20;
 
 const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    const [openState, setOpenState] = useState(() => ({
+        isMobile,
+        isOpen: !isMobile,
+    }));
+    const isOpen = openState.isMobile === isMobile ? openState.isOpen : !isMobile;
 
     const sidebarCollections = useMemo(() => {
         if (!collections) {
@@ -63,22 +67,13 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
         return [...topCollections, ...omittedDirectLinkCollections];
     }, [collections]);
 
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
-
     if (!collections || collections.length === 0) {
         return null;
     }
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setOpenState({ isMobile, isOpen: !isOpen })} sx={{ borderRadius: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('collections')}
                 </Typography>

--- a/frontend/src/components/Header/useHeaderScrollState.ts
+++ b/frontend/src/components/Header/useHeaderScrollState.ts
@@ -1,31 +1,27 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 export const useHeaderScrollState = (
     isMobile: boolean,
     infiniteScroll: boolean,
     isHomePage: boolean
 ): boolean => {
-    const [isScrolled, setIsScrolled] = useState(false);
-
-    useEffect(() => {
-        const shouldDetectScroll = isMobile || (infiniteScroll && isHomePage);
+    const shouldDetectScroll = isMobile || (infiniteScroll && isHomePage);
+    const subscribe = useCallback((onStoreChange: () => void) => {
         if (!shouldDetectScroll) {
-            setIsScrolled(false);
-            return;
+            return () => undefined;
         }
-
-        const handleScroll = () => {
-            const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            setIsScrolled(scrollTop > 50);
-        };
-
-        window.addEventListener('scroll', handleScroll, { passive: true });
-        handleScroll();
-
+        window.addEventListener('scroll', onStoreChange, { passive: true });
         return () => {
-            window.removeEventListener('scroll', handleScroll);
+            window.removeEventListener('scroll', onStoreChange);
         };
-    }, [isMobile, infiniteScroll, isHomePage]);
+    }, [shouldDetectScroll]);
+    const getSnapshot = useCallback(() => {
+        if (!shouldDetectScroll) {
+            return false;
+        }
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        return scrollTop > 50;
+    }, [shouldDetectScroll]);
 
-    return isScrolled;
+    return useSyncExternalStore(subscribe, getSnapshot, () => false);
 };

--- a/frontend/src/components/Header/useHeaderSubscriptions.ts
+++ b/frontend/src/components/Header/useHeaderSubscriptions.ts
@@ -12,11 +12,20 @@ const hasActiveTask = (tasks: SubscriptionTask[]): boolean => {
 };
 
 export const useHeaderSubscriptions = (isVisitor: boolean): boolean => {
-    const [hasActiveSubscriptions, setHasActiveSubscriptions] = useState(false);
+    const [subscriptionState, setSubscriptionState] = useState({
+        isVisitor,
+        hasActiveSubscriptions: false,
+    });
+    const hasActiveSubscriptions =
+        subscriptionState.isVisitor === isVisitor
+            ? subscriptionState.hasActiveSubscriptions
+            : false;
+    if (subscriptionState.isVisitor !== isVisitor) {
+        setSubscriptionState({ isVisitor, hasActiveSubscriptions: false });
+    }
 
     useEffect(() => {
         if (isVisitor) {
-            setHasActiveSubscriptions(false);
             return;
         }
 
@@ -33,12 +42,16 @@ export const useHeaderSubscriptions = (isVisitor: boolean): boolean => {
                 const subscriptions = Array.isArray(subscriptionsRes.data) ? subscriptionsRes.data : [];
                 const tasks = Array.isArray(tasksRes.data) ? tasksRes.data : [];
                 if (isActive) {
-                    setHasActiveSubscriptions(subscriptions.length > 0 || hasActiveTask(tasks));
+                    setSubscriptionState({
+                        isVisitor,
+                        hasActiveSubscriptions:
+                            subscriptions.length > 0 || hasActiveTask(tasks),
+                    });
                 }
             } catch (error) {
                 console.error('Error checking subscriptions:', error);
                 if (isActive) {
-                    setHasActiveSubscriptions(false);
+                    setSubscriptionState({ isVisitor, hasActiveSubscriptions: false });
                 }
             }
         };

--- a/frontend/src/components/PasswordModal.tsx
+++ b/frontend/src/components/PasswordModal.tsx
@@ -23,7 +23,7 @@ interface PasswordModalProps {
     isLoading?: boolean;
 }
 
-const PasswordModal: React.FC<PasswordModalProps> = ({
+const PasswordModalContent: React.FC<PasswordModalProps> = ({
     isOpen,
     onClose,
     onConfirm,
@@ -35,14 +35,6 @@ const PasswordModal: React.FC<PasswordModalProps> = ({
     const { t } = useLanguage();
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
-
-    // Reset state when modal opens
-    React.useEffect(() => {
-        if (isOpen) {
-            setPassword('');
-            setShowPassword(false);
-        }
-    }, [isOpen]);
 
     const handleConfirm = (e?: React.FormEvent) => {
         e?.preventDefault();
@@ -135,5 +127,8 @@ const PasswordModal: React.FC<PasswordModalProps> = ({
         </Dialog>
     );
 };
+
+const PasswordModal: React.FC<PasswordModalProps> = (props) =>
+    props.isOpen ? <PasswordModalContent {...props} /> : null;
 
 export default PasswordModal;

--- a/frontend/src/components/Settings/FilenameTemplateSettings.tsx
+++ b/frontend/src/components/Settings/FilenameTemplateSettings.tsx
@@ -110,6 +110,7 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
         if (!shouldLoadPreview) {
             return;
         }
+        let isCurrent = true;
         const timer = setTimeout(async () => {
             try {
                 const res = await api.post<FilenameTemplatePreviewResponse>(
@@ -119,8 +120,14 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                         template: namingMode === 'template' ? template : undefined,
                     }
                 );
+                if (!isCurrent) {
+                    return;
+                }
                 setPreviewState({ key: previewKey, value: res.data });
             } catch (e: unknown) {
+                if (!isCurrent) {
+                    return;
+                }
                 setPreviewState({
                     key: previewKey,
                     value: {
@@ -136,7 +143,10 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                 });
             }
         }, 600);
-        return () => clearTimeout(timer);
+        return () => {
+            isCurrent = false;
+            clearTimeout(timer);
+        };
     }, [effectiveTemplate, namingMode, presetId, previewKey, shouldLoadPreview]);
 
     const handlePresetChange = (value: string) => {

--- a/frontend/src/components/Settings/FilenameTemplateSettings.tsx
+++ b/frontend/src/components/Settings/FilenameTemplateSettings.tsx
@@ -77,12 +77,22 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
     const presetId = resolveFilenamePresetSelectValue(
         derivedPresetId,
         namingMode,
-        forceCustomSelection
+        namingMode === 'template' && derivedPresetId !== 'custom' && forceCustomSelection
     );
 
-    const [preview, setPreview] = useState<FilenameTemplatePreviewResponse | null>(null);
-    const [isValidating, setIsValidating] = useState(false);
-
+    // Compute effective template for preview
+    const effectiveTemplate = deriveFilenameEffectiveTemplate(settings, presetDefinitions);
+    const previewKey = JSON.stringify([namingMode, effectiveTemplate, presetId]);
+    const shouldLoadPreview = namingMode !== 'template' || Boolean(effectiveTemplate);
+    const [previewState, setPreviewState] = useState<{
+        key: string;
+        value: FilenameTemplatePreviewResponse;
+    } | null>(null);
+    const preview =
+        shouldLoadPreview && previewState?.key === previewKey
+            ? previewState.value
+            : null;
+    const isValidating = shouldLoadPreview && previewState?.key !== previewKey;
     // Batch rename uses the current form state shown above, not only the last
     // saved defaults used for future downloads.
     const currentTemplateInvalid =
@@ -94,28 +104,12 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                 scenarioPreview.videoPath.split('/').filter(Boolean).length >= 3
         );
 
-    // Compute effective template for preview
-    const effectiveTemplate = deriveFilenameEffectiveTemplate(settings, presetDefinitions);
-
-    useEffect(() => {
-        if (settings.downloadFilenameMode !== 'template') {
-            setForceCustomSelection(false);
-            return;
-        }
-
-        if (derivedPresetId === 'custom') {
-            setForceCustomSelection(false);
-        }
-    }, [derivedPresetId, settings.downloadFilenameMode]);
-
     // Debounced preview fetch
     useEffect(() => {
         const template = effectiveTemplate;
-        if (namingMode === 'template' && !template) {
-            setPreview(null);
+        if (!shouldLoadPreview) {
             return;
         }
-        setIsValidating(true);
         const timer = setTimeout(async () => {
             try {
                 const res = await api.post<FilenameTemplatePreviewResponse>(
@@ -125,24 +119,25 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                         template: namingMode === 'template' ? template : undefined,
                     }
                 );
-                setPreview(res.data);
+                setPreviewState({ key: previewKey, value: res.data });
             } catch (e: unknown) {
-                setPreview({
-                    valid: false,
-                    errors: [getApiErrorMessage(e) || String(e)],
-                    resolved: {
-                        mode: namingMode,
-                        matchedPresetId: presetId,
-                        template: namingMode === 'template' ? template : null,
+                setPreviewState({
+                    key: previewKey,
+                    value: {
+                        valid: false,
+                        errors: [getApiErrorMessage(e) || String(e)],
+                        resolved: {
+                            mode: namingMode,
+                            matchedPresetId: presetId,
+                            template: namingMode === 'template' ? template : null,
+                        },
+                        previews: null,
                     },
-                    previews: null,
                 });
-            } finally {
-                setIsValidating(false);
             }
         }, 600);
         return () => clearTimeout(timer);
-    }, [effectiveTemplate, namingMode, presetId]);
+    }, [effectiveTemplate, namingMode, presetId, previewKey, shouldLoadPreview]);
 
     const handlePresetChange = (value: string) => {
         if (value === 'legacy') {

--- a/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
+++ b/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
@@ -12,7 +12,7 @@ import {
     Typography,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { CreateTokenInput, RssFilters, RssToken, UpdateTokenInput } from '../../../utils/rssApi';
 import RssFilterEditor from './RssFilterEditor';
@@ -37,7 +37,7 @@ interface RssTokenDialogProps {
 
 const DEFAULT_FILTERS: RssFilters = { maxItems: 50 };
 
-const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
+const RssTokenDialogContent: React.FC<RssTokenDialogProps> = ({
     open,
     mode,
     token,
@@ -50,23 +50,13 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
     isLoading = false,
 }) => {
     const { t } = useLanguage();
-    const [label, setLabel] = useState('');
-    const [role, setRole] = useState<'admin' | 'visitor'>('visitor');
-    const [filters, setFilters] = useState<RssFilters>(DEFAULT_FILTERS);
-
-    useEffect(() => {
-        if (open) {
-            if (mode === 'edit' && token) {
-                setLabel(token.label);
-                setRole(token.role);
-                setFilters({ maxItems: 50, ...token.filters });
-            } else {
-                setLabel('');
-                setRole('visitor');
-                setFilters(DEFAULT_FILTERS);
-            }
-        }
-    }, [open, mode, token]);
+    const [label, setLabel] = useState(mode === 'edit' && token ? token.label : '');
+    const [role, setRole] = useState<'admin' | 'visitor'>(
+        mode === 'edit' && token ? token.role : 'visitor'
+    );
+    const [filters, setFilters] = useState<RssFilters>(
+        mode === 'edit' && token ? { maxItems: 50, ...token.filters } : DEFAULT_FILTERS
+    );
 
     const showAdminWarning = role === 'admin';
 
@@ -178,5 +168,19 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
         </Dialog>
     );
 };
+
+const RssTokenDialog: React.FC<RssTokenDialogProps> = (props) =>
+    props.open ? (
+        <RssTokenDialogContent
+            key={JSON.stringify([
+                props.mode,
+                props.token?.id ?? 'new',
+                props.token?.label,
+                props.token?.role,
+                props.token?.filters,
+            ])}
+            {...props}
+        />
+    ) : null;
 
 export default RssTokenDialog;

--- a/frontend/src/components/Settings/UserManagementSettings.tsx
+++ b/frontend/src/components/Settings/UserManagementSettings.tsx
@@ -29,7 +29,7 @@ import {
     Typography,
 } from '@mui/material';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { VisitorUser } from '../../types';
@@ -202,21 +202,6 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
         },
     });
 
-    useEffect(() => {
-        if (dialogMode === 'create') {
-            setUsername('');
-            setPassword('');
-            setSetNewPassword(true);
-            setShowPassword(false);
-        }
-        if (dialogMode === 'edit' && selectedUser) {
-            setUsername(selectedUser.username);
-            setPassword('');
-            setSetNewPassword(false);
-            setShowPassword(false);
-        }
-    }, [dialogMode, selectedUser]);
-
     const closeDialog = () => {
         setDialogMode(null);
         setSelectedUser(null);
@@ -228,11 +213,19 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
 
     const openCreateDialog = () => {
         setSelectedUser(null);
+        setUsername('');
+        setPassword('');
+        setSetNewPassword(true);
+        setShowPassword(false);
         setDialogMode('create');
     };
 
     const openEditDialog = (user: VisitorUser) => {
         setSelectedUser(user);
+        setUsername(user.username);
+        setPassword('');
+        setSetNewPassword(false);
+        setShowPassword(false);
         setDialogMode('edit');
     };
 

--- a/frontend/src/components/Settings/YtDlpSettings.tsx
+++ b/frontend/src/components/Settings/YtDlpSettings.tsx
@@ -7,7 +7,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 interface YtDlpSettingsProps {
@@ -241,28 +241,29 @@ const DEFAULT_CONFIG = `# yt-dlp Configuration File
 const YtDlpSettings: React.FC<YtDlpSettingsProps> = ({ config, proxyOnlyYoutube = false, onChange, onProxyOnlyYoutubeChange }) => {
     const { t } = useLanguage();
     const [isExpanded, setIsExpanded] = useState(false);
-    const [localConfig, setLocalConfig] = useState(config || DEFAULT_CONFIG);
-
-    // Sync local config when prop changes
-    useEffect(() => {
-        setLocalConfig(config || DEFAULT_CONFIG);
-    }, [config]);
+    const configValue = config || DEFAULT_CONFIG;
+    const [localConfigState, setLocalConfigState] = useState({
+        source: configValue,
+        value: configValue,
+    });
+    const localConfig =
+        localConfigState.source === configValue ? localConfigState.value : configValue;
 
     const handleCustomize = () => {
         setIsExpanded(!isExpanded);
         if (!isExpanded) {
             // When expanding, sync local config with prop
-            setLocalConfig(config || DEFAULT_CONFIG);
+            setLocalConfigState({ source: configValue, value: configValue });
         }
     };
 
     const handleConfigChange = (value: string) => {
-        setLocalConfig(value);
+        setLocalConfigState({ source: configValue, value });
         onChange(value);
     };
 
     const handleReset = () => {
-        setLocalConfig(DEFAULT_CONFIG);
+        setLocalConfigState({ source: configValue, value: DEFAULT_CONFIG });
         onChange(DEFAULT_CONFIG);
     };
 

--- a/frontend/src/components/Settings/__tests__/FilenameTemplateSettings.render.test.tsx
+++ b/frontend/src/components/Settings/__tests__/FilenameTemplateSettings.render.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { act, render as rtlRender, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -223,5 +223,98 @@ describe('FilenameTemplateSettings preview tab grouping', () => {
         ).toBeInTheDocument();
         // ...but no scenario tabs, since all three results are identical.
         expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+    });
+});
+
+describe('FilenameTemplateSettings preview request ordering', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(api.get).mockResolvedValue({
+            data: {
+                presets: [],
+                deprecatedPresetAliases: [],
+                informationNotes: [],
+                referenceSections: [],
+            },
+        } as any);
+    });
+
+    it('ignores an obsolete preview response after the template changes', async () => {
+        let resolvePreviewA!: (value: any) => void;
+        let resolvePreviewB!: (value: any) => void;
+        const previewA = new Promise<any>((resolve) => {
+            resolvePreviewA = resolve;
+        });
+        const previewB = new Promise<any>((resolve) => {
+            resolvePreviewB = resolve;
+        });
+        vi.mocked(api.post).mockImplementation((_url, body: any) => {
+            return body.template === 'template-a' ? previewA : previewB;
+        });
+
+        const queryClient = createTestQueryClient();
+        const renderSettings = (template: string) => (
+            <QueryClientProvider client={queryClient}>
+                <FilenameTemplateSettings
+                    settings={{
+                        downloadFilenameMode: 'template',
+                        downloadFilenameTemplate: template,
+                        mediaServerExportMode: 'off',
+                    } as any}
+                    onChange={vi.fn()}
+                />
+            </QueryClientProvider>
+        );
+        const createPreviewResponse = (template: string, videoPath: string) => ({
+            data: {
+                valid: true,
+                errors: [],
+                resolved: {
+                    mode: 'template',
+                    matchedPresetId: 'custom',
+                    template,
+                },
+                previews: {
+                    channel: { videoPath, warnings: [] },
+                    playlist: { videoPath, warnings: [] },
+                    single: { videoPath, warnings: [] },
+                },
+            },
+        });
+
+        const { rerender } = rtlRender(renderSettings('template-a'));
+        await waitFor(() => {
+            expect(api.post).toHaveBeenCalledWith(
+                '/settings/filename-template/preview',
+                expect.objectContaining({ template: 'template-a' })
+            );
+        });
+
+        rerender(renderSettings('template-b'));
+        await waitFor(() => {
+            expect(api.post).toHaveBeenCalledWith(
+                '/settings/filename-template/preview',
+                expect.objectContaining({ template: 'template-b' })
+            );
+        });
+
+        await act(async () => {
+            resolvePreviewB(createPreviewResponse('template-b', 'preview-b.mp4'));
+            await previewB;
+        });
+        expect(
+            await screen.findByText(/filenamePreviewVideo:\s*preview-b\.mp4/)
+        ).toBeInTheDocument();
+
+        await act(async () => {
+            resolvePreviewA(createPreviewResponse('template-a', 'preview-a.mp4'));
+            await previewA;
+        });
+        expect(
+            screen.getByText(/filenamePreviewVideo:\s*preview-b\.mp4/)
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText(/filenamePreviewVideo:\s*preview-a\.mp4/)
+        ).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -16,7 +16,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
@@ -53,7 +53,7 @@ interface SubscribeModalProps {
     downloadPreviousHelp?: string;
 }
 
-const SubscribeModal: React.FC<SubscribeModalProps> = ({
+const SubscribeModalContent: React.FC<SubscribeModalProps> = ({
     open,
     onClose,
     onConfirm,
@@ -93,10 +93,6 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
         setFilenameTemplate('');
         setIsTemplateValid(true);
     }, []);
-
-    useEffect(() => {
-        resetFilenameTemplate();
-    }, [resetFilenameTemplate, url]);
 
     const handleClose = () => {
         if (!isSubmitting) {
@@ -255,5 +251,8 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
         </Dialog>
     );
 };
+
+const SubscribeModal: React.FC<SubscribeModalProps> = (props) =>
+    props.open ? <SubscribeModalContent key={props.url} {...props} /> : null;
 
 export default SubscribeModal;

--- a/frontend/src/components/SubscriptionFilenameTemplateField.tsx
+++ b/frontend/src/components/SubscriptionFilenameTemplateField.tsx
@@ -61,7 +61,6 @@ const SubscriptionFilenameTemplateField: React.FC<
 > = ({ value, onChange, sourceCollectionType, disabled, autoFocus, onValidityChange }) => {
   const { t } = useLanguage();
   const [validation, setValidation] = useState<ValidationState | null>(null);
-  const [isValidating, setIsValidating] = useState(false);
   const requestId = useRef(0);
   const helperTextId = useId();
   const validationMessageId = useId();
@@ -75,6 +74,7 @@ const SubscriptionFilenameTemplateField: React.FC<
     validation.sourceCollectionType === sourceCollectionType
       ? validation.response
       : null;
+  const isValidating = hasTemplate && validationResponse === null;
   const hasErrors = hasTemplate && validationResponse?.valid === false;
   const isInputValid =
     !hasTemplate ||
@@ -93,12 +93,9 @@ const SubscriptionFilenameTemplateField: React.FC<
       // this, a late response for a value that was cleared (or retyped) could
       // become the current validation state.
       requestId.current += 1;
-      setValidation(null);
-      setIsValidating(false);
       return;
     }
 
-    setIsValidating(true);
     const currentRequestId = requestId.current + 1;
     requestId.current = currentRequestId;
     const timer = setTimeout(async () => {
@@ -126,10 +123,6 @@ const SubscriptionFilenameTemplateField: React.FC<
             rendered: null,
           },
         });
-      } finally {
-        if (requestId.current === currentRequestId) {
-          setIsValidating(false);
-        }
       }
     }, DEBOUNCE_MS);
 

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { normalizeTagKey, sortTagsByUsage } from '../utils/tagUtils';
@@ -41,18 +41,13 @@ const TagsList: React.FC<TagsListProps> = ({
     linkToAllTags = false,
 }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
+    const [openState, setOpenState] = useState(() => ({
+        isMobile,
+        isOpen: !isMobile,
+    }));
+    const isOpen = openState.isMobile === isMobile ? openState.isOpen : !isMobile;
 
     const { displayTags, hasMore } = useMemo(() => {
         if (!availableTags || availableTags.length === 0) {
@@ -101,7 +96,7 @@ const TagsList: React.FC<TagsListProps> = ({
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, mb: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setOpenState({ isMobile, isOpen: !isOpen })} sx={{ borderRadius: 1, mb: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('tags') || 'Tags'}
                 </Typography>

--- a/frontend/src/components/TagsModal.tsx
+++ b/frontend/src/components/TagsModal.tsx
@@ -11,7 +11,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useSettings } from '../hooks/useSettings';
@@ -25,7 +25,7 @@ interface TagsModalProps {
     onSave: (tags: string[]) => Promise<void>;
 }
 
-const TagsModal: React.FC<TagsModalProps> = ({
+const TagsModalContent: React.FC<TagsModalProps> = ({
     open,
     onClose,
     videoTags,
@@ -41,18 +41,9 @@ const TagsModal: React.FC<TagsModalProps> = ({
     });
 
     // State for selected tags (starts with videoTags)
-    const [selectedTags, setSelectedTags] = useState<string[]>([]);
+    const [selectedTags, setSelectedTags] = useState<string[]>(videoTags || []);
     const [newTag, setNewTag] = useState('');
     const [saving, setSaving] = useState(false);
-
-    // Reset state when modal opens
-    useEffect(() => {
-        if (open) {
-            setSelectedTags(videoTags || []);
-            setNewTag('');
-            setSaving(false);
-        }
-    }, [open, videoTags]);
 
     const handleToggleTag = (tag: string) => {
         setSelectedTags(prev =>
@@ -201,5 +192,10 @@ const TagsModal: React.FC<TagsModalProps> = ({
         </Dialog>
     );
 };
+
+const TagsModal: React.FC<TagsModalProps> = (props) =>
+    props.open ? (
+        <TagsModalContent key={props.videoTags.join('\u0000')} {...props} />
+    ) : null;
 
 export default TagsModal;

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -36,16 +36,14 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     const [dateWidth, setDateWidth] = useState<number | null>(null);
 
     const marqueeing = isHovered && isTruncated;
-    // Whether the date has finished collapsing/expanding, so the author container
-    // is at its final width for the marquee to measure against.
-    const [layoutSettled, setLayoutSettled] = useState(false);
-
     // Truncation is only meaningful in the resting layout (date visible). Once we
     // start marqueeing we free the date's space, which changes the container width;
     // measuring then would flip isTruncated off and oscillate the layout. This ref
     // keeps measurement pinned to the non-marqueeing state.
     const isMarqueeingRef = useRef(false);
-    isMarqueeingRef.current = marqueeing;
+    useLayoutEffect(() => {
+        isMarqueeingRef.current = marqueeing;
+    }, [marqueeing]);
 
     // Measure whether the author name overflows its (clipped) container.
     const measureTruncation = useCallback(() => {
@@ -79,16 +77,6 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
         if (el) setDateWidth(el.scrollWidth);
     }, [video.addedAt, video.date, t]);
 
-    // Flip layoutSettled only after the date collapse/expand transition finishes,
-    // so the marquee measures scroll distance against the final container width.
-    useEffect(() => {
-        if (marqueeing) {
-            const id = setTimeout(() => setLayoutSettled(true), DATE_COLLAPSE_MS);
-            return () => clearTimeout(id);
-        }
-        setLayoutSettled(false);
-    }, [marqueeing]);
-
     // Scroll the name left then right while hovered, holding ~1s at each end.
     useEffect(() => {
         const container = authorContainerRef.current;
@@ -98,41 +86,44 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
         animationRef.current?.cancel();
         animationRef.current = null;
 
-        if (!layoutSettled) {
+        if (!marqueeing) {
             text.style.transform = '';
             return;
         }
 
-        const overflow = text.scrollWidth - container.clientWidth;
-        if (overflow <= 1 || typeof text.animate !== 'function') {
-            text.style.transform = '';
-            return;
-        }
+        const startTimer = window.setTimeout(() => {
+            const overflow = text.scrollWidth - container.clientWidth;
+            if (overflow <= 1 || typeof text.animate !== 'function') {
+                text.style.transform = '';
+                return;
+            }
 
-        const pxPerSecond = 30; // scroll speed
-        const moveMs = Math.max(600, (overflow / pxPerSecond) * 1000);
-        const holdMs = 1000; // dwell at the beginning and ending
-        const totalMs = moveMs * 2 + holdMs * 2;
-        const holdFrac = holdMs / totalMs;
-        const moveFrac = moveMs / totalMs;
-        const endOffset = holdFrac + moveFrac; // start of the ending hold
+            const pxPerSecond = 30;
+            const moveMs = Math.max(600, (overflow / pxPerSecond) * 1000);
+            const holdMs = 1000;
+            const totalMs = moveMs * 2 + holdMs * 2;
+            const holdFrac = holdMs / totalMs;
+            const moveFrac = moveMs / totalMs;
+            const endOffset = holdFrac + moveFrac;
 
-        animationRef.current = text.animate(
-            [
-                { transform: 'translateX(0)', offset: 0 },
-                { transform: 'translateX(0)', offset: holdFrac }, // hold at beginning
-                { transform: `translateX(${-overflow}px)`, offset: endOffset },
-                { transform: `translateX(${-overflow}px)`, offset: endOffset + holdFrac }, // hold at ending
-                { transform: 'translateX(0)', offset: 1 } // scroll back to beginning
-            ],
-            { duration: totalMs, iterations: Infinity, easing: 'linear' }
-        );
+            animationRef.current = text.animate(
+                [
+                    { transform: 'translateX(0)', offset: 0 },
+                    { transform: 'translateX(0)', offset: holdFrac },
+                    { transform: `translateX(${-overflow}px)`, offset: endOffset },
+                    { transform: `translateX(${-overflow}px)`, offset: endOffset + holdFrac },
+                    { transform: 'translateX(0)', offset: 1 }
+                ],
+                { duration: totalMs, iterations: Infinity, easing: 'linear' }
+            );
+        }, DATE_COLLAPSE_MS);
 
         return () => {
+            window.clearTimeout(startTimer);
             animationRef.current?.cancel();
             animationRef.current = null;
         };
-    }, [layoutSettled, video.author]);
+    }, [marqueeing, video.author]);
 
     return (
         <CardContent sx={{ flexGrow: 1, px: 1, py: isMobile ? 1.5 : 1, display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -1,16 +1,12 @@
 import { Box, IconButton, Typography } from '@mui/material';
 import { Pause, PlayArrow } from '@mui/icons-material';
-import React, { useMemo } from 'react';
+import React, { useId, useMemo } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { neutral, overlay } from '../../../theme/colors';
 import { getBackendUrl } from '../../../utils/apiUrl';
 import { getSubtitleLanguageLabel, getSubtitleTrackLanguage } from '../../../utils/formatUtils';
 import { getMediaCrossOriginAttr } from '../../../utils/mediaOrigin';
 import { computePreloadStrategy } from '../../../utils/preloadStrategy';
-
-type GlobalVideoCounterScope = typeof globalThis & {
-    __videoControlCounter?: number;
-};
 
 interface VideoElementProps {
     videoRef: React.RefObject<HTMLVideoElement | null>;
@@ -70,14 +66,7 @@ const VideoElement: React.FC<VideoElementProps> = ({
     isPlaying = false,
 }) => {
     const { t } = useLanguage();
-    // Use useMemo to generate a stable unique ID per component instance
-    // Using Date.now() and a simple counter is safe for non-cryptographic purposes
-    const videoId = useMemo(() => {
-        const globalScope = globalThis as GlobalVideoCounterScope;
-        const counter = (globalScope.__videoControlCounter || 0) + 1;
-        globalScope.__videoControlCounter = counter;
-        return `video-controls-${Date.now()}-${counter}`;
-    }, []);
+    const videoId = `video-controls-${useId().replaceAll(':', '')}`;
 
     // Compute during render so the <video> element never starts loading
     // with a downgraded placeholder, and recalculate when the media changes.
@@ -85,12 +74,12 @@ const VideoElement: React.FC<VideoElementProps> = ({
         () => computePreloadStrategy({ src, mediaPath }),
         [src, mediaPath]
     );
-    const [mobileAspectRatio, setMobileAspectRatio] = React.useState<string>('16/9');
-
-    React.useEffect(() => {
-        // Reset to default ratio while new source metadata is loading
-        setMobileAspectRatio('16/9');
-    }, [src]);
+    const [mobileAspectRatioState, setMobileAspectRatioState] = React.useState({
+        src,
+        ratio: '16/9',
+    });
+    const mobileAspectRatio =
+        mobileAspectRatioState.src === src ? mobileAspectRatioState.ratio : '16/9';
 
     return (
         <Box
@@ -249,7 +238,10 @@ const VideoElement: React.FC<VideoElementProps> = ({
                 onLoadedMetadata={(e) => {
                     const { videoWidth, videoHeight } = e.currentTarget;
                     if (videoWidth > 0 && videoHeight > 0) {
-                        setMobileAspectRatio(`${videoWidth}/${videoHeight}`);
+                        setMobileAspectRatioState({
+                            src,
+                            ratio: `${videoWidth}/${videoHeight}`,
+                        });
                     }
                     onLoadedMetadata(e);
                     onSubtitleInit(e);

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface Subtitle {
     language: string;
@@ -29,6 +29,24 @@ interface UseSubtitlesProps {
 
 const MAX_ACTIVE_TRACKS = 2;
 
+const applyTextTrackModes = (
+    video: HTMLVideoElement | null,
+    fileTrackCount: number,
+    fileIndices: number[],
+    liveTrack: TextTrack | null,
+    liveSelected: boolean
+) => {
+    if (video) {
+        const tracks = video.textTracks;
+        for (let i = 0; i < fileTrackCount && i < tracks.length; i++) {
+            tracks[i].mode = fileIndices.includes(i) ? 'showing' : 'hidden';
+        }
+    }
+    if (liveTrack) {
+        liveTrack.mode = liveSelected ? 'showing' : 'hidden';
+    }
+};
+
 export const useSubtitles = ({
     subtitles,
     initialSubtitlesEnabled,
@@ -37,106 +55,89 @@ export const useSubtitles = ({
     liveSubtitle,
     forceLiveSubtitleOnAvailable = false,
 }: UseSubtitlesProps) => {
-    const [subtitlesEnabled, setSubtitlesEnabled] = useState<boolean>(
-        initialSubtitlesEnabled && subtitles.length > 0
-    );
-    const [selectedSubtitleIndices, setSelectedSubtitleIndices] = useState<number[]>(
-        initialSubtitlesEnabled && subtitles.length > 0 ? [0] : []
-    );
-    const [liveSubtitleSelected, setLiveSubtitleSelected] = useState<boolean>(false);
+    const liveAvailable = liveSubtitle?.available === true;
+    const subtitleKey = subtitles
+        .map((subtitle) => `${subtitle.language}:${subtitle.filename}:${subtitle.path}`)
+        .join('|');
+    const initialFileIndices =
+        initialSubtitlesEnabled && subtitles.length > 0 ? [0] : [];
+    const initiallySelectLive =
+        liveAvailable &&
+        (initialSubtitlesEnabled || forceLiveSubtitleOnAvailable);
+    const [selectionState, setSelectionState] = useState(() => ({
+        subtitleKey,
+        liveAvailable,
+        forceLiveSubtitleOnAvailable,
+        fileIndices:
+            initiallySelectLive && initialFileIndices.length >= MAX_ACTIVE_TRACKS
+                ? initialFileIndices.slice(1)
+                : initialFileIndices,
+        liveSelected: initiallySelectLive,
+    }));
+    let currentSelection = selectionState;
+    if (
+        selectionState.subtitleKey !== subtitleKey ||
+        selectionState.liveAvailable !== liveAvailable ||
+        selectionState.forceLiveSubtitleOnAvailable !== forceLiveSubtitleOnAvailable
+    ) {
+        let fileIndices =
+            selectionState.subtitleKey === subtitleKey
+                ? selectionState.fileIndices
+                : initialFileIndices;
+        let liveSelected = selectionState.liveSelected;
+        const liveBecameAvailable =
+            liveAvailable && !selectionState.liveAvailable;
+        const forceBecameEnabled =
+            forceLiveSubtitleOnAvailable &&
+            !selectionState.forceLiveSubtitleOnAvailable;
+
+        if (!liveAvailable) {
+            liveSelected = false;
+        } else if (
+            (liveBecameAvailable &&
+                (initialSubtitlesEnabled || forceLiveSubtitleOnAvailable)) ||
+            forceBecameEnabled
+        ) {
+            if (fileIndices.length >= MAX_ACTIVE_TRACKS) {
+                fileIndices = fileIndices.slice(1);
+            }
+            liveSelected = true;
+        } else if (liveBecameAvailable) {
+            liveSelected = false;
+        }
+
+        currentSelection = {
+            subtitleKey,
+            liveAvailable,
+            forceLiveSubtitleOnAvailable,
+            fileIndices,
+            liveSelected,
+        };
+        setSelectionState(currentSelection);
+    }
+    const selectedSubtitleIndices = currentSelection.fileIndices;
+    const liveSubtitleSelected = currentSelection.liveSelected;
+    const subtitlesEnabled =
+        selectedSubtitleIndices.length > 0 || liveSubtitleSelected;
     const [subtitleMenuAnchor, setSubtitleMenuAnchor] = useState<null | HTMLElement>(null);
 
-    const liveAvailable = liveSubtitle?.available === true;
-    const prevLiveAvailableRef = useRef(false);
-    const prevForceLiveSubtitleRef = useRef(false);
-
-    // Apply showing/hidden modes by identity: file tracks occupy textTracks
-    // [0..subtitles.length-1] (in array order); the dynamic live track — added via
-    // addTextTrack — always sorts after them, so we address it by reference and
-    // never by index. File-driven effects must not touch it.
-    const applyTrackModes = (fileIndices: number[], liveSelected: boolean) => {
-        const video = videoRef.current;
-        if (video) {
-            const tracks = video.textTracks;
-            for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
-                tracks[i].mode = fileIndices.includes(i) ? 'showing' : 'hidden';
-            }
-        }
-        const liveTrack = liveSubtitle?.track;
-        if (liveTrack) {
-            liveTrack.mode = liveSelected ? 'showing' : 'hidden';
-        }
-    };
-
-    const selectLiveSubtitleTrack = () => {
-        setSelectedSubtitleIndices((fileIndices) => {
-            let nextFile = fileIndices;
-            if (fileIndices.length >= MAX_ACTIVE_TRACKS) {
-                // Replace the oldest selected file subtitle.
-                nextFile = fileIndices.slice(1);
-            }
-            applyTrackModes(nextFile, true);
-            return nextFile;
-        });
-        setLiveSubtitleSelected(true);
-        setSubtitlesEnabled(true);
-    };
-
-    // Re-initialize FILE subtitle tracks only when the subtitles array changes
-    // (upload/delete). Must not include initialSubtitlesEnabled (feedback loop)
-    // and must preserve the live selection/track.
+    // TextTrack is an external browser object. Keep it synchronized with the
+    // React-owned selection without changing React state from this effect.
     useEffect(() => {
-        if (!videoRef.current || subtitles.length === 0) return;
-
-        const tracks = videoRef.current.textTracks;
-        const newIndices = initialSubtitlesEnabled && tracks.length > 0 ? [0] : [];
-
-        setSelectedSubtitleIndices(newIndices);
-        setSubtitlesEnabled(initialSubtitlesEnabled || liveSubtitleSelected);
-
-        for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
-            tracks[i].mode = newIndices.includes(i) ? 'showing' : 'hidden';
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [subtitles]); // intentionally omit initialSubtitlesEnabled — see comment above
-
-    // Auto-select the live track when it becomes available if subtitles are
-    // globally enabled, or when subtitle-only live translation requires captions
-    // as its only output. Otherwise keep the live option in the menu without showing it.
-    useEffect(() => {
-        const wasAvailable = prevLiveAvailableRef.current;
-        const wasForceLiveSubtitle = prevForceLiveSubtitleRef.current;
-        prevLiveAvailableRef.current = liveAvailable;
-        prevForceLiveSubtitleRef.current = forceLiveSubtitleOnAvailable;
-
-        const shouldAutoSelectLive =
-            initialSubtitlesEnabled || forceLiveSubtitleOnAvailable;
-
-        if (liveAvailable && !wasAvailable) {
-            if (shouldAutoSelectLive) {
-                selectLiveSubtitleTrack();
-            } else {
-                applyTrackModes(selectedSubtitleIndices, false);
-                setLiveSubtitleSelected(false);
-                setSubtitlesEnabled(selectedSubtitleIndices.length > 0);
-            }
-        } else if (!liveAvailable && wasAvailable) {
-            setLiveSubtitleSelected(false);
-            setSelectedSubtitleIndices((fileIndices) => {
-                applyTrackModes(fileIndices, false);
-                setSubtitlesEnabled(fileIndices.length > 0);
-                return fileIndices;
-            });
-        } else if (
-            liveAvailable &&
-            forceLiveSubtitleOnAvailable &&
-            !wasForceLiveSubtitle
-        ) {
-            // Subtitle-only mode became active after the live track already existed.
-            selectLiveSubtitleTrack();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [liveAvailable, forceLiveSubtitleOnAvailable]);
+        applyTextTrackModes(
+            videoRef.current,
+            subtitles.length,
+            selectedSubtitleIndices,
+            liveSubtitle?.track ?? null,
+            liveSubtitleSelected
+        );
+    }, [
+        liveSubtitle?.track,
+        liveSubtitleSelected,
+        selectedSubtitleIndices,
+        subtitles.length,
+        videoRef,
+    ]);
 
     const handleSubtitleClick = (event: React.MouseEvent<HTMLElement>) => {
         setSubtitleMenuAnchor(event.currentTarget);
@@ -151,10 +152,7 @@ export const useSubtitles = ({
 
         if (index < 0) {
             // "Off" — deselect everything (file + live) and close menu.
-            applyTrackModes([], false);
-            setSelectedSubtitleIndices([]);
-            setLiveSubtitleSelected(false);
-            setSubtitlesEnabled(false);
+            setSelectionState({ ...currentSelection, fileIndices: [], liveSelected: false });
             if (onSubtitlesToggle) onSubtitlesToggle(false);
             handleCloseSubtitleMenu();
             return;
@@ -170,10 +168,7 @@ export const useSubtitles = ({
             return; // already at max, ignore
         }
 
-        applyTrackModes(newIndices, liveSubtitleSelected);
-        setSelectedSubtitleIndices(newIndices);
-        const enabled = newIndices.length > 0 || liveSubtitleSelected;
-        setSubtitlesEnabled(enabled);
+        setSelectionState({ ...currentSelection, fileIndices: newIndices });
         if (onSubtitlesToggle) onSubtitlesToggle(newIndices.length > 0);
     };
 
@@ -182,9 +177,7 @@ export const useSubtitles = ({
 
         if (liveSubtitleSelected) {
             // Deselect live.
-            applyTrackModes(selectedSubtitleIndices, false);
-            setLiveSubtitleSelected(false);
-            setSubtitlesEnabled(selectedSubtitleIndices.length > 0);
+            setSelectionState({ ...currentSelection, liveSelected: false });
             return;
         }
 
@@ -194,10 +187,11 @@ export const useSubtitles = ({
             // Replace the oldest selected file subtitle with live.
             nextFile = selectedSubtitleIndices.slice(1);
         }
-        applyTrackModes(nextFile, true);
-        setSelectedSubtitleIndices(nextFile);
-        setLiveSubtitleSelected(true);
-        setSubtitlesEnabled(true);
+        setSelectionState({
+            ...currentSelection,
+            fileIndices: nextFile,
+            liveSelected: true,
+        });
     };
 
     const initializeSubtitles = (e: React.SyntheticEvent<HTMLVideoElement>) => {
@@ -208,7 +202,10 @@ export const useSubtitles = ({
         for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
             tracks[i].mode = newIndices.includes(i) ? 'showing' : 'hidden';
         }
-        setSelectedSubtitleIndices(newIndices);
+        setSelectionState({
+            ...currentSelection,
+            fileIndices: newIndices,
+        });
     };
 
     return {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -23,7 +23,12 @@ export const useVideoPlayer = ({
 }: UseVideoPlayerProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
-  const [isLooping, setIsLooping] = useState<boolean>(autoLoop);
+  const [loopState, setLoopState] = useState({
+    autoLoop,
+    isLooping: autoLoop,
+  });
+  const isLooping =
+    loopState.autoLoop === autoLoop ? loopState.isLooping : autoLoop;
   const [playbackRate, setPlaybackRate] = useState<number>(1);
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [duration, setDuration] = useState<number>(0);
@@ -217,10 +222,7 @@ export const useVideoPlayer = ({
       if (autoPlay) {
         videoRef.current.autoplay = true;
       }
-      if (autoLoop) {
-        videoRef.current.loop = true;
-        setIsLooping(true);
-      }
+      videoRef.current.loop = autoLoop;
     }
   }, [autoPlay, autoLoop]);
 
@@ -305,7 +307,7 @@ export const useVideoPlayer = ({
     if (videoRef.current) {
       const newState = !isLooping;
       videoRef.current.loop = newState;
-      setIsLooping(newState);
+      setLoopState({ autoLoop, isLooping: newState });
       return newState;
     }
     return isLooping;

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -103,7 +103,13 @@ const VideoControls: React.FC<VideoControlsProps> = ({
     });
 
     // Fullscreen management
-    const fullscreen = useFullscreen(videoPlayer.videoRef);
+    const {
+        controlsVisible,
+        handleControlsMouseEnter,
+        handleToggleFullscreen,
+        isFullscreen,
+        videoContainerRef,
+    } = useFullscreen(videoPlayer.videoRef);
 
     // Loading and error states
     const loading = useVideoLoading();
@@ -217,7 +223,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
 
     return (
         <Box
-            ref={fullscreen.videoContainerRef}
+            ref={videoContainerRef}
             sx={{
                 width: '100%',
                 bgcolor: neutral.black,
@@ -225,7 +231,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 overflow: 'hidden',
                 boxShadow: 4,
                 position: 'relative',
-                ...(fullscreen.isFullscreen && {
+                ...(isFullscreen && {
                     width: '100vw',
                     height: '100vh',
                     display: 'flex',
@@ -234,7 +240,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 })
             }}
         >
-            <Box sx={{ position: 'relative', flex: fullscreen.isFullscreen ? 1 : undefined, minHeight: fullscreen.isFullscreen ? 0 : undefined }}>
+            <Box sx={{ position: 'relative', flex: isFullscreen ? 1 : undefined, minHeight: isFullscreen ? 0 : undefined }}>
                 <VideoElement
                     videoRef={videoPlayer.videoRef}
                     src={src}
@@ -242,7 +248,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                     poster={poster}
                     isLoading={loading.isLoading}
                     loadError={loading.loadError}
-                    isFullscreen={fullscreen.isFullscreen}
+                    isFullscreen={isFullscreen}
                     subtitles={subtitles}
                     onClick={videoPlayer.handlePlayPause}
                     onPlay={videoPlayer.handlePlay}
@@ -266,7 +272,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
 
                 <Box
                     sx={{
-                        ...(fullscreen.isFullscreen
+                        ...(isFullscreen
                             ? {
                                   position: 'absolute',
                                   left: 0,
@@ -278,8 +284,8 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                     }}
                 >
                     <ControlsOverlay
-                        isFullscreen={fullscreen.isFullscreen}
-                        controlsVisible={fullscreen.controlsVisible}
+                        isFullscreen={isFullscreen}
+                        controlsVisible={controlsVisible}
                         isPlaying={videoPlayer.isPlaying}
                         currentTime={videoPlayer.currentTime}
                         duration={videoPlayer.duration}
@@ -310,9 +316,9 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                         liveSubtitleLabel={subtitlesHook.liveSubtitleLabel}
                         liveSubtitleSelected={subtitlesHook.liveSubtitleSelected}
                         onSelectLiveSubtitle={subtitlesHook.handleSelectLiveSubtitle}
-                        onToggleFullscreen={fullscreen.handleToggleFullscreen}
+                        onToggleFullscreen={handleToggleFullscreen}
                         onToggleLoop={handleToggleLoop}
-                        onControlsMouseEnter={fullscreen.handleControlsMouseEnter}
+                        onControlsMouseEnter={handleControlsMouseEnter}
                         playbackRate={videoPlayer.playbackRate}
                         onPlaybackRateChange={videoPlayer.handlePlaybackRateChange}
                         isCinemaMode={isCinemaMode}
@@ -321,8 +327,8 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                             if (!toggle) return undefined;
                             return () => {
                                 toggle();
-                                if (fullscreen.isFullscreen) {
-                                    fullscreen.handleToggleFullscreen();
+                                if (isFullscreen) {
+                                    handleToggleFullscreen();
                                 }
                             };
                         })()}

--- a/frontend/src/contexts/DownloadContext.tsx
+++ b/frontend/src/contexts/DownloadContext.tsx
@@ -198,6 +198,21 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         collectionInfo: null // For collection/series, stores the API response
     });
     const [isCheckingParts, setIsCheckingParts] = useState<boolean>(false);
+
+    // Subscription logic
+    const [showSubscribeModal, setShowSubscribeModal] = useState(false);
+    const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+    const [subscribeUrl, setSubscribeUrl] = useState('');
+    const [subscribeSource, setSubscribeSource] = useState<'youtube' | 'bilibili' | 'twitch' | undefined>(undefined);
+    const [subscribeMode, setSubscribeMode] = useState<'video' | 'playlist'>('video');
+
+    // Channel subscribe choice modal
+    const [showChannelSubscribeChoiceModal, setShowChannelSubscribeChoiceModal] = useState(false);
+
+    // Channel playlists confirmation modal
+    const [showChannelPlaylistsModal, setShowChannelPlaylistsModal] = useState(false);
+    const [channelPlaylistsUrl, setChannelPlaylistsUrl] = useState('');
+
     // Reference to track current download IDs for detecting completion
     const currentDownloadIdsRef = useRef<Set<string>>(new Set());
     // Tracks the last persisted (active count, queued count) so we only write
@@ -627,20 +642,6 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         // Pass true to skip collection/series check AND parts check since we already know about it
         return await handleVideoSubmit(bilibiliPartsInfo.url, true, true);
     }, [handleVideoSubmit, bilibiliPartsInfo.url]);
-
-    // Subscription logic
-    const [showSubscribeModal, setShowSubscribeModal] = useState(false);
-    const [showDuplicateModal, setShowDuplicateModal] = useState(false);
-    const [subscribeUrl, setSubscribeUrl] = useState('');
-    const [subscribeSource, setSubscribeSource] = useState<'youtube' | 'bilibili' | 'twitch' | undefined>(undefined);
-    const [subscribeMode, setSubscribeMode] = useState<'video' | 'playlist'>('video');
-
-    // Channel subscribe choice modal
-    const [showChannelSubscribeChoiceModal, setShowChannelSubscribeChoiceModal] = useState(false);
-
-    // Channel playlists confirmation modal
-    const [showChannelPlaylistsModal, setShowChannelPlaylistsModal] = useState(false);
-    const [channelPlaylistsUrl, setChannelPlaylistsUrl] = useState('');
 
     const handleSubscribe = async (
         interval: number,

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -1,6 +1,6 @@
 import { hasAxiosStatus, hasAnyAxiosStatus } from '../utils/errors';
 import { useQueryClient } from '@tanstack/react-query';
-import React, { createContext, ReactNode, useCallback, useContext, useEffect, useEffectEvent, useMemo, useState } from 'react';
+import React, { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { defaultTranslations, Language, loadLocale, TranslationKey } from '../utils/translations';
 import { api } from '../utils/apiClient';
 import { fetchReadableSettings } from '../utils/settingsQueries';
@@ -71,40 +71,37 @@ export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }
 
     // Always try to fetch settings on mount so language persists across browsers
     // (backend returns language when login is disabled, or when cookies are sent)
-    const syncLanguagePreference = useEffectEvent(async () => {
-        try {
-            const settings = await fetchReadableSettings(queryClient, { forceRefresh: true });
-            if (!settings || settings.language === undefined) {
-                return;
-            }
-
-            const backendLanguage = normalizeLanguage(settings.language);
-            setLanguageState(backendLanguage);
-            // Sync localStorage with backend
-            try {
-                localStorage.setItem(LANGUAGE_STORAGE_SLOT, backendLanguage);
-            } catch (error) {
-                console.error('Error saving language to localStorage:', error);
-            }
-        } catch (error: unknown) {
-            // Silently handle auth-related failures when not authenticated
-            if (!hasAnyAxiosStatus(error, [401, 403])) {
-                console.error('Error fetching settings for language:', error);
-            }
-            // If backend fails, keep using localStorage value
-        }
-    });
+    const syncLanguagePreference = useCallback(() => {
+        void fetchReadableSettings(queryClient, { forceRefresh: true })
+            .then((settings) => {
+                if (!settings || settings.language === undefined) {
+                    return;
+                }
+                const backendLanguage = normalizeLanguage(settings.language);
+                setLanguageState(backendLanguage);
+                try {
+                    localStorage.setItem(LANGUAGE_STORAGE_SLOT, backendLanguage);
+                } catch (error) {
+                    console.error('Error saving language to localStorage:', error);
+                }
+            })
+            .catch((error: unknown) => {
+                if (!hasAnyAxiosStatus(error, [401, 403])) {
+                    console.error('Error fetching settings for language:', error);
+                }
+            });
+    }, [queryClient]);
 
     useEffect(() => {
         syncLanguagePreference();
-    }, [queryClient, syncLanguagePreference]);
+    }, [syncLanguagePreference]);
 
     // Refetch settings when user logs in (e.g. opening app in another browser)
     useEffect(() => {
         const onLogin = () => syncLanguagePreference();
         window.addEventListener('mytube-login', onLogin);
         return () => window.removeEventListener('mytube-login', onLogin);
-    }, [queryClient, syncLanguagePreference]);
+    }, [syncLanguagePreference]);
 
     const setLanguage = useCallback(async (lang: Language) => {
         const normalizedLanguage = normalizeLanguage(lang);

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,7 +1,7 @@
 import { hasAnyAxiosStatus } from '../utils/errors';
 import { useQueryClient } from '@tanstack/react-query';
 import { CssBaseline, GlobalStyles, ThemeProvider as MuiThemeProvider, PaletteMode, useMediaQuery } from '@mui/material';
-import React, { createContext, useCallback, useContext, useEffect, useEffectEvent, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import getTheme from '../theme';
 import { applyThemeCssVariables } from '../theme/cssVariables';
 import { api } from '../utils/apiClient';
@@ -64,35 +64,34 @@ export const ThemeContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
         return 'system';
     });
 
-    const syncThemePreference = useEffectEvent(async () => {
-        try {
-            const settings = await fetchReadableSettings(queryClient, { forceRefresh: true });
-            if (!settings || settings.theme === undefined) {
-                return;
-            }
-
-            const backendTheme = normalizeThemePreference(settings.theme);
-            setPreferenceState(backendTheme);
-            localStorage.setItem('themeMode', backendTheme);
-        } catch (error: unknown) {
-            // Silently handle auth-related failures when not authenticated
-            if (!hasAnyAxiosStatus(error, [401, 403])) {
-                console.error('Error fetching settings for theme:', error);
-            }
-        }
-    });
+    const syncThemePreference = useCallback(() => {
+        void fetchReadableSettings(queryClient, { forceRefresh: true })
+            .then((settings) => {
+                if (!settings || settings.theme === undefined) {
+                    return;
+                }
+                const backendTheme = normalizeThemePreference(settings.theme);
+                setPreferenceState(backendTheme);
+                localStorage.setItem('themeMode', backendTheme);
+            })
+            .catch((error: unknown) => {
+                if (!hasAnyAxiosStatus(error, [401, 403])) {
+                    console.error('Error fetching settings for theme:', error);
+                }
+            });
+    }, [queryClient]);
 
     // Fetch settings on mount
     useEffect(() => {
         syncThemePreference();
-    }, [queryClient, syncThemePreference]);
+    }, [syncThemePreference]);
 
     // Listen for login events to refetch
     useEffect(() => {
         const onLogin = () => syncThemePreference();
         window.addEventListener('mytube-login', onLogin);
         return () => window.removeEventListener('mytube-login', onLogin);
-    }, [queryClient, syncThemePreference]);
+    }, [syncThemePreference]);
 
     const setPreference = useCallback(async (newPreference: ThemePreference) => {
         const normalizedPreference = normalizeThemePreference(newPreference);

--- a/frontend/src/hooks/__tests__/useLiveTranslationSubtitleTrack.test.tsx
+++ b/frontend/src/hooks/__tests__/useLiveTranslationSubtitleTrack.test.tsx
@@ -114,6 +114,24 @@ describe('useLiveTranslationSubtitleTrack', () => {
     expect(result.current.isActive).toBe(false);
   });
 
+  it('does not update state when activation status is already unchanged', () => {
+    const { el } = makeFakeVideo();
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useLiveTranslationSubtitleTrack(el, 'en', 'Live');
+    });
+
+    const inactiveRenderCount = renderCount;
+    act(() => result.current.deactivate());
+    expect(renderCount).toBe(inactiveRenderCount);
+
+    act(() => result.current.activate());
+    const activeRenderCount = renderCount;
+    act(() => result.current.activate());
+    expect(renderCount).toBe(activeRenderCount);
+  });
+
   it('no-ops when there is no video element', () => {
     const { result } = renderHook(() =>
       useLiveTranslationSubtitleTrack(null, 'en', 'Live'),

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -120,6 +120,54 @@ describe("useVideoProgress", () => {
     dateNowSpy.mockRestore();
   });
 
+  it("counts a video again after navigating away and back before another view", async () => {
+    const videoA = {
+      id: "video-a",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const videoB = {
+      id: "video-b",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const { wrapper } = createWrapper();
+
+    const { result, rerender } = renderHook(
+      ({ videoId, video }) => useVideoProgress({ videoId, video }),
+      {
+        initialProps: { videoId: "video-a", video: videoA },
+        wrapper,
+      },
+    );
+
+    act(() => {
+      result.current.handleTimeUpdate(10);
+    });
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/videos/video-a/view");
+    });
+
+    rerender({ videoId: "video-b", video: videoB });
+    rerender({ videoId: "video-a", video: videoA });
+
+    act(() => {
+      result.current.handleTimeUpdate(10);
+    });
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(2);
+      expect(mockApiPost).toHaveBeenNthCalledWith(2, "/videos/video-a/view");
+    });
+
+    act(() => {
+      result.current.setIsDeleting(true);
+    });
+  });
+
   it("syncs progress writes into the cache before the view threshold is reached", async () => {
     let now = 1000;
     const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);

--- a/frontend/src/hooks/useCloudStorageUrl.ts
+++ b/frontend/src/hooks/useCloudStorageUrl.ts
@@ -60,15 +60,19 @@ export const useCloudStorageUrl = (
   }, [path, initialUrl]);
 
   // Only use async state for cloud storage and mount paths
-  const [asyncUrl, setAsyncUrl] = useState<string | undefined>(undefined);
+  const asyncKey = `${type}:${path ?? ""}`;
+  const [asyncResult, setAsyncResult] = useState<{
+    key: string;
+    url: string | undefined;
+  } | null>(null);
+  const asyncUrl = asyncResult?.key === asyncKey ? asyncResult.url : undefined;
 
   useEffect(() => {
     // Check if async handling is needed
     const needsAsync =
       path && (isCloudStoragePath(path) || isMountDirectoryPath(path));
 
-    if (!needsAsync) {
-      setAsyncUrl(undefined);
+    if (!needsAsync || initialUrl) {
       return;
     }
 
@@ -82,7 +86,7 @@ export const useCloudStorageUrl = (
       getFileUrl(path, type)
         .then((signedUrl) => {
           if (!cancelled) {
-            setAsyncUrl(signedUrl);
+            setAsyncResult({ key: asyncKey, url: signedUrl });
           }
         })
         .catch((error) => {
@@ -93,7 +97,7 @@ export const useCloudStorageUrl = (
               `Failed to load cloud storage URL for ${path}:`,
               error
             );
-            setAsyncUrl(undefined);
+            setAsyncResult({ key: asyncKey, url: undefined });
           }
         });
 
@@ -101,12 +105,8 @@ export const useCloudStorageUrl = (
       return () => {
         cancelled = true;
       };
-    } else if (path && isMountDirectoryPath(path)) {
-      // Mount directory paths should have signedUrl from the video object
-      // If we get here without signedUrl, it's an error
-      setAsyncUrl(undefined);
     }
-  }, [path, type, initialUrl]);
+  }, [path, type, initialUrl, asyncKey]);
 
   // Return sync URL if available (for regular paths), otherwise return async URL
   return syncUrl !== undefined ? syncUrl : asyncUrl;

--- a/frontend/src/hooks/useHomeSettings.ts
+++ b/frontend/src/hooks/useHomeSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { Settings } from '../types';
 import { api } from '../utils/apiClient';
@@ -38,47 +38,54 @@ const getErrorStatus = (error: unknown): number | undefined => {
 };
 
 export const useHomeSettings = ({ settings, settingsLoading = false }: UseHomeSettingsParams = {}): UseHomeSettingsReturn => {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-    const [settingsLoaded, setSettingsLoaded] = useState(false);
-    const [infiniteScroll, setInfiniteScroll] = useState(false);
-    const [videoColumns, setVideoColumns] = useState(4);
-    const [itemsPerPage, setItemsPerPage] = useState(12);
-    const [defaultSort, setDefaultSort] = useState('dateDesc');
-    const [showTagsOnThumbnail, setShowTagsOnThumbnail] = useState(true);
     const { isAuthenticated } = useAuth();
-
-    // Sync local home settings state from shared settings query
-    useEffect(() => {
-        if (!isAuthenticated) {
-            setSettingsLoaded(true);
-            return;
-        }
-
-        if (settingsLoading) return;
-
-        if (settings) {
-            if (typeof settings.homeSidebarOpen !== 'undefined') {
-                setIsSidebarOpen(settings.homeSidebarOpen);
-            }
-            if (typeof settings.itemsPerPage !== 'undefined') {
-                setItemsPerPage(settings.itemsPerPage);
-            }
-            if (typeof settings.infiniteScroll !== 'undefined') {
-                setInfiniteScroll(settings.infiniteScroll);
-            }
-            if (typeof settings.videoColumns !== 'undefined') {
-                setVideoColumns(settings.videoColumns);
-            }
-            if (typeof settings.defaultSort !== 'undefined') {
-                setDefaultSort(settings.defaultSort);
-            }
-            if (typeof settings.showTagsOnThumbnail !== 'undefined') {
-                setShowTagsOnThumbnail(settings.showTagsOnThumbnail);
-            }
-        }
-
-        setSettingsLoaded(true);
-    }, [isAuthenticated, settingsLoading, settings]);
+    const settingsKey = JSON.stringify([
+        isAuthenticated,
+        settingsLoading,
+        settings?.homeSidebarOpen,
+        settings?.itemsPerPage,
+        settings?.infiniteScroll,
+        settings?.videoColumns,
+        settings?.defaultSort,
+        settings?.showTagsOnThumbnail,
+    ]);
+    const externalState = {
+        isSidebarOpen: settings?.homeSidebarOpen ?? true,
+        itemsPerPage: settings?.itemsPerPage ?? 12,
+        infiniteScroll: settings?.infiniteScroll ?? false,
+        videoColumns: settings?.videoColumns ?? 4,
+        defaultSort: settings?.defaultSort ?? 'dateDesc',
+        showTagsOnThumbnail: settings?.showTagsOnThumbnail ?? true,
+    };
+    const [localState, setLocalState] = useState(() => ({
+        key: settingsKey,
+        ...externalState,
+    }));
+    const currentState =
+        localState.key === settingsKey
+            ? localState
+            : { key: settingsKey, ...externalState };
+    const {
+        isSidebarOpen,
+        itemsPerPage,
+        infiniteScroll,
+        videoColumns,
+        defaultSort,
+        showTagsOnThumbnail,
+    } = currentState;
+    const settingsLoaded = !isAuthenticated || !settingsLoading;
+    const updateState = <
+        Key extends keyof Omit<typeof currentState, 'key'>
+    >(key: Key, value: Omit<typeof currentState, 'key'>[Key]) => {
+        setLocalState({ ...currentState, [key]: value });
+    };
+    const setIsSidebarOpen = (value: boolean) => updateState('isSidebarOpen', value);
+    const setItemsPerPage = (value: number) => updateState('itemsPerPage', value);
+    const setInfiniteScroll = (value: boolean) => updateState('infiniteScroll', value);
+    const setVideoColumns = (value: number) => updateState('videoColumns', value);
+    const setDefaultSort = (value: string) => updateState('defaultSort', value);
+    const setShowTagsOnThumbnail = (value: boolean) =>
+        updateState('showTagsOnThumbnail', value);
 
     const handleSidebarToggle = async () => {
         const newState = !isSidebarOpen;

--- a/frontend/src/hooks/useLiveTranslationSession.ts
+++ b/frontend/src/hooks/useLiveTranslationSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { api, ensureCsrfToken } from '../utils/apiClient';
 import { getBackendUrl } from '../utils/apiUrl';
 import { int16ToBase64 } from '../utils/pcmAudio';
@@ -91,12 +91,15 @@ export function useLiveTranslationSession(
   const pausedRef = useRef(false);
   // Keep latest values for callbacks/cleanup without re-creating handlers.
   const videoElementRef = useRef(videoElement);
-  videoElementRef.current = videoElement;
   const onTranscriptRef = useRef(onTranscript);
-  onTranscriptRef.current = onTranscript;
   const latestOriginalAudioWithSubtitlesRef = useRef(false);
-  latestOriginalAudioWithSubtitlesRef.current = !!originalAudioWithSubtitles;
   const sessionOriginalAudioWithSubtitlesRef = useRef(false);
+
+  useLayoutEffect(() => {
+    videoElementRef.current = videoElement;
+    onTranscriptRef.current = onTranscript;
+    latestOriginalAudioWithSubtitlesRef.current = !!originalAudioWithSubtitles;
+  }, [videoElement, onTranscript, originalAudioWithSubtitles]);
 
   const detachMediaListeners = useCallback(() => {
     mediaListenersRef.current?.();

--- a/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
+++ b/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { LiveTranslationTranscriptEvent } from './useLiveTranslationSession';
 
 /**
@@ -14,6 +14,20 @@ import { LiveTranslationTranscriptEvent } from './useLiveTranslationSession';
 
 const DEFAULT_CUE_DURATION_S = 4;
 
+const disableAndClearTrack = (track: TextTrack) => {
+  try {
+    const cues = track.cues;
+    if (cues) {
+      for (let i = cues.length - 1; i >= 0; i--) {
+        track.removeCue(cues[i]);
+      }
+    }
+    track.mode = 'disabled';
+  } catch {
+    // ignore
+  }
+};
+
 export interface LiveTranslationSubtitleTrackController {
   track: TextTrack | null;
   isActive: boolean;
@@ -28,60 +42,60 @@ export function useLiveTranslationSubtitleTrack(
   targetLanguageCode: string,
   label: string,
 ): LiveTranslationSubtitleTrackController {
-  const [isActive, setIsActive] = useState(false);
-  // Bump to surface a freshly created track to consumers (refs don't re-render).
-  const [, setVersion] = useState(0);
-  const trackRef = useRef<TextTrack | null>(null);
-  const elementRef = useRef<HTMLVideoElement | null>(null);
-
-  // A track belongs to one element; drop the reference if the element changes.
-  useEffect(() => {
-    if (elementRef.current !== videoElement) {
-      trackRef.current = null;
-      elementRef.current = videoElement;
-      setIsActive(false);
-    }
-  }, [videoElement]);
+  const [trackState, setTrackState] = useState<{
+    element: HTMLVideoElement | null;
+    track: TextTrack | null;
+    isActive: boolean;
+  }>({
+    element: null,
+    track: null,
+    isActive: false,
+  });
+  const track = trackState.element === videoElement ? trackState.track : null;
+  const isActive = trackState.element === videoElement && trackState.isActive;
 
   const ensureTrack = useCallback((): TextTrack | null => {
     const el = videoElement;
     if (!el || typeof el.addTextTrack !== 'function') {
       return null;
     }
-    if (trackRef.current) {
-      return trackRef.current;
+    if (track) {
+      return track;
     }
-    const track = el.addTextTrack('subtitles', label, targetLanguageCode || 'und');
+    const createdTrack = el.addTextTrack('subtitles', label, targetLanguageCode || 'und');
     // Keep it non-disabled so cues can be added/read; selection sets showing/hidden.
-    track.mode = 'hidden';
-    trackRef.current = track;
-    setVersion((v) => v + 1);
-    return track;
-  }, [videoElement, label, targetLanguageCode]);
+    createdTrack.mode = 'hidden';
+    setTrackState({
+      element: el,
+      track: createdTrack,
+      isActive: false,
+    });
+    return createdTrack;
+  }, [videoElement, label, targetLanguageCode, track]);
 
   const activate = useCallback(() => {
-    if (ensureTrack()) {
-      setIsActive(true);
+    const activeTrack = ensureTrack();
+    if (activeTrack && videoElement) {
+      setTrackState({
+        element: videoElement,
+        track: activeTrack,
+        isActive: true,
+      });
     }
-  }, [ensureTrack]);
+  }, [ensureTrack, videoElement]);
 
   const deactivate = useCallback(() => {
-    const track = trackRef.current;
     if (track) {
-      try {
-        const cues = track.cues;
-        if (cues) {
-          for (let i = cues.length - 1; i >= 0; i--) {
-            track.removeCue(cues[i]);
-          }
-        }
-        track.mode = 'disabled';
-      } catch {
-        // ignore
-      }
+      disableAndClearTrack(track);
     }
-    setIsActive(false);
-  }, []);
+    if (videoElement) {
+      setTrackState({
+        element: videoElement,
+        track,
+        isActive: false,
+      });
+    }
+  }, [track, videoElement]);
 
   const addCue = useCallback(
     (event: LiveTranslationTranscriptEvent) => {
@@ -97,7 +111,13 @@ export function useLiveTranslationSubtitleTrack(
       if (!track) {
         return;
       }
-      setIsActive(true);
+      if (videoElement) {
+        setTrackState({
+          element: videoElement,
+          track,
+          isActive: true,
+        });
+      }
 
       const baseTime =
         typeof event.mediaTime === 'number'
@@ -129,7 +149,7 @@ export function useLiveTranslationSubtitleTrack(
   );
 
   return {
-    track: trackRef.current,
+    track,
     isActive,
     label,
     activate,

--- a/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
+++ b/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
@@ -74,6 +74,9 @@ export function useLiveTranslationSubtitleTrack(
   }, [videoElement, label, targetLanguageCode, track]);
 
   const activate = useCallback(() => {
+    if (isActive) {
+      return;
+    }
     const activeTrack = ensureTrack();
     if (activeTrack && videoElement) {
       setTrackState({
@@ -82,9 +85,12 @@ export function useLiveTranslationSubtitleTrack(
         isActive: true,
       });
     }
-  }, [ensureTrack, videoElement]);
+  }, [ensureTrack, isActive, videoElement]);
 
   const deactivate = useCallback(() => {
+    if (!isActive) {
+      return;
+    }
     if (track) {
       disableAndClearTrack(track);
     }
@@ -95,7 +101,7 @@ export function useLiveTranslationSubtitleTrack(
         isActive: false,
       });
     }
-  }, [track, videoElement]);
+  }, [isActive, track, videoElement]);
 
   const addCue = useCallback(
     (event: LiveTranslationTranscriptEvent) => {
@@ -111,7 +117,7 @@ export function useLiveTranslationSubtitleTrack(
       if (!track) {
         return;
       }
-      if (videoElement) {
+      if (videoElement && !isActive) {
         setTrackState({
           element: videoElement,
           track,
@@ -145,7 +151,7 @@ export function useLiveTranslationSubtitleTrack(
         // ignore malformed cue
       }
     },
-    [ensureTrack, videoElement],
+    [ensureTrack, isActive, videoElement],
   );
 
   return {

--- a/frontend/src/hooks/useStatisticsIngestion.ts
+++ b/frontend/src/hooks/useStatisticsIngestion.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from './useSettings';
 import { api, sendStatisticsEventsWithKeepalive } from '../utils/apiClient';
@@ -153,10 +153,12 @@ export function useStatisticsIngestion(): {
   const isVisitor = userRole === 'visitor';
   const ingestionAllowed = enabled && (!isVisitor || trackVisitor);
 
-  const sessionIdRef = useRef<string>('');
-  if (!sessionIdRef.current) {
-    sessionIdRef.current = getOrCreateSessionId(userRole ?? null);
-  }
+  const role = userRole ?? null;
+  const [session, setSession] = useState<{ role: string | null; sessionId: string }>({
+    role,
+    sessionId: '',
+  });
+  const sessionId = session.role === role ? session.sessionId : '';
 
   // Flush on visibility/pagehide (best-effort).
   useEffect(() => {
@@ -179,26 +181,35 @@ export function useStatisticsIngestion(): {
 
   // Drop unflushed buffer when role changes; design §7.1.
   useEffect(() => {
-    const stored = loadSessionRecord();
-    if (stored && stored.role !== (userRole ?? null)) {
-      outboundQueue = [];
-      const sessionId = generateUUID();
-      saveSessionRecord({
-        sessionId,
-        createdAt: Date.now(),
-        role: userRole ?? null,
-      });
-      sessionIdRef.current = sessionId;
-    }
-  }, [userRole]);
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      const stored = loadSessionRecord();
+      if (stored && stored.role !== role) {
+        outboundQueue = [];
+      }
+      const nextSessionId = getOrCreateSessionId(role);
+      setSession({ role, sessionId: nextSessionId });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [role]);
 
   const recordEvent = useCallback(
     (input: StatisticsEventInput): string | null => {
       if (!ingestionAllowed) return null;
       const id = generateUUID();
+      if (session.role !== role) {
+        outboundQueue = [];
+      }
+      const currentSessionId = sessionId || getOrCreateSessionId(role);
+      if (!sessionId) {
+        setSession({ role, sessionId: currentSessionId });
+      }
       const event: OutboundEvent = {
         id,
-        sessionId: sessionIdRef.current,
+        sessionId: currentSessionId,
         clientOccurredAt: input.clientOccurredAt ?? Date.now(),
         ...input,
       };
@@ -210,7 +221,7 @@ export function useStatisticsIngestion(): {
       }
       return id;
     },
-    [ingestionAllowed]
+    [ingestionAllowed, role, session, sessionId]
   );
 
   const flushNow = useCallback(() => {
@@ -234,6 +245,6 @@ export function useStatisticsIngestion(): {
     recordEvent,
     flushNow,
     flushKeepalive,
-    sessionId: sessionIdRef.current,
+    sessionId,
   };
 }

--- a/frontend/src/hooks/useVideoCollections.ts
+++ b/frontend/src/hooks/useVideoCollections.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useCollection } from '../contexts/CollectionContext';
 import { Collection } from '../types';
 
@@ -19,19 +19,13 @@ export function useVideoCollections({ videoId }: UseVideoCollectionsProps) {
 
     const [showCollectionModal, setShowCollectionModal] = useState<boolean>(false);
     const [activeCollectionVideoId, setActiveCollectionVideoId] = useState<string | null>(null);
-    const [videoCollections, setVideoCollections] = useState<Collection[]>([]);
-
-    // Find collections that contain the current video
-    useEffect(() => {
-        if (collections.length > 0 && videoId) {
-            const belongsToCollections = collections.filter(collection =>
-                collection.videos.includes(videoId)
-            );
-            setVideoCollections(belongsToCollections);
-        } else {
-            setVideoCollections([]);
-        }
-    }, [collections, videoId]);
+    const videoCollections = useMemo<Collection[]>(
+        () =>
+            videoId
+                ? collections.filter((collection) => collection.videos.includes(videoId))
+                : [],
+        [collections, videoId]
+    );
 
     // Calculate collections for the modal (can be current video or sidebar video)
     const modalVideoCollections = useMemo(() => {

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -76,7 +76,12 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     videoId,
     hasViewed: false,
   });
-  const hasViewed = viewState.videoId === videoId && viewState.hasViewed;
+  let currentViewState = viewState;
+  if (viewState.videoId !== videoId) {
+    currentViewState = { videoId, hasViewed: false };
+    setViewState(currentViewState);
+  }
+  const hasViewed = currentViewState.hasViewed;
   const lastProgressSave = useRef<number>(0);
   const currentTimeRef = useRef<number>(0);
   const isDeletingRef = useRef<boolean>(false);
@@ -86,7 +91,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const resumeGuardObservedRef = useRef<boolean>(true);
   const videoDuration = video?.duration;
 
-  // Reset hasViewed when video changes
+  // Reset playback sampling guards when video changes
   useEffect(() => {
     const storedProgress = readVideoResumeProgress(videoId)?.progress ?? 0;
     currentTimeRef.current = storedProgress;

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -72,7 +72,11 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const { userRole } = useAuth();
   const isVisitor = userRole === "visitor";
   const queryClient = useQueryClient();
-  const [hasViewed, setHasViewed] = useState<boolean>(false);
+  const [viewState, setViewState] = useState({
+    videoId,
+    hasViewed: false,
+  });
+  const hasViewed = viewState.videoId === videoId && viewState.hasViewed;
   const lastProgressSave = useRef<number>(0);
   const currentTimeRef = useRef<number>(0);
   const isDeletingRef = useRef<boolean>(false);
@@ -84,7 +88,6 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
 
   // Reset hasViewed when video changes
   useEffect(() => {
-    setHasViewed(false);
     const storedProgress = readVideoResumeProgress(videoId)?.progress ?? 0;
     currentTimeRef.current = storedProgress;
     resumeGuardTargetRef.current =
@@ -329,7 +332,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
     // Increment views and refresh watch history at the same threshold.
     const viewThreshold = getViewThreshold(videoDuration);
     if (trustedCurrentTime >= viewThreshold && !hasViewed && videoId && !isVisitor) {
-      setHasViewed(true);
+      setViewState({ videoId, hasViewed: true });
       const lastPlayedAt = Date.now();
       api
         .post(`/videos/${videoId}/view`)

--- a/frontend/src/hooks/useVideoResolution.ts
+++ b/frontend/src/hooks/useVideoResolution.ts
@@ -69,9 +69,6 @@ const hasWebMExtension = (value: string | null | undefined): boolean => {
 
 export const useVideoResolution = (video: Video) => {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [detectedResolution, setDetectedResolution] = useState<string | null>(
-    null
-  );
   const videoUrl = useCloudStorageUrl(
     video.videoPath,
     video.mediaType === "audio" ? "audio" : "video",
@@ -87,28 +84,36 @@ export const useVideoResolution = (video: Video) => {
   // compete with the main player. Safari's WebM loader is linear, so a hidden
   // probe of a large WebM can interfere with the visible player's resume seek.
   const needsDetection = !resolutionFromObject && !skipSafariWebMDetection;
+  const detectionKey = `${video.id}:${videoUrl || video.sourceUrl || ""}`;
+  const [detectionResult, setDetectionResult] = useState<{
+    key: string;
+    resolution: string | null;
+  } | null>(null);
+  const detectedResolution =
+    detectionResult?.key === detectionKey ? detectionResult.resolution : null;
 
   useEffect(() => {
     // Skip video element creation if resolution is already available
     if (!needsDetection) {
-      setDetectedResolution(null);
       return;
     }
 
     const videoElement = videoRef.current;
     const videoSrc = videoUrl || video.sourceUrl;
     if (!videoElement || !videoSrc) {
-      setDetectedResolution(null);
       return;
     }
 
     const handleLoadedMetadata = () => {
       const height = videoElement.videoHeight;
-      setDetectedResolution(formatHeightAsResolution(height));
+      setDetectionResult({
+        key: detectionKey,
+        resolution: formatHeightAsResolution(height),
+      });
     };
 
     const handleError = () => {
-      setDetectedResolution(null);
+      setDetectionResult({ key: detectionKey, resolution: null });
     };
 
     // Delay resolution detection to avoid blocking video playback
@@ -168,7 +173,7 @@ export const useVideoResolution = (video: Video) => {
     }
 
     return cleanup;
-  }, [needsDetection, videoUrl, video.sourceUrl, video.id]);
+  }, [needsDetection, videoUrl, video.sourceUrl, video.id, detectionKey]);
 
   // Use resolution from object if available, otherwise use detected resolution
   const videoResolution = resolutionFromObject || detectedResolution;

--- a/frontend/src/hooks/useVideoSort.ts
+++ b/frontend/src/hooks/useVideoSort.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 import { Video } from "../types";
@@ -41,37 +41,19 @@ export const useVideoSort = ({
     }
   }, [storageKey, validatedDefaultSort]);
 
-  // Initialize sort from URL or default
-  const paramSort = searchParams.get("sort");
-  const initialSort = validateSortOption(
-    paramSort,
+  const sortOption = validateSortOption(
+    searchParams.get("sort"),
     getStoredSort() ?? validatedDefaultSort
   );
-
-  const [sortOption, setSortOption] = useState<SortOption>(initialSort);
-  const [shuffleSeed, setShuffleSeed] = useState<number>(() => {
-    const paramSeed = parseInt(searchParams.get("seed") || "0", 10);
-    if (paramSeed > 0) return paramSeed;
-    return initialSort === "random" ? getRandomSeed() : 0;
-  });
+  const [fallbackRandomSeed] = useState(getRandomSeed);
+  const requestedSeed = parseInt(searchParams.get("seed") || "0", 10);
+  const shuffleSeed =
+    sortOption === "random"
+      ? requestedSeed > 0
+        ? requestedSeed
+        : fallbackRandomSeed
+      : 0;
   const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
-
-  // Sync state with URL or validatedDefaultSort
-  useEffect(() => {
-    const currentParam = searchParams.get("sort");
-    const nextSort = currentParam
-      ? validateSortOption(currentParam, validatedDefaultSort)
-      : getStoredSort() ?? validatedDefaultSort;
-
-    setSortOption(nextSort);
-
-    const currentSeed = parseInt(searchParams.get("seed") || "0", 10);
-    if (nextSort === "random") {
-      setShuffleSeed(currentSeed > 0 ? currentSeed : getRandomSeed());
-    } else {
-      setShuffleSeed(0);
-    }
-  }, [searchParams, validatedDefaultSort, getStoredSort]);
 
   const handleSortClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setSortAnchorEl(event.currentTarget);

--- a/frontend/src/hooks/useViewMode.ts
+++ b/frontend/src/hooks/useViewMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 export type ViewMode = 'favorite' | 'collections' | 'all-videos' | 'history';
@@ -24,30 +24,27 @@ const resolveStoredViewMode = (): ViewMode => {
 
 export const useViewMode = (initialMode?: ViewMode): UseViewModeReturn => {
     const [_searchParams, setSearchParams] = useSearchParams();
-    const [viewMode, setViewMode] = useState<ViewMode>(
-        () => initialMode ?? resolveStoredViewMode()
-    );
-
-    // React Router reuses the Home instance between `/` and `/favorites`, so
-    // the state initializer above does not re-run when the route (and thus
-    // `initialMode`) changes. Keep viewMode in sync with the route: adopt an
-    // authoritative mode when provided (so the `/favorites` deep link stays
-    // correct after Back from `/`), and fall back to the saved/default mode
-    // when it is cleared (so leaving `/favorites` via a plain link such as the
-    // logo stops rendering FavoritePage at `/`).
-    useEffect(() => {
-        setViewMode(initialMode ?? resolveStoredViewMode());
+    const [viewState, setViewState] = useState(() => ({
+        initialMode,
+        viewMode: initialMode ?? resolveStoredViewMode(),
+    }));
+    const viewMode =
+        viewState.initialMode === initialMode
+            ? viewState.viewMode
+            : initialMode ?? resolveStoredViewMode();
+    const setViewMode = useCallback((mode: ViewMode) => {
+        setViewState({ initialMode, viewMode: mode });
     }, [initialMode]);
 
     const handleViewModeChange = useCallback((mode: ViewMode) => {
-        setViewMode(mode);
+        setViewState({ initialMode, viewMode: mode });
         localStorage.setItem('homeViewMode', mode);
         setSearchParams((prev: URLSearchParams) => {
             const newParams = new URLSearchParams(prev);
             newParams.set('page', '1');
             return newParams;
         });
-    }, [setSearchParams]);
+    }, [initialMode, setSearchParams]);
 
     return {
         viewMode,

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -101,7 +101,9 @@ const CollectionPage: React.FC = () => {
 
     // Keep a ref so the context always reads current values (menu gets latest when it opens)
     const filterRef = useRef({ availableTags, selectedTags, onTagToggle: handleTagToggle });
-    filterRef.current = { availableTags, selectedTags, onTagToggle: handleTagToggle };
+    useEffect(() => {
+        filterRef.current = { availableTags, selectedTags, onTagToggle: handleTagToggle };
+    }, [availableTags, selectedTags, handleTagToggle]);
 
     // Register page tag filter; bump filterVersion only in handleTagToggle so Header re-renders on tag click (no effect loop)
     useEffect(() => {

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -11,7 +11,7 @@ import {
     Tooltip,
     Typography
 } from '@mui/material';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import DeleteCollectionModal from '../components/DeleteCollectionModal';
 import FavoriteToggle from '../components/FavoriteToggle';
@@ -82,14 +82,11 @@ const CollectionPage: React.FC = () => {
     }, [collectionVideos]);
     const showTagsOnThumbnail = settings?.showTagsOnThumbnail ?? true;
 
-    const [filterVersion, setFilterVersion] = useState(0);
-
     const handleTagToggle = useCallback((tag: string) => {
         setSelectedTags(prev =>
             prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
         );
         setPage(1);
-        setFilterVersion(v => v + 1);
     }, []);
 
     const videosFilteredByTags = useMemo(() => {
@@ -99,27 +96,16 @@ const CollectionPage: React.FC = () => {
         );
     }, [collectionVideos, selectedTags]);
 
-    // Keep a ref so the context always reads current values (menu gets latest when it opens)
-    const filterRef = useRef({ availableTags, selectedTags, onTagToggle: handleTagToggle });
+    // Re-publish the filter whenever its inputs change so mobile consumers
+    // receive fresh tag arrays after collection videos load or are edited.
     useEffect(() => {
-        filterRef.current = { availableTags, selectedTags, onTagToggle: handleTagToggle };
-    }, [availableTags, selectedTags, handleTagToggle]);
-
-    // Register page tag filter; bump filterVersion only in handleTagToggle so Header re-renders on tag click (no effect loop)
-    useEffect(() => {
-        const stableFilter = {
-            get availableTags() {
-                return filterRef.current.availableTags;
-            },
-            get selectedTags() {
-                return filterRef.current.selectedTags;
-            },
-            onTagToggle: (tag: string) => filterRef.current.onTagToggle(tag),
-            _version: filterVersion
-        };
-        setPageTagFilter(stableFilter);
+        setPageTagFilter({
+            availableTags,
+            selectedTags,
+            onTagToggle: handleTagToggle,
+        });
         return () => setPageTagFilter(null);
-    }, [filterVersion, setPageTagFilter]);
+    }, [availableTags, handleTagToggle, selectedTags, setPageTagFilter]);
 
     // Sort videos (after tag filter)
     const {

--- a/frontend/src/pages/DownloadPage/HistoryTab.tsx
+++ b/frontend/src/pages/DownloadPage/HistoryTab.tsx
@@ -59,18 +59,16 @@ export function HistoryTab({
         });
     }, [history, filterType]);
 
-    // Reset page when filter changes
-    React.useEffect(() => {
-        setPage(1);
-    }, [filterType]);
-
     return (
         <>
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2, gap: 2, flexWrap: 'wrap' }}>
                 <Select
                     size="small"
                     value={filterType}
-                    onChange={(e) => setFilterType(e.target.value)}
+                    onChange={(e) => {
+                        setFilterType(e.target.value);
+                        setPage(1);
+                    }}
                     sx={{ minWidth: 150 }}
                 >
                     <MenuItem value="all">{t('filterAll') || 'All'}</MenuItem>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -38,7 +38,6 @@ const LoginPage: React.FC = () => {
     const [alertOpen, setAlertOpen] = useState(false);
     const [alertTitle, setAlertTitle] = useState('');
     const [alertMessage, setAlertMessage] = useState('');
-    const [websiteName, setWebsiteName] = useState('MyTube');
     const { t } = useLanguage();
     const { login } = useAuth();
 
@@ -83,12 +82,7 @@ const LoginPage: React.FC = () => {
     const visitorUserEnabled = passwordEnabledData?.visitorUserEnabled !== false;
     const showVisitorTab = visitorUserEnabled && (!!passwordEnabledData?.hasVisitorUsers || !!passwordEnabledData?.isVisitorPasswordSet);
 
-    // Update website name when settings are loaded
-    useEffect(() => {
-        if (passwordEnabledData && passwordEnabledData.websiteName) {
-            setWebsiteName(passwordEnabledData.websiteName);
-        }
-    }, [passwordEnabledData]);
+    const websiteName = passwordEnabledData?.websiteName || 'MyTube';
 
     // Check if passkeys exist
     const { data: passkeysData } = useQuery({

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -48,8 +48,8 @@ const SearchPage: React.FC = () => {
     const sortOptionP = validateSortOption(searchParams.get('sort'), 'dateDesc');
     const seedP = parseInt(searchParams.get('seed') || '0', 10);
 
-    const [sortOption, setSortOption] = useState<SortOption>(sortOptionP);
-    const [shuffleSeed, setShuffleSeed] = useState<number>(seedP);
+    const sortOption: SortOption = sortOptionP;
+    const shuffleSeed = seedP;
     const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
 
     const query = searchParams.get('q');
@@ -59,13 +59,6 @@ const SearchPage: React.FC = () => {
             handleSearch(query);
         }
     }, [query, contextSearchTerm, handleSearch]);
-
-    useEffect(() => {
-        const currentSort = validateSortOption(searchParams.get('sort'), 'dateDesc');
-        const currentSeed = parseInt(searchParams.get('seed') || '0', 10);
-        setSortOption(currentSort);
-        setShuffleSeed(currentSeed);
-    }, [searchParams]);
 
     const handleSortClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         setSortAnchorEl(event.currentTarget);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -112,7 +112,20 @@ const SettingsPage: React.FC = () => {
     const [liveTranslationApiKeyDraft, setLiveTranslationApiKeyDraft] = useState('');
     const [clearLiveTranslationApiKeyRequested, setClearLiveTranslationApiKeyRequested] =
         useState(false);
-    const [currentTab, setCurrentTab] = useState(0);
+    const tabParam = new URLSearchParams(location.search).get('tab');
+    const tabFromUrl = tabParam === null ? 0 : parseInt(tabParam, 10);
+    const resolvedTabFromUrl = Number.isNaN(tabFromUrl) ? 0 : tabFromUrl;
+    const [tabState, setTabState] = useState({
+        search: location.search,
+        currentTab: resolvedTabFromUrl,
+    });
+    const currentTab =
+        tabState.search === location.search
+            ? tabState.currentTab
+            : resolvedTabFromUrl;
+    const setCurrentTab = (nextTab: number) => {
+        setTabState({ search: location.search, currentTab: nextTab });
+    };
     const [showTrustDetailsModal, setShowTrustDetailsModal] = useState(false);
     const twitchCredentialValidationCode = getTwitchCredentialValidationCode(
         settings.twitchClientId,
@@ -173,15 +186,6 @@ const SettingsPage: React.FC = () => {
 
     // Handle initial tab selection from URL and scrolling
     useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const tabParam = params.get('tab');
-        if (tabParam) {
-            const tabIndex = parseInt(tabParam, 10);
-            if (!isNaN(tabIndex)) {
-                setCurrentTab(tabIndex);
-            }
-        }
-
         // Handle scrolling to element if hash is present
         if (location.hash) {
             const id = location.hash.replace('#', '');

--- a/frontend/src/pages/__tests__/CollectionPage.test.tsx
+++ b/frontend/src/pages/__tests__/CollectionPage.test.tsx
@@ -445,5 +445,28 @@ describe('CollectionPage', () => {
             unmount();
             expect(mockSetPageTagFilter).toHaveBeenCalledWith(null);
         });
+
+        it('re-publishes available tags when collection video tags change', async () => {
+            const { rerender } = renderCollectionPage();
+            mockSetPageTagFilter.mockClear();
+            mockVideoContext.videos = [
+                { ...mockVideos[0], tags: ['tag1', 'new-tag'] },
+                mockVideos[1],
+            ];
+
+            rerender(
+                <ThemeProvider theme={theme}>
+                    <CollectionPage />
+                </ThemeProvider>
+            );
+
+            await waitFor(() => {
+                expect(mockSetPageTagFilter).toHaveBeenLastCalledWith(
+                    expect.objectContaining({
+                        availableTags: ['new-tag', 'tag1', 'tag2'],
+                    })
+                );
+            });
+        });
     });
 });

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -43,6 +43,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
     const suppressClick = useRef(false);
     const suppressClickTimer = useRef<number | null>(null);
     const count = items.length;
+    const safeIndex = count > 0 && index < count ? index : 0;
 
     // Clear the pending suppress-click reset on unmount.
     useEffect(() => () => {
@@ -77,23 +78,25 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
             suppressClickTimer.current = null;
         }, 400);
         if (horizontalDistance < 0) {
-            go(index + 1, 1);
+            go(safeIndex + 1, 1);
         } else {
-            go(index - 1, -1);
+            go(safeIndex - 1, -1);
         }
     };
 
     useEffect(() => {
         if (isReducedMotion || paused || count <= 1) return undefined;
         const id = window.setInterval(() => {
-            setIndex((current) => (current + 1) % count);
+            setIndex((current) => {
+                const currentSafeIndex = current < count ? current : 0;
+                return (currentSafeIndex + 1) % count;
+            });
         }, AUTO_ADVANCE_MS);
         return () => window.clearInterval(id);
     }, [isReducedMotion, paused, count]);
 
     if (count === 0) return null;
 
-    const safeIndex = index < count ? index : 0;
     const current = items[safeIndex];
     const openCollection = (event: MouseEvent<HTMLButtonElement>) => {
         if (!current.collection) return;

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -49,11 +49,6 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
     }, []);
 
-    // Keep the index valid if the favorites list shrinks under us.
-    useEffect(() => {
-        if (index >= count && count > 0) setIndex(0);
-    }, [count, index]);
-
     const go = useCallback((next: number, direction = 1) => {
         setSlideDirection(direction);
         setIndex(((next % count) + count) % count);
@@ -98,7 +93,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
 
     if (count === 0) return null;
 
-    const safeIndex = Math.min(index, count - 1);
+    const safeIndex = index < count ? index : 0;
     const current = items[safeIndex];
     const openCollection = (event: MouseEvent<HTMLButtonElement>) => {
         if (!current.collection) return;

--- a/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
+++ b/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
@@ -112,6 +112,40 @@ describe('FavoriteHeroCarousel', () => {
         expect(screen.getByTestId('hero-slide')).toHaveTextContent('B');
     });
 
+    it('uses the visible slide as the swipe origin after the items shrink', () => {
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: query.includes('max-width'),
+            media: query,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })) as never;
+        const { rerender } = renderCarousel(makeItems(['A', 'B', 'C', 'D']));
+        const carousel = screen.getByTestId('favorite-hero-carousel');
+        for (let swipe = 0; swipe < 3; swipe += 1) {
+            fireEvent.touchStart(carousel, { touches: [{ clientX: 240, clientY: 80 }] });
+            fireEvent.touchEnd(carousel, { changedTouches: [{ clientX: 140, clientY: 84 }] });
+        }
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('D');
+
+        rerender(
+            <MemoryRouter>
+                <ThemeProvider theme={createTheme()}>
+                    <FavoriteHeroCarousel items={makeItems(['A', 'B'])} />
+                </ThemeProvider>
+            </MemoryRouter>,
+        );
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('A');
+
+        const shrunkCarousel = screen.getByTestId('favorite-hero-carousel');
+        fireEvent.touchStart(shrunkCarousel, { touches: [{ clientX: 240, clientY: 80 }] });
+        fireEvent.touchEnd(shrunkCarousel, { changedTouches: [{ clientX: 140, clientY: 84 }] });
+
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('B');
+    });
+
     it('jumps to a slide when its dot is clicked', () => {
         renderCarousel(makeItems(['A', 'B', 'C']));
         fireEvent.click(screen.getByRole('button', { name: 'featured 3' }));


### PR DESCRIPTION
## Summary

- upgrade `@eslint/js` to 10.0.1 and `eslint-plugin-react-hooks` to 7.1.1
- fix all violations enabled by the React Hooks 7 recommended rules
- replace effect-driven derived state with keyed or derived state where appropriate
- move render-time ref and media-object mutations into effects or event-driven synchronization
- preserve controlled-dialog reset behavior through keyed remounts

## Root cause

PR #380 upgrades ESLint to 10, but `eslint-plugin-react-hooks` 5.x does not declare ESLint 10 support, so `npm ci` fails on its peer dependency. Upgrading the hooks plugin resolves installation and enables additional recommended React rules, which exposed 66 existing lint errors that also needed to be corrected.

## Impact

This restores the frontend CI dependency install and keeps the full React Hooks recommended rule set enabled. The refactors are intended to preserve existing UI behavior while avoiding cascading effect renders, render-time ref access, prop mutation, and impure ID generation.

This is a stacked PR targeting the source branch of #380 so merging it updates #380 without duplicating the Dependabot diff against `master`.

## Validation

- `npm run lint` — passes with 0 errors
- `npm run typecheck` — passes
- `npm test` — 175 files, 1684 tests passed
- `npm run build` — passes
- `docker build --no-cache --target frontend-builder -f backend/Dockerfile .` — passes (`npm ci` + production build)
- `git diff --check` — passes