### PR TITLE
Fix Dependabot npm alerts

### DIFF
--- a/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
+++ b/backend/bgutil-ytdlp-pot-provider/server/package-lock.json
@@ -21,20 +21,20 @@
             },
             "devDependencies": {
                 "@commander-js/extra-typings": "^14.0.0",
-                "@eslint/js": "^9.32.0",
+                "@eslint/js": "^10.0.1",
                 "@types/body-parser": "^1.19.6",
                 "@types/express": "^5.0.3",
                 "@types/jsdom": "^21.1.7",
                 "@types/node": "^24.1.0",
-                "@typescript-eslint/parser": "^8.38.0",
-                "eslint": "^9.32.0",
+                "@typescript-eslint/parser": "^8.65.0",
+                "eslint": "^10.8.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-only-warn": "^1.1.0",
                 "eslint-plugin-prettier": "^5.5.3",
                 "prettier": "3.6.2",
                 "swc-node": "^1.0.0",
                 "typescript": "^5.9.3",
-                "typescript-eslint": "^8.38.0"
+                "typescript-eslint": "^8.65.0"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
@@ -253,153 +253,89 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.21.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-            "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+            "version": "0.23.5",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+            "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.7",
+                "@eslint/object-schema": "^3.0.5",
                 "debug": "^4.3.1",
-                "minimatch": "^3.1.2"
+                "minimatch": "^10.2.4"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+            "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0"
+                "@eslint/core": "^1.2.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+            "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/json-schema": "^7.0.15"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            }
-        },
-        "node_modules/@eslint/eslintrc": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.12.4",
-                "debug": "^4.3.2",
-                "espree": "^10.0.1",
-                "globals": "^14.0.0",
-                "ignore": "^5.2.0",
-                "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.2",
-                "strip-json-comments": "^3.1.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.39.2",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-            "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+            "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "eslint": "^10.0.0"
+            },
+            "peerDependenciesMeta": {
+                "eslint": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.7",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+            "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+            "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.17.0",
+                "@eslint/core": "^1.2.1",
                 "levn": "^0.4.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             }
         },
         "node_modules/@humanfs/core": {
@@ -1108,6 +1044,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/esrecurse": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+            "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1219,20 +1162,20 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
-            "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.53.0",
-                "@typescript-eslint/type-utils": "8.53.0",
-                "@typescript-eslint/utils": "8.53.0",
-                "@typescript-eslint/visitor-keys": "8.53.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1242,15 +1185,15 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.53.0",
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "@typescript-eslint/parser": "^8.65.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1258,16 +1201,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-            "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.53.0",
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/typescript-estree": "8.53.0",
-                "@typescript-eslint/visitor-keys": "8.53.0",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1278,19 +1221,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
-            "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.53.0",
-                "@typescript-eslint/types": "^8.53.0",
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1301,18 +1244,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
-            "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/visitor-keys": "8.53.0"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1323,9 +1266,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
-            "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1336,21 +1279,21 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
-            "integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/typescript-estree": "8.53.0",
-                "@typescript-eslint/utils": "8.53.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
                 "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1360,14 +1303,14 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-            "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1379,21 +1322,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
-            "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.53.0",
-                "@typescript-eslint/tsconfig-utils": "8.53.0",
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/visitor-keys": "8.53.0",
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
+                "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1403,20 +1346,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
-            "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.53.0",
-                "@typescript-eslint/types": "8.53.0",
-                "@typescript-eslint/typescript-estree": "8.53.0"
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1426,19 +1369,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
-            "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.53.0",
-                "eslint-visitor-keys": "^4.2.1"
+                "@typescript-eslint/types": "8.65.0",
+                "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1462,9 +1405,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -1493,9 +1436,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1508,29 +1451,6 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
             }
-        },
-        "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "license": "Python-2.0"
         },
         "node_modules/ast-types": {
             "version": "0.13.4",
@@ -1597,11 +1517,14 @@
             }
         },
         "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
         },
         "node_modules/base64-js": {
             "version": "1.5.1",
@@ -1690,13 +1613,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/buffer": {
@@ -1768,16 +1694,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/callsites": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/canvas": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.1.tgz",
@@ -1792,48 +1708,11 @@
                 "node": "^18.12.0 || >= 20.9.0"
             }
         },
-        "node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
         "node_modules/chownr": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "license": "ISC"
-        },
-        "node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/colorette": {
             "version": "2.0.20",
@@ -1862,13 +1741,6 @@
             "engines": {
                 "node": ">=20"
             }
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/content-disposition": {
             "version": "1.0.1",
@@ -2191,33 +2063,33 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.39.2",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-            "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+            "version": "10.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
             "dev": true,
             "license": "MIT",
+            "workspaces": [
+                "packages/*"
+            ],
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
-                "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.21.1",
-                "@eslint/config-helpers": "^0.4.2",
-                "@eslint/core": "^0.17.0",
-                "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.39.2",
-                "@eslint/plugin-kit": "^0.4.1",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@eslint/config-array": "^0.23.5",
+                "@eslint/config-helpers": "^0.7.0",
+                "@eslint/core": "^1.2.1",
+                "@eslint/plugin-kit": "^0.7.2",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
-                "ajv": "^6.12.4",
-                "chalk": "^4.0.0",
+                "ajv": "^6.14.0",
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.4.0",
-                "eslint-visitor-keys": "^4.2.1",
-                "espree": "^10.4.0",
-                "esquery": "^1.5.0",
+                "eslint-scope": "^9.1.2",
+                "eslint-visitor-keys": "^5.0.1",
+                "espree": "^11.2.0",
+                "esquery": "^1.7.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^8.0.0",
@@ -2227,8 +2099,7 @@
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
+                "minimatch": "^10.2.5",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3"
             },
@@ -2236,7 +2107,7 @@
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://eslint.org/donate"
@@ -2308,72 +2179,50 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+            "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
+                "@types/esrecurse": "^4.3.1",
+                "@types/estree": "^1.0.8",
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/espree": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+            "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.1"
+                "eslint-visitor-keys": "^5.0.1"
             },
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -2775,19 +2624,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/globals": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2798,16 +2634,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/has-symbols": {
@@ -2953,23 +2779,6 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/import-fresh": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "parent-module": "^1.0.0",
-                "resolve-from": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3062,29 +2871,6 @@
             "license": "MIT",
             "dependencies": {
                 "acorn": "^8.8.0"
-            }
-        },
-        "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/puzrin"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/nodeca"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/jsdom": {
@@ -3187,13 +2973,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash.merge": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lru-cache": {
             "version": "10.4.3",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -3268,16 +3047,16 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3506,19 +3285,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/parent-module": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "callsites": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/parse5": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -3571,9 +3337,9 @@
             }
         },
         "node_modules/picomatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3799,16 +3565,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/resolve-from": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/router": {
@@ -4140,32 +3896,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "node_modules/strip-json-comments": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/swc-node": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/swc-node/-/swc-node-1.0.0.tgz",
@@ -4230,14 +3960,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -4298,9 +4028,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4387,16 +4117,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
-            "integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.53.0",
-                "@typescript-eslint/parser": "8.53.0",
-                "@typescript-eslint/typescript-estree": "8.53.0",
-                "@typescript-eslint/utils": "8.53.0"
+                "@typescript-eslint/eslint-plugin": "8.65.0",
+                "@typescript-eslint/parser": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4406,8 +4136,8 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/undici": {

