### PR TITLE
Skip members-only YouTube videos in subscription checks instead of failing (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Replace the high-saturation cyan/red UI palette with a calmer teal-led color scheme and a mode-aware secondary purple (softer violet in light mode, stronger contrast in dark), updating favorite-page gradient accents, the browser theme color, and the web manifest without changing logo assets (#366)
 
+### Fix
+
+- Skip members-only YouTube uploads in subscription checks instead of failing and retrying them every cycle: detect yt-dlp's members-only error, record the upload as skipped, log it informationally, and advance the subscription cursor so the same video isn't re-attempted. Closes #393
+
 ## v1.10.16 (2026-07-13)
 
 ### Feat

--- a/backend/src/__tests__/services/downloadManager.test.ts
+++ b/backend/src/__tests__/services/downloadManager.test.ts
@@ -452,16 +452,15 @@ describe('DownloadManager', () => {
       );
     });
 
-    it('treats members-only failures as skips: no failed row, no fail hook, no retry (issue #393)', async () => {
+    const membersOnlyError = () =>
+      Object.assign(new Error('yt-dlp process exited with code 1'), {
+        stderr:
+          "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n",
+      });
+
+    it('treats members-only subscription failures as skips: no failed row, no fail hook, no retry (issue #393)', async () => {
       const telegram = await import('../../services/telegramService');
-      const membersOnlyError = Object.assign(
-        new Error('yt-dlp process exited with code 1'),
-        {
-          stderr:
-            "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n",
-        },
-      );
-      const mockDownloadFn = vi.fn().mockRejectedValue(membersOnlyError);
+      const mockDownloadFn = vi.fn().mockRejectedValue(membersOnlyError());
       // Auto-retry is enabled to prove members-only is never retried.
       (storageService.getSettings as any).mockReturnValue({
         autoRetryEnabled: true,
@@ -476,6 +475,7 @@ describe('DownloadManager', () => {
           'Members Video',
           'https://youtube.com/watch?v=members',
           'youtube',
+          { sourceKind: 'subscription' },
         ),
       ).rejects.toThrow('yt-dlp process exited with code 1');
       // Flush the fire-and-forget notify path.
@@ -497,6 +497,79 @@ describe('DownloadManager', () => {
         expect.anything(),
       );
       expect(telegram.TelegramService.notifyTaskComplete).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'fail' }),
+      );
+    });
+
+    it('keeps normal failure automation for a manually-queued members-only download (PR #395 review)', async () => {
+      vi.useFakeTimers();
+      try {
+        const telegram = await import('../../services/telegramService');
+        const mockDownloadFn = vi.fn().mockRejectedValue(membersOnlyError());
+        (storageService.getSettings as any).mockReturnValue({
+          autoRetryEnabled: true,
+          autoRetryTimes: 3,
+          autoRetryIntervalMinutes: 1,
+        });
+
+        // No subscription attribution -> this is a manual/admin download.
+        void downloadManager.addDownload(
+          mockDownloadFn,
+          'manual-members-1',
+          'Manual Members Video',
+          'https://youtube.com/watch?v=manual-members',
+          'youtube',
+          { sourceKind: 'manual' },
+        );
+
+        await vi.runOnlyPendingTimersAsync();
+        await Promise.resolve();
+
+        // Manual members-only download retains full failure automation:
+        // a configured auto-retry is scheduled, never silently skipped.
+        expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+          expect.objectContaining({ id: 'manual-members-1', status: 'pending_retry' }),
+        );
+        expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+          expect.objectContaining({ status: 'skipped' }),
+        );
+
+        void telegram;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fires task_fail and records a failed row for a manual members-only download with retry disabled (PR #395 review)', async () => {
+      const telegram = await import('../../services/telegramService');
+      const mockDownloadFn = vi.fn().mockRejectedValue(membersOnlyError());
+      (storageService.getSettings as any).mockReturnValue({ autoRetryEnabled: false });
+
+      await expect(
+        downloadManager.addDownload(
+          mockDownloadFn,
+          'manual-members-2',
+          'Manual Members Video',
+          'https://youtube.com/watch?v=manual-members-2',
+          'youtube',
+          { sourceKind: 'manual' },
+        ),
+      ).rejects.toThrow('yt-dlp process exited with code 1');
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // A manual failure keeps its normal automation: failed row, task_fail
+      // hook, and fail notification all fire.
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'manual-members-2', status: 'failed' }),
+      );
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'skipped' }),
+      );
+      expect(HookService.executeHook).toHaveBeenCalledWith(
+        'task_fail',
+        expect.objectContaining({ taskId: 'manual-members-2' }),
+      );
+      expect(telegram.TelegramService.notifyTaskComplete).toHaveBeenCalledWith(
         expect.objectContaining({ status: 'fail' }),
       );
     });

