### PR TITLE
fix(missav): stop rejecting valid locale/route paths as SSRF

### DIFF
--- a/backend/src/__tests__/services/downloaders/missavNavigation.test.ts
+++ b/backend/src/__tests__/services/downloaders/missavNavigation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { buildSafeMissAvNavigationTarget } from '../../../services/downloaders/missav/navigation';
+
+describe('buildSafeMissAvNavigationTarget', () => {
+  it('keeps a route prefix plus language segment', () => {
+    expect(
+      buildSafeMissAvNavigationTarget('https://missav.ai/dm9/cn/tysf-026-uncensored-leak').url,
+    ).toBe('https://missav.ai/dm9/cn/tysf-026-uncensored-leak');
+    expect(
+      buildSafeMissAvNavigationTarget('https://missav.ai/dm30/en/juq-819-uncensored-leak').url,
+    ).toBe('https://missav.ai/dm30/en/juq-819-uncensored-leak');
+  });
+
+  it('keeps language segments that are not part of any hardcoded list', () => {
+    for (const language of ['cn', 'zh', 'ja', 'ko', 'th', 'fil', 'pt-br']) {
+      expect(
+        buildSafeMissAvNavigationTarget(`https://missav.ws/${language}/san-467`).url,
+      ).toBe(`https://missav.ws/${language}/san-467`);
+    }
+  });
+
+  it('keeps routed /v/ paths on every mirror, not just 123av-style hosts', () => {
+    expect(buildSafeMissAvNavigationTarget('https://123av.com/en/v/fc2-ppv-2683017').url).toBe(
+      'https://123av.com/en/v/fc2-ppv-2683017',
+    );
+    expect(buildSafeMissAvNavigationTarget('https://javxx.com/en/v/fc2-ppv-2683017').url).toBe(
+      'https://javxx.com/en/v/fc2-ppv-2683017',
+    );
+    expect(buildSafeMissAvNavigationTarget('https://njavtv.com/cn/v/fc2-ppv-2683017').url).toBe(
+      'https://njavtv.com/cn/v/fc2-ppv-2683017',
+    );
+    expect(buildSafeMissAvNavigationTarget('https://missav.ai/v/fc2-ppv-1627274').url).toBe(
+      'https://missav.ai/v/fc2-ppv-1627274',
+    );
+  });
+
+  it('accepts bare and single-prefix video paths', () => {
+    expect(buildSafeMissAvNavigationTarget('https://missav.ai/fc2-ppv-1627274').url).toBe(
+      'https://missav.ai/fc2-ppv-1627274',
+    );
+    expect(buildSafeMissAvNavigationTarget('https://missav.ai/en/fc2-ppv-1627274').url).toBe(
+      'https://missav.ai/en/fc2-ppv-1627274',
+    );
+  });
+
+  it('re-pins subdomains and lowercases route segments onto the allowlisted origin', () => {
+    const target = buildSafeMissAvNavigationTarget('https://www.missav.ai/DM9/CN/tysf-026');
+    expect(target.origin).toBe('https://missav.ai');
+    expect(target.url).toBe('https://missav.ai/dm9/cn/tysf-026');
+  });
+
+  it('drops query strings and fragments', () => {
+    expect(
+      buildSafeMissAvNavigationTarget('https://missav.ai/dm9/cn/tysf-026?next=//evil.test#x').url,
+    ).toBe('https://missav.ai/dm9/cn/tysf-026');
+  });
+
+  it('rejects paths that are deeper than a video page', () => {
+    expect(() =>
+      buildSafeMissAvNavigationTarget('https://missav.ai/a/dm9/cn/tysf-026'),
+    ).toThrow('Invalid MissAV video path');
+  });
+
+  it('rejects unexpected characters in route segments', () => {
+    expect(() => buildSafeMissAvNavigationTarget('https://missav.ai/dm9%2F/tysf-026')).toThrow(
+      'Invalid MissAV route segment',
+    );
+  });
+
+  it('collapses traversal segments instead of following them', () => {
+    // The URL parser resolves "..", so the rebuilt path can never climb out.
+    expect(buildSafeMissAvNavigationTarget('https://missav.ai/dm9/../tysf-026').url).toBe(
+      'https://missav.ai/tysf-026',
+    );
+  });
+
+  it('rejects foreign hosts, credentials and ports', () => {
+    expect(() => buildSafeMissAvNavigationTarget('https://evil.test/dm9/cn/tysf-026')).toThrow(
+      'Hostname evil.test is not allowed',
+    );
+    expect(() =>
+      buildSafeMissAvNavigationTarget('https://user:pass@missav.ai/dm9/cn/tysf-026'),
+    ).toThrow('credentials or explicit ports');
+    expect(() => buildSafeMissAvNavigationTarget('https://missav.ai:8080/dm9/cn/tysf-026')).toThrow(
+      'credentials or explicit ports',
+    );
+    expect(() => buildSafeMissAvNavigationTarget('file:///etc/passwd')).toThrow(
+      'Unsupported protocol',
+    );
+  });
+
+  it('rejects an empty or malformed video id', () => {
+    expect(() => buildSafeMissAvNavigationTarget('https://missav.ai/')).toThrow(
+      'Invalid MissAV video path',
+    );
+    expect(() => buildSafeMissAvNavigationTarget('https://missav.ai/dm9/cn/tysf 026')).toThrow(
+      'Invalid MissAV video path',
+    );
+  });
+});

