### PR TITLE
Fix remaining unresolved review comments from PR #392

### DIFF
--- a/backend/src/__tests__/services/continuousDownloadService.test.ts
+++ b/backend/src/__tests__/services/continuousDownloadService.test.ts
@@ -566,10 +566,12 @@ describe("ContinuousDownloadService", () => {
       expect((service as any).videoUrlCache.size).toBe(0);
     });
 
-    it("should process YouTube playlists incrementally without prefetch cache", async () => {
+    it("should process YouTube channel-uploads playlists incrementally without prefetch cache", async () => {
       const task = {
         id: "pl",
-        authorUrl: "https://youtube.com/playlist?list=PLX",
+        // `UU...` is the auto-generated uploads playlist (newest-first), so the
+        // dateDesc incremental fast path is safe here.
+        authorUrl: "https://youtube.com/playlist?list=UUabcdef",
         platform: "YouTube",
         status: "active",
       };
@@ -582,6 +584,51 @@ describe("ContinuousDownloadService", () => {
       expect(fetcher.getAllVideoUrls).not.toHaveBeenCalled();
       expect(fetcher.getAllVideoEntries).not.toHaveBeenCalled();
       expect(processor.processTask).toHaveBeenCalledWith(task, undefined);
+    });
+
+    it("should route manually-ordered YouTube playlists through the sorted frozen-plan path", async () => {
+      // A `PL...` playlist can be in any order, so a dateDesc request must not
+      // take the incremental fast path (which would hand playlist order straight
+      // to the processor); it has to fetch, sort, and freeze instead. The sort
+      // itself is a stubbed identity here — sortVideoEntries has its own tests —
+      // so this asserts the branch, not the ordering math.
+      const task = {
+        id: "manual-pl",
+        authorUrl: "https://youtube.com/playlist?list=PLX",
+        platform: "YouTube",
+        status: "active",
+        downloadOrder: "dateDesc",
+      };
+      repo.getTaskById
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce(task);
+      fetcher.getAllVideoEntries.mockResolvedValue([
+        { url: "u1", sourceVideoId: "u1", publishedAtMs: Date.UTC(2024, 0, 1), publishedDatePrecision: "day", viewCount: 1, sourceIndex: 0 },
+        { url: "u2", sourceVideoId: "u2", publishedAtMs: Date.UTC(2024, 0, 2), publishedDatePrecision: "day", viewCount: 2, sourceIndex: 1 },
+      ]);
+
+      const ensureDirSpy = vi
+        .spyOn(security, "ensureDirSafeSync")
+        .mockImplementation(() => undefined);
+      const writeSpy = vi
+        .spyOn(security, "writeFileSafeSync")
+        .mockImplementation(() => undefined);
+
+      await (service as any).processTask("manual-pl");
+
+      // Full-fetch path taken: entries are enumerated and frozen, and the
+      // processor receives the resolved URL list rather than `undefined`.
+      expect(fetcher.getAllVideoEntries).toHaveBeenCalledWith(
+        "https://youtube.com/playlist?list=PLX",
+        "YouTube",
+        null,
+        "dateDesc"
+      );
+      expect(writeSpy).toHaveBeenCalled();
+      expect(processor.processTask).toHaveBeenCalledWith(task, ["u1", "u2"]);
+
+      ensureDirSpy.mockRestore();
+      writeSpy.mockRestore();
     });
 
     it("should create and persist frozen list for full-fetch tasks", async () => {

--- a/backend/src/__tests__/services/continuousDownloadService.test.ts
+++ b/backend/src/__tests__/services/continuousDownloadService.test.ts
@@ -631,6 +631,58 @@ describe("ContinuousDownloadService", () => {
       writeSpy.mockRestore();
     });
 
+    it("should keep an in-flight legacy incremental playlist on the incremental path", async () => {
+      // A non-uploads playlist that already has numeric progress and no frozen
+      // plan was created before the ordering change and has been downloading in
+      // raw playlist order. Re-sorting it now would desync TaskProcessor's saved
+      // index, so it must stay on the incremental path until it completes.
+      const task = {
+        id: "legacy-pl",
+        authorUrl: "https://youtube.com/playlist?list=PLX",
+        platform: "YouTube",
+        status: "active",
+        downloadOrder: "dateDesc",
+        currentVideoIndex: 3,
+        frozenVideoListPath: null,
+      };
+      repo.getTaskById
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce(task);
+
+      await (service as any).processTask("legacy-pl");
+
+      expect(fetcher.getAllVideoEntries).not.toHaveBeenCalled();
+      expect(processor.processTask).toHaveBeenCalledWith(task, undefined);
+    });
+
+    it("should route a fresh manually-ordered playlist through the sorted path even with saved progress once frozen", async () => {
+      // Once a manual playlist has a frozen plan, progress is an index into the
+      // sorted order, so it must not fall back to the incremental path.
+      const task = {
+        id: "frozen-pl",
+        authorUrl: "https://youtube.com/playlist?list=PLX",
+        platform: "YouTube",
+        status: "active",
+        downloadOrder: "dateDesc",
+        currentVideoIndex: 3,
+        frozenVideoListPath: path.join(frozenListsRoot, "frozen-pl.json"),
+      };
+      repo.getTaskById
+        .mockResolvedValueOnce(task)
+        .mockResolvedValueOnce(task);
+      const readFrozenSpy = vi
+        .spyOn(service as any, "readFrozenPlanUrls")
+        .mockReturnValue(["a", "b"]);
+
+      await (service as any).processTask("frozen-pl");
+
+      expect(fetcher.getAllVideoEntries).not.toHaveBeenCalled();
+      expect(readFrozenSpy).toHaveBeenCalled();
+      expect(processor.processTask).toHaveBeenCalledWith(task, ["a", "b"]);
+
+      readFrozenSpy.mockRestore();
+    });
+
     it("should create and persist frozen list for full-fetch tasks", async () => {
       const task = {
         id: "freeze-create",

--- a/backend/src/__tests__/services/storageService/collectionFileManager.integration.test.ts
+++ b/backend/src/__tests__/services/storageService/collectionFileManager.integration.test.ts
@@ -215,6 +215,77 @@ describe("collectionFileManager allocator-backed family relocation", () => {
     expect(journalEntries()).toEqual([]);
   });
 
+  it("assigns distinct targets to subtitles that share a language and extension", () => {
+    // The subtitle upload endpoint permits two managed subtitles with the same
+    // language and extension. Both would otherwise resolve to the identical
+    // `<stem>.<lang>.vtt` target; the second no-overwrite move would then fail
+    // and the journal would roll the whole relocation back.
+    const current = makeVideo({
+      id: "current",
+      sourceVideoId: "yt-current",
+      videoPath: "/videos/Episode.mp4",
+      thumbnailPath: "/images/Episode.jpg",
+      subtitles: [
+        {
+          language: "en",
+          filename: "Episode.en.vtt",
+          path: "/subtitles/Episode.en.vtt",
+        },
+        {
+          language: "en",
+          filename: "Episode.en.extra.vtt",
+          path: "/subtitles/Episode.en.extra.vtt",
+        },
+      ],
+    });
+    const collections: Collection[] = [
+      { id: "collection", title: "Series", name: "Series", videos: [] },
+    ];
+    videoStore.videos = [current];
+
+    fs.outputFileSync(path.join(testPaths.videos, "Episode.mp4"), "source-video");
+    fs.outputFileSync(path.join(testPaths.images, "Episode.jpg"), "source-thumb");
+    fs.outputFileSync(path.join(testPaths.subtitles, "Episode.en.vtt"), "sub-one");
+    fs.outputFileSync(
+      path.join(testPaths.subtitles, "Episode.en.extra.vtt"),
+      "sub-two"
+    );
+
+    const updates = moveAllFilesToCollection(current, "Series", collections);
+
+    expect(updates.subtitles).toEqual([
+      {
+        language: "en",
+        filename: "Episode.en.vtt",
+        path: "/subtitles/Series/Episode.en.vtt",
+      },
+      {
+        language: "en",
+        filename: "Episode.en.2.vtt",
+        path: "/subtitles/Series/Episode.en.2.vtt",
+      },
+    ]);
+    expect(
+      fs.readFileSync(
+        path.join(testPaths.subtitles, "Series", "Episode.en.vtt"),
+        "utf8"
+      )
+    ).toBe("sub-one");
+    expect(
+      fs.readFileSync(
+        path.join(testPaths.subtitles, "Series", "Episode.en.2.vtt"),
+        "utf8"
+      )
+    ).toBe("sub-two");
+    expect(
+      fs.existsSync(path.join(testPaths.subtitles, "Episode.en.vtt"))
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(testPaths.subtitles, "Episode.en.extra.vtt"))
+    ).toBe(false);
+    expect(journalEntries()).toEqual([]);
+  });
+
   it("keeps central subtitles in the subtitle root when unlinking to the root", () => {
     // removeVideoFromCollection passes no subtitlePathPrefix when the unlink
     // target is the storage root. That must not be read as "store subtitles in

--- a/backend/src/services/continuousDownloadService.ts
+++ b/backend/src/services/continuousDownloadService.ts
@@ -696,13 +696,27 @@ export class ContinuousDownloadService {
       // fields in the wrong order.
       const effectiveOrder: DownloadOrder = task.downloadOrder ?? "dateDesc";
       const playlistMatch = task.authorUrl.match(YOUTUBE_PLAYLIST_ID_REGEX);
-      const isUploadsPlaylist = playlistMatch
-        ? isYouTubeUploadsPlaylistId(playlistMatch[1])
-        : false;
-      const useIncremental =
-        isUploadsPlaylist &&
+      const isYouTubePlaylistDateDesc =
+        playlistMatch !== null &&
         task.platform === "YouTube" &&
         effectiveOrder === "dateDesc";
+      const isUploadsPlaylist =
+        playlistMatch !== null && isYouTubeUploadsPlaylistId(playlistMatch[1]);
+      // Migration guard: a non-uploads playlist that is already mid-flight —
+      // numeric progress but no frozen plan — was created before this ordering
+      // change and has been running incrementally in raw playlist order.
+      // Switching it to a freshly date-sorted plan now would leave TaskProcessor
+      // resuming from `currentVideoIndex`, an index into the *old* order, so it
+      // would silently skip some videos and re-download others. Keep such
+      // in-flight tasks on the legacy incremental path; only fresh (unprogressed
+      // or already-frozen) tasks adopt the sorted plan.
+      const isInProgressLegacyIncremental =
+        isYouTubePlaylistDateDesc &&
+        task.currentVideoIndex > 0 &&
+        !task.frozenVideoListPath;
+      const useIncremental =
+        isYouTubePlaylistDateDesc &&
+        (isUploadsPlaylist || isInProgressLegacyIncremental);
 
       let cachedVideoUrls: string[] | undefined;
 

--- a/backend/src/services/continuousDownloadService.ts
+++ b/backend/src/services/continuousDownloadService.ts
@@ -36,6 +36,24 @@ import { sortVideoEntries, VideoUrlFetcher } from "./continuousDownload/videoUrl
 
 const FROZEN_LISTS_DIR = path.join(DATA_DIR, "frozen-lists");
 const SAFE_FROZEN_LIST_TASK_ID = /^[A-Za-z0-9_-]+$/;
+const YOUTUBE_PLAYLIST_ID_REGEX = /[?&]list=([a-zA-Z0-9_-]+)/;
+
+/**
+ * YouTube auto-generates an "uploads" playlist for every channel whose items
+ * are always ordered newest-first. Its id starts with `UU` (the channel id with
+ * the leading `UC` replaced by `UU`), including the `UULF`/`UUSH`/... variants
+ * for long-form, shorts, and so on. Those are the only `list=` sources we can
+ * process with the incremental fast path and still honour a dateDesc
+ * (newest-first) request without hydrating publication dates.
+ *
+ * Every other playlist kind can be in an arbitrary order — `PL` user playlists,
+ * `LL` liked, `WL` watch-later, `RD`/`RDCLAK` mixes, `OLAK5uy_` album playlists —
+ * so a dateDesc request against them must go through the sorted frozen-plan path
+ * rather than following raw playlist order.
+ */
+function isYouTubeUploadsPlaylistId(listId: string): boolean {
+  return listId.startsWith("UU");
+}
 
 /**
  * Main service for managing continuous download tasks
@@ -669,11 +687,22 @@ export class ContinuousDownloadService {
         return;
       }
 
-      // Mode decision: incremental fast path only for YouTube playlist + dateDesc
+      // Mode decision: the incremental fast path is only safe for a YouTube
+      // channel-uploads playlist processed newest-first, because that is the one
+      // `list=` source whose raw order is guaranteed to match dateDesc without
+      // hydrating publication dates. A manually-ordered playlist selected as
+      // dateDesc must instead go through the sorted frozen-plan path, otherwise
+      // it would download in playlist order and receive playlist-index filename
+      // fields in the wrong order.
       const effectiveOrder: DownloadOrder = task.downloadOrder ?? "dateDesc";
-      const playlistRegex = /[?&]list=([a-zA-Z0-9_-]+)/;
-      const isPlaylist = playlistRegex.test(task.authorUrl);
-      const useIncremental = isPlaylist && task.platform === "YouTube" && effectiveOrder === "dateDesc";
+      const playlistMatch = task.authorUrl.match(YOUTUBE_PLAYLIST_ID_REGEX);
+      const isUploadsPlaylist = playlistMatch
+        ? isYouTubeUploadsPlaylistId(playlistMatch[1])
+        : false;
+      const useIncremental =
+        isUploadsPlaylist &&
+        task.platform === "YouTube" &&
+        effectiveOrder === "dateDesc";
 
       let cachedVideoUrls: string[] | undefined;
 

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -217,6 +217,12 @@ export class MissAVDownloader extends BaseDownloader {
     let releaseOutputReservation: (() => void) | null = null;
     let stagedVideoPathForCleanup: string | null = null;
     let stagedThumbnailPathForCleanup: string | null = null;
+    // Final destinations of any in-place owned replacement. Once we commit to
+    // replacing an owned file, its destination always holds a live library file
+    // (the original before publication, the new download afterwards) with the
+    // backup already removed, so the failure cleanup below must never delete it.
+    let ownedVideoDestinationPath: string | null = null;
+    let ownedThumbnailDestinationPath: string | null = null;
     let existingLocalVideo: Video | undefined;
 
     try {
@@ -460,6 +466,9 @@ export class MissAVDownloader extends BaseDownloader {
         [IMAGES_DIR, VIDEOS_DIR],
         existingLocalVideo?.id
       );
+      ownedVideoDestinationPath = ownedVideoReplacement?.finalPath ?? null;
+      ownedThumbnailDestinationPath =
+        ownedThumbnailReplacement?.finalPath ?? null;
       const videoDownloadPath = ownedVideoReplacement?.stagingPath ?? newVideoPath;
       const thumbnailDownloadPath =
         ownedThumbnailReplacement?.stagingPath ?? newThumbnailPath;
@@ -936,6 +945,25 @@ export class MissAVDownloader extends BaseDownloader {
       }
 
       logger.error("Error in downloadMissAVVideo:", error);
+      // When an in-place owned replacement was planned, its final destination is
+      // a live library file (its backup is already gone once the replacement
+      // commits). In legacy root naming that destination coincides with the
+      // filename recomputed below, so removing it blindly would leave the
+      // existing row pointing at a missing file. Skip those paths during cleanup.
+      const removeUnlessOwnedDestination = async (
+        candidatePath: string,
+      ): Promise<void> => {
+        const normalized = path.normalize(candidatePath);
+        if (
+          (ownedVideoDestinationPath &&
+            path.normalize(ownedVideoDestinationPath) === normalized) ||
+          (ownedThumbnailDestinationPath &&
+            path.normalize(ownedThumbnailDestinationPath) === normalized)
+        ) {
+          return;
+        }
+        await safeRemove(candidatePath);
+      };
       // Cleanup - try to get the correct extension from config, fallback to mp4
       try {
         if (stagedVideoPathForCleanup) {
@@ -962,14 +990,14 @@ export class MissAVDownloader extends BaseDownloader {
           IMAGES_DIR,
           `${cleanupSafeBaseFilename}.jpg`
         );
-        await safeRemove(cleanupVideoPath);
-        await safeRemove(cleanupThumbnailPath);
+        await removeUnlessOwnedDestination(cleanupVideoPath);
+        await removeUnlessOwnedDestination(cleanupThumbnailPath);
         // Also try mp4 in case the file was created with default extension
         const cleanupVideoPathMp4 = resolveSafeChildPath(
           VIDEOS_DIR,
           `${cleanupSafeBaseFilename}.mp4`
         );
-        await safeRemove(cleanupVideoPathMp4);
+        await removeUnlessOwnedDestination(cleanupVideoPathMp4);
       } catch (cleanupError) {
         // If cleanup fails, try with default mp4 extension
         const cleanupSafeBaseFilename = formatVideoFilename(
@@ -985,8 +1013,8 @@ export class MissAVDownloader extends BaseDownloader {
           IMAGES_DIR,
           `${cleanupSafeBaseFilename}.jpg`
         );
-        await safeRemove(cleanupVideoPath);
-        await safeRemove(cleanupThumbnailPath);
+        await removeUnlessOwnedDestination(cleanupVideoPath);
+        await removeUnlessOwnedDestination(cleanupThumbnailPath);
       }
       throw error;
     } finally {

--- a/backend/src/services/storageService/collectionFileManager.ts
+++ b/backend/src/services/storageService/collectionFileManager.ts
@@ -707,6 +707,14 @@ function moveManagedFamilyToRelativeDirs(
 
     const newSubtitles: NonNullable<Video["subtitles"]> = [];
     let subtitlesChanged = false;
+    // A video may legitimately carry two managed subtitles that share a
+    // language and extension (the subtitle upload endpoint permits it). Both
+    // would otherwise resolve to the same `<stem>.<lang><ext>` target, queuing
+    // two moves to one path; the second no-overwrite move then fails and the
+    // journal rolls the whole relocation back. Track assigned target filenames
+    // and give each colliding subtitle a distinct numeric suffix.
+    const subtitleStem = path.basename(reservation.subtitleBaseRelativePath);
+    const usedSubtitleFilenames = new Set<string>();
     for (const originalSubtitle of video.subtitles || []) {
       const subtitleSource = subtitleSources.find(
         (candidate) => candidate.original === originalSubtitle
@@ -716,7 +724,15 @@ function moveManagedFamilyToRelativeDirs(
         continue;
       }
 
-      const filename = `${path.basename(reservation.subtitleBaseRelativePath)}.${subtitleSource.language}${subtitleSource.extension}`;
+      let filename = `${subtitleStem}.${subtitleSource.language}${subtitleSource.extension}`;
+      if (usedSubtitleFilenames.has(filename)) {
+        let suffix = 2;
+        do {
+          filename = `${subtitleStem}.${subtitleSource.language}.${suffix}${subtitleSource.extension}`;
+          suffix += 1;
+        } while (usedSubtitleFilenames.has(filename));
+      }
+      usedSubtitleFilenames.add(filename);
       const relativeDir = path.dirname(reservation.subtitleBaseRelativePath);
       const subtitleRelative = joinRelativePath(
         relativeDir === "." ? "" : relativeDir,


### PR DESCRIPTION
## Summary

[PR #392](https://github.com/franklioxygen/MyTube/pull/392) merged with some review comments still open. This PR addresses them. Two were unresolved **inline** threads; one was a still-valid **review-body** (Codex Review) comment. The other review-body comments on #392 (the pagination/enumeration-failure ones) were already fixed on master by `765dd4cf`, so they're not touched here.

### 1. Retain the MissAV owned file when persistence fails (P1, inline)

`backend/src/services/downloaders/MissAVDownloader.ts`

During an in-place MissAV redownload using legacy root naming, `replaceOwnedFileWithBackupSync` publishes the newly downloaded file to the existing owned path and removes the original's backup — but database persistence (`updateVideo` / `persistDownloadedMediaIdentity`) runs afterwards. If persistence threw, the outer `catch` cleanup recomputed the legacy filename via `formatVideoFilename(...)` and unconditionally `safeRemove`'d it. In legacy root naming that path **is** the live library file, so the row was left pointing at a missing file with no backup to restore.

**Fix:** capture the owned replacement's final destination path(s) and skip them during failure cleanup — those destinations always hold a live library file (the original before publication, the new download afterwards), never an orphan.

### 2. Keep duplicate-language subtitle targets distinct (P2, inline)

`backend/src/services/storageService/collectionFileManager.ts`

When a video carries two managed subtitles with the same language **and** extension (which the subtitle upload endpoint permits), both resolved to the identical `<stem>.<lang><ext>` target. Linking/unlinking the video then queued two moves to one path; the second no-overwrite move failed and the journal rolled the entire relocation back, so collection organization could never complete for that valid subtitle set.

**Fix:** track assigned subtitle target filenames within the family and give each colliding subtitle a distinct numeric suffix (`<stem>.<lang>.2<ext>`, `<stem>.<lang>.3<ext>`, …). Adds a regression test (verified to fail before the fix, pass after).

### 3. Sort manually-ordered YouTube playlists newest-first (P1, review body)

`backend/src/services/continuousDownloadService.ts`

The dateDesc incremental fast path was taken for **every** YouTube `list=` URL. Manually-ordered playlists were therefore downloaded in raw playlist order (and got playlist-index filename fields in the wrong order) rather than newest-first.

**Fix:** restrict the incremental fast path to YouTube channel-**uploads** playlists (`list=UU…`), whose raw order is guaranteed newest-first, so it keeps that optimization without hydrating publication dates. Every other playlist kind (`PL`/`LL`/`WL`/mixes/album playlists) now flows through the sorted frozen-plan path for dateDesc. Updates the incremental test to use an uploads playlist and adds a test that a manual `PL` playlist is fetched, sorted, and frozen.

> The related pagination/enumeration-failure review comments on #392 were already resolved on master by `765dd4cf` — the YouTube pager now throws `SourceEnumerationFailedError` instead of truncating the plan — so this PR does not touch them.

## Validation

- `backend`: `npm run build` (tsc) — clean
- `backend`: `npx vitest run` — 202 files, 2653 tests passing
- New regression tests confirmed to fail on the pre-fix code and pass on the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)