--- a/backend/src/__tests__/services/downloadManager.test.ts
+++ b/backend/src/__tests__/services/downloadManager.test.ts
@@ -452,6 +452,55 @@ describe('DownloadManager', () => {
       );
     });
 
+    it('treats members-only failures as skips: no failed row, no fail hook, no retry (issue #393)', async () => {
+      const telegram = await import('../../services/telegramService');
+      const membersOnlyError = Object.assign(
+        new Error('yt-dlp process exited with code 1'),
+        {
+          stderr:
+            "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n",
+        },
+      );
+      const mockDownloadFn = vi.fn().mockRejectedValue(membersOnlyError);
+      // Auto-retry is enabled to prove members-only is never retried.
+      (storageService.getSettings as any).mockReturnValue({
+        autoRetryEnabled: true,
+        autoRetryTimes: 3,
+        autoRetryIntervalMinutes: 1,
+      });
+
+      await expect(
+        downloadManager.addDownload(
+          mockDownloadFn,
+          'members-1',
+          'Members Video',
+          'https://youtube.com/watch?v=members',
+          'youtube',
+        ),
+      ).rejects.toThrow('yt-dlp process exited with code 1');
+      // Flush the fire-and-forget notify path.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      // Recorded as a skip, never failed or pending_retry.
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'members-1', status: 'skipped' }),
+      );
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed' }),
+      );
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'pending_retry' }),
+      );
+      // No failure automation fires for a benign skip.
+      expect(HookService.executeHook).not.toHaveBeenCalledWith(
+        'task_fail',
+        expect.anything(),
+      );
+      expect(telegram.TelegramService.notifyTaskComplete).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'fail' }),
+      );
+    });
+
     it('settles awaited tasks that are cancelled while still queued', async () => {
       downloadManager.setMaxConcurrentDownloads(1);
       let releaseFirst: (value: unknown) => void = () => {};

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -329,6 +329,84 @@ describe('SubscriptionService', () => {
       expect(db.update).toHaveBeenCalled();
     });
 
+    it('skips a members-only video and advances the cursor without failing (issue #393)', async () => {
+      const sub = {
+        id: 'sub-members',
+        author: 'Learn Linux TV',
+        platform: 'YouTube',
+        authorUrl: 'url',
+        lastCheck: 0,
+        interval: 10,
+        lastVideoLink: 'old-link',
+      };
+
+      mockBuilder.then = (cb: any) => Promise.resolve([sub]).then(cb);
+
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue('members-link');
+      (downloadService.downloadYouTubeVideo as any).mockRejectedValue(
+        Object.assign(new Error('yt-dlp process exited with code 1'), {
+          stderr:
+            "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n",
+        })
+      );
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(downloadService.downloadYouTubeVideo).toHaveBeenCalled();
+      // Recorded as skipped, never as failed.
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'skipped', subscriptionId: 'sub-members' })
+      );
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed' })
+      );
+      // Cursor advanced so the same upload isn't retried next check.
+      expect(mockBuilder.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastVideoLink: 'members-link' })
+      );
+      // No failure notification is sent for a benign skip.
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
+    });
+
+    it('skips a members-only short and advances the short cursor (issue #393)', async () => {
+      const sub = {
+        id: 'sub-members-short',
+        author: 'Linus Tech Tips',
+        platform: 'YouTube',
+        authorUrl: 'url',
+        lastCheck: 0,
+        interval: 10,
+        lastVideoLink: 'same-link',
+        downloadShorts: 1,
+        lastShortVideoLink: 'old-short',
+      };
+
+      mockBuilder.then = (cb: any) => Promise.resolve([sub]).then(cb);
+
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue('same-link');
+      (YtDlpDownloader.getLatestShortsUrl as any).mockResolvedValue('members-short');
+      (downloadService.downloadYouTubeVideo as any).mockRejectedValue(
+        Object.assign(new Error('yt-dlp process exited with code 1'), {
+          stderr:
+            "ERROR: [youtube] xbxWkOmaqfU: This video is available to this channel's members on level: LTT Members Plus (or any higher level). Join this channel to get access to members-only content and other exclusive perks.\n",
+        })
+      );
+
+      await subscriptionService.checkSubscriptions();
+
+      expect(YtDlpDownloader.getLatestShortsUrl).toHaveBeenCalled();
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'skipped', subscriptionId: 'sub-members-short' })
+      );
+      expect(storageService.addDownloadHistoryItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failed' })
+      );
+      expect(mockBuilder.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastShortVideoLink: 'members-short' })
+      );
+      expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
+    });
+
     it('polls Bilibili collection playlist subscriptions through the collection API', async () => {
       const sub = {
         id: 'bili-playlist-sub',

--- a/backend/src/__tests__/services/subscriptionService.test.ts
+++ b/backend/src/__tests__/services/subscriptionService.test.ts
@@ -407,6 +407,57 @@ describe('SubscriptionService', () => {
       expect(TelegramService.notifyTaskComplete).not.toHaveBeenCalled();
     });
 
+    it('still downloads a new Short after skipping a members-only main video (issue #393)', async () => {
+      const sub = {
+        id: 'sub-members-then-short',
+        author: 'Creator',
+        platform: 'YouTube',
+        authorUrl: 'url',
+        lastCheck: 0,
+        interval: 10,
+        lastVideoLink: 'old-link',
+        downloadShorts: 1,
+        lastShortVideoLink: 'old-short',
+      };
+
+      mockBuilder.then = (cb: any) => Promise.resolve([sub]).then(cb);
+
+      (YtDlpDownloader.getLatestVideoUrl as any).mockResolvedValue('members-link');
+      (YtDlpDownloader.getLatestShortsUrl as any).mockResolvedValue('new-short');
+      (downloadService.downloadYouTubeVideo as any)
+        // Main video: members-only -> skipped.
+        .mockRejectedValueOnce(
+          Object.assign(new Error('yt-dlp process exited with code 1'), {
+            stderr:
+              'ERROR: [youtube] abc: Join this channel to get access to members-only content.\n',
+          })
+        )
+        // Short: a normal public upload downloads successfully.
+        .mockResolvedValueOnce({ videoData: { id: 'short-vid', title: 'New Short' } });
+
+      await subscriptionService.checkSubscriptions();
+
+      // Main upload skipped and cursor advanced.
+      expect(mockBuilder.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastVideoLink: 'members-link' })
+      );
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'skipped' })
+      );
+      // The Short check still ran this cycle and downloaded successfully.
+      expect(YtDlpDownloader.getLatestShortsUrl).toHaveBeenCalled();
+      expect(downloadService.downloadYouTubeVideo).toHaveBeenCalledWith(
+        'new-short',
+        expect.anything()
+      );
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'success', title: 'New Short' })
+      );
+      expect(mockBuilder.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastShortVideoLink: 'new-short' })
+      );
+    });
+
     it('polls Bilibili collection playlist subscriptions through the collection API', async () => {
       const sub = {
         id: 'bili-playlist-sub',

--- a/backend/src/__tests__/utils/errorClassification.test.ts
+++ b/backend/src/__tests__/utils/errorClassification.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { isMembersOnlyError } from "../../utils/ytdlp/errorClassification";
+import { YtDlpExecutionError } from "../../utils/ytdlp/execute";
+
+describe("isMembersOnlyError", () => {
+  it("detects the members-only content error from stderr", () => {
+    const error = new YtDlpExecutionError("yt-dlp process exited with code 1", {
+      stderr:
+        "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n",
+      code: 1,
+    });
+
+    expect(isMembersOnlyError(error)).toBe(true);
+  });
+
+  it("detects the tiered members-only error from stderr", () => {
+    const error = new YtDlpExecutionError("yt-dlp process exited with code 1", {
+      stderr:
+        "ERROR: [youtube] xbxWkOmaqfU: This video is available to this channel's members on level: LTT Members Plus (or any higher level). Join this channel to get access to members-only content and other exclusive perks.\n",
+      code: 1,
+    });
+
+    expect(isMembersOnlyError(error)).toBe(true);
+  });
+
+  it("detects the members-only text carried in the error message", () => {
+    expect(
+      isMembersOnlyError(
+        new Error("Join this channel to get access to members-only content")
+      )
+    ).toBe(true);
+  });
+
+  it("detects a plain string containing the members-only text", () => {
+    expect(isMembersOnlyError("members-only content")).toBe(true);
+  });
+
+  it("unwraps a nested cause / originalError", () => {
+    const inner = new YtDlpExecutionError("boom", {
+      stderr: "members on level: Tier 1",
+    });
+    const wrapper = Object.assign(new Error("Download failed"), {
+      originalError: inner,
+    });
+
+    expect(isMembersOnlyError(wrapper)).toBe(true);
+  });
+
+  it("returns false for unrelated yt-dlp failures", () => {
+    const error = new YtDlpExecutionError("yt-dlp process exited with code 1", {
+      stderr: "ERROR: [youtube] abc: Video unavailable\n",
+      code: 1,
+    });
+
+    expect(isMembersOnlyError(error)).toBe(false);
+  });
+
+  it("returns false for null / undefined / empty input", () => {
+    expect(isMembersOnlyError(null)).toBe(false);
+    expect(isMembersOnlyError(undefined)).toBe(false);
+    expect(isMembersOnlyError("")).toBe(false);
+    expect(isMembersOnlyError(new Error(""))).toBe(false);
+  });
+});

--- a/backend/src/__tests__/utils/ytDlpUtils.test.ts
+++ b/backend/src/__tests__/utils/ytDlpUtils.test.ts
@@ -1776,6 +1776,39 @@ describe("ytDlpUtils", () => {
       });
     });
 
+    it("logs members-only stderr as info, not error, on non-zero exit (issue #393)", async () => {
+      const proc = createMockProcess();
+      mockSpawnWithVersionCheck(proc);
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+      const infoSpy = vi.spyOn(logger, "info").mockImplementation(() => {});
+
+      const membersOnlyStderr =
+        "ERROR: [youtube] v8INHztfIzs: Join this channel to get access to members-only content like this video, and other exclusive perks.\n";
+      const subprocess = executeYtDlpSpawn("https://example.com/video");
+      const promise = Promise.resolve(subprocess);
+      await flushAsyncSpawns();
+      proc.stderr?.emit("data", Buffer.from(membersOnlyStderr));
+      proc.emit("close", 1);
+
+      await expect(promise).rejects.toMatchObject({
+        message: "yt-dlp process exited with code 1",
+        code: 1,
+        stderr: membersOnlyStderr,
+      });
+      // Benign skip: no error-level record for the members-only stderr.
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        "yt-dlp error output:",
+        membersOnlyStderr,
+      );
+      expect(infoSpy).toHaveBeenCalledWith(
+        "yt-dlp skipped members-only content:",
+        membersOnlyStderr,
+      );
+
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
     it("should classify a killed subprocess as cancellation instead of code null", async () => {
       const proc = createMockProcess();
       mockSpawnWithVersionCheck(proc);

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -742,15 +742,20 @@ class DownloadManager {
       }
 
       // Members-only content can never be downloaded without a channel
-      // membership, so this is a benign skip rather than a failure. Log it
-      // informationally and suppress every failure side effect below (retry,
-      // failed-history row, task_fail hook, fail notification); we still reject
-      // so awaiting callers (e.g. the subscription check) can do their own
-      // skip bookkeeping. Detecting it here — before those side effects fire —
-      // is what makes the skip benign (issue #393).
-      const membersOnly = isMembersOnlyError(error);
+      // membership. For *subscription* downloads this is a benign skip rather
+      // than a failure: log it informationally and suppress every failure side
+      // effect below (retry, failed-history row, task_fail hook, fail
+      // notification); we still reject so the subscription check can advance
+      // its own cursor. Detecting it here — before those side effects fire — is
+      // what makes the skip benign (issue #393). Manually-queued downloads keep
+      // their normal failure automation: an admin who explicitly requested a
+      // members-only URL should still see it fail, fire task_fail, and honor
+      // configured auto-retries (PR #395 review).
+      const isSubscriptionTask =
+        task.statistics?.sourceKind === "subscription";
+      const membersOnlySkip = isSubscriptionTask && isMembersOnlyError(error);
 
-      if (membersOnly) {
+      if (membersOnlySkip) {
         logger.info(
           "Skipping members-only content:",
           sanitizeLogMessage(task.title),
@@ -767,9 +772,9 @@ class DownloadManager {
       storageService.removeActiveDownload(task.id);
 
       // Add to history (unless already added by cancelDownload). Members-only
-      // skips are never retried — retrying can't succeed.
+      // subscription skips are never retried — retrying can't succeed.
       let retryScheduled = false;
-      if (!task.cancelled && !membersOnly) {
+      if (!task.cancelled && !membersOnlySkip) {
         retryScheduled = this.maybeScheduleRetry(task, error);
       }
 
@@ -781,12 +786,12 @@ class DownloadManager {
             id: task.id,
             title: task.title,
             finishedAt: Date.now(),
-            status: membersOnly
+            status: membersOnlySkip
               ? "skipped"
               : structuredResult?.partial === true
                 ? PARTIAL_STATUS
                 : "failed",
-            error: membersOnly
+            error: membersOnlySkip
               ? "Skipped members-only content"
               : getErrorMessage(error),
             sourceUrl: task.sourceUrl,
@@ -803,8 +808,8 @@ class DownloadManager {
 
       if (!retryScheduled) {
         // Failure automation (task_fail hook + fail notification) only fires
-        // for genuine failures, not skips.
-        if (!membersOnly) {
+        // for genuine failures, not benign subscription skips.
+        if (!membersOnlySkip) {
           // Await failure hooks so notifications and other side effects complete
           // before the task rejection propagates to callers.
           await awaitTaskFailHook({

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -4,6 +4,7 @@ import {
 } from "../errors/DownloadErrors";
 import { extractSourceVideoId } from "../utils/helpers";
 import { getErrorMessage } from "../utils/errors";
+import { isMembersOnlyError } from "../utils/ytdlp/errorClassification";
 import { sanitizeLogMessage } from "../utils/logger";
 import { CloudStorageService } from "./CloudStorageService";
 import {
@@ -738,6 +739,22 @@ class DownloadManager {
           isCancelledError(error) ? error : DownloadCancelledError.create(),
         );
         return;
+      }
+
+      // Members-only content can never be downloaded without a channel
+      // membership, so this is a benign skip rather than a failure. Log it
+      // informationally and suppress every failure side effect below (retry,
+      // failed-history row, task_fail hook, fail notification); we still reject
+      // so awaiting callers (e.g. the subscription check) can do their own
+      // skip bookkeeping. Detecting it here — before those side effects fire —
+      // is what makes the skip benign (issue #393).
+      const membersOnly = isMembersOnlyError(error);
+
+      if (membersOnly) {
+        logger.info(
+          "Skipping members-only content:",
+          sanitizeLogMessage(task.title),
+        );
       } else {
         logger.error(
           "Error downloading task:",
@@ -749,9 +766,10 @@ class DownloadManager {
       // Download failed
       storageService.removeActiveDownload(task.id);
 
-      // Add to history (unless already added by cancelDownload)
+      // Add to history (unless already added by cancelDownload). Members-only
+      // skips are never retried — retrying can't succeed.
       let retryScheduled = false;
-      if (!task.cancelled) {
+      if (!task.cancelled && !membersOnly) {
         retryScheduled = this.maybeScheduleRetry(task, error);
       }
 
@@ -763,8 +781,14 @@ class DownloadManager {
             id: task.id,
             title: task.title,
             finishedAt: Date.now(),
-            status: structuredResult?.partial === true ? PARTIAL_STATUS : "failed",
-            error: getErrorMessage(error),
+            status: membersOnly
+              ? "skipped"
+              : structuredResult?.partial === true
+                ? PARTIAL_STATUS
+                : "failed",
+            error: membersOnly
+              ? "Skipped members-only content"
+              : getErrorMessage(error),
             sourceUrl: task.sourceUrl,
             platform: platformFromUrl(task.sourceUrl),
             sourceKind: task.statistics?.sourceKind ?? "unknown",
@@ -778,25 +802,29 @@ class DownloadManager {
       }
 
       if (!retryScheduled) {
-        // Await failure hooks so notifications and other side effects complete
-        // before the task rejection propagates to callers.
-        await awaitTaskFailHook({
-          taskId: task.id,
-          taskTitle: task.title,
-          sourceUrl: task.sourceUrl,
-          status: "fail",
-          error: getErrorMessage(error),
-        });
+        // Failure automation (task_fail hook + fail notification) only fires
+        // for genuine failures, not skips.
+        if (!membersOnly) {
+          // Await failure hooks so notifications and other side effects complete
+          // before the task rejection propagates to callers.
+          await awaitTaskFailHook({
+            taskId: task.id,
+            taskTitle: task.title,
+            sourceUrl: task.sourceUrl,
+            status: "fail",
+            error: getErrorMessage(error),
+          });
 
-        if (!task.options?.suppressCompletionNotification) {
-          import("./telegramService").then(({ TelegramService }) =>
-            TelegramService.notifyTaskComplete({
-              taskTitle: task.title,
-              status: "fail",
-              sourceUrl: task.sourceUrl,
-              error: getErrorMessage(error),
-            })
-          ).catch(() => {});
+          if (!task.options?.suppressCompletionNotification) {
+            import("./telegramService").then(({ TelegramService }) =>
+              TelegramService.notifyTaskComplete({
+                taskTitle: task.title,
+                status: "fail",
+                sourceUrl: task.sourceUrl,
+                error: getErrorMessage(error),
+              })
+            ).catch(() => {});
+          }
         }
 
         task.reject(error);

--- a/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
+++ b/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
@@ -34,6 +34,7 @@ import {
   getUserYtDlpConfig,
   InvalidProxyError,
 } from "../../../utils/ytDlpUtils";
+import { isMembersOnlyError } from "../../../utils/ytdlp/errorClassification";
 import {
   pathExistsSafeSync,
   removeSafe,
@@ -607,13 +608,26 @@ export async function downloadVideo(
   } catch (error) {
     releaseOutputReservation?.();
     releaseOutputReservation = null;
-    logger.error(
-      "Error in download process:",
-      error,
-      typeof (error as { stderr?: unknown })?.stderr === "string"
-        ? { stderr: (error as { stderr: string }).stderr }
-        : undefined,
-    );
+    // Members-only content is an expected, benign skip rather than a real
+    // failure (issue #393). Keep it out of the error log so the subscription
+    // path stays informational-only; callers classify the thrown error the
+    // same way and record it as skipped.
+    if (isMembersOnlyError(error)) {
+      logger.info(
+        "Skipping members-only content in download process:",
+        typeof (error as { stderr?: unknown })?.stderr === "string"
+          ? (error as { stderr: string }).stderr
+          : getErrorMessage(error, "members-only content"),
+      );
+    } else {
+      logger.error(
+        "Error in download process:",
+        error,
+        typeof (error as { stderr?: unknown })?.stderr === "string"
+          ? { stderr: (error as { stderr: string }).stderr }
+          : undefined,
+      );
+    }
     throw error;
   }
 

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -898,7 +898,9 @@ export class SubscriptionService {
 
           // Members-only uploads can't be fetched without a channel membership,
           // so retrying every check is pointless. Treat them as skipped and
-          // advance the cursor instead of failing the check (issue #393).
+          // advance the cursor instead of failing the check (issue #393). Fall
+          // through (no return) so an independent new Short is still checked
+          // this cycle, matching the ordinary-failure path below.
           if (isMembersOnlyError(downloadError)) {
             await this.markSubscriptionVideoSkipped(
               sub,
@@ -906,42 +908,41 @@ export class SubscriptionService {
               "video",
               "members-only"
             );
-            return;
+          } else {
+            logger.error(
+              "Error downloading subscription video",
+              downloadError,
+              getSubscriptionLogContext(sub, { latestVideoUrl })
+            );
+            notifySubscriptionDownloadResult({
+              taskTitle: `Video from ${sub.author}`,
+              status: "fail",
+              sourceUrl: latestVideoUrl,
+              error: errorMessage,
+            });
+
+            // Add to download history on failure
+            storageService.addDownloadHistoryItem({
+              id: uuidv4(),
+              title: `Video from ${sub.author}`,
+              author: sub.author,
+              sourceUrl: latestVideoUrl,
+              finishedAt: Date.now(),
+              status: "failed",
+              error: errorMessage,
+              subscriptionId: sub.id,
+              platform:
+                typeof sub.platform === "string"
+                  ? sub.platform.toLowerCase()
+                  : undefined,
+              sourceKind: "subscription",
+            });
+            checkStatus = "fail";
+            checkFailureReason = bucketDownloadError(errorMessage);
+
+            // Note: We already updated lastCheck, so we won't retry until next interval.
+            // This acts as a "backoff" preventing retry loops for broken downloads.
           }
-
-          logger.error(
-            "Error downloading subscription video",
-            downloadError,
-            getSubscriptionLogContext(sub, { latestVideoUrl })
-          );
-          notifySubscriptionDownloadResult({
-            taskTitle: `Video from ${sub.author}`,
-            status: "fail",
-            sourceUrl: latestVideoUrl,
-            error: errorMessage,
-          });
-
-          // Add to download history on failure
-          storageService.addDownloadHistoryItem({
-            id: uuidv4(),
-            title: `Video from ${sub.author}`,
-            author: sub.author,
-            sourceUrl: latestVideoUrl,
-            finishedAt: Date.now(),
-            status: "failed",
-            error: errorMessage,
-            subscriptionId: sub.id,
-            platform:
-              typeof sub.platform === "string"
-                ? sub.platform.toLowerCase()
-                : undefined,
-            sourceKind: "subscription",
-          });
-          checkStatus = "fail";
-          checkFailureReason = bucketDownloadError(errorMessage);
-
-          // Note: We already updated lastCheck, so we won't retry until next interval.
-          // This acts as a "backoff" preventing retry loops for broken downloads.
         }
       } else {
         // Just update lastCheck.

--- a/backend/src/services/subscriptionService.ts
+++ b/backend/src/services/subscriptionService.ts
@@ -20,6 +20,7 @@ import {
 } from "../utils/helpers";
 import { logger } from "../utils/logger";
 import { runWithConcurrencyLimit } from "../utils/concurrency";
+import { isMembersOnlyError } from "../utils/ytdlp/errorClassification";
 import downloadManager from "./downloadManager";
 import {
     downloadSingleBilibiliPart,
@@ -895,6 +896,19 @@ export class SubscriptionService {
             return;
           }
 
+          // Members-only uploads can't be fetched without a channel membership,
+          // so retrying every check is pointless. Treat them as skipped and
+          // advance the cursor instead of failing the check (issue #393).
+          if (isMembersOnlyError(downloadError)) {
+            await this.markSubscriptionVideoSkipped(
+              sub,
+              latestVideoUrl,
+              "video",
+              "members-only"
+            );
+            return;
+          }
+
           logger.error(
             "Error downloading subscription video",
             downloadError,
@@ -1043,6 +1057,19 @@ export class SubscriptionService {
               getSubscriptionLogContext(sub, { latestShortUrl })
             );
           } catch (downloadError: unknown) {
+            // Members-only shorts can't be fetched without a channel
+            // membership; skip and advance the cursor rather than failing
+            // and retrying every check (issue #393).
+            if (!shortDownloaded && isMembersOnlyError(downloadError)) {
+              await this.markSubscriptionVideoSkipped(
+                sub,
+                latestShortUrl,
+                "short",
+                "members-only"
+              );
+              return;
+            }
+
             logger.error(
               shortDownloaded
                 ? "Error updating subscription after short download"
@@ -1121,6 +1148,64 @@ export class SubscriptionService {
         // statistics is best-effort
       }
     }
+  }
+
+  /**
+   * Record a subscription upload that cannot be downloaded (currently only
+   * members-only YouTube videos) as skipped and advance the subscription's
+   * cursor so the same upload isn't retried on every check (issue #393).
+   *
+   * The download genuinely failed at yt-dlp, but retrying is pointless without
+   * a channel membership, so we treat it as a benign skip rather than a
+   * failure: an informational log, a "skipped" history row, and a cursor bump.
+   * The subscription's downloadCount is intentionally left unchanged since
+   * nothing was downloaded.
+   */
+  private async markSubscriptionVideoSkipped(
+    sub: Subscription,
+    videoUrl: string,
+    kind: "video" | "short",
+    reason: string
+  ): Promise<void> {
+    logger.info(
+      `Skipping members-only ${kind} for subscription; marking as processed`,
+      getSubscriptionLogContext(sub, { videoUrl, reason })
+    );
+
+    const cursorUpdate =
+      kind === "short"
+        ? { lastShortVideoLink: videoUrl }
+        : { lastVideoLink: videoUrl };
+
+    const updateResult = await db
+      .update(subscriptions)
+      .set(cursorUpdate)
+      .where(eq(subscriptions.id, sub.id))
+      .returning({ id: subscriptions.id });
+
+    if (updateResult.length === 0) {
+      logger.warn(
+        "Subscription was deleted before members-only skip could be recorded",
+        getSubscriptionLogContext(sub, { videoUrl })
+      );
+      return;
+    }
+
+    storageService.addDownloadHistoryItem({
+      id: uuidv4(),
+      title: `${kind === "short" ? "Short" : "Video"} from ${sub.author}`,
+      author: sub.author,
+      sourceUrl: videoUrl,
+      finishedAt: Date.now(),
+      status: "skipped",
+      error: `Skipped ${reason} content`,
+      subscriptionId: sub.id,
+      platform:
+        typeof sub.platform === "string"
+          ? sub.platform.toLowerCase()
+          : undefined,
+      sourceKind: "subscription",
+    });
   }
 
   /**

--- a/backend/src/utils/ytDlpUtils.ts
+++ b/backend/src/utils/ytDlpUtils.ts
@@ -16,6 +16,7 @@ export {
   downloadChannelAvatar,
   executeYtDlpSpawn,
 } from "./ytdlp/execute";
+export { isMembersOnlyError } from "./ytdlp/errorClassification";
 export {
   parseYtDlpConfig,
   getUserYtDlpConfig,

--- a/backend/src/utils/ytdlp/errorClassification.ts
+++ b/backend/src/utils/ytdlp/errorClassification.ts
@@ -1,0 +1,58 @@
+/**
+ * Classification helpers for yt-dlp failures.
+ *
+ * Kept intentionally dependency-light (no spawn/install imports) so any service
+ * can import it without pulling in the full yt-dlp runtime.
+ */
+
+// yt-dlp emits one of these fragments when a video is gated behind a channel
+// membership. The exact wording varies by membership tier / video, so match on
+// the stable substrings rather than the whole message. Examples:
+//   "Join this channel to get access to members-only content like this video…"
+//   "This video is available to this channel's members on level: … Join this
+//    channel to get access to members-only content and other exclusive perks."
+const MEMBERS_ONLY_ERROR_NEEDLES = [
+  "members-only content",
+  "join this channel to get access",
+  "members on level",
+] as const;
+
+/**
+ * Collect the human-readable text carried by an error into a single string.
+ *
+ * yt-dlp reports failures on stderr while exiting non-zero, so the resulting
+ * error carries the useful detail on `stderr` rather than in `message`. Walk
+ * `message`, `stderr`, and any nested `cause`/`originalError` (bounded depth)
+ * so classification is robust to wrapping.
+ */
+function collectErrorText(error: unknown, depth = 0): string {
+  if (error == null || depth > 3) return "";
+  if (typeof error === "string") return error;
+  if (typeof error !== "object") return String(error);
+
+  const err = error as {
+    message?: unknown;
+    stderr?: unknown;
+    cause?: unknown;
+    originalError?: unknown;
+  };
+
+  const parts: string[] = [];
+  if (typeof err.message === "string") parts.push(err.message);
+  if (typeof err.stderr === "string") parts.push(err.stderr);
+  if (err.cause) parts.push(collectErrorText(err.cause, depth + 1));
+  if (err.originalError) parts.push(collectErrorText(err.originalError, depth + 1));
+  return parts.join("\n");
+}
+
+/**
+ * Detect whether a yt-dlp failure was caused by members-only content.
+ *
+ * Such videos can never be downloaded without an authenticated channel
+ * membership, so callers should treat them as skipped rather than retrying.
+ */
+export function isMembersOnlyError(error: unknown): boolean {
+  const haystack = collectErrorText(error).toLowerCase();
+  if (!haystack) return false;
+  return MEMBERS_ONLY_ERROR_NEEDLES.some((needle) => haystack.includes(needle));
+}

--- a/backend/src/utils/ytdlp/execute.ts
+++ b/backend/src/utils/ytdlp/execute.ts
@@ -17,6 +17,7 @@ import {
   withDefaultYouTubeExtractorArgs,
 } from "./extractorArgs";
 import { flagsToArgs } from "./flags";
+import { isMembersOnlyError } from "./errorClassification";
 import { logger } from "../logger";
 
 /**
@@ -535,7 +536,14 @@ export function executeYtDlpSpawn(
                 );
               } else {
                 rejected = true;
-                logger.error("yt-dlp error output:", stderr);
+                // Members-only content is an expected, benign skip rather than
+                // a real failure — keep it out of the error log so the
+                // subscription path stays informational-only (issue #393).
+                if (isMembersOnlyError(stderr)) {
+                  logger.info("yt-dlp skipped members-only content:", stderr);
+                } else {
+                  logger.error("yt-dlp error output:", stderr);
+                }
                 reject(
                   new YtDlpExecutionError(
                     signal


### PR DESCRIPTION
## Summary

Closes #393.

Subscription checks treated yt-dlp's members-only error as a plain download failure. Because the subscription cursor (`lastVideoLink`) was only advanced on success, the same gated upload was re-attempted — and re-failed — on **every** subscription check, spamming error logs and fail notifications.

This detects the members-only case and treats it as a benign **skip** instead: informational log, a `"skipped"` history row, and a cursor bump so it isn't retried.

## Changes

- **`isMembersOnlyError()`** (`backend/src/utils/ytdlp/errorClassification.ts`) — new dependency-light classifier. yt-dlp reports members-only failures on **stderr** (the error's `.message` is just `"exited with code 1"`), so it walks `message`, `stderr`, and any nested `cause`/`originalError`, matching the stable fragments `members-only content`, `join this channel to get access`, and `members on level`.
- **`markSubscriptionVideoSkipped()`** (`subscriptionService.ts`) — records a `"skipped"` download-history row, advances `lastVideoLink`/`lastShortVideoLink`, and logs informationally. `downloadCount` is left unchanged since nothing was downloaded; no failure notification is sent.
- Wired into both the **main-video** and **shorts** subscription download catch blocks. Playlist subscriptions share the main-video path, so they're covered too.

## The four requested changes

- [x] Detect yt-dlp members-only errors
- [x] Return a "skipped" result
- [x] Log an informational message instead of an error
- [x] Mark the subscription as processed so the same video isn't retried

## Testing

- `tsc --noEmit` clean.
- 7 new unit tests for the classifier (using the exact error strings from the issue) + 2 new subscription integration tests asserting skip-and-advance for videos and shorts.
- Full backend suite: **2664 passing**.

## Scope note

Twitch subscriber-only VODs go through a separate path (`processTwitchSubscriptionVideosImpl`) and emit different errors, so they're intentionally left out to match the issue's scope. Easy to extend later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