--- a/backend/src/services/downloaders/missav/constants.ts
+++ b/backend/src/services/downloaders/missav/constants.ts
@@ -1,19 +1,6 @@
 export const YT_DLP_PATH = process.env.YT_DLP_PATH || "yt-dlp";
 export const MISSAV_PROGRESS_LOG_INTERVAL_MS = 10_000;
 
-export const ALLOWED_MISSAV_LANGUAGE_SEGMENTS = new Set(["en", "ja", "zh", "ko"]);
-export const ALLOWED_ROUTED_VIDEO_LANGUAGE_SEGMENTS = new Set([
-  ...ALLOWED_MISSAV_LANGUAGE_SEGMENTS,
-  "th",
-  "ms",
-  "de",
-  "fr",
-  "vi",
-  "id",
-  "fil",
-  "hi",
-]);
-
 export const MISSAV_NAVIGATION_ORIGINS: Record<string, string> = {
   "missav.com": "https://missav.com",
   "missav.ai": "https://missav.ai",
@@ -40,6 +27,11 @@ export const PUPPETEER_LINUX_EXECUTABLE_PATHS = [
 export const MISSAV_BROWSER_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36";
 export const MISSAV_BROWSER_ACCEPT_LANGUAGE = "en-US,en;q=0.9";
-export const MISSAV_ROUTE_PREFIX_PATTERN = /^[a-zA-Z0-9_-]{2,20}$/;
+// MissAV-style video URLs are at most three segments deep: an optional route
+// prefix and/or language segment followed by the video id, e.g.
+// /dm9/cn/tysf-026-uncensored-leak, /en/fc2-ppv-1627274 or /en/v/fc2-ppv-2683017.
+export const MISSAV_MAX_VIDEO_PATH_PREFIX_SEGMENTS = 2;
+export const MISSAV_PATH_PREFIX_SEGMENT_PATTERN = /^[a-z0-9_-]{1,20}$/;
+export const MISSAV_VIDEO_ID_PATTERN = /^[a-zA-Z0-9_-]{2,120}$/;
 export const MISSAV_CLOUDFLARE_CHALLENGE_PATTERN =
   /cf-turnstile|Just a moment|security verification|challenge-platform/i;

--- a/backend/src/services/downloaders/missav/navigation.ts
+++ b/backend/src/services/downloaders/missav/navigation.ts
@@ -1,9 +1,9 @@
 import {
-  ALLOWED_MISSAV_LANGUAGE_SEGMENTS,
-  ALLOWED_ROUTED_VIDEO_LANGUAGE_SEGMENTS,
   MISSAV_CLOUDFLARE_CHALLENGE_PATTERN,
+  MISSAV_MAX_VIDEO_PATH_PREFIX_SEGMENTS,
   MISSAV_NAVIGATION_ORIGINS,
-  MISSAV_ROUTE_PREFIX_PATTERN,
+  MISSAV_PATH_PREFIX_SEGMENT_PATTERN,
+  MISSAV_VIDEO_ID_PATTERN,
 } from "./constants";
 
 export function isCloudflareChallengeHtml(html: string): boolean {
@@ -44,10 +44,6 @@ function getCanonicalMissAvHost(hostname: string): string | null {
   return null;
 }
 
-function usesRoutedVideoPath(canonicalHost: string): boolean {
-  return canonicalHost.startsWith("123av.") || canonicalHost === "javxx.com";
-}
-
 export function buildSafeMissAvNavigationTarget(url: string): {
   origin: string;
   path: string;
@@ -74,85 +70,37 @@ export function buildSafeMissAvNavigationTarget(url: string): {
   }
 
   const videoId = pathSegments[pathSegments.length - 1];
-  if (!videoId || !/^[a-zA-Z0-9_-]{2,120}$/.test(videoId)) {
+  if (!videoId || !MISSAV_VIDEO_ID_PATTERN.test(videoId)) {
     throw new Error(
       `SSRF protection: Invalid MissAV video path in URL: ${parsedUrl.pathname}`,
     );
   }
 
-  if (
-    usesRoutedVideoPath(canonicalHost) &&
-    pathSegments[pathSegments.length - 2]?.toLowerCase() === "v"
-  ) {
-    const prefixSegments = pathSegments.slice(0, -2);
-    if (prefixSegments.length > 1) {
-      throw new Error(
-        `SSRF protection: Invalid routed video path in URL: ${parsedUrl.pathname}`,
-      );
-    }
-
-    const normalizedRouteLanguage =
-      prefixSegments.length === 1 ? prefixSegments[0].toLowerCase() : null;
-    if (
-      normalizedRouteLanguage &&
-      !ALLOWED_ROUTED_VIDEO_LANGUAGE_SEGMENTS.has(normalizedRouteLanguage)
-    ) {
-      throw new Error(
-        `SSRF protection: Invalid routed video language segment in URL: ${parsedUrl.pathname}`,
-      );
-    }
-
-    const encodedVideoId = encodeURIComponent(videoId);
-    const safeOrigin = MISSAV_NAVIGATION_ORIGINS[canonicalHost];
-    if (!safeOrigin) {
-      throw new Error(
-        `SSRF protection: Hostname ${canonicalHost} has no allowed navigation origin.`,
-      );
-    }
-
-    const path = normalizedRouteLanguage
-      ? `/${normalizedRouteLanguage}/v/${encodedVideoId}`
-      : `/v/${encodedVideoId}`;
-    return {
-      origin: safeOrigin,
-      path,
-      url: `${safeOrigin}${path}`,
-    };
-  }
-
-  const maybeLanguage = pathSegments[pathSegments.length - 2]?.toLowerCase();
-  const normalizedLanguage =
-    maybeLanguage && ALLOWED_MISSAV_LANGUAGE_SEGMENTS.has(maybeLanguage)
-      ? maybeLanguage
-      : null;
-  const prefixSegments = normalizedLanguage
-    ? pathSegments.slice(0, -2)
-    : pathSegments.slice(0, -1);
-  if (prefixSegments.length > 1) {
+  // Everything before the video id is a route prefix and/or a language segment
+  // (e.g. /dm9/cn/<id>, /en/v/<id>, /cn/<id>). The exact segments differ per
+  // mirror and per locale, so they are validated by shape rather than against a
+  // fixed list, and the result is always re-pinned to an allow-listed origin.
+  const prefixSegments = pathSegments.slice(0, -1);
+  if (prefixSegments.length > MISSAV_MAX_VIDEO_PATH_PREFIX_SEGMENTS) {
     throw new Error(
       `SSRF protection: Invalid MissAV video path in URL: ${parsedUrl.pathname}`,
     );
   }
 
-  let normalizedRoutePrefix: string | null = null;
-  if (prefixSegments.length === 1) {
-    const candidatePrefix = prefixSegments[0]?.toLowerCase();
-    if (!candidatePrefix || !MISSAV_ROUTE_PREFIX_PATTERN.test(candidatePrefix)) {
-      throw new Error(
-        `SSRF protection: Invalid MissAV route prefix in URL: ${parsedUrl.pathname}`,
-      );
-    }
-    normalizedRoutePrefix = candidatePrefix;
+  const normalizedPrefixSegments = prefixSegments.map((segment) =>
+    segment.toLowerCase(),
+  );
+  const invalidPrefixSegment = normalizedPrefixSegments.find(
+    (segment) => !MISSAV_PATH_PREFIX_SEGMENT_PATTERN.test(segment),
+  );
+  if (invalidPrefixSegment !== undefined) {
+    throw new Error(
+      `SSRF protection: Invalid MissAV route segment "${invalidPrefixSegment}" in URL: ${parsedUrl.pathname}`,
+    );
   }
 
   const encodedVideoId = encodeURIComponent(videoId);
-  const safePath = normalizedRoutePrefix
-    ? normalizedLanguage
-      ? `/${normalizedRoutePrefix}/${normalizedLanguage}/${encodedVideoId}`
-      : `/${normalizedRoutePrefix}/${encodedVideoId}`
-    : normalizedLanguage
-      ? `/${normalizedLanguage}/${encodedVideoId}`
-      : `/${encodedVideoId}`;
+  const safePath = `/${[...normalizedPrefixSegments, encodedVideoId].join("/")}`;
 
   const safeOrigin = MISSAV_NAVIGATION_ORIGINS[canonicalHost];
   if (!safeOrigin) {


### PR DESCRIPTION
## Problem

Downloading a MissAV URL whose path contains a `/cn/` language segment always failed before the browser ever opened:

```
SSRF protection: Invalid MissAV video path in URL: /dm9/cn/tysf-026-uncensored-leak
```

`buildSafeMissAvNavigationTarget` decided whether the segment before the video id was a language by looking it up in a hardcoded set — `{en, ja, zh, ko}`. `cn` was missing, so `dm9` **and** `cn` were both counted as route prefixes, which tripped the "at most one prefix segment" rule and threw. Every `/cn/` video URL was affected.

Two instances of the same class of bug were next to it:

- The `/v/` route form was only honored when the host was `123av.*` or `javxx.com`, so `https://njavtv.com/en/v/<id>` — identical shape, different mirror — hit the same error.
- Those hosts had a *second*, longer locale list (`th, ms, de, fr, vi, id, fil, hi`); anything outside it failed too.

The lists were a guess about which locale slugs the site serves, and the site serves more than were listed.

## Fix

Validate the path by **shape** instead of by locale enumeration:

- at most 2 segments before the video id — covers `/dm9/cn/<id>`, `/en/v/<id>`, `/cn/<id>`, `/<id>`
- each prefix segment must match `^[a-z0-9_-]{1,20}$` (lowercased)
- video id unchanged: `^[a-zA-Z0-9_-]{2,120}$`, URL-encoded
- path rebuilt onto the origin from the fixed host map

This also drops the host-specific `/v/` branch, so all mirrors behave the same. The rejection message now names the offending segment rather than blaming the whole path.

### SSRF properties are unchanged

The guarantees that matter all still apply: host pinned to the allow-list map, non-http(s) protocols rejected, credentials/explicit ports rejected, per-segment charset enforced, path depth bounded, query and fragment stripped. What was removed is only the locale guess — it never contributed to containment, it just broke legitimate downloads. Net effect on reachable pages is a few extra 3-segment paths *on an already-allow-listed origin*.

## Tests

New `backend/src/__tests__/services/downloaders/missavNavigation.test.ts` — 11 cases covering the reported URL, arbitrary locales, `/v/` on every mirror, subdomain re-pinning, query/fragment stripping, and rejections (foreign host, credentials, port, non-http protocol, over-deep path, bad charset).

- MissAV suites + helpers: **119 passed**
- Backend downloaders/controllers/utils sweep: **1126 passed, 4 failed** — all 4 in `ytdlpHelpers.test.ts`, which fails identically on a clean checkout of `master`. Pre-existing and unrelated.
- `tsc --noEmit`: clean

Not verified: whether a download then completes end to end. The MissAV tests mock Puppeteer and a real run depends on the Cloudflare challenge, so this is verified up to producing the correct navigation URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