--- a/backend/bgutil-ytdlp-pot-provider/server/package.json
+++ b/backend/bgutil-ytdlp-pot-provider/server/package.json
@@ -31,20 +31,20 @@
     },
     "devDependencies": {
         "@commander-js/extra-typings": "^14.0.0",
-        "@eslint/js": "^9.32.0",
+        "@eslint/js": "^10.0.1",
         "@types/body-parser": "^1.19.6",
         "@types/express": "^5.0.3",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^24.1.0",
-        "@typescript-eslint/parser": "^8.38.0",
-        "eslint": "^9.32.0",
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-only-warn": "^1.1.0",
         "eslint-plugin-prettier": "^5.5.3",
         "prettier": "3.6.2",
         "swc-node": "^1.0.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.38.0"
+        "typescript-eslint": "^8.65.0"
     },
     "overrides": {
         "ajv": "^6.14.0",

--- a/backend/bgutil-ytdlp-pot-provider/server/src/generate_once.ts
+++ b/backend/bgutil-ytdlp-pot-provider/server/src/generate_once.ts
@@ -15,7 +15,9 @@ function parseJsonOption<T>(value: string | undefined, optionName: string): T | 
         return JSON.parse(value) as T;
     } catch (error) {
         const reason = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to parse ${optionName}: ${reason}`);
+        throw new Error(`Failed to parse ${optionName}: ${reason}`, {
+            cause: error,
+        });
     }
 }
 

--- a/backend/bgutil-ytdlp-pot-provider/server/src/session_manager.ts
+++ b/backend/bgutil-ytdlp-pot-provider/server/src/session_manager.ts
@@ -311,7 +311,7 @@ export class SessionManager {
                     { cause: eInner },
                 );
             }
-            throw new Error("Could not get Botguard challenge");
+            throw new Error("Could not get Botguard challenge", { cause: e });
         }
     }
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2232,16 +2232,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4142,9 +4142,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -4737,9 +4737,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5156,9 +5156,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5176,7 +5176,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -40,7 +40,8 @@ export default tseslint.config(
       "react-refresh": reactRefresh,
     },
     rules: {
-      ...reactHooks.configs.recommended.rules,
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -40,8 +40,7 @@ export default tseslint.config(
       "react-refresh": reactRefresh,
     },
     rules: {
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
+      ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "react-virtuoso": "^4.18.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.21.0",
+        "@eslint/js": "^10.0.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
         "@testing-library/user-event": "^14.6.1",
@@ -34,13 +34,13 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.8",
         "esbuild": "0.28.1",
-        "eslint": "^9.21.0",
-        "eslint-plugin-react-hooks": "^5.1.0",
-        "eslint-plugin-react-refresh": "^0.4.19",
+        "eslint": "^10.8.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^15.15.0",
         "jsdom": "^27.3.0",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.54.0",
+        "typescript-eslint": "^8.65.0",
         "vite": "^8.0.16",
         "vitest": "^4.1.8"
       },
@@ -131,6 +131,57 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -145,6 +196,33 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-globals": {
@@ -169,6 +247,24 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -183,6 +279,30 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1075,118 +1195,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1262,6 +1353,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -2019,6 +2121,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -2084,20 +2193,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
-      "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/type-utils": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2107,15 +2216,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.54.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2123,16 +2232,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
-      "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2143,19 +2252,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
-      "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.54.0",
-        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2166,18 +2275,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
-      "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2188,9 +2297,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
-      "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2201,21 +2310,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
-      "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2225,14 +2334,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-      "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2244,21 +2353,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-      "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.54.0",
-        "@typescript-eslint/tsconfig-utils": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/visitor-keys": "8.54.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2268,59 +2377,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
-      "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.54.0",
-        "@typescript-eslint/types": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2330,19 +2400,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-      "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.54.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2523,9 +2593,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2556,9 +2626,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2582,29 +2652,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2704,11 +2751,27 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.5.tgz",
+      "integrity": "sha512-xJo6a6YZnwZfnyGmQKWMbVOcii7XRibjOskRh+WJ9UHQoX16xrQrcIgAMQOzfvs8XiLMx6ih/fsLPF73iY2D1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bidi-js": {
       "version": "1.0.3",
@@ -2721,14 +2784,50 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2753,6 +2852,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2763,23 +2883,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2788,26 +2891,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2820,13 +2903,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3041,6 +3117,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -3157,6 +3240,16 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3170,33 +3263,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -3206,8 +3299,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3215,7 +3307,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -3230,80 +3322,89 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.19.tgz",
-      "integrity": "sha512-eyy8pcr/YxSYjBoqIFSrlbn9i/xvxUFa8CjzAYo9cFjgGXqq1hyjihcpZvxRLalpaWmueWR81xn7vuKmAFijDQ==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=8.40"
+        "eslint": "^9 || ^10"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3549,6 +3650,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3671,6 +3782,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -3898,29 +4026,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/jsdom": {
       "version": "27.3.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.3.0.tgz",
@@ -3999,6 +4104,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4307,13 +4425,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4324,6 +4435,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
@@ -4375,19 +4496,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4436,16 +4544,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/motion-dom": {
@@ -4494,6 +4605,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4969,6 +5090,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -5043,19 +5177,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stylis": {
@@ -5187,9 +5308,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5233,16 +5354,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.54.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.54.0.tgz",
-      "integrity": "sha512-CKsJ+g53QpsNPqbzUsfKVgd3Lny4yKZ1pP4qN3jdMOg/sisIDLGyDMezycquXLE5JsEU0wp3dGNdzig0/fmSVQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.54.0",
-        "@typescript-eslint/parser": "8.54.0",
-        "@typescript-eslint/typescript-estree": "8.54.0",
-        "@typescript-eslint/utils": "8.54.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5252,8 +5373,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {
@@ -5262,6 +5383,37 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -5583,6 +5735,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5594,6 +5753,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,7 +33,7 @@
     "react-virtuoso": "^4.18.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.21.0",
+    "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",
     "@testing-library/user-event": "^14.6.1",
@@ -42,14 +42,14 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.8",
-    "eslint": "^9.21.0",
-    "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.19",
+    "esbuild": "0.28.1",
+    "eslint": "^10.8.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^15.15.0",
     "jsdom": "^27.3.0",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.54.0",
-    "esbuild": "0.28.1",
+    "typescript-eslint": "^8.65.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   }

--- a/frontend/src/components/AuthorsList.tsx
+++ b/frontend/src/components/AuthorsList.tsx
@@ -11,12 +11,13 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { Video } from '../types';
 import { authorAvatarFallbackSx } from '../utils/authorAvatarStyles';
+import { useBreakpointSynchronizedOpen } from './useBreakpointSynchronizedOpen';
 
 interface AuthorsListProps {
     videos: Video[];
@@ -78,7 +79,7 @@ const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
     const { t } = useLanguage();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
+    const [isOpen, setIsOpen] = useBreakpointSynchronizedOpen(isMobile);
 
     // Count videos per author, then show only the most prolific authors.
     // "Show all" (and the full /authors page) only matters when the list is
@@ -124,7 +125,7 @@ const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setIsOpen((current) => !current)} sx={{ borderRadius: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('authors')}
                 </Typography>

--- a/frontend/src/components/AuthorsList.tsx
+++ b/frontend/src/components/AuthorsList.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
@@ -76,9 +76,9 @@ const TOP_AUTHORS_LIMIT = 20;
 
 const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
 
     // Count videos per author, then show only the most prolific authors.
     // "Show all" (and the full /authors page) only matters when the list is
@@ -117,15 +117,6 @@ const AuthorsList: React.FC<AuthorsListProps> = ({ videos, onItemClick }) => {
         }
         return map;
     }, [videos]);
-
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
 
     if (!topAuthors.length) {
         return null;

--- a/frontend/src/components/BilibiliPartsModal.tsx
+++ b/frontend/src/components/BilibiliPartsModal.tsx
@@ -10,7 +10,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
@@ -47,7 +47,7 @@ interface BilibiliPartsModalProps {
 const isSubscribableType = (type: string) =>
     type === 'playlist' || type === 'collection' || type === 'series';
 
-const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
+const BilibiliPartsModalContent: React.FC<BilibiliPartsModalProps> = ({
     isOpen,
     onClose,
     videosNumber,
@@ -73,18 +73,13 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     const [filenameTemplate, setFilenameTemplate] = useState<string>('');
     const [isTemplateValid, setIsTemplateValid] = useState<boolean>(true);
 
-    // The successful submission path closes this controlled dialog from the
-    // parent, bypassing handleClose. Reset the destructive choice whenever
-    // that happens so it cannot be carried to the next detected playlist.
-    useEffect(() => {
-        if (!isOpen) {
-            setSubscribeToPlaylist(false);
-            setDownloadExistingVideos(false);
-            setIntervalInput('60');
-            setFilenameTemplate('');
-            setIsTemplateValid(true);
-        }
-    }, [isOpen]);
+    const resetSubscribeForm = () => {
+        setSubscribeToPlaylist(false);
+        setDownloadExistingVideos(false);
+        setIntervalInput('60');
+        setFilenameTemplate('');
+        setIsTemplateValid(true);
+    };
 
     const subscribable = isSubscribableType(type);
 
@@ -114,6 +109,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
         setIsSubmitting(true);
         try {
             await onConfirm(action);
+            resetSubscribeForm();
         } catch {
             // DownloadContext displays the actionable error. Keep this dialog
             // open with its current selection so the user can retry.
@@ -127,11 +123,7 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
     // sources (design §10.2).
     const handleClose = () => {
         if (isLoading || isSubmitting) return;
-        setSubscribeToPlaylist(false);
-        setDownloadExistingVideos(false);
-        setIntervalInput('60');
-        setFilenameTemplate('');
-        setIsTemplateValid(true);
+        resetSubscribeForm();
         onClose();
     };
 
@@ -339,6 +331,19 @@ const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = ({
                 </Button>
             </DialogActions>
         </Dialog>
+    );
+};
+
+const BilibiliPartsModal: React.FC<BilibiliPartsModalProps> = (props) => {
+    if (!props.isOpen) {
+        return null;
+    }
+
+    return (
+        <BilibiliPartsModalContent
+            key={`${props.type ?? 'parts'}:${props.videoTitle}:${props.videosNumber}`}
+            {...props}
+        />
     );
 };
 

--- a/frontend/src/components/Collections.tsx
+++ b/frontend/src/components/Collections.tsx
@@ -11,10 +11,11 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
+import { useBreakpointSynchronizedOpen } from './useBreakpointSynchronizedOpen';
 
 interface CollectionsProps {
     collections: Collection[];
@@ -27,7 +28,7 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
     const { t } = useLanguage();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
+    const [isOpen, setIsOpen] = useBreakpointSynchronizedOpen(isMobile);
 
     const sidebarCollections = useMemo(() => {
         if (!collections) {
@@ -69,7 +70,7 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setIsOpen((current) => !current)} sx={{ borderRadius: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('collections')}
                 </Typography>

--- a/frontend/src/components/Collections.tsx
+++ b/frontend/src/components/Collections.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { Collection } from '../types';
@@ -25,9 +25,9 @@ const TOP_COLLECTIONS_LIMIT = 20;
 
 const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
 
     const sidebarCollections = useMemo(() => {
         if (!collections) {
@@ -62,15 +62,6 @@ const Collections: React.FC<CollectionsProps> = ({ collections, onItemClick }) =
 
         return [...topCollections, ...omittedDirectLinkCollections];
     }, [collections]);
-
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
 
     if (!collections || collections.length === 0) {
         return null;

--- a/frontend/src/components/Header/useHeaderScrollState.ts
+++ b/frontend/src/components/Header/useHeaderScrollState.ts
@@ -1,31 +1,33 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 export const useHeaderScrollState = (
     isMobile: boolean,
     infiniteScroll: boolean,
     isHomePage: boolean
 ): boolean => {
-    const [isScrolled, setIsScrolled] = useState(false);
+    const shouldDetectScroll = isMobile || (infiniteScroll && isHomePage);
 
-    useEffect(() => {
-        const shouldDetectScroll = isMobile || (infiniteScroll && isHomePage);
-        if (!shouldDetectScroll) {
-            setIsScrolled(false);
-            return;
+    const getSnapshot = useCallback(() => {
+        if (!shouldDetectScroll || typeof window === 'undefined') {
+            return false;
         }
 
-        const handleScroll = () => {
-            const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            setIsScrolled(scrollTop > 50);
-        };
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        return scrollTop > 50;
+    }, [shouldDetectScroll]);
 
-        window.addEventListener('scroll', handleScroll, { passive: true });
-        handleScroll();
+    const subscribe = useCallback((onStoreChange: () => void) => {
+        if (!shouldDetectScroll || typeof window === 'undefined') {
+            return () => {};
+        }
 
+        window.addEventListener('scroll', onStoreChange, { passive: true });
+        window.addEventListener('resize', onStoreChange);
         return () => {
-            window.removeEventListener('scroll', handleScroll);
+            window.removeEventListener('scroll', onStoreChange);
+            window.removeEventListener('resize', onStoreChange);
         };
-    }, [isMobile, infiniteScroll, isHomePage]);
+    }, [shouldDetectScroll]);
 
-    return isScrolled;
+    return useSyncExternalStore(subscribe, getSnapshot, () => false);
 };

--- a/frontend/src/components/Header/useHeaderSubscriptions.ts
+++ b/frontend/src/components/Header/useHeaderSubscriptions.ts
@@ -16,7 +16,6 @@ export const useHeaderSubscriptions = (isVisitor: boolean): boolean => {
 
     useEffect(() => {
         if (isVisitor) {
-            setHasActiveSubscriptions(false);
             return;
         }
 
@@ -59,5 +58,5 @@ export const useHeaderSubscriptions = (isVisitor: boolean): boolean => {
         };
     }, [isVisitor]);
 
-    return hasActiveSubscriptions;
+    return isVisitor ? false : hasActiveSubscriptions;
 };

--- a/frontend/src/components/PasswordModal.tsx
+++ b/frontend/src/components/PasswordModal.tsx
@@ -36,14 +36,6 @@ const PasswordModal: React.FC<PasswordModalProps> = ({
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
 
-    // Reset state when modal opens
-    React.useEffect(() => {
-        if (isOpen) {
-            setPassword('');
-            setShowPassword(false);
-        }
-    }, [isOpen]);
-
     const handleConfirm = (e?: React.FormEvent) => {
         e?.preventDefault();
         onConfirm(password);

--- a/frontend/src/components/PasswordModal.tsx
+++ b/frontend/src/components/PasswordModal.tsx
@@ -23,7 +23,7 @@ interface PasswordModalProps {
     isLoading?: boolean;
 }
 
-const PasswordModal: React.FC<PasswordModalProps> = ({
+const PasswordModalContent: React.FC<PasswordModalProps> = ({
     isOpen,
     onClose,
     onConfirm,
@@ -126,6 +126,14 @@ const PasswordModal: React.FC<PasswordModalProps> = ({
             </form>
         </Dialog>
     );
+};
+
+const PasswordModal: React.FC<PasswordModalProps> = (props) => {
+    if (!props.isOpen) {
+        return null;
+    }
+
+    return <PasswordModalContent {...props} />;
 };
 
 export default PasswordModal;

--- a/frontend/src/components/Settings/FilenameTemplateSettings.tsx
+++ b/frontend/src/components/Settings/FilenameTemplateSettings.tsx
@@ -74,14 +74,25 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
     const customTemplate = settings.downloadFilenameTemplate || '';
     const namingMode = settings.downloadFilenameMode || (derivedPresetId === 'legacy' ? 'legacy' : 'template');
     const [forceCustomSelection, setForceCustomSelection] = useState(false);
+    const customSelectionForced =
+        namingMode === 'template' && derivedPresetId !== 'custom' && forceCustomSelection;
     const presetId = resolveFilenamePresetSelectValue(
         derivedPresetId,
         namingMode,
-        forceCustomSelection
+        customSelectionForced
     );
 
-    const [preview, setPreview] = useState<FilenameTemplatePreviewResponse | null>(null);
-    const [isValidating, setIsValidating] = useState(false);
+    const [previewState, setPreviewState] = useState<{
+        key: string;
+        preview: FilenameTemplatePreviewResponse;
+    } | null>(null);
+    const [validatingKey, setValidatingKey] = useState<string | null>(null);
+
+    // Compute effective template for preview
+    const effectiveTemplate = deriveFilenameEffectiveTemplate(settings, presetDefinitions);
+    const previewKey = `${namingMode}\u0000${effectiveTemplate}\u0000${presetId}`;
+    const preview = previewState?.key === previewKey ? previewState.preview : null;
+    const isValidating = validatingKey === previewKey;
 
     // Batch rename uses the current form state shown above, not only the last
     // saved defaults used for future downloads.
@@ -94,29 +105,14 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                 scenarioPreview.videoPath.split('/').filter(Boolean).length >= 3
         );
 
-    // Compute effective template for preview
-    const effectiveTemplate = deriveFilenameEffectiveTemplate(settings, presetDefinitions);
-
-    useEffect(() => {
-        if (settings.downloadFilenameMode !== 'template') {
-            setForceCustomSelection(false);
-            return;
-        }
-
-        if (derivedPresetId === 'custom') {
-            setForceCustomSelection(false);
-        }
-    }, [derivedPresetId, settings.downloadFilenameMode]);
-
     // Debounced preview fetch
     useEffect(() => {
         const template = effectiveTemplate;
         if (namingMode === 'template' && !template) {
-            setPreview(null);
             return;
         }
-        setIsValidating(true);
         const timer = setTimeout(async () => {
+            setValidatingKey(previewKey);
             try {
                 const res = await api.post<FilenameTemplatePreviewResponse>(
                     '/settings/filename-template/preview',
@@ -125,24 +121,27 @@ const FilenameTemplateSettings: React.FC<FilenameTemplateSettingsProps> = ({
                         template: namingMode === 'template' ? template : undefined,
                     }
                 );
-                setPreview(res.data);
+                setPreviewState({ key: previewKey, preview: res.data });
             } catch (e: unknown) {
-                setPreview({
-                    valid: false,
-                    errors: [getApiErrorMessage(e) || String(e)],
-                    resolved: {
-                        mode: namingMode,
-                        matchedPresetId: presetId,
-                        template: namingMode === 'template' ? template : null,
+                setPreviewState({
+                    key: previewKey,
+                    preview: {
+                        valid: false,
+                        errors: [getApiErrorMessage(e) || String(e)],
+                        resolved: {
+                            mode: namingMode,
+                            matchedPresetId: presetId,
+                            template: namingMode === 'template' ? template : null,
+                        },
+                        previews: null,
                     },
-                    previews: null,
                 });
             } finally {
-                setIsValidating(false);
+                setValidatingKey((current) => current === previewKey ? null : current);
             }
         }, 600);
         return () => clearTimeout(timer);
-    }, [effectiveTemplate, namingMode, presetId]);
+    }, [effectiveTemplate, namingMode, presetId, previewKey]);
 
     const handlePresetChange = (value: string) => {
         if (value === 'legacy') {

--- a/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
+++ b/frontend/src/components/Settings/RssFeedSettings/RssTokenDialog.tsx
@@ -12,7 +12,7 @@ import {
     Typography,
 } from '@mui/material';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { CreateTokenInput, RssFilters, RssToken, UpdateTokenInput } from '../../../utils/rssApi';
 import RssFilterEditor from './RssFilterEditor';
@@ -37,7 +37,16 @@ interface RssTokenDialogProps {
 
 const DEFAULT_FILTERS: RssFilters = { maxItems: 50 };
 
-const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
+const getInitialLabel = (mode: RssTokenDialogProps['mode'], token?: RssToken): string =>
+    mode === 'edit' && token ? token.label : '';
+
+const getInitialRole = (mode: RssTokenDialogProps['mode'], token?: RssToken): 'admin' | 'visitor' =>
+    mode === 'edit' && token ? token.role : 'visitor';
+
+const getInitialFilters = (mode: RssTokenDialogProps['mode'], token?: RssToken): RssFilters =>
+    mode === 'edit' && token ? { maxItems: 50, ...token.filters } : { ...DEFAULT_FILTERS };
+
+const RssTokenDialogContent: React.FC<RssTokenDialogProps> = ({
     open,
     mode,
     token,
@@ -50,23 +59,9 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
     isLoading = false,
 }) => {
     const { t } = useLanguage();
-    const [label, setLabel] = useState('');
-    const [role, setRole] = useState<'admin' | 'visitor'>('visitor');
-    const [filters, setFilters] = useState<RssFilters>(DEFAULT_FILTERS);
-
-    useEffect(() => {
-        if (open) {
-            if (mode === 'edit' && token) {
-                setLabel(token.label);
-                setRole(token.role);
-                setFilters({ maxItems: 50, ...token.filters });
-            } else {
-                setLabel('');
-                setRole('visitor');
-                setFilters(DEFAULT_FILTERS);
-            }
-        }
-    }, [open, mode, token]);
+    const [label, setLabel] = useState(() => getInitialLabel(mode, token));
+    const [role, setRole] = useState<'admin' | 'visitor'>(() => getInitialRole(mode, token));
+    const [filters, setFilters] = useState<RssFilters>(() => getInitialFilters(mode, token));
 
     const showAdminWarning = role === 'admin';
 
@@ -176,6 +171,19 @@ const RssTokenDialog: React.FC<RssTokenDialogProps> = ({
                 </Button>
             </DialogActions>
         </Dialog>
+    );
+};
+
+const RssTokenDialog: React.FC<RssTokenDialogProps> = (props) => {
+    if (!props.open) {
+        return null;
+    }
+
+    return (
+        <RssTokenDialogContent
+            key={`${props.mode}:${props.token?.id ?? 'new'}`}
+            {...props}
+        />
     );
 };
 

--- a/frontend/src/components/Settings/UserManagementSettings.tsx
+++ b/frontend/src/components/Settings/UserManagementSettings.tsx
@@ -29,7 +29,7 @@ import {
     Typography,
 } from '@mui/material';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { VisitorUser } from '../../types';
@@ -202,21 +202,6 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
         },
     });
 
-    useEffect(() => {
-        if (dialogMode === 'create') {
-            setUsername('');
-            setPassword('');
-            setSetNewPassword(true);
-            setShowPassword(false);
-        }
-        if (dialogMode === 'edit' && selectedUser) {
-            setUsername(selectedUser.username);
-            setPassword('');
-            setSetNewPassword(false);
-            setShowPassword(false);
-        }
-    }, [dialogMode, selectedUser]);
-
     const closeDialog = () => {
         setDialogMode(null);
         setSelectedUser(null);
@@ -228,11 +213,19 @@ const UserManagementSettings: React.FC<UserManagementSettingsProps> = ({
 
     const openCreateDialog = () => {
         setSelectedUser(null);
+        setUsername('');
+        setPassword('');
+        setSetNewPassword(true);
+        setShowPassword(false);
         setDialogMode('create');
     };
 
     const openEditDialog = (user: VisitorUser) => {
         setSelectedUser(user);
+        setUsername(user.username);
+        setPassword('');
+        setSetNewPassword(false);
+        setShowPassword(false);
         setDialogMode('edit');
     };
 

--- a/frontend/src/components/Settings/YtDlpSettings.tsx
+++ b/frontend/src/components/Settings/YtDlpSettings.tsx
@@ -7,7 +7,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 
 interface YtDlpSettingsProps {
@@ -241,28 +241,33 @@ const DEFAULT_CONFIG = `# yt-dlp Configuration File
 const YtDlpSettings: React.FC<YtDlpSettingsProps> = ({ config, proxyOnlyYoutube = false, onChange, onProxyOnlyYoutubeChange }) => {
     const { t } = useLanguage();
     const [isExpanded, setIsExpanded] = useState(false);
-    const [localConfig, setLocalConfig] = useState(config || DEFAULT_CONFIG);
-
-    // Sync local config when prop changes
-    useEffect(() => {
-        setLocalConfig(config || DEFAULT_CONFIG);
-    }, [config]);
+    const [localConfigState, setLocalConfigState] = useState({
+        sourceConfig: config,
+        value: config || DEFAULT_CONFIG,
+    });
+    const localConfig =
+        localConfigState.sourceConfig === config
+            ? localConfigState.value
+            : config || DEFAULT_CONFIG;
 
     const handleCustomize = () => {
         setIsExpanded(!isExpanded);
         if (!isExpanded) {
             // When expanding, sync local config with prop
-            setLocalConfig(config || DEFAULT_CONFIG);
+            setLocalConfigState({
+                sourceConfig: config,
+                value: config || DEFAULT_CONFIG,
+            });
         }
     };
 
     const handleConfigChange = (value: string) => {
-        setLocalConfig(value);
+        setLocalConfigState({ sourceConfig: config, value });
         onChange(value);
     };
 
     const handleReset = () => {
-        setLocalConfig(DEFAULT_CONFIG);
+        setLocalConfigState({ sourceConfig: config, value: DEFAULT_CONFIG });
         onChange(DEFAULT_CONFIG);
     };
 

--- a/frontend/src/components/SubscribeModal.tsx
+++ b/frontend/src/components/SubscribeModal.tsx
@@ -16,7 +16,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import DialogHeader from './DialogHeader';
 import SubscriptionFilenameTemplateField from './SubscriptionFilenameTemplateField';
@@ -72,8 +72,15 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
     const [downloadAllPrevious, setDownloadAllPrevious] = useState<boolean>(false);
     const [downloadShorts, setDownloadShorts] = useState<boolean>(false);
     const [downloadOrder, setDownloadOrder] = useState<DownloadOrder>('dateDesc');
-    const [filenameTemplate, setFilenameTemplate] = useState<string>('');
-    const [isTemplateValid, setIsTemplateValid] = useState<boolean>(true);
+    const [filenameTemplateState, setFilenameTemplateState] = useState<{
+        url: string;
+        value: string;
+        isValid: boolean;
+    }>({ url, value: '', isValid: true });
+    const filenameTemplate =
+        filenameTemplateState.url === url ? filenameTemplateState.value : '';
+    const isTemplateValid =
+        filenameTemplateState.url === url ? filenameTemplateState.isValid : true;
     const [isSubmitting, setIsSubmitting] = useState(false);
     const isTwitch = source === 'twitch';
     const showDownloadShorts = source !== 'bilibili' && source !== 'twitch';
@@ -89,14 +96,25 @@ const SubscribeModal: React.FC<SubscribeModalProps> = ({
         ? t('twitchSubscriptionVodsOnly')
         : t('subscribeDescription');
 
-    const resetFilenameTemplate = useCallback(() => {
-        setFilenameTemplate('');
-        setIsTemplateValid(true);
-    }, []);
+    const setFilenameTemplate = (value: string) => {
+        setFilenameTemplateState((current) => ({
+            url,
+            value,
+            isValid: current.url === url ? current.isValid : true,
+        }));
+    };
 
-    useEffect(() => {
-        resetFilenameTemplate();
-    }, [resetFilenameTemplate, url]);
+    const setIsTemplateValid = useCallback((isValid: boolean) => {
+        setFilenameTemplateState((current) => ({
+            url,
+            value: current.url === url ? current.value : '',
+            isValid,
+        }));
+    }, [url]);
+
+    const resetFilenameTemplate = () => {
+        setFilenameTemplateState({ url, value: '', isValid: true });
+    };
 
     const handleClose = () => {
         if (!isSubmitting) {

--- a/frontend/src/components/SubscriptionFilenameTemplateField.tsx
+++ b/frontend/src/components/SubscriptionFilenameTemplateField.tsx
@@ -61,7 +61,7 @@ const SubscriptionFilenameTemplateField: React.FC<
 > = ({ value, onChange, sourceCollectionType, disabled, autoFocus, onValidityChange }) => {
   const { t } = useLanguage();
   const [validation, setValidation] = useState<ValidationState | null>(null);
-  const [isValidating, setIsValidating] = useState(false);
+  const [validatingKey, setValidatingKey] = useState<string | null>(null);
   const requestId = useRef(0);
   const helperTextId = useId();
   const validationMessageId = useId();
@@ -70,11 +70,13 @@ const SubscriptionFilenameTemplateField: React.FC<
   // to the server for validation.
   const trimmed = value.trim();
   const hasTemplate = trimmed.length > 0;
+  const validationKey = `${sourceCollectionType}\u0000${trimmed}`;
   const validationResponse =
     validation?.template === trimmed &&
     validation.sourceCollectionType === sourceCollectionType
       ? validation.response
       : null;
+  const isValidating = hasTemplate && validatingKey === validationKey;
   const hasErrors = hasTemplate && validationResponse?.valid === false;
   const isInputValid =
     !hasTemplate ||
@@ -93,15 +95,13 @@ const SubscriptionFilenameTemplateField: React.FC<
       // this, a late response for a value that was cleared (or retyped) could
       // become the current validation state.
       requestId.current += 1;
-      setValidation(null);
-      setIsValidating(false);
       return;
     }
 
-    setIsValidating(true);
     const currentRequestId = requestId.current + 1;
     requestId.current = currentRequestId;
     const timer = setTimeout(async () => {
+      setValidatingKey(validationKey);
       try {
         const res = await api.post<ValidateResponse>(
           '/settings/filename-template/validate',
@@ -128,13 +128,15 @@ const SubscriptionFilenameTemplateField: React.FC<
         });
       } finally {
         if (requestId.current === currentRequestId) {
-          setIsValidating(false);
+          setValidatingKey((current) =>
+            current === validationKey ? null : current
+          );
         }
       }
     }, DEBOUNCE_MS);
 
     return () => clearTimeout(timer);
-  }, [trimmed, sourceCollectionType]);
+  }, [trimmed, sourceCollectionType, validationKey]);
 
   return (
     <Box>

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -11,10 +11,11 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { normalizeTagKey, sortTagsByUsage } from '../utils/tagUtils';
+import { useBreakpointSynchronizedOpen } from './useBreakpointSynchronizedOpen';
 
 const TOP_TAGS_LIMIT = 20;
 
@@ -43,7 +44,7 @@ const TagsList: React.FC<TagsListProps> = ({
     const { t } = useLanguage();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
+    const [isOpen, setIsOpen] = useBreakpointSynchronizedOpen(isMobile);
 
     const { displayTags, hasMore } = useMemo(() => {
         if (!availableTags || availableTags.length === 0) {
@@ -92,7 +93,7 @@ const TagsList: React.FC<TagsListProps> = ({
 
     return (
         <Paper elevation={0} sx={{ bgcolor: 'transparent' }}>
-            <ListItemButton onClick={() => setIsOpen(!isOpen)} sx={{ borderRadius: 1, mb: 1, minWidth: 0 }}>
+            <ListItemButton onClick={() => setIsOpen((current) => !current)} sx={{ borderRadius: 1, mb: 1, minWidth: 0 }}>
                 <Typography variant="h6" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0, fontWeight: 600 }}>
                     {t('tags') || 'Tags'}
                 </Typography>

--- a/frontend/src/components/TagsList.tsx
+++ b/frontend/src/components/TagsList.tsx
@@ -11,7 +11,7 @@ import {
     useMediaQuery,
     useTheme
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { useLanguage } from '../contexts/LanguageContext';
 import { normalizeTagKey, sortTagsByUsage } from '../utils/tagUtils';
@@ -41,18 +41,9 @@ const TagsList: React.FC<TagsListProps> = ({
     linkToAllTags = false,
 }) => {
     const { t } = useLanguage();
-    const [isOpen, setIsOpen] = useState<boolean>(true);
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-    // Auto-collapse on mobile by default
-    useEffect(() => {
-        if (isMobile) {
-            setIsOpen(false);
-        } else {
-            setIsOpen(true);
-        }
-    }, [isMobile]);
+    const [isOpen, setIsOpen] = useState<boolean>(() => !isMobile);
 
     const { displayTags, hasMore } = useMemo(() => {
         if (!availableTags || availableTags.length === 0) {

--- a/frontend/src/components/TagsModal.tsx
+++ b/frontend/src/components/TagsModal.tsx
@@ -25,7 +25,10 @@ interface TagsModalProps {
     onSave: (tags: string[]) => Promise<void>;
 }
 
-const TagsModal: React.FC<TagsModalProps> = ({
+const getTagsModalKey = (videoTags: string[]) =>
+    JSON.stringify([...videoTags].sort());
+
+const TagsModalContent: React.FC<TagsModalProps> = ({
     open,
     onClose,
     videoTags,
@@ -194,6 +197,14 @@ const TagsModal: React.FC<TagsModalProps> = ({
             </DialogActions>
         </Dialog>
     );
+};
+
+const TagsModal: React.FC<TagsModalProps> = (props) => {
+    if (!props.open) {
+        return null;
+    }
+
+    return <TagsModalContent key={getTagsModalKey(props.videoTags || [])} {...props} />;
 };
 
 export default TagsModal;

--- a/frontend/src/components/TagsModal.tsx
+++ b/frontend/src/components/TagsModal.tsx
@@ -11,7 +11,7 @@ import {
     TextField,
     Typography
 } from '@mui/material';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useSettings } from '../hooks/useSettings';
@@ -41,18 +41,9 @@ const TagsModal: React.FC<TagsModalProps> = ({
     });
 
     // State for selected tags (starts with videoTags)
-    const [selectedTags, setSelectedTags] = useState<string[]>([]);
+    const [selectedTags, setSelectedTags] = useState<string[]>(() => videoTags || []);
     const [newTag, setNewTag] = useState('');
     const [saving, setSaving] = useState(false);
-
-    // Reset state when modal opens
-    useEffect(() => {
-        if (open) {
-            setSelectedTags(videoTags || []);
-            setNewTag('');
-            setSaving(false);
-        }
-    }, [open, videoTags]);
 
     const handleToggleTag = (tag: string) => {
         setSelectedTags(prev =>
@@ -116,6 +107,9 @@ const TagsModal: React.FC<TagsModalProps> = ({
 
     const handleClose = () => {
         if (!saving) {
+            setSelectedTags(videoTags || []);
+            setNewTag('');
+            setSaving(false);
             onClose();
         }
     };

--- a/frontend/src/components/TagsModal.tsx
+++ b/frontend/src/components/TagsModal.tsx
@@ -20,13 +20,17 @@ import { useSettingsMutations } from '../hooks/useSettingsMutations';
 interface TagsModalProps {
     open: boolean;
     onClose: () => void;
+    identityKey?: string;
     videoTags: string[];
     availableTags: string[];
     onSave: (tags: string[]) => Promise<void>;
 }
 
-const getTagsModalKey = (videoTags: string[]) =>
-    JSON.stringify([...videoTags].sort());
+const getTagsModalKey = (videoTags: string[], identityKey?: string) =>
+    JSON.stringify({
+        identityKey: identityKey ?? null,
+        videoTags: [...videoTags].sort(),
+    });
 
 const TagsModalContent: React.FC<TagsModalProps> = ({
     open,
@@ -204,7 +208,12 @@ const TagsModal: React.FC<TagsModalProps> = (props) => {
         return null;
     }
 
-    return <TagsModalContent key={getTagsModalKey(props.videoTags || [])} {...props} />;
+    return (
+        <TagsModalContent
+            key={getTagsModalKey(props.videoTags || [], props.identityKey)}
+            {...props}
+        />
+    );
 };
 
 export default TagsModal;

--- a/frontend/src/components/VideoCard/VideoCardActions.tsx
+++ b/frontend/src/components/VideoCard/VideoCardActions.tsx
@@ -170,6 +170,7 @@ export const VideoCardActions: React.FC<VideoCardActionsProps> = ({
                 <TagsModal
                     open={showTagsModal}
                     onClose={() => setShowTagsModal(false)}
+                    identityKey={video.id}
                     videoTags={video.tags || []}
                     availableTags={availableTags}
                     onSave={handleSaveTags}

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -36,10 +36,6 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     const [dateWidth, setDateWidth] = useState<number | null>(null);
 
     const marqueeing = isHovered && isTruncated;
-    // Whether the date has finished collapsing/expanding, so the author container
-    // is at its final width for the marquee to measure against.
-    const [settledAuthor, setSettledAuthor] = useState<string | null>(null);
-    const layoutSettled = marqueeing && settledAuthor === video.author;
 
     // Truncation is only meaningful in the resting layout (date visible). Once we
     // start marqueeing we free the date's space, which changes the container width;
@@ -82,15 +78,6 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
         if (el) setDateWidth(el.scrollWidth);
     }, [video.addedAt, video.date, t]);
 
-    // Flip layoutSettled only after the date collapse/expand transition finishes,
-    // so the marquee measures scroll distance against the final container width.
-    useEffect(() => {
-        if (marqueeing) {
-            const id = setTimeout(() => setSettledAuthor(video.author), DATE_COLLAPSE_MS);
-            return () => clearTimeout(id);
-        }
-    }, [marqueeing, video.author]);
-
     // Scroll the name left then right while hovered, holding ~1s at each end.
     useEffect(() => {
         const container = authorContainerRef.current;
@@ -100,41 +87,44 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
         animationRef.current?.cancel();
         animationRef.current = null;
 
-        if (!layoutSettled) {
+        if (!marqueeing) {
             text.style.transform = '';
             return;
         }
 
-        const overflow = text.scrollWidth - container.clientWidth;
-        if (overflow <= 1 || typeof text.animate !== 'function') {
-            text.style.transform = '';
-            return;
-        }
+        const id = window.setTimeout(() => {
+            const overflow = text.scrollWidth - container.clientWidth;
+            if (overflow <= 1 || typeof text.animate !== 'function') {
+                text.style.transform = '';
+                return;
+            }
 
-        const pxPerSecond = 30; // scroll speed
-        const moveMs = Math.max(600, (overflow / pxPerSecond) * 1000);
-        const holdMs = 1000; // dwell at the beginning and ending
-        const totalMs = moveMs * 2 + holdMs * 2;
-        const holdFrac = holdMs / totalMs;
-        const moveFrac = moveMs / totalMs;
-        const endOffset = holdFrac + moveFrac; // start of the ending hold
+            const pxPerSecond = 30; // scroll speed
+            const moveMs = Math.max(600, (overflow / pxPerSecond) * 1000);
+            const holdMs = 1000; // dwell at the beginning and ending
+            const totalMs = moveMs * 2 + holdMs * 2;
+            const holdFrac = holdMs / totalMs;
+            const moveFrac = moveMs / totalMs;
+            const endOffset = holdFrac + moveFrac; // start of the ending hold
 
-        animationRef.current = text.animate(
-            [
-                { transform: 'translateX(0)', offset: 0 },
-                { transform: 'translateX(0)', offset: holdFrac }, // hold at beginning
-                { transform: `translateX(${-overflow}px)`, offset: endOffset },
-                { transform: `translateX(${-overflow}px)`, offset: endOffset + holdFrac }, // hold at ending
-                { transform: 'translateX(0)', offset: 1 } // scroll back to beginning
-            ],
-            { duration: totalMs, iterations: Infinity, easing: 'linear' }
-        );
+            animationRef.current = text.animate(
+                [
+                    { transform: 'translateX(0)', offset: 0 },
+                    { transform: 'translateX(0)', offset: holdFrac }, // hold at beginning
+                    { transform: `translateX(${-overflow}px)`, offset: endOffset },
+                    { transform: `translateX(${-overflow}px)`, offset: endOffset + holdFrac }, // hold at ending
+                    { transform: 'translateX(0)', offset: 1 } // scroll back to beginning
+                ],
+                { duration: totalMs, iterations: Infinity, easing: 'linear' }
+            );
+        }, DATE_COLLAPSE_MS);
 
         return () => {
+            window.clearTimeout(id);
             animationRef.current?.cancel();
             animationRef.current = null;
         };
-    }, [layoutSettled, video.author]);
+    }, [marqueeing, video.author]);
 
     return (
         <CardContent sx={{ flexGrow: 1, px: 1, py: isMobile ? 1.5 : 1, display: 'flex', flexDirection: 'column' }}>

--- a/frontend/src/components/VideoCard/VideoCardContent.tsx
+++ b/frontend/src/components/VideoCard/VideoCardContent.tsx
@@ -38,14 +38,17 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     const marqueeing = isHovered && isTruncated;
     // Whether the date has finished collapsing/expanding, so the author container
     // is at its final width for the marquee to measure against.
-    const [layoutSettled, setLayoutSettled] = useState(false);
+    const [settledAuthor, setSettledAuthor] = useState<string | null>(null);
+    const layoutSettled = marqueeing && settledAuthor === video.author;
 
     // Truncation is only meaningful in the resting layout (date visible). Once we
     // start marqueeing we free the date's space, which changes the container width;
     // measuring then would flip isTruncated off and oscillate the layout. This ref
     // keeps measurement pinned to the non-marqueeing state.
     const isMarqueeingRef = useRef(false);
-    isMarqueeingRef.current = marqueeing;
+    useEffect(() => {
+        isMarqueeingRef.current = marqueeing;
+    }, [marqueeing]);
 
     // Measure whether the author name overflows its (clipped) container.
     const measureTruncation = useCallback(() => {
@@ -83,11 +86,10 @@ export const VideoCardContent: React.FC<VideoCardContentProps> = ({
     // so the marquee measures scroll distance against the final container width.
     useEffect(() => {
         if (marqueeing) {
-            const id = setTimeout(() => setLayoutSettled(true), DATE_COLLAPSE_MS);
+            const id = setTimeout(() => setSettledAuthor(video.author), DATE_COLLAPSE_MS);
             return () => clearTimeout(id);
         }
-        setLayoutSettled(false);
-    }, [marqueeing]);
+    }, [marqueeing, video.author]);
 
     // Scroll the name left then right while hovered, holding ~1s at each end.
     useEffect(() => {

--- a/frontend/src/components/VideoCard/__tests__/VideoCardContent.test.tsx
+++ b/frontend/src/components/VideoCard/__tests__/VideoCardContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VideoCardContent } from '../VideoCardContent';
@@ -101,5 +101,81 @@ describe('VideoCardContent', () => {
 
         expect(screen.getByText('My Playlist')).toBeInTheDocument();
         expect(screen.getByText('+1')).toBeInTheDocument();
+    });
+
+    it('delays marquee animation after each repeated hover', () => {
+        vi.useFakeTimers();
+        const cancelAnimation = vi.fn();
+        const animate = vi.fn(() => ({ cancel: cancelAnimation }) as unknown as Animation);
+        const originalAnimate = HTMLElement.prototype.animate;
+        const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, 'scrollWidth', 'get').mockReturnValue(240);
+        const clientWidthSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(100);
+        HTMLElement.prototype.animate = animate as typeof HTMLElement.prototype.animate;
+
+        try {
+            const rendered = render(
+                <VideoCardContent
+                    video={defaultVideo}
+                    collectionInfo={defaultCollectionInfo}
+                    onAuthorClick={mockOnAuthorClick}
+                />
+            );
+
+            rendered.rerender(
+                <VideoCardContent
+                    video={defaultVideo}
+                    collectionInfo={defaultCollectionInfo}
+                    onAuthorClick={mockOnAuthorClick}
+                    isHovered
+                />
+            );
+
+            expect(animate).not.toHaveBeenCalled();
+
+            act(() => {
+                vi.advanceTimersByTime(300);
+            });
+
+            expect(animate).toHaveBeenCalledTimes(1);
+
+            rendered.rerender(
+                <VideoCardContent
+                    video={defaultVideo}
+                    collectionInfo={defaultCollectionInfo}
+                    onAuthorClick={mockOnAuthorClick}
+                />
+            );
+            rendered.rerender(
+                <VideoCardContent
+                    video={defaultVideo}
+                    collectionInfo={defaultCollectionInfo}
+                    onAuthorClick={mockOnAuthorClick}
+                    isHovered
+                />
+            );
+
+            expect(animate).toHaveBeenCalledTimes(1);
+
+            act(() => {
+                vi.advanceTimersByTime(299);
+            });
+
+            expect(animate).toHaveBeenCalledTimes(1);
+
+            act(() => {
+                vi.advanceTimersByTime(1);
+            });
+
+            expect(animate).toHaveBeenCalledTimes(2);
+        } finally {
+            scrollWidthSpy.mockRestore();
+            clientWidthSpy.mockRestore();
+            if (originalAnimate) {
+                HTMLElement.prototype.animate = originalAnimate;
+            } else {
+                delete (HTMLElement.prototype as Partial<HTMLElement>).animate;
+            }
+            vi.useRealTimers();
+        }
     });
 });

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -1,16 +1,12 @@
 import { Box, IconButton, Typography } from '@mui/material';
 import { Pause, PlayArrow } from '@mui/icons-material';
-import React, { useMemo } from 'react';
+import React, { useId, useMemo } from 'react';
 import { useLanguage } from '../../../contexts/LanguageContext';
 import { neutral, overlay } from '../../../theme/colors';
 import { getBackendUrl } from '../../../utils/apiUrl';
 import { getSubtitleLanguageLabel, getSubtitleTrackLanguage } from '../../../utils/formatUtils';
 import { getMediaCrossOriginAttr } from '../../../utils/mediaOrigin';
 import { computePreloadStrategy } from '../../../utils/preloadStrategy';
-
-type GlobalVideoCounterScope = typeof globalThis & {
-    __videoControlCounter?: number;
-};
 
 interface VideoElementProps {
     videoRef: React.RefObject<HTMLVideoElement | null>;
@@ -70,14 +66,8 @@ const VideoElement: React.FC<VideoElementProps> = ({
     isPlaying = false,
 }) => {
     const { t } = useLanguage();
-    // Use useMemo to generate a stable unique ID per component instance
-    // Using Date.now() and a simple counter is safe for non-cryptographic purposes
-    const videoId = useMemo(() => {
-        const globalScope = globalThis as GlobalVideoCounterScope;
-        const counter = (globalScope.__videoControlCounter || 0) + 1;
-        globalScope.__videoControlCounter = counter;
-        return `video-controls-${Date.now()}-${counter}`;
-    }, []);
+    const reactId = useId();
+    const videoId = `video-controls-${reactId.replace(/:/g, '')}`;
 
     // Compute during render so the <video> element never starts loading
     // with a downgraded placeholder, and recalculate when the media changes.
@@ -85,12 +75,12 @@ const VideoElement: React.FC<VideoElementProps> = ({
         () => computePreloadStrategy({ src, mediaPath }),
         [src, mediaPath]
     );
-    const [mobileAspectRatio, setMobileAspectRatio] = React.useState<string>('16/9');
-
-    React.useEffect(() => {
-        // Reset to default ratio while new source metadata is loading
-        setMobileAspectRatio('16/9');
-    }, [src]);
+    const [mobileAspectRatioState, setMobileAspectRatioState] = React.useState<{
+        src: string;
+        ratio: string;
+    } | null>(null);
+    const mobileAspectRatio =
+        mobileAspectRatioState?.src === src ? mobileAspectRatioState.ratio : '16/9';
 
     return (
         <Box
@@ -246,11 +236,14 @@ const VideoElement: React.FC<VideoElementProps> = ({
                 onPause={onPause}
                 onEnded={onEnded}
                 onTimeUpdate={onTimeUpdate}
-                onLoadedMetadata={(e) => {
-                    const { videoWidth, videoHeight } = e.currentTarget;
-                    if (videoWidth > 0 && videoHeight > 0) {
-                        setMobileAspectRatio(`${videoWidth}/${videoHeight}`);
-                    }
+	                onLoadedMetadata={(e) => {
+	                    const { videoWidth, videoHeight } = e.currentTarget;
+	                    if (videoWidth > 0 && videoHeight > 0) {
+	                        setMobileAspectRatioState({
+	                            src,
+	                            ratio: `${videoWidth}/${videoHeight}`,
+	                        });
+	                    }
                     onLoadedMetadata(e);
                     onSubtitleInit(e);
                 }}

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useSubtitles.live.test.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/__tests__/useSubtitles.live.test.ts
@@ -92,6 +92,36 @@ describe('useSubtitles — live translation option', () => {
     expect(result.current.subtitlesEnabled).toBe(true);
   });
 
+  it('forces the live track back on after a prior manual deselection', () => {
+    const liveTrack = { mode: 'hidden' } as unknown as TextTrack;
+    const videoRef = makeVideoRef(2);
+    const { result, rerender } = renderHook(
+      ({ force }: { force: boolean }) =>
+        useSubtitles({
+          subtitles: subtitles2,
+          initialSubtitlesEnabled: true,
+          videoRef,
+          liveSubtitle: { available: true, label: 'Live', track: liveTrack },
+          forceLiveSubtitleOnAvailable: force,
+        }),
+      { initialProps: { force: false } },
+    );
+
+    expect(result.current.liveSubtitleSelected).toBe(true);
+    expect(liveTrack.mode).toBe('showing');
+
+    act(() => result.current.handleSelectLiveSubtitle());
+
+    expect(result.current.liveSubtitleSelected).toBe(false);
+    expect(liveTrack.mode).toBe('hidden');
+
+    rerender({ force: true });
+
+    expect(result.current.liveSubtitleSelected).toBe(true);
+    expect(liveTrack.mode).toBe('showing');
+    expect(result.current.subtitlesEnabled).toBe(true);
+  });
+
   it('toggles the live track on and off', () => {
     const liveTrack = { mode: 'hidden' } as unknown as TextTrack;
     const { result } = renderHook(() =>

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
@@ -73,11 +73,11 @@ export const useSubtitles = ({
 
     const liveAvailable = liveSubtitle?.available === true;
     const liveTrack = liveSubtitle?.track ?? null;
-    const liveSubtitleSelected = liveAvailable
-        ? liveSelectionOverride?.track === liveTrack
-            ? liveSelectionOverride.selected
-            : initialSubtitlesEnabled || forceLiveSubtitleOnAvailable
-        : false;
+    const liveSelectionOverrideSelected = liveSelectionOverride?.track === liveTrack
+        ? liveSelectionOverride.selected
+        : initialSubtitlesEnabled;
+    const liveSubtitleSelected =
+        liveAvailable && (forceLiveSubtitleOnAvailable || liveSelectionOverrideSelected);
     const rawSelectedSubtitleIndices =
         fileSelectionState.key === subtitleKey ? fileSelectionState.indices : initialFileIndices;
     const selectedSubtitleIndices = useMemo(

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useSubtitles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface Subtitle {
     language: string;
@@ -29,6 +29,22 @@ interface UseSubtitlesProps {
 
 const MAX_ACTIVE_TRACKS = 2;
 
+type FileSelectionState = {
+    key: string;
+    indices: number[];
+};
+
+type IndicesUpdate = number[] | ((indices: number[]) => number[]);
+
+const getInitialFileIndices = (
+    initialSubtitlesEnabled: boolean,
+    subtitlesLength: number
+): number[] => (initialSubtitlesEnabled && subtitlesLength > 0 ? [0] : []);
+
+const setTextTrackMode = (track: TextTrack, mode: TextTrackMode) => {
+    track.mode = mode;
+};
+
 export const useSubtitles = ({
     subtitles,
     initialSubtitlesEnabled,
@@ -37,106 +53,75 @@ export const useSubtitles = ({
     liveSubtitle,
     forceLiveSubtitleOnAvailable = false,
 }: UseSubtitlesProps) => {
-    const [subtitlesEnabled, setSubtitlesEnabled] = useState<boolean>(
-        initialSubtitlesEnabled && subtitles.length > 0
+    const subtitleKey = useMemo(
+        () => subtitles.map((subtitle) => subtitle.path).join('\0'),
+        [subtitles]
     );
-    const [selectedSubtitleIndices, setSelectedSubtitleIndices] = useState<number[]>(
-        initialSubtitlesEnabled && subtitles.length > 0 ? [0] : []
+    const initialFileIndices = useMemo(
+        () => getInitialFileIndices(initialSubtitlesEnabled, subtitles.length),
+        [initialSubtitlesEnabled, subtitles.length]
     );
-    const [liveSubtitleSelected, setLiveSubtitleSelected] = useState<boolean>(false);
+    const [fileSelectionState, setFileSelectionState] = useState<FileSelectionState>(() => ({
+        key: subtitleKey,
+        indices: initialFileIndices,
+    }));
+    const [liveSelectionOverride, setLiveSelectionOverride] = useState<{
+        track: TextTrack | null;
+        selected: boolean;
+    } | null>(null);
     const [subtitleMenuAnchor, setSubtitleMenuAnchor] = useState<null | HTMLElement>(null);
 
     const liveAvailable = liveSubtitle?.available === true;
-    const prevLiveAvailableRef = useRef(false);
-    const prevForceLiveSubtitleRef = useRef(false);
+    const liveTrack = liveSubtitle?.track ?? null;
+    const liveSubtitleSelected = liveAvailable
+        ? liveSelectionOverride?.track === liveTrack
+            ? liveSelectionOverride.selected
+            : initialSubtitlesEnabled || forceLiveSubtitleOnAvailable
+        : false;
+    const rawSelectedSubtitleIndices =
+        fileSelectionState.key === subtitleKey ? fileSelectionState.indices : initialFileIndices;
+    const selectedSubtitleIndices = useMemo(
+        () =>
+            liveSubtitleSelected && rawSelectedSubtitleIndices.length >= MAX_ACTIVE_TRACKS
+                ? rawSelectedSubtitleIndices.slice(1)
+                : rawSelectedSubtitleIndices,
+        [liveSubtitleSelected, rawSelectedSubtitleIndices]
+    );
+    const subtitlesEnabled = selectedSubtitleIndices.length > 0 || liveSubtitleSelected;
+
+    const updateSelectedSubtitleIndices = (update: IndicesUpdate) => {
+        setFileSelectionState((previous) => {
+            const current =
+                previous.key === subtitleKey ? previous.indices : initialFileIndices;
+            const next = typeof update === 'function' ? update(current) : update;
+
+            return {
+                key: subtitleKey,
+                indices: next,
+            };
+        });
+    };
 
     // Apply showing/hidden modes by identity: file tracks occupy textTracks
     // [0..subtitles.length-1] (in array order); the dynamic live track — added via
     // addTextTrack — always sorts after them, so we address it by reference and
     // never by index. File-driven effects must not touch it.
-    const applyTrackModes = (fileIndices: number[], liveSelected: boolean) => {
+    const applyTrackModes = useCallback((fileIndices: number[], liveSelected: boolean) => {
         const video = videoRef.current;
         if (video) {
             const tracks = video.textTracks;
             for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
-                tracks[i].mode = fileIndices.includes(i) ? 'showing' : 'hidden';
+                setTextTrackMode(tracks[i], fileIndices.includes(i) ? 'showing' : 'hidden');
             }
         }
-        const liveTrack = liveSubtitle?.track;
         if (liveTrack) {
-            liveTrack.mode = liveSelected ? 'showing' : 'hidden';
+            setTextTrackMode(liveTrack, liveSelected ? 'showing' : 'hidden');
         }
-    };
+    }, [liveTrack, subtitles.length, videoRef]);
 
-    const selectLiveSubtitleTrack = () => {
-        setSelectedSubtitleIndices((fileIndices) => {
-            let nextFile = fileIndices;
-            if (fileIndices.length >= MAX_ACTIVE_TRACKS) {
-                // Replace the oldest selected file subtitle.
-                nextFile = fileIndices.slice(1);
-            }
-            applyTrackModes(nextFile, true);
-            return nextFile;
-        });
-        setLiveSubtitleSelected(true);
-        setSubtitlesEnabled(true);
-    };
-
-    // Re-initialize FILE subtitle tracks only when the subtitles array changes
-    // (upload/delete). Must not include initialSubtitlesEnabled (feedback loop)
-    // and must preserve the live selection/track.
     useEffect(() => {
-        if (!videoRef.current || subtitles.length === 0) return;
-
-        const tracks = videoRef.current.textTracks;
-        const newIndices = initialSubtitlesEnabled && tracks.length > 0 ? [0] : [];
-
-        setSelectedSubtitleIndices(newIndices);
-        setSubtitlesEnabled(initialSubtitlesEnabled || liveSubtitleSelected);
-
-        for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
-            tracks[i].mode = newIndices.includes(i) ? 'showing' : 'hidden';
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [subtitles]); // intentionally omit initialSubtitlesEnabled — see comment above
-
-    // Auto-select the live track when it becomes available if subtitles are
-    // globally enabled, or when subtitle-only live translation requires captions
-    // as its only output. Otherwise keep the live option in the menu without showing it.
-    useEffect(() => {
-        const wasAvailable = prevLiveAvailableRef.current;
-        const wasForceLiveSubtitle = prevForceLiveSubtitleRef.current;
-        prevLiveAvailableRef.current = liveAvailable;
-        prevForceLiveSubtitleRef.current = forceLiveSubtitleOnAvailable;
-
-        const shouldAutoSelectLive =
-            initialSubtitlesEnabled || forceLiveSubtitleOnAvailable;
-
-        if (liveAvailable && !wasAvailable) {
-            if (shouldAutoSelectLive) {
-                selectLiveSubtitleTrack();
-            } else {
-                applyTrackModes(selectedSubtitleIndices, false);
-                setLiveSubtitleSelected(false);
-                setSubtitlesEnabled(selectedSubtitleIndices.length > 0);
-            }
-        } else if (!liveAvailable && wasAvailable) {
-            setLiveSubtitleSelected(false);
-            setSelectedSubtitleIndices((fileIndices) => {
-                applyTrackModes(fileIndices, false);
-                setSubtitlesEnabled(fileIndices.length > 0);
-                return fileIndices;
-            });
-        } else if (
-            liveAvailable &&
-            forceLiveSubtitleOnAvailable &&
-            !wasForceLiveSubtitle
-        ) {
-            // Subtitle-only mode became active after the live track already existed.
-            selectLiveSubtitleTrack();
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [liveAvailable, forceLiveSubtitleOnAvailable]);
+        applyTrackModes(selectedSubtitleIndices, liveSubtitleSelected);
+    }, [applyTrackModes, liveSubtitleSelected, selectedSubtitleIndices]);
 
     const handleSubtitleClick = (event: React.MouseEvent<HTMLElement>) => {
         setSubtitleMenuAnchor(event.currentTarget);
@@ -152,9 +137,8 @@ export const useSubtitles = ({
         if (index < 0) {
             // "Off" — deselect everything (file + live) and close menu.
             applyTrackModes([], false);
-            setSelectedSubtitleIndices([]);
-            setLiveSubtitleSelected(false);
-            setSubtitlesEnabled(false);
+            updateSelectedSubtitleIndices([]);
+            setLiveSelectionOverride({ track: liveTrack, selected: false });
             if (onSubtitlesToggle) onSubtitlesToggle(false);
             handleCloseSubtitleMenu();
             return;
@@ -171,9 +155,7 @@ export const useSubtitles = ({
         }
 
         applyTrackModes(newIndices, liveSubtitleSelected);
-        setSelectedSubtitleIndices(newIndices);
-        const enabled = newIndices.length > 0 || liveSubtitleSelected;
-        setSubtitlesEnabled(enabled);
+        updateSelectedSubtitleIndices(newIndices);
         if (onSubtitlesToggle) onSubtitlesToggle(newIndices.length > 0);
     };
 
@@ -183,8 +165,7 @@ export const useSubtitles = ({
         if (liveSubtitleSelected) {
             // Deselect live.
             applyTrackModes(selectedSubtitleIndices, false);
-            setLiveSubtitleSelected(false);
-            setSubtitlesEnabled(selectedSubtitleIndices.length > 0);
+            setLiveSelectionOverride({ track: liveTrack, selected: false });
             return;
         }
 
@@ -195,9 +176,8 @@ export const useSubtitles = ({
             nextFile = selectedSubtitleIndices.slice(1);
         }
         applyTrackModes(nextFile, true);
-        setSelectedSubtitleIndices(nextFile);
-        setLiveSubtitleSelected(true);
-        setSubtitlesEnabled(true);
+        updateSelectedSubtitleIndices(nextFile);
+        setLiveSelectionOverride({ track: liveTrack, selected: true });
     };
 
     const initializeSubtitles = (e: React.SyntheticEvent<HTMLVideoElement>) => {
@@ -206,9 +186,9 @@ export const useSubtitles = ({
 
         const newIndices = shouldShow && tracks.length > 0 ? [0] : [];
         for (let i = 0; i < subtitles.length && i < tracks.length; i++) {
-            tracks[i].mode = newIndices.includes(i) ? 'showing' : 'hidden';
+            setTextTrackMode(tracks[i], newIndices.includes(i) ? 'showing' : 'hidden');
         }
-        setSelectedSubtitleIndices(newIndices);
+        updateSelectedSubtitleIndices(newIndices);
     };
 
     return {

--- a/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
+++ b/frontend/src/components/VideoPlayer/VideoControls/hooks/useVideoPlayer.ts
@@ -23,7 +23,8 @@ export const useVideoPlayer = ({
 }: UseVideoPlayerProps) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
-  const [isLooping, setIsLooping] = useState<boolean>(autoLoop);
+  const [loopOverride, setLoopOverride] = useState<boolean | null>(null);
+  const isLooping = loopOverride ?? autoLoop;
   const [playbackRate, setPlaybackRate] = useState<number>(1);
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [duration, setDuration] = useState<number>(0);
@@ -217,12 +218,9 @@ export const useVideoPlayer = ({
       if (autoPlay) {
         videoRef.current.autoplay = true;
       }
-      if (autoLoop) {
-        videoRef.current.loop = true;
-        setIsLooping(true);
-      }
+      videoRef.current.loop = isLooping;
     }
-  }, [autoPlay, autoLoop]);
+  }, [autoPlay, isLooping]);
 
   useEffect(() => {
     const videoElement = videoRef.current;
@@ -305,7 +303,7 @@ export const useVideoPlayer = ({
     if (videoRef.current) {
       const newState = !isLooping;
       videoRef.current.loop = newState;
-      setIsLooping(newState);
+      setLoopOverride(newState);
       return newState;
     }
     return isLooping;

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -109,7 +109,13 @@ const VideoControls: React.FC<VideoControlsProps> = ({
     });
 
     // Fullscreen management
-    const fullscreen = useFullscreen(videoPlayer.videoRef);
+    const {
+        isFullscreen,
+        controlsVisible,
+        videoContainerRef,
+        handleToggleFullscreen,
+        handleControlsMouseEnter,
+    } = useFullscreen(videoPlayer.videoRef);
 
     // Loading and error states
     const loading = useVideoLoading();
@@ -223,7 +229,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
 
     return (
         <Box
-            ref={fullscreen.videoContainerRef}
+            ref={videoContainerRef}
             sx={{
                 width: '100%',
                 bgcolor: neutral.black,
@@ -231,7 +237,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 overflow: 'hidden',
                 boxShadow: 4,
                 position: 'relative',
-                ...(fullscreen.isFullscreen && {
+                ...(isFullscreen && {
                     width: '100vw',
                     height: '100vh',
                     display: 'flex',
@@ -240,7 +246,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 })
             }}
         >
-            <Box sx={{ position: 'relative', flex: fullscreen.isFullscreen ? 1 : undefined, minHeight: fullscreen.isFullscreen ? 0 : undefined }}>
+            <Box sx={{ position: 'relative', flex: isFullscreen ? 1 : undefined, minHeight: isFullscreen ? 0 : undefined }}>
                 <VideoElement
                     videoRef={videoPlayer.videoRef}
                     src={src}
@@ -248,7 +254,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                     poster={poster}
                     isLoading={loading.isLoading}
                     loadError={loading.loadError}
-                    isFullscreen={fullscreen.isFullscreen}
+                    isFullscreen={isFullscreen}
                     subtitles={subtitles}
                     onClick={videoPlayer.handlePlayPause}
                     onPlay={videoPlayer.handlePlay}
@@ -272,7 +278,7 @@ const VideoControls: React.FC<VideoControlsProps> = ({
 
                 <Box
                     sx={{
-                        ...(fullscreen.isFullscreen
+                        ...(isFullscreen
                             ? {
                                   position: 'absolute',
                                   left: 0,
@@ -284,8 +290,8 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                     }}
                 >
                     <ControlsOverlay
-                        isFullscreen={fullscreen.isFullscreen}
-                        controlsVisible={fullscreen.controlsVisible}
+                        isFullscreen={isFullscreen}
+                        controlsVisible={controlsVisible}
                         isPlaying={videoPlayer.isPlaying}
                         currentTime={videoPlayer.currentTime}
                         duration={videoPlayer.duration}
@@ -316,9 +322,9 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                         liveSubtitleLabel={subtitlesHook.liveSubtitleLabel}
                         liveSubtitleSelected={subtitlesHook.liveSubtitleSelected}
                         onSelectLiveSubtitle={subtitlesHook.handleSelectLiveSubtitle}
-                        onToggleFullscreen={fullscreen.handleToggleFullscreen}
+                        onToggleFullscreen={handleToggleFullscreen}
                         onToggleLoop={handleToggleLoop}
-                        onControlsMouseEnter={fullscreen.handleControlsMouseEnter}
+                        onControlsMouseEnter={handleControlsMouseEnter}
                         playbackRate={videoPlayer.playbackRate}
                         onPlaybackRateChange={videoPlayer.handlePlaybackRateChange}
                         seekIntervals={seekIntervals}
@@ -328,8 +334,8 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                             if (!toggle) return undefined;
                             return () => {
                                 toggle();
-                                if (fullscreen.isFullscreen) {
-                                    fullscreen.handleToggleFullscreen();
+                                if (isFullscreen) {
+                                    handleToggleFullscreen();
                                 }
                             };
                         })()}

--- a/frontend/src/components/VideoPlayer/VideoInfo.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo.tsx
@@ -102,6 +102,7 @@ const VideoInfo: React.FC<VideoInfoProps> = ({
             />
 
             <VideoTags
+                videoId={video.id}
                 tags={video.tags}
                 availableTags={availableTags}
                 onTagsUpdate={onTagsUpdate}

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoTags.tsx
@@ -5,12 +5,13 @@ import { useLanguage } from '../../../contexts/LanguageContext';
 import TagsModal from '../../TagsModal';
 
 interface VideoTagsProps {
+    videoId: string;
     tags: string[] | undefined;
     availableTags: string[];
     onTagsUpdate: (tags: string[]) => Promise<void>;
 }
 
-const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate }) => {
+const VideoTags: React.FC<VideoTagsProps> = ({ videoId, tags, availableTags, onTagsUpdate }) => {
     const { t } = useLanguage();
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -49,6 +50,7 @@ const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate
                 <TagsModal
                     open={modalOpen}
                     onClose={() => setModalOpen(false)}
+                    identityKey={videoId}
                     videoTags={tagsArray}
                     availableTags={availableTagsArray}
                     onSave={onTagsUpdate}
@@ -162,4 +164,3 @@ const VideoTags: React.FC<VideoTagsProps> = ({ tags, availableTags, onTagsUpdate
 };
 
 export default VideoTags;
-

--- a/frontend/src/components/__tests__/PasswordModal.test.tsx
+++ b/frontend/src/components/__tests__/PasswordModal.test.tsx
@@ -39,6 +39,24 @@ describe('PasswordModal', () => {
         expect(defaultProps.onConfirm).toHaveBeenCalledWith('secret');
     });
 
+    it('clears password and visibility after a controlled close and reopen', async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(<PasswordModal {...defaultProps} />);
+
+        const input = screen.getByLabelText('password');
+        await user.type(input, 'secret');
+        await user.click(screen.getByLabelText('togglePasswordVisibility'));
+
+        expect(input).toHaveValue('secret');
+        expect(input).toHaveAttribute('type', 'text');
+
+        rerender(<PasswordModal {...defaultProps} isOpen={false} />);
+        rerender(<PasswordModal {...defaultProps} isOpen />);
+
+        expect(screen.getByLabelText('password')).toHaveValue('');
+        expect(screen.getByLabelText('password')).toHaveAttribute('type', 'password');
+    });
+
     it('should show error message when error prop is provided', () => {
         render(<PasswordModal {...defaultProps} error="Wrong password" />);
         expect(screen.getByText('Wrong password')).toBeInTheDocument();

--- a/frontend/src/components/__tests__/TagsModal.test.tsx
+++ b/frontend/src/components/__tests__/TagsModal.test.tsx
@@ -106,6 +106,40 @@ describe('TagsModal', () => {
         expect(screen.queryByText('Select Tags')).not.toBeInTheDocument();
     });
 
+    it('uses current video tags after a controlled close and reopen', async () => {
+        const rendered = renderComponent({ videoTags: ['Tag1'] });
+        fireEvent.click(screen.getByText('Tag2'));
+
+        rendered.rerender(
+            <ThemeProvider theme={createTheme()}>
+                <TagsModal
+                    open={false}
+                    onClose={mockOnClose}
+                    videoTags={['Tag3']}
+                    availableTags={defaultAvailableTags}
+                    onSave={mockOnSave}
+                />
+            </ThemeProvider>
+        );
+        rendered.rerender(
+            <ThemeProvider theme={createTheme()}>
+                <TagsModal
+                    open
+                    onClose={mockOnClose}
+                    videoTags={['Tag3']}
+                    availableTags={defaultAvailableTags}
+                    onSave={mockOnSave}
+                />
+            </ThemeProvider>
+        );
+
+        fireEvent.click(screen.getByText('Save'));
+
+        await waitFor(() => {
+            expect(mockOnSave).toHaveBeenCalledWith(['Tag3']);
+        });
+    });
+
     it('toggles tag selection', async () => {
         renderComponent();
 

--- a/frontend/src/components/__tests__/TagsModal.test.tsx
+++ b/frontend/src/components/__tests__/TagsModal.test.tsx
@@ -70,10 +70,12 @@ describe('TagsModal', () => {
 
     const renderComponent = ({
         open = true,
+        identityKey,
         videoTags = defaultVideoTags,
         availableTags = defaultAvailableTags,
     }: {
         open?: boolean;
+        identityKey?: string;
         videoTags?: string[];
         availableTags?: string[];
     } = {}) => {
@@ -83,6 +85,7 @@ describe('TagsModal', () => {
                 <TagsModal
                     open={open}
                     onClose={mockOnClose}
+                    identityKey={identityKey}
                     videoTags={videoTags}
                     availableTags={availableTags}
                     onSave={mockOnSave}
@@ -137,6 +140,31 @@ describe('TagsModal', () => {
 
         await waitFor(() => {
             expect(mockOnSave).toHaveBeenCalledWith(['Tag3']);
+        });
+    });
+
+    it('resets unsaved selections when the edited identity changes while open', async () => {
+        const rendered = renderComponent({ identityKey: 'video-1', videoTags: ['Tag1'] });
+
+        fireEvent.click(screen.getByText('Tag2'));
+
+        rendered.rerender(
+            <ThemeProvider theme={createTheme()}>
+                <TagsModal
+                    open
+                    onClose={mockOnClose}
+                    identityKey="video-2"
+                    videoTags={['Tag1']}
+                    availableTags={defaultAvailableTags}
+                    onSave={mockOnSave}
+                />
+            </ThemeProvider>
+        );
+
+        fireEvent.click(screen.getByText('Save'));
+
+        await waitFor(() => {
+            expect(mockOnSave).toHaveBeenCalledWith(['Tag1']);
         });
     });
 

--- a/frontend/src/components/__tests__/useBreakpointSynchronizedOpen.test.ts
+++ b/frontend/src/components/__tests__/useBreakpointSynchronizedOpen.test.ts
@@ -1,0 +1,33 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useBreakpointSynchronizedOpen } from '../useBreakpointSynchronizedOpen';
+
+describe('useBreakpointSynchronizedOpen', () => {
+    it('uses desktop-open and mobile-collapsed defaults when the breakpoint changes', () => {
+        const { result, rerender } = renderHook(
+            ({ isMobile }) => useBreakpointSynchronizedOpen(isMobile),
+            { initialProps: { isMobile: false } }
+        );
+
+        expect(result.current[0]).toBe(true);
+
+        rerender({ isMobile: true });
+        expect(result.current[0]).toBe(false);
+
+        rerender({ isMobile: false });
+        expect(result.current[0]).toBe(true);
+    });
+
+    it('keeps manual toggles within the current breakpoint', () => {
+        const { result } = renderHook(
+            ({ isMobile }) => useBreakpointSynchronizedOpen(isMobile),
+            { initialProps: { isMobile: false } }
+        );
+
+        act(() => {
+            result.current[1]((current) => !current);
+        });
+
+        expect(result.current[0]).toBe(false);
+    });
+});

--- a/frontend/src/components/useBreakpointSynchronizedOpen.ts
+++ b/frontend/src/components/useBreakpointSynchronizedOpen.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+type OpenState = {
+    isMobile: boolean;
+    isOpen: boolean;
+};
+
+type OpenStateUpdate = boolean | ((current: boolean) => boolean);
+
+export const useBreakpointSynchronizedOpen = (isMobile: boolean) => {
+    const [openState, setOpenState] = useState<OpenState>(() => ({
+        isMobile,
+        isOpen: !isMobile,
+    }));
+    const isOpen = openState.isMobile === isMobile ? openState.isOpen : !isMobile;
+
+    const setIsOpen = (update: OpenStateUpdate) => {
+        setOpenState((currentState) => {
+            const current =
+                currentState.isMobile === isMobile ? currentState.isOpen : !isMobile;
+            const next = typeof update === 'function' ? update(current) : update;
+
+            return {
+                isMobile,
+                isOpen: next,
+            };
+        });
+    };
+
+    return [isOpen, setIsOpen] as const;
+};

--- a/frontend/src/contexts/DownloadContext.tsx
+++ b/frontend/src/contexts/DownloadContext.tsx
@@ -198,6 +198,20 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         collectionInfo: null // For collection/series, stores the API response
     });
     const [isCheckingParts, setIsCheckingParts] = useState<boolean>(false);
+    // Subscription logic
+    const [showSubscribeModal, setShowSubscribeModal] = useState(false);
+    const [showDuplicateModal, setShowDuplicateModal] = useState(false);
+    const [subscribeUrl, setSubscribeUrl] = useState('');
+    const [subscribeSource, setSubscribeSource] = useState<'youtube' | 'bilibili' | 'twitch' | undefined>(undefined);
+    const [subscribeMode, setSubscribeMode] = useState<'video' | 'playlist'>('video');
+
+    // Channel subscribe choice modal
+    const [showChannelSubscribeChoiceModal, setShowChannelSubscribeChoiceModal] = useState(false);
+
+    // Channel playlists confirmation modal
+    const [showChannelPlaylistsModal, setShowChannelPlaylistsModal] = useState(false);
+    const [channelPlaylistsUrl, setChannelPlaylistsUrl] = useState('');
+
     // Reference to track current download IDs for detecting completion
     const currentDownloadIdsRef = useRef<Set<string>>(new Set());
     // Tracks the last persisted (active count, queued count) so we only write
@@ -627,20 +641,6 @@ export const DownloadProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         // Pass true to skip collection/series check AND parts check since we already know about it
         return await handleVideoSubmit(bilibiliPartsInfo.url, true, true);
     }, [handleVideoSubmit, bilibiliPartsInfo.url]);
-
-    // Subscription logic
-    const [showSubscribeModal, setShowSubscribeModal] = useState(false);
-    const [showDuplicateModal, setShowDuplicateModal] = useState(false);
-    const [subscribeUrl, setSubscribeUrl] = useState('');
-    const [subscribeSource, setSubscribeSource] = useState<'youtube' | 'bilibili' | 'twitch' | undefined>(undefined);
-    const [subscribeMode, setSubscribeMode] = useState<'video' | 'playlist'>('video');
-
-    // Channel subscribe choice modal
-    const [showChannelSubscribeChoiceModal, setShowChannelSubscribeChoiceModal] = useState(false);
-
-    // Channel playlists confirmation modal
-    const [showChannelPlaylistsModal, setShowChannelPlaylistsModal] = useState(false);
-    const [channelPlaylistsUrl, setChannelPlaylistsUrl] = useState('');
 
     const handleSubscribe = async (
         interval: number,

--- a/frontend/src/contexts/LanguageContext.tsx
+++ b/frontend/src/contexts/LanguageContext.tsx
@@ -96,15 +96,20 @@ export const LanguageProvider: React.FC<{ children: ReactNode }> = ({ children }
     });
 
     useEffect(() => {
-        syncLanguagePreference();
-    }, [queryClient, syncLanguagePreference]);
+        const timeoutId = window.setTimeout(() => {
+            void syncLanguagePreference();
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, []);
 
     // Refetch settings when user logs in (e.g. opening app in another browser)
     useEffect(() => {
-        const onLogin = () => syncLanguagePreference();
+        const onLogin = () => {
+            void syncLanguagePreference();
+        };
         window.addEventListener('mytube-login', onLogin);
         return () => window.removeEventListener('mytube-login', onLogin);
-    }, [queryClient, syncLanguagePreference]);
+    }, []);
 
     const setLanguage = useCallback(async (lang: Language) => {
         const normalizedLanguage = normalizeLanguage(lang);

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -84,15 +84,20 @@ export const ThemeContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
 
     // Fetch settings on mount
     useEffect(() => {
-        syncThemePreference();
-    }, [queryClient, syncThemePreference]);
+        const timeoutId = window.setTimeout(() => {
+            void syncThemePreference();
+        }, 0);
+        return () => window.clearTimeout(timeoutId);
+    }, []);
 
     // Listen for login events to refetch
     useEffect(() => {
-        const onLogin = () => syncThemePreference();
+        const onLogin = () => {
+            void syncThemePreference();
+        };
         window.addEventListener('mytube-login', onLogin);
         return () => window.removeEventListener('mytube-login', onLogin);
-    }, [queryClient, syncThemePreference]);
+    }, []);
 
     const setPreference = useCallback(async (newPreference: ThemePreference) => {
         const normalizedPreference = normalizeThemePreference(newPreference);

--- a/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
+++ b/frontend/src/hooks/__tests__/useVideoProgress.test.tsx
@@ -201,6 +201,53 @@ describe("useVideoProgress", () => {
     dateNowSpy.mockRestore();
   });
 
+  it("counts a repeat visit after an intermediate video leaves before the view threshold", async () => {
+    const videoA = {
+      id: "video-repeat-a",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const videoB = {
+      id: "video-repeat-b",
+      duration: "120",
+      progress: 0,
+      viewCount: 0,
+    } as any;
+    const { wrapper } = createWrapper();
+
+    const { result, rerender } = renderHook(
+      ({ video }) => useVideoProgress({ videoId: video.id, video }),
+      {
+        wrapper,
+        initialProps: { video: videoA },
+      },
+    );
+
+    act(() => {
+      result.current.handleTimeUpdate(10);
+    });
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith("/videos/video-repeat-a/view");
+    });
+
+    rerender({ video: videoB });
+    act(() => {
+      result.current.handleTimeUpdate(2);
+    });
+    expect(mockApiPost).toHaveBeenCalledTimes(1);
+
+    rerender({ video: videoA });
+    act(() => {
+      result.current.handleTimeUpdate(10);
+    });
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledTimes(2);
+    });
+    expect(mockApiPost).toHaveBeenLastCalledWith("/videos/video-repeat-a/view");
+  });
+
   it("sends progress on unmount and keeps the cache resume point fresh", () => {
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
     const video = {

--- a/frontend/src/hooks/useCloudStorageUrl.ts
+++ b/frontend/src/hooks/useCloudStorageUrl.ts
@@ -27,8 +27,8 @@ const constructFullUrl = (initialUrl: string): string => {
  */
 export const useCloudStorageUrl = (
   path: string | null | undefined,
-  type: "video" | "audio" | "thumbnail" = "video",
-  initialUrl?: string
+type: "video" | "audio" | "thumbnail" = "video",
+    initialUrl?: string
 ): string | undefined => {
   // For regular paths (non-cloud, non-mount), compute URL synchronously with useMemo
   // This avoids unnecessary state and effects for common cases like /avatars/xxx.jpg
@@ -60,7 +60,11 @@ export const useCloudStorageUrl = (
   }, [path, initialUrl]);
 
   // Only use async state for cloud storage and mount paths
-  const [asyncUrl, setAsyncUrl] = useState<string | undefined>(undefined);
+  const [asyncUrlState, setAsyncUrlState] = useState<{
+    path: string;
+    type: "video" | "audio" | "thumbnail";
+    url: string | undefined;
+  } | null>(null);
 
   useEffect(() => {
     // Check if async handling is needed
@@ -68,7 +72,6 @@ export const useCloudStorageUrl = (
       path && (isCloudStoragePath(path) || isMountDirectoryPath(path));
 
     if (!needsAsync) {
-      setAsyncUrl(undefined);
       return;
     }
 
@@ -82,7 +85,7 @@ export const useCloudStorageUrl = (
       getFileUrl(path, type)
         .then((signedUrl) => {
           if (!cancelled) {
-            setAsyncUrl(signedUrl);
+            setAsyncUrlState({ path, type, url: signedUrl });
           }
         })
         .catch((error) => {
@@ -93,7 +96,7 @@ export const useCloudStorageUrl = (
               `Failed to load cloud storage URL for ${path}:`,
               error
             );
-            setAsyncUrl(undefined);
+            setAsyncUrlState({ path, type, url: undefined });
           }
         });
 
@@ -104,10 +107,18 @@ export const useCloudStorageUrl = (
     } else if (path && isMountDirectoryPath(path)) {
       // Mount directory paths should have signedUrl from the video object
       // If we get here without signedUrl, it's an error
-      setAsyncUrl(undefined);
+      return;
     }
   }, [path, type, initialUrl]);
 
   // Return sync URL if available (for regular paths), otherwise return async URL
-  return syncUrl !== undefined ? syncUrl : asyncUrl;
+  if (syncUrl !== undefined) {
+    return syncUrl;
+  }
+
+  if (asyncUrlState && asyncUrlState.path === path && asyncUrlState.type === type) {
+    return asyncUrlState.url;
+  }
+
+  return undefined;
 };

--- a/frontend/src/hooks/useHomeSettings.ts
+++ b/frontend/src/hooks/useHomeSettings.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { Settings } from '../types';
 import { api } from '../utils/apiClient';
@@ -38,47 +38,21 @@ const getErrorStatus = (error: unknown): number | undefined => {
 };
 
 export const useHomeSettings = ({ settings, settingsLoading = false }: UseHomeSettingsParams = {}): UseHomeSettingsReturn => {
-    const [isSidebarOpen, setIsSidebarOpen] = useState(true);
-    const [settingsLoaded, setSettingsLoaded] = useState(false);
-    const [infiniteScroll, setInfiniteScroll] = useState(false);
-    const [videoColumns, setVideoColumns] = useState(4);
-    const [itemsPerPage, setItemsPerPage] = useState(12);
-    const [defaultSort, setDefaultSort] = useState('dateDesc');
-    const [showTagsOnThumbnail, setShowTagsOnThumbnail] = useState(true);
+    const [isSidebarOpenOverride, setIsSidebarOpen] = useState<boolean | null>(null);
+    const [infiniteScrollOverride, setInfiniteScroll] = useState<boolean | null>(null);
+    const [videoColumnsOverride, setVideoColumns] = useState<number | null>(null);
+    const [itemsPerPageOverride, setItemsPerPage] = useState<number | null>(null);
+    const [defaultSortOverride, setDefaultSort] = useState<string | null>(null);
+    const [showTagsOnThumbnailOverride, setShowTagsOnThumbnail] = useState<boolean | null>(null);
     const { isAuthenticated } = useAuth();
-
-    // Sync local home settings state from shared settings query
-    useEffect(() => {
-        if (!isAuthenticated) {
-            setSettingsLoaded(true);
-            return;
-        }
-
-        if (settingsLoading) return;
-
-        if (settings) {
-            if (typeof settings.homeSidebarOpen !== 'undefined') {
-                setIsSidebarOpen(settings.homeSidebarOpen);
-            }
-            if (typeof settings.itemsPerPage !== 'undefined') {
-                setItemsPerPage(settings.itemsPerPage);
-            }
-            if (typeof settings.infiniteScroll !== 'undefined') {
-                setInfiniteScroll(settings.infiniteScroll);
-            }
-            if (typeof settings.videoColumns !== 'undefined') {
-                setVideoColumns(settings.videoColumns);
-            }
-            if (typeof settings.defaultSort !== 'undefined') {
-                setDefaultSort(settings.defaultSort);
-            }
-            if (typeof settings.showTagsOnThumbnail !== 'undefined') {
-                setShowTagsOnThumbnail(settings.showTagsOnThumbnail);
-            }
-        }
-
-        setSettingsLoaded(true);
-    }, [isAuthenticated, settingsLoading, settings]);
+    const isSidebarOpen = isSidebarOpenOverride ?? settings?.homeSidebarOpen ?? true;
+    const itemsPerPage = itemsPerPageOverride ?? settings?.itemsPerPage ?? 12;
+    const infiniteScroll = infiniteScrollOverride ?? settings?.infiniteScroll ?? false;
+    const videoColumns = videoColumnsOverride ?? settings?.videoColumns ?? 4;
+    const defaultSort = defaultSortOverride ?? settings?.defaultSort ?? 'dateDesc';
+    const showTagsOnThumbnail =
+        showTagsOnThumbnailOverride ?? settings?.showTagsOnThumbnail ?? true;
+    const settingsLoaded = !isAuthenticated || !settingsLoading;
 
     const handleSidebarToggle = async () => {
         const newState = !isSidebarOpen;

--- a/frontend/src/hooks/useLiveTranslationSession.ts
+++ b/frontend/src/hooks/useLiveTranslationSession.ts
@@ -91,12 +91,21 @@ export function useLiveTranslationSession(
   const pausedRef = useRef(false);
   // Keep latest values for callbacks/cleanup without re-creating handlers.
   const videoElementRef = useRef(videoElement);
-  videoElementRef.current = videoElement;
   const onTranscriptRef = useRef(onTranscript);
-  onTranscriptRef.current = onTranscript;
   const latestOriginalAudioWithSubtitlesRef = useRef(false);
-  latestOriginalAudioWithSubtitlesRef.current = !!originalAudioWithSubtitles;
   const sessionOriginalAudioWithSubtitlesRef = useRef(false);
+
+  useEffect(() => {
+    videoElementRef.current = videoElement;
+  }, [videoElement]);
+
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+
+  useEffect(() => {
+    latestOriginalAudioWithSubtitlesRef.current = !!originalAudioWithSubtitles;
+  }, [originalAudioWithSubtitles]);
 
   const detachMediaListeners = useCallback(() => {
     mediaListenersRef.current?.();

--- a/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
+++ b/frontend/src/hooks/useLiveTranslationSubtitleTrack.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { LiveTranslationTranscriptEvent } from './useLiveTranslationSession';
 
 /**
@@ -13,6 +13,10 @@ import { LiveTranslationTranscriptEvent } from './useLiveTranslationSession';
  */
 
 const DEFAULT_CUE_DURATION_S = 4;
+
+const setTextTrackMode = (track: TextTrack, mode: TextTrackMode) => {
+  track.mode = mode;
+};
 
 export interface LiveTranslationSubtitleTrackController {
   track: TextTrack | null;
@@ -29,35 +33,27 @@ export function useLiveTranslationSubtitleTrack(
   label: string,
 ): LiveTranslationSubtitleTrackController {
   const [isActive, setIsActive] = useState(false);
-  // Bump to surface a freshly created track to consumers (refs don't re-render).
-  const [, setVersion] = useState(0);
-  const trackRef = useRef<TextTrack | null>(null);
-  const elementRef = useRef<HTMLVideoElement | null>(null);
-
-  // A track belongs to one element; drop the reference if the element changes.
-  useEffect(() => {
-    if (elementRef.current !== videoElement) {
-      trackRef.current = null;
-      elementRef.current = videoElement;
-      setIsActive(false);
-    }
-  }, [videoElement]);
+  const [trackState, setTrackState] = useState<{
+    element: HTMLVideoElement;
+    track: TextTrack;
+  } | null>(null);
+  const track = trackState?.element === videoElement ? trackState.track : null;
+  const active = isActive && trackState?.element === videoElement;
 
   const ensureTrack = useCallback((): TextTrack | null => {
     const el = videoElement;
     if (!el || typeof el.addTextTrack !== 'function') {
       return null;
     }
-    if (trackRef.current) {
-      return trackRef.current;
+    if (track) {
+      return track;
     }
-    const track = el.addTextTrack('subtitles', label, targetLanguageCode || 'und');
+    const newTrack = el.addTextTrack('subtitles', label, targetLanguageCode || 'und');
     // Keep it non-disabled so cues can be added/read; selection sets showing/hidden.
-    track.mode = 'hidden';
-    trackRef.current = track;
-    setVersion((v) => v + 1);
-    return track;
-  }, [videoElement, label, targetLanguageCode]);
+    setTextTrackMode(newTrack, 'hidden');
+    setTrackState({ element: el, track: newTrack });
+    return newTrack;
+  }, [videoElement, label, targetLanguageCode, track]);
 
   const activate = useCallback(() => {
     if (ensureTrack()) {
@@ -66,7 +62,6 @@ export function useLiveTranslationSubtitleTrack(
   }, [ensureTrack]);
 
   const deactivate = useCallback(() => {
-    const track = trackRef.current;
     if (track) {
       try {
         const cues = track.cues;
@@ -75,13 +70,13 @@ export function useLiveTranslationSubtitleTrack(
             track.removeCue(cues[i]);
           }
         }
-        track.mode = 'disabled';
+        setTextTrackMode(track, 'disabled');
       } catch {
         // ignore
       }
     }
     setIsActive(false);
-  }, []);
+  }, [track]);
 
   const addCue = useCallback(
     (event: LiveTranslationTranscriptEvent) => {
@@ -129,8 +124,8 @@ export function useLiveTranslationSubtitleTrack(
   );
 
   return {
-    track: trackRef.current,
-    isActive,
+    track,
+    isActive: active,
     label,
     activate,
     deactivate,

--- a/frontend/src/hooks/useStatisticsIngestion.ts
+++ b/frontend/src/hooks/useStatisticsIngestion.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useSettings } from './useSettings';
 import { api, sendStatisticsEventsWithKeepalive } from '../utils/apiClient';
@@ -153,10 +153,14 @@ export function useStatisticsIngestion(): {
   const isVisitor = userRole === 'visitor';
   const ingestionAllowed = enabled && (!isVisitor || trackVisitor);
 
-  const sessionIdRef = useRef<string>('');
-  if (!sessionIdRef.current) {
-    sessionIdRef.current = getOrCreateSessionId(userRole ?? null);
-  }
+  const [sessionId, setSessionId] = useState(() =>
+    getOrCreateSessionId(userRole ?? null)
+  );
+  const sessionIdRef = useRef<string>(sessionId);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
 
   // Flush on visibility/pagehide (best-effort).
   useEffect(() => {
@@ -189,6 +193,8 @@ export function useStatisticsIngestion(): {
         role: userRole ?? null,
       });
       sessionIdRef.current = sessionId;
+      const timeoutId = window.setTimeout(() => setSessionId(sessionId), 0);
+      return () => window.clearTimeout(timeoutId);
     }
   }, [userRole]);
 
@@ -234,6 +240,6 @@ export function useStatisticsIngestion(): {
     recordEvent,
     flushNow,
     flushKeepalive,
-    sessionId: sessionIdRef.current,
+    sessionId,
   };
 }

--- a/frontend/src/hooks/useVideoCollections.ts
+++ b/frontend/src/hooks/useVideoCollections.ts
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useCollection } from '../contexts/CollectionContext';
-import { Collection } from '../types';
 
 interface UseVideoCollectionsProps {
     videoId: string | undefined;
@@ -19,18 +18,13 @@ export function useVideoCollections({ videoId }: UseVideoCollectionsProps) {
 
     const [showCollectionModal, setShowCollectionModal] = useState<boolean>(false);
     const [activeCollectionVideoId, setActiveCollectionVideoId] = useState<string | null>(null);
-    const [videoCollections, setVideoCollections] = useState<Collection[]>([]);
-
-    // Find collections that contain the current video
-    useEffect(() => {
+    const videoCollections = useMemo(() => {
         if (collections.length > 0 && videoId) {
-            const belongsToCollections = collections.filter(collection =>
+            return collections.filter(collection =>
                 collection.videos.includes(videoId)
             );
-            setVideoCollections(belongsToCollections);
-        } else {
-            setVideoCollections([]);
         }
+        return [];
     }, [collections, videoId]);
 
     // Calculate collections for the modal (can be current video or sidebar video)

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -72,7 +72,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const { userRole } = useAuth();
   const isVisitor = userRole === "visitor";
   const queryClient = useQueryClient();
-  const [hasViewed, setHasViewed] = useState<boolean>(false);
+  const [viewedVideoId, setViewedVideoId] = useState<string | null>(null);
   const lastProgressSave = useRef<number>(0);
   const currentTimeRef = useRef<number>(0);
   const isDeletingRef = useRef<boolean>(false);
@@ -82,9 +82,7 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const resumeGuardObservedRef = useRef<boolean>(true);
   const videoDuration = video?.duration;
 
-  // Reset hasViewed when video changes
   useEffect(() => {
-    setHasViewed(false);
     const storedProgress = readVideoResumeProgress(videoId)?.progress ?? 0;
     currentTimeRef.current = storedProgress;
     resumeGuardTargetRef.current =
@@ -328,8 +326,9 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
 
     // Increment views and refresh watch history at the same threshold.
     const viewThreshold = getViewThreshold(videoDuration);
+    const hasViewed = viewedVideoId === videoId;
     if (trustedCurrentTime >= viewThreshold && !hasViewed && videoId && !isVisitor) {
-      setHasViewed(true);
+      setViewedVideoId(videoId);
       const lastPlayedAt = Date.now();
       api
         .post(`/videos/${videoId}/view`)

--- a/frontend/src/hooks/useVideoProgress.ts
+++ b/frontend/src/hooks/useVideoProgress.ts
@@ -16,6 +16,12 @@ interface UseVideoProgressProps {
   videoElement?: HTMLVideoElement | null;
 }
 
+interface ViewedState {
+  videoId: string | undefined;
+  visitId: number;
+  viewedVisitId: number | null;
+}
+
 const PROGRESS_SAVE_INTERVAL_MS = 5000;
 const LOCAL_PROGRESS_SAMPLE_INTERVAL_MS = 1000;
 const RESTORE_GUARD_MIN_PROGRESS_SECONDS = 30;
@@ -72,7 +78,11 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const { userRole } = useAuth();
   const isVisitor = userRole === "visitor";
   const queryClient = useQueryClient();
-  const [viewedVideoId, setViewedVideoId] = useState<string | null>(null);
+  const [viewedState, setViewedState] = useState<ViewedState>(() => ({
+    videoId,
+    visitId: 0,
+    viewedVisitId: null,
+  }));
   const lastProgressSave = useRef<number>(0);
   const currentTimeRef = useRef<number>(0);
   const isDeletingRef = useRef<boolean>(false);
@@ -81,6 +91,15 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
   const resumeGuardTargetRef = useRef<number>(0);
   const resumeGuardObservedRef = useRef<boolean>(true);
   const videoDuration = video?.duration;
+  let currentViewedState = viewedState;
+  if (currentViewedState.videoId !== videoId) {
+    currentViewedState = {
+      videoId,
+      visitId: currentViewedState.visitId + 1,
+      viewedVisitId: null,
+    };
+    setViewedState(currentViewedState);
+  }
 
   useEffect(() => {
     const storedProgress = readVideoResumeProgress(videoId)?.progress ?? 0;
@@ -326,9 +345,16 @@ export function useVideoProgress({ videoId, video, videoElement }: UseVideoProgr
 
     // Increment views and refresh watch history at the same threshold.
     const viewThreshold = getViewThreshold(videoDuration);
-    const hasViewed = viewedVideoId === videoId;
+    const visitId = currentViewedState.visitId;
+    const hasViewed =
+      currentViewedState.videoId === videoId &&
+      currentViewedState.viewedVisitId === visitId;
     if (trustedCurrentTime >= viewThreshold && !hasViewed && videoId && !isVisitor) {
-      setViewedVideoId(videoId);
+      setViewedState((state) =>
+        state.videoId === videoId && state.visitId === visitId
+          ? { ...state, viewedVisitId: visitId }
+          : state
+      );
       const lastPlayedAt = Date.now();
       api
         .post(`/videos/${videoId}/view`)

--- a/frontend/src/hooks/useVideoResolution.ts
+++ b/frontend/src/hooks/useVideoResolution.ts
@@ -69,9 +69,10 @@ const hasWebMExtension = (value: string | null | undefined): boolean => {
 
 export const useVideoResolution = (video: Video) => {
   const videoRef = useRef<HTMLVideoElement>(null);
-  const [detectedResolution, setDetectedResolution] = useState<string | null>(
-    null
-  );
+  const [detectedResolutionState, setDetectedResolutionState] = useState<{
+    src: string;
+    resolution: string | null;
+  } | null>(null);
   const videoUrl = useCloudStorageUrl(
     video.videoPath,
     video.mediaType === "audio" ? "audio" : "video",
@@ -87,28 +88,36 @@ export const useVideoResolution = (video: Video) => {
   // compete with the main player. Safari's WebM loader is linear, so a hidden
   // probe of a large WebM can interfere with the visible player's resume seek.
   const needsDetection = !resolutionFromObject && !skipSafariWebMDetection;
+  const videoSrc = videoUrl || video.sourceUrl;
+  const detectedResolution =
+    needsDetection && detectedResolutionState && detectedResolutionState.src === videoSrc
+      ? detectedResolutionState.resolution
+      : null;
 
   useEffect(() => {
     // Skip video element creation if resolution is already available
     if (!needsDetection) {
-      setDetectedResolution(null);
       return;
     }
 
     const videoElement = videoRef.current;
-    const videoSrc = videoUrl || video.sourceUrl;
     if (!videoElement || !videoSrc) {
-      setDetectedResolution(null);
       return;
     }
 
     const handleLoadedMetadata = () => {
       const height = videoElement.videoHeight;
-      setDetectedResolution(formatHeightAsResolution(height));
+      setDetectedResolutionState({
+        src: videoSrc,
+        resolution: formatHeightAsResolution(height),
+      });
     };
 
     const handleError = () => {
-      setDetectedResolution(null);
+      setDetectedResolutionState({
+        src: videoSrc,
+        resolution: null,
+      });
     };
 
     // Delay resolution detection to avoid blocking video playback
@@ -168,7 +177,7 @@ export const useVideoResolution = (video: Video) => {
     }
 
     return cleanup;
-  }, [needsDetection, videoUrl, video.sourceUrl, video.id]);
+  }, [needsDetection, videoSrc, video.id]);
 
   // Use resolution from object if available, otherwise use detected resolution
   const videoResolution = resolutionFromObject || detectedResolution;

--- a/frontend/src/hooks/useVideoSort.ts
+++ b/frontend/src/hooks/useVideoSort.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { Video } from "../types";
@@ -25,6 +25,7 @@ export const useVideoSort = ({
   storageKey,
 }: UseVideoSortProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [fallbackShuffleSeed] = useState(getRandomSeed);
 
   // Validate defaultSort
   const validatedDefaultSort = validateSortOption(defaultSort, "dateDesc");
@@ -41,37 +42,18 @@ export const useVideoSort = ({
     }
   }, [storageKey, validatedDefaultSort]);
 
-  // Initialize sort from URL or default
   const paramSort = searchParams.get("sort");
-  const initialSort = validateSortOption(
+  const sortOption = validateSortOption(
     paramSort,
     getStoredSort() ?? validatedDefaultSort
   );
-
-  const [sortOption, setSortOption] = useState<SortOption>(initialSort);
-  const [shuffleSeed, setShuffleSeed] = useState<number>(() => {
-    const paramSeed = parseInt(searchParams.get("seed") || "0", 10);
-    if (paramSeed > 0) return paramSeed;
-    return initialSort === "random" ? getRandomSeed() : 0;
-  });
+  const seedParam = searchParams.get("seed");
+  const seedFromParams = seedParam ? parseInt(seedParam, 10) : NaN;
+  const shuffleSeed =
+    sortOption === "random"
+      ? Math.max(0, Number.isNaN(seedFromParams) ? fallbackShuffleSeed : seedFromParams)
+      : 0;
   const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
-
-  // Sync state with URL or validatedDefaultSort
-  useEffect(() => {
-    const currentParam = searchParams.get("sort");
-    const nextSort = currentParam
-      ? validateSortOption(currentParam, validatedDefaultSort)
-      : getStoredSort() ?? validatedDefaultSort;
-
-    setSortOption(nextSort);
-
-    const currentSeed = parseInt(searchParams.get("seed") || "0", 10);
-    if (nextSort === "random") {
-      setShuffleSeed(currentSeed > 0 ? currentSeed : getRandomSeed());
-    } else {
-      setShuffleSeed(0);
-    }
-  }, [searchParams, validatedDefaultSort, getStoredSort]);
 
   const handleSortClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setSortAnchorEl(event.currentTarget);

--- a/frontend/src/hooks/useViewMode.ts
+++ b/frontend/src/hooks/useViewMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router';
 
 export type ViewMode = 'favorite' | 'collections' | 'all-videos' | 'history';
@@ -24,23 +24,11 @@ const resolveStoredViewMode = (): ViewMode => {
 
 export const useViewMode = (initialMode?: ViewMode): UseViewModeReturn => {
     const [_searchParams, setSearchParams] = useSearchParams();
-    const [viewMode, setViewMode] = useState<ViewMode>(
-        () => initialMode ?? resolveStoredViewMode()
-    );
-
-    // React Router reuses the Home instance between `/` and `/favorites`, so
-    // the state initializer above does not re-run when the route (and thus
-    // `initialMode`) changes. Keep viewMode in sync with the route: adopt an
-    // authoritative mode when provided (so the `/favorites` deep link stays
-    // correct after Back from `/`), and fall back to the saved/default mode
-    // when it is cleared (so leaving `/favorites` via a plain link such as the
-    // logo stops rendering FavoritePage at `/`).
-    useEffect(() => {
-        setViewMode(initialMode ?? resolveStoredViewMode());
-    }, [initialMode]);
+    const [storedViewMode, setStoredViewMode] = useState<ViewMode>(resolveStoredViewMode);
+    const viewMode = initialMode ?? storedViewMode;
 
     const handleViewModeChange = useCallback((mode: ViewMode) => {
-        setViewMode(mode);
+        setStoredViewMode(mode);
         localStorage.setItem('homeViewMode', mode);
         setSearchParams((prev: URLSearchParams) => {
             const newParams = new URLSearchParams(prev);
@@ -51,7 +39,7 @@ export const useViewMode = (initialMode?: ViewMode): UseViewModeReturn => {
 
     return {
         viewMode,
-        setViewMode,
+        setViewMode: setStoredViewMode,
         handleViewModeChange
     };
 };

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -11,7 +11,7 @@ import {
     Tooltip,
     Typography
 } from '@mui/material';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import DeleteCollectionModal from '../components/DeleteCollectionModal';
 import FavoriteToggle from '../components/FavoriteToggle';
@@ -99,25 +99,18 @@ const CollectionPage: React.FC = () => {
         );
     }, [collectionVideos, selectedTags]);
 
-    // Keep a ref so the context always reads current values (menu gets latest when it opens)
-    const filterRef = useRef({ availableTags, selectedTags, onTagToggle: handleTagToggle });
-    filterRef.current = { availableTags, selectedTags, onTagToggle: handleTagToggle };
+    const pageTagFilter = useMemo(() => ({
+        availableTags,
+        selectedTags,
+        onTagToggle: handleTagToggle,
+        _version: filterVersion,
+    }), [availableTags, filterVersion, handleTagToggle, selectedTags]);
 
-    // Register page tag filter; bump filterVersion only in handleTagToggle so Header re-renders on tag click (no effect loop)
+    // Register page tag filter; bump filterVersion only in handleTagToggle so Header re-renders on tag click.
     useEffect(() => {
-        const stableFilter = {
-            get availableTags() {
-                return filterRef.current.availableTags;
-            },
-            get selectedTags() {
-                return filterRef.current.selectedTags;
-            },
-            onTagToggle: (tag: string) => filterRef.current.onTagToggle(tag),
-            _version: filterVersion
-        };
-        setPageTagFilter(stableFilter);
+        setPageTagFilter(pageTagFilter);
         return () => setPageTagFilter(null);
-    }, [filterVersion, setPageTagFilter]);
+    }, [pageTagFilter, setPageTagFilter]);
 
     // Sort videos (after tag filter)
     const {

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -386,6 +386,7 @@ const CollectionPage: React.FC = () => {
             <TagsModal
                 open={isTagsModalOpen}
                 onClose={() => setIsTagsModalOpen(false)}
+                identityKey={`collection:${collection.id}`}
                 videoTags={commonTags}
                 availableTags={globalAvailableTags ?? []}
                 onSave={handleSaveCollectionTags}

--- a/frontend/src/pages/DownloadPage/HistoryTab.tsx
+++ b/frontend/src/pages/DownloadPage/HistoryTab.tsx
@@ -59,18 +59,16 @@ export function HistoryTab({
         });
     }, [history, filterType]);
 
-    // Reset page when filter changes
-    React.useEffect(() => {
-        setPage(1);
-    }, [filterType]);
-
     return (
         <>
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2, gap: 2, flexWrap: 'wrap' }}>
                 <Select
                     size="small"
                     value={filterType}
-                    onChange={(e) => setFilterType(e.target.value)}
+                    onChange={(e) => {
+                        setFilterType(e.target.value);
+                        setPage(1);
+                    }}
                     sx={{ minWidth: 150 }}
                 >
                     <MenuItem value="all">{t('filterAll') || 'All'}</MenuItem>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -38,7 +38,6 @@ const LoginPage: React.FC = () => {
     const [alertOpen, setAlertOpen] = useState(false);
     const [alertTitle, setAlertTitle] = useState('');
     const [alertMessage, setAlertMessage] = useState('');
-    const [websiteName, setWebsiteName] = useState('MyTube');
     const { t } = useLanguage();
     const { login } = useAuth();
 
@@ -78,17 +77,11 @@ const LoginPage: React.FC = () => {
     // Get settings from password-enabled endpoint (doesn't require auth)
     // This endpoint now includes visitor password info and other login-related settings
     const passwordEnabledData = statusData;
+    const websiteName = passwordEnabledData?.websiteName || 'MyTube';
 
     const passwordLoginAllowed = passwordEnabledData?.passwordLoginAllowed !== false;
     const visitorUserEnabled = passwordEnabledData?.visitorUserEnabled !== false;
     const showVisitorTab = visitorUserEnabled && (!!passwordEnabledData?.hasVisitorUsers || !!passwordEnabledData?.isVisitorPasswordSet);
-
-    // Update website name when settings are loaded
-    useEffect(() => {
-        if (passwordEnabledData && passwordEnabledData.websiteName) {
-            setWebsiteName(passwordEnabledData.websiteName);
-        }
-    }, [passwordEnabledData]);
 
     // Check if passkeys exist
     const { data: passkeysData } = useQuery({

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -23,7 +23,7 @@ import { useVideo } from '../contexts/VideoContext';
 import { neutral, overlay, platform } from '../theme/colors';
 import { formatDuration } from '../utils/formatUtils';
 import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../utils/thumbnailPlaceholder';
-import { getRandomSeed, sortVideos, SortOption, validateSortOption } from '../utils/videoSort';
+import { getRandomSeed, sortVideos, validateSortOption } from '../utils/videoSort';
 
 const SearchPage: React.FC = () => {
     const { t } = useLanguage();
@@ -44,12 +44,11 @@ const SearchPage: React.FC = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const [downloadingId, setDownloadingId] = useState<string | null>(null);
 
-    // Initialize sort option from URL or default
-    const sortOptionP = validateSortOption(searchParams.get('sort'), 'dateDesc');
-    const seedP = parseInt(searchParams.get('seed') || '0', 10);
-
-    const [sortOption, setSortOption] = useState<SortOption>(sortOptionP);
-    const [shuffleSeed, setShuffleSeed] = useState<number>(seedP);
+    const sortOption = validateSortOption(searchParams.get('sort'), 'dateDesc');
+    const shuffleSeed =
+        sortOption === 'random'
+            ? Math.max(0, parseInt(searchParams.get('seed') || '0', 10) || 0)
+            : 0;
     const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
 
     const query = searchParams.get('q');
@@ -59,13 +58,6 @@ const SearchPage: React.FC = () => {
             handleSearch(query);
         }
     }, [query, contextSearchTerm, handleSearch]);
-
-    useEffect(() => {
-        const currentSort = validateSortOption(searchParams.get('sort'), 'dateDesc');
-        const currentSeed = parseInt(searchParams.get('seed') || '0', 10);
-        setSortOption(currentSort);
-        setShuffleSeed(currentSeed);
-    }, [searchParams]);
 
     const handleSortClick = (event: React.MouseEvent<HTMLButtonElement>) => {
         setSortAnchorEl(event.currentTarget);

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -90,6 +90,11 @@ function getInitialSettingsTab(search: string): number {
     return Number.isNaN(tabIndex) ? 0 : tabIndex;
 }
 
+interface SettingsTabState {
+    search: string;
+    tab: number;
+}
+
 const SettingsPage: React.FC = () => {
     const { t, setLanguage } = useLanguage();
     const { activeDownloads } = useDownload();
@@ -150,7 +155,10 @@ const SettingsPage: React.FC = () => {
     const [liveTranslationApiKeyDraft, setLiveTranslationApiKeyDraft] = useState('');
     const [clearLiveTranslationApiKeyRequested, setClearLiveTranslationApiKeyRequested] =
         useState(false);
-    const [currentTab, setCurrentTab] = useState(() => getInitialSettingsTab(location.search));
+    const [currentTabState, setCurrentTabState] = useState<SettingsTabState>(() => ({
+        search: location.search,
+        tab: getInitialSettingsTab(location.search),
+    }));
     const [seekIntervalsValid, setSeekIntervalsValid] = useState(true);
     const [showTrustDetailsModal, setShowTrustDetailsModal] = useState(false);
     const twitchCredentialValidationCode = getTwitchCredentialValidationCode(
@@ -672,6 +680,14 @@ const SettingsPage: React.FC = () => {
             { label: t('advanced'), index: 5 }
         ] : [])
     ];
+    const locationTab = getInitialSettingsTab(location.search);
+    const selectedTab =
+        currentTabState.search === location.search
+            ? currentTabState.tab
+            : locationTab;
+    const currentTab = tabs.some((tabItem) => tabItem.index === selectedTab)
+        ? selectedTab
+        : 0;
 
     const renderDesktopTabContent = () => {
         if (currentTab === 0) return renderBasicSettingsContent();
@@ -698,7 +714,10 @@ const SettingsPage: React.FC = () => {
         // unmounts. Reconcile the page-level save guard to the settings draft
         // that survives the tab switch, while preserving ordering errors.
         setSeekIntervalsValid(arePersistedSeekIntervalsValid(settings));
-        setCurrentTab(newValue);
+        setCurrentTabState({
+            search: location.search,
+            tab: newValue,
+        });
     };
 
     return (

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -91,8 +91,12 @@ function getInitialSettingsTab(search: string): number {
 }
 
 interface SettingsTabState {
-    search: string;
+    urlKey: string;
     tab: number;
+}
+
+function getSettingsTabUrlKey(search: string, hash: string): string {
+    return `${search}\0${hash}`;
 }
 
 const SettingsPage: React.FC = () => {
@@ -155,8 +159,9 @@ const SettingsPage: React.FC = () => {
     const [liveTranslationApiKeyDraft, setLiveTranslationApiKeyDraft] = useState('');
     const [clearLiveTranslationApiKeyRequested, setClearLiveTranslationApiKeyRequested] =
         useState(false);
+    const settingsTabUrlKey = getSettingsTabUrlKey(location.search, location.hash);
     const [currentTabState, setCurrentTabState] = useState<SettingsTabState>(() => ({
-        search: location.search,
+        urlKey: settingsTabUrlKey,
         tab: getInitialSettingsTab(location.search),
     }));
     const [seekIntervalsValid, setSeekIntervalsValid] = useState(true);
@@ -682,7 +687,7 @@ const SettingsPage: React.FC = () => {
     ];
     const locationTab = getInitialSettingsTab(location.search);
     const selectedTab =
-        currentTabState.search === location.search
+        currentTabState.urlKey === settingsTabUrlKey
             ? currentTabState.tab
             : locationTab;
     const currentTab = tabs.some((tabItem) => tabItem.index === selectedTab)
@@ -715,7 +720,7 @@ const SettingsPage: React.FC = () => {
         // that survives the tab switch, while preserving ordering errors.
         setSeekIntervalsValid(arePersistedSeekIntervalsValid(settings));
         setCurrentTabState({
-            search: location.search,
+            urlKey: settingsTabUrlKey,
             tab: newValue,
         });
     };

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -80,6 +80,16 @@ function arePersistedSeekIntervalsValid(settings: Settings): boolean {
     );
 }
 
+function getInitialSettingsTab(search: string): number {
+    const tabParam = new URLSearchParams(search).get('tab');
+    if (!tabParam) {
+        return 0;
+    }
+
+    const tabIndex = parseInt(tabParam, 10);
+    return Number.isNaN(tabIndex) ? 0 : tabIndex;
+}
+
 const SettingsPage: React.FC = () => {
     const { t, setLanguage } = useLanguage();
     const { activeDownloads } = useDownload();
@@ -140,7 +150,7 @@ const SettingsPage: React.FC = () => {
     const [liveTranslationApiKeyDraft, setLiveTranslationApiKeyDraft] = useState('');
     const [clearLiveTranslationApiKeyRequested, setClearLiveTranslationApiKeyRequested] =
         useState(false);
-    const [currentTab, setCurrentTab] = useState(0);
+    const [currentTab, setCurrentTab] = useState(() => getInitialSettingsTab(location.search));
     const [seekIntervalsValid, setSeekIntervalsValid] = useState(true);
     const [showTrustDetailsModal, setShowTrustDetailsModal] = useState(false);
     const twitchCredentialValidationCode = getTwitchCredentialValidationCode(
@@ -202,15 +212,6 @@ const SettingsPage: React.FC = () => {
 
     // Handle initial tab selection from URL and scrolling
     useEffect(() => {
-        const params = new URLSearchParams(location.search);
-        const tabParam = params.get('tab');
-        if (tabParam) {
-            const tabIndex = parseInt(tabParam, 10);
-            if (!isNaN(tabIndex)) {
-                setCurrentTab(tabIndex);
-            }
-        }
-
         // Handle scrolling to element if hash is present
         if (location.hash) {
             const id = location.hash.replace('#', '');

--- a/frontend/src/pages/__tests__/CollectionPage.test.tsx
+++ b/frontend/src/pages/__tests__/CollectionPage.test.tsx
@@ -7,8 +7,9 @@ import CollectionPage from '../CollectionPage';
 
 const mockNavigate = vi.fn();
 const mockSetSearchParams = vi.fn();
+let mockCollectionId = 'col-1';
 vi.mock('react-router', () => ({
-    useParams: () => ({ id: 'col-1' }),
+    useParams: () => ({ id: mockCollectionId }),
     useNavigate: () => mockNavigate,
     useSearchParams: () => [new URLSearchParams(), mockSetSearchParams],
 }));
@@ -150,6 +151,7 @@ describe('CollectionPage', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         capturedDeleteModalProps = {};
+        mockCollectionId = 'col-1';
 
         // Reset context data to defaults
         mockCollectionContext.collections = [...mockCollections];
@@ -363,6 +365,35 @@ describe('CollectionPage', () => {
 
             // customTag should now appear as a chip in the modal
             expect(within(dialog).getByText('customTag')).toBeInTheDocument();
+        });
+
+        it('resets unsaved tags when the collection route changes while the modal is open', async () => {
+            mockCollectionContext.collections = [
+                { id: 'col-1', name: 'Collection One', videos: ['v1'], createdAt: '2024-01-01' },
+                { id: 'col-2', name: 'Collection Two', videos: ['v2'], createdAt: '2024-01-01' },
+            ];
+            mockVideoContext.videos = [
+                { id: 'v1', title: 'Video 1', tags: ['tag1'], author: 'Author' },
+                { id: 'v2', title: 'Video 2', tags: ['tag1'], author: 'Author' },
+            ];
+
+            const rendered = renderCollectionPage();
+            fireEvent.click(screen.getByLabelText('add tags to collection'));
+            fireEvent.click(within(screen.getByRole('dialog')).getByText('tag2'));
+
+            mockCollectionId = 'col-2';
+            rendered.rerender(
+                <ThemeProvider theme={theme}>
+                    <CollectionPage />
+                </ThemeProvider>
+            );
+
+            fireEvent.click(within(screen.getByRole('dialog')).getByText('save'));
+
+            await waitFor(() => {
+                expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+            });
+            expect(mockUpdateVideo).not.toHaveBeenCalled();
         });
     });
 

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -199,6 +199,7 @@ vi.mock('../../components/Settings/InterfaceDisplaySettings', () => ({
 vi.mock('../../components/Settings/SecuritySettings', () => ({
   default: ({ onChange }: any) => (
     <div data-testid="security-settings">
+      <div id="security-access-target" />
       <button onClick={() => onChange('loginEnabled', true)}>security-change</button>
     </div>
   ),
@@ -360,6 +361,9 @@ const SettingsPageWithNavigation = () => {
       <button onClick={() => navigate('/settings?tab=4#dontSkipDeletedVideo-setting')}>
         go-data-management-hash
       </button>
+      <button onClick={() => navigate('/settings?tab=1#security-access-target')}>
+        go-security-hash
+      </button>
       <SettingsPage />
     </>
   );
@@ -489,6 +493,37 @@ describe('SettingsPage', () => {
     expect(screen.queryByTestId('security-settings')).not.toBeInTheDocument();
 
     const target = document.getElementById('dontSkipDeletedVideo-setting')!;
+    target.scrollIntoView = vi.fn();
+
+    vi.advanceTimersByTime(500);
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    expect(target.style.backgroundColor).toBe(overlay.highlightYellow);
+  });
+
+  it('resynchronizes the selected desktop tab when only the URL hash changes', async () => {
+    mockIsDesktop = true;
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=1']}>
+        <SettingsPageWithNavigation />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('security-settings')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'dataManagement' }));
+
+    expect(screen.getByTestId('database-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('security-settings')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('go-security-hash'));
+
+    expect(screen.getByTestId('security-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('database-settings')).not.toBeInTheDocument();
+
+    const target = document.getElementById('security-access-target')!;
     target.scrollIntoView = vi.fn();
 
     vi.advanceTimersByTime(500);

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useNavigate } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { overlay } from '../../theme/colors';
 import SettingsPage from '../SettingsPage';
@@ -300,6 +300,7 @@ vi.mock('../../components/Settings/DatabaseSettings', () => ({
     onAuthorOrganizationModeChange,
   }: any) => (
     <div data-testid="database-settings">
+      <div id="dontSkipDeletedVideo-setting" />
       <button onClick={onMigrate}>open-migrate-modal</button>
       <button onClick={onDeleteLegacy}>open-delete-legacy-modal</button>
       <button onClick={onFormatFilenames}>open-format-modal</button>
@@ -350,6 +351,19 @@ const renderPage = (path = '/settings') =>
       <SettingsPage />
     </MemoryRouter>
   );
+
+const SettingsPageWithNavigation = () => {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button onClick={() => navigate('/settings?tab=4#dontSkipDeletedVideo-setting')}>
+        go-data-management-hash
+      </button>
+      <SettingsPage />
+    </>
+  );
+};
 
 describe('SettingsPage', () => {
   beforeEach(() => {
@@ -454,6 +468,33 @@ describe('SettingsPage', () => {
 
     vi.advanceTimersByTime(2000);
     expect(target.style.backgroundColor).toBe('');
+  });
+
+  it('resynchronizes the selected desktop tab when the URL query changes on the mounted route', async () => {
+    mockIsDesktop = true;
+    vi.useFakeTimers();
+
+    render(
+      <MemoryRouter initialEntries={['/settings?tab=1']}>
+        <SettingsPageWithNavigation />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByTestId('security-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('database-settings')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('go-data-management-hash'));
+
+    expect(screen.getByTestId('database-settings')).toBeInTheDocument();
+    expect(screen.queryByTestId('security-settings')).not.toBeInTheDocument();
+
+    const target = document.getElementById('dontSkipDeletedVideo-setting')!;
+    target.scrollIntoView = vi.fn();
+
+    vi.advanceTimersByTime(500);
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth', block: 'center' });
+    expect(target.style.backgroundColor).toBe(overlay.highlightYellow);
   });
 
   it('switches desktop tabs and renders each tab content', () => {

--- a/frontend/src/pages/authorVideos/AuthorVideosPage.tsx
+++ b/frontend/src/pages/authorVideos/AuthorVideosPage.tsx
@@ -186,6 +186,7 @@ const AuthorVideosPage: React.FC = () => {
             <TagsModal
                 open={actions.isTagsModalOpen}
                 onClose={actions.closeTagsModal}
+                identityKey={`author:${authorName ?? authorDisplayName}`}
                 videoTags={commonTags}
                 availableTags={globalAvailableTags}
                 onSave={actions.handleSaveAuthorTags}

--- a/frontend/src/pages/authorVideos/__tests__/AuthorVideosPage.test.tsx
+++ b/frontend/src/pages/authorVideos/__tests__/AuthorVideosPage.test.tsx
@@ -184,9 +184,10 @@ vi.mock('../../../components/ConfirmationModal', () => ({
 }));
 
 vi.mock('../../../components/TagsModal', () => ({
-    default: ({ open, onClose, videoTags, availableTags, onSave }: { open: unknown; onClose: MouseEventHandler; videoTags: unknown; availableTags: unknown; onSave: (tags: string[]) => void; [key: string]: unknown }) =>
+    default: ({ open, onClose, identityKey, videoTags, availableTags, onSave }: { open: unknown; onClose: MouseEventHandler; identityKey?: string; videoTags: unknown; availableTags: unknown; onSave: (tags: string[]) => void; [key: string]: unknown }) =>
         open ? (
             <div data-testid="tags-modal">
+                <span data-testid="tags-modal-identity-key">{identityKey}</span>
                 <span data-testid="tags-modal-video-tags">{JSON.stringify(videoTags)}</span>
                 <span data-testid="tags-modal-available-tags">{JSON.stringify(availableTags)}</span>
                 <button data-testid="tags-modal-save-btn" onClick={() => { onSave(['newTag']); }}>Save Tags</button>
@@ -542,6 +543,12 @@ describe('AuthorVideosPage', () => {
             expect(screen.getByTestId('tags-modal-video-tags')).toHaveTextContent(
                 JSON.stringify(['sharedTag1', 'sharedTag2'])
             );
+        });
+
+        it('tags modal receives the author route identity key', () => {
+            mockActionsOverrides = { isTagsModalOpen: true };
+            renderPage();
+            expect(screen.getByTestId('tags-modal-identity-key')).toHaveTextContent('author:TestAuthor');
         });
 
         it('tags modal receives globalAvailableTags as availableTags', () => {

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -49,11 +49,6 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
         if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
     }, []);
 
-    // Keep the index valid if the favorites list shrinks under us.
-    useEffect(() => {
-        if (index >= count && count > 0) setIndex(0);
-    }, [count, index]);
-
     const go = useCallback((next: number, direction = 1) => {
         setSlideDirection(direction);
         setIndex(((next % count) + count) % count);
@@ -98,7 +93,7 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
 
     if (count === 0) return null;
 
-    const safeIndex = Math.min(index, count - 1);
+    const safeIndex = index >= 0 && index < count ? index : 0;
     const current = items[safeIndex];
     const openCollection = (event: MouseEvent<HTMLButtonElement>) => {
         if (!current.collection) return;

--- a/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
+++ b/frontend/src/pages/favorite/FavoriteHeroCarousel.tsx
@@ -22,7 +22,24 @@ interface FavoriteHeroCarouselProps {
     items: FavoriteHeroItem[];
 }
 
+type CarouselIndexState = {
+    count: number;
+    index: number;
+};
+
+type CarouselIndexUpdate = number | ((current: number) => number);
+
 const AUTO_ADVANCE_MS = 7000;
+
+const normalizeIndex = (index: number, count: number): number => {
+    if (count <= 0) return 0;
+    return Math.min(Math.max(index, 0), count - 1);
+};
+
+const wrapIndex = (index: number, count: number): number => {
+    if (count <= 0) return 0;
+    return ((index % count) + count) % count;
+};
 
 /**
  * Rotating Featured hero: cycles through the top 5-star videos. Auto-advances
@@ -36,23 +53,45 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
     const theme = useTheme();
     const isReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
     const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-    const [index, setIndex] = useState(0);
+    const count = items.length;
+    const [indexState, setIndexState] = useState<CarouselIndexState>(() => ({
+        count,
+        index: 0,
+    }));
+    const index =
+        indexState.count === count
+            ? indexState.index
+            : normalizeIndex(indexState.index, count);
     const [paused, setPaused] = useState(false);
     const [slideDirection, setSlideDirection] = useState(1);
     const touchStart = useRef<{ x: number; y: number } | null>(null);
     const suppressClick = useRef(false);
     const suppressClickTimer = useRef<number | null>(null);
-    const count = items.length;
 
     // Clear the pending suppress-click reset on unmount.
     useEffect(() => () => {
         if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
     }, []);
 
+    const setCarouselIndex = useCallback((next: CarouselIndexUpdate) => {
+        setIndexState((currentState) => {
+            const current =
+                currentState.count === count
+                    ? currentState.index
+                    : normalizeIndex(currentState.index, count);
+            const nextIndex = typeof next === 'function' ? next(current) : next;
+
+            return {
+                count,
+                index: wrapIndex(nextIndex, count),
+            };
+        });
+    }, [count]);
+
     const go = useCallback((next: number, direction = 1) => {
         setSlideDirection(direction);
-        setIndex(((next % count) + count) % count);
-    }, [count]);
+        setCarouselIndex(next);
+    }, [setCarouselIndex]);
 
     const handleTouchEnd = (event: React.TouchEvent<HTMLDivElement>) => {
         const start = touchStart.current;
@@ -86,14 +125,14 @@ const FavoriteHeroCarousel: React.FC<FavoriteHeroCarouselProps> = ({ items }) =>
     useEffect(() => {
         if (isReducedMotion || paused || count <= 1) return undefined;
         const id = window.setInterval(() => {
-            setIndex((current) => (current + 1) % count);
+            setCarouselIndex((current) => current + 1);
         }, AUTO_ADVANCE_MS);
         return () => window.clearInterval(id);
-    }, [isReducedMotion, paused, count]);
+    }, [isReducedMotion, paused, count, setCarouselIndex]);
 
     if (count === 0) return null;
 
-    const safeIndex = index >= 0 && index < count ? index : 0;
+    const safeIndex = normalizeIndex(index, count);
     const current = items[safeIndex];
     const openCollection = (event: MouseEvent<HTMLButtonElement>) => {
         if (!current.collection) return;

--- a/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
+++ b/frontend/src/pages/favorite/__tests__/FavoriteHeroCarousel.test.tsx
@@ -118,6 +118,25 @@ describe('FavoriteHeroCarousel', () => {
         expect(screen.getByTestId('hero-slide')).toHaveTextContent('C');
     });
 
+    it('normalizes the active index when the item list shrinks', () => {
+        const rendered = renderCarousel(makeItems(['A', 'B', 'C', 'D', 'E']));
+
+        fireEvent.click(screen.getByRole('button', { name: 'featured 5' }));
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('E');
+
+        rendered.rerender(
+            <MemoryRouter>
+                <ThemeProvider theme={createTheme()}>
+                    <FavoriteHeroCarousel items={makeItems(['A', 'B', 'C'])} />
+                </ThemeProvider>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('C');
+        fireEvent.click(screen.getByRole('button', { name: 'next' }));
+        expect(screen.getByTestId('hero-slide')).toHaveTextContent('A');
+    });
+
     it('auto-advances on a timer', () => {
         vi.useFakeTimers();
         renderCarousel(makeItems(['A', 'B']));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "concurrently": "^10.0.3"
+        "concurrently": "^10.0.4"
       },
       "engines": {
         "node": ">=22.22.0 <27"
@@ -67,14 +67,14 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "concurrently": "^10.0.3"
+    "concurrently": "^10.0.4"
   },
   "overrides": {
     "@babel/runtime": "^7.26.10"


### PR DESCRIPTION
## Summary

- Updates root `concurrently` so `shell-quote` resolves to a patched release.
- Refreshes backend, frontend, bgutil provider, and chrome extension npm dependency trees to patched `brace-expansion`, `js-yaml`, and `postcss` versions.
- Moves frontend and bgutil provider lint tooling to ESLint 10-compatible versions.
- Keeps frontend on `...reactHooks.configs.recommended.rules` and fixes the newly enforced React Hooks violations instead of narrowing or suppressing them.
- Adds `ErrorOptions.cause` in two bgutil provider rethrows required by the updated lint stack.

## Validation

- `npm audit --audit-level=moderate` in root, `backend`, `frontend`, `backend/bgutil-ytdlp-pot-provider/server`, and `chrome-extension`: 0 vulnerabilities
- `npm run lint:frontend`
- `npm run typecheck:frontend`
- `npm run build` at repo root / frontend production build
- Focused Vitest suites covering the React hook-rule correction: sidebars, subscription dialogs/fields, settings panels, header hooks, video card/player controls, contexts, hooks, and changed page flows all passed
- Earlier dependency-update validation on this branch: `npm run test:backend`, provider server lint/typecheck, backend build

Note: local full `npm run test:frontend` was attempted after the hook-rule correction, but did not reach a completion summary in this environment; the focused suites above cover the changed frontend surfaces.