### PR TITLE
fix: mobile kebab menu wrapping + hide lock button when auto-delete off

### DIFF
--- a/frontend/src/components/VideoCard/VideoCardActions.tsx
+++ b/frontend/src/components/VideoCard/VideoCardActions.tsx
@@ -4,6 +4,7 @@ import { useCollection } from '../../contexts/CollectionContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useSnackbar } from '../../contexts/SnackbarContext';
 import { useVideoActions, useVideoTags } from '../../contexts/VideoContext';
+import { useSettings } from '../../hooks/useSettings';
 import { useShareVideo } from '../../hooks/useShareVideo';
 import { Video } from '../../types';
 import { neutral, overlay } from '../../theme/colors';
@@ -53,6 +54,7 @@ export const VideoCardActions: React.FC<VideoCardActionsProps> = ({
     const { availableTags } = useVideoTags();
     const { handleShare } = useShareVideo(video);
     const { showSnackbar } = useSnackbar();
+    const { data: settings } = useSettings();
     const [showCollectionModal, setShowCollectionModal] = React.useState(false);
     const [showTagsModal, setShowTagsModal] = React.useState(false);
     const [isTogglingLock, setIsTogglingLock] = React.useState(false);
@@ -127,7 +129,7 @@ export const VideoCardActions: React.FC<VideoCardActionsProps> = ({
                     isTogglingVisibility={isTogglingVisibility}
                     onToggleVisibility={handleToggleVisibility}
                     isTogglingLock={isTogglingLock}
-                    onToggleLock={handleToggleLock}
+                    onToggleLock={settings?.autoDeleteEnabled ? handleToggleLock : undefined}
                     isLocked={isLocked}
                     onAddTag={() => setShowTagsModal(true)}
                     video={video}

--- a/frontend/src/components/VideoCard/__tests__/VideoCardActions.test.tsx
+++ b/frontend/src/components/VideoCard/__tests__/VideoCardActions.test.tsx
@@ -37,6 +37,13 @@ vi.mock('../../../contexts/SnackbarContext', () => ({
     useSnackbar: () => ({ showSnackbar: mockShowSnackbar }),
 }));
 
+// Auto-delete master toggle gates the lock/unlock button; default enabled so
+// the existing lock tests exercise the button. Override per test.
+let mockAutoDeleteEnabled = true;
+vi.mock('../../../hooks/useSettings', () => ({
+    useSettings: () => ({ data: { autoDeleteEnabled: mockAutoDeleteEnabled } }),
+}));
+
 const mockUpdateVideo = vi.fn();
 // Mock child components that trigger complex logic or portals
 vi.mock('../../../contexts/VideoContext', () => {
@@ -120,6 +127,7 @@ describe('VideoCardActions', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockUpdateVideo.mockResolvedValue({ success: true });
+        mockAutoDeleteEnabled = true;
     });
 
     it('should render actions when hovered', () => {
@@ -192,6 +200,15 @@ describe('VideoCardActions', () => {
         await user.click(screen.getByText('Lock Video'));
 
         expect(mockShowSnackbar).toHaveBeenCalledWith('lock failed', 'error');
+    });
+
+    it('should hide the lock button when auto-delete is disabled', () => {
+        mockAutoDeleteEnabled = false;
+        render(<VideoCardActions {...defaultProps} />);
+
+        expect(screen.getByTestId('kebab-menu')).toBeInTheDocument();
+        expect(screen.queryByText('Lock Video')).not.toBeInTheDocument();
+        expect(screen.queryByText('Unlock Video')).not.toBeInTheDocument();
     });
 
     it('should open delete modal', async () => {

--- a/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenu.tsx
+++ b/frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenu.tsx
@@ -97,7 +97,12 @@ const VideoKebabMenu: React.FC<VideoKebabMenuProps> = ({
                 }
             }}
         >
-            <Stack direction="row" spacing={2} sx={{ justifyContent: 'flex-end' }}>
+            <Stack
+                direction="row"
+                spacing={2}
+                useFlexGap
+                sx={{ flexWrap: 'wrap', justifyContent: 'center', maxWidth: 240 }}
+            >
                 <Tooltip title={t('playWith')} disableHoverListener={isTouch}>
                     <Button
                         variant="outlined"

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -598,7 +598,7 @@ const VideoPlayer: React.FC = () => {
                             onSubscribe={handleSubscribe}
                             onUnsubscribe={handleUnsubscribe}
                             onToggleVisibility={handleToggleVisibility}
-                            onToggleLock={handleToggleLock}
+                            onToggleLock={settings?.autoDeleteEnabled ? handleToggleLock : undefined}
                         />
 
                         {(video.source === 'youtube' || video.source === 'bilibili') && (


### PR DESCRIPTION
## Summary
Two related touch-ups to the video action controls:

### 1. Wrap the mobile action menu onto 2 lines
On mobile, tapping the ⋮ (MoreVert) button on the video player opens a menu that laid out up to 7 action buttons in a single non-wrapping row, overflowing narrow screens. The button `Stack` in `VideoKebabMenu.tsx` now uses `flexWrap: 'wrap'` + `useFlexGap` with a capped width, so the full set breaks into two lines (4 + 3) while smaller sets stay on one line.

### 2. Hide the lock/unlock button when auto-delete is disabled
The lock/unlock action only protects a video from the auto-delete sweep, so it is meaningless when the `autoDeleteEnabled` master toggle (off by default) is disabled. The `onToggleLock` prop is now gated on `settings.autoDeleteEnabled` at both consumers — the video player page (`VideoPlayer.tsx`) and the card action buttons (`VideoCardActions.tsx`) — which hides the button in the desktop action row, the mobile kebab menu, and the card overlay menu.

## Changes
- `frontend/src/components/VideoPlayer/VideoInfo/VideoKebabMenu.tsx`: wrap the action-button row.
- `frontend/src/pages/VideoPlayer.tsx`: gate `onToggleLock` on `autoDeleteEnabled`.
- `frontend/src/components/VideoCard/VideoCardActions.tsx`: read `useSettings` and gate `onToggleLock`.
- `frontend/src/components/VideoCard/__tests__/VideoCardActions.test.tsx`: mock `useSettings` and add a disabled-case test.

## Testing
- `tsc --noEmit` passes with no errors.
- `VideoCardActions` suite 17/17 pass (incl. new disabled-case test); `VideoPlayer`, `VideoKebabMenu`, `VideoInfo` suites 67/67 pass.
- In-browser verification of the exact mobile states was not run as it requires the backend and seeded data; the changes are contained layout/prop-gating tweaks.

### Note
If a video was locked earlier and auto-delete is then turned off, its `autoDeleteLocked` flag remains in the DB but the unlock button is hidden. This is harmless — the flag has no effect while auto-delete is off, and the button returns if the feature is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)