### PR TITLE
fix(bilibili): resolve b23.tv short links so author avatars download

### DIFF
--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -101,7 +101,11 @@ vi.mock("../../utils/helpers", () => ({
     platform: url.includes("bilibili") ? "bilibili" : url.includes("missav") ? "missav" : "youtube",
   })),
   resolveShortUrl: vi.fn(async (url: string) => url),
-  targetsNonFirstBilibiliPart: vi.fn((url: string) => /[?&]p=(?!1(?:&|$))\d+/.test(url)),
+  getBilibiliPartNumber: vi.fn((url: string) => {
+    const match = /[?&]p=(\d+)/.exec(url);
+    const part = match ? Number(match[1]) : 0;
+    return part > 0 ? part : null;
+  }),
   trimBilibiliUrl: vi.fn((url: string) => url),
 }));
 vi.mock("fs-extra");
@@ -142,9 +146,8 @@ describe("VideoController", () => {
     (storageService.checkVideoDownloadBySourceId as any) = vi.fn().mockReturnValue({
       found: false,
     });
-    (storageService.checkVideoDownloadByUrl as any) = vi.fn().mockReturnValue({
-      found: false,
-    });
+    // Per-part fallback for Bilibili duplicate detection: no saved part by default.
+    (storageService.getVideoBySourceUrl as any) = vi.fn().mockReturnValue(undefined);
     (storageService.getSettings as any) = vi.fn().mockReturnValue({
       dontSkipDeletedVideo: false,
     });

--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -101,6 +101,12 @@ vi.mock("../../utils/helpers", () => ({
     platform: url.includes("bilibili") ? "bilibili" : url.includes("missav") ? "missav" : "youtube",
   })),
   resolveShortUrl: vi.fn(async (url: string) => url),
+  bilibiliPartSourceUrlAliases: vi.fn((url: string) => {
+    const base = url.split("?")[0];
+    const m = /[?&]p=(\d+)/.exec(url);
+    const part = m ? Number(m[1]) : 1;
+    return part === 1 ? [base, base + "?p=1"] : [base + "?p=" + part];
+  }),
   getBilibiliPartNumber: vi.fn((url: string) => {
     const match = /[?&]p=(\d+)/.exec(url);
     const part = match ? Number(match[1]) : 0;

--- a/backend/src/__tests__/controllers/videoController.test.ts
+++ b/backend/src/__tests__/controllers/videoController.test.ts
@@ -101,6 +101,7 @@ vi.mock("../../utils/helpers", () => ({
     platform: url.includes("bilibili") ? "bilibili" : url.includes("missav") ? "missav" : "youtube",
   })),
   resolveShortUrl: vi.fn(async (url: string) => url),
+  targetsNonFirstBilibiliPart: vi.fn((url: string) => /[?&]p=(?!1(?:&|$))\d+/.test(url)),
   trimBilibiliUrl: vi.fn((url: string) => url),
 }));
 vi.mock("fs-extra");
@@ -139,6 +140,9 @@ describe("VideoController", () => {
       shouldForce: false,
     });
     (storageService.checkVideoDownloadBySourceId as any) = vi.fn().mockReturnValue({
+      found: false,
+    });
+    (storageService.checkVideoDownloadByUrl as any) = vi.fn().mockReturnValue({
       found: false,
     });
     (storageService.getSettings as any) = vi.fn().mockReturnValue({

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -26,6 +26,7 @@ import {
   isValidUrl,
   processVideoUrl,
   resolveShortUrl,
+  targetsNonFirstBilibiliPart,
   trimBilibiliUrl,
 } from "../../utils/helpers";
 import { validateUrl } from "../../utils/security";
@@ -52,6 +53,7 @@ vi.mock("../../services/downloadService", () => ({
 
 vi.mock("../../services/storageService", () => ({
   checkVideoDownloadBySourceId: vi.fn(),
+  checkVideoDownloadByUrl: vi.fn(),
   verifyVideoExists: vi.fn(),
   getVideoById: vi.fn(),
   getSettings: vi.fn(),
@@ -101,6 +103,7 @@ vi.mock("../../utils/helpers", () => ({
   isValidUrl: vi.fn(),
   processVideoUrl: vi.fn(),
   resolveShortUrl: vi.fn(),
+  targetsNonFirstBilibiliPart: vi.fn(() => false),
   trimBilibiliUrl: vi.fn((url: string) => url),
 }));
 
@@ -283,6 +286,84 @@ describe("videoDownloadController extra coverage", () => {
       "https://youtube.com/watch?v=status123"
     );
     expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus keys a multipart part on its part URL, not the BV id", async () => {
+    // Every part of a multipart video shares one source video id, so an
+    // id-keyed lookup would report part 2 as downloaded because part 1 exists.
+    req.query = { url: "https://www.bilibili.com/video/BV1x?p=2" } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://www.bilibili.com/video/BV1x?p=2",
+      sourceVideoId: "BV1x",
+      platform: "bilibili",
+    } as any);
+    vi.mocked(isBilibiliUrl).mockReturnValue(true);
+    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(true);
+    vi.mocked(storageService.checkVideoDownloadByUrl).mockReturnValue({
+      found: false,
+    } as any);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "part-1-video",
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.checkVideoDownloadByUrl).toHaveBeenCalledWith(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "video"
+    );
+    expect(storageService.checkVideoDownloadBySourceId).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus still keys a bare bilibili URL on the source id", async () => {
+    req.query = { url: "https://www.bilibili.com/video/BV1x" } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://www.bilibili.com/video/BV1x",
+      sourceVideoId: "BV1x",
+      platform: "bilibili",
+    } as any);
+    vi.mocked(isBilibiliUrl).mockReturnValue(true);
+    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(false);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
+      "BV1x",
+      "bilibili",
+      "video"
+    );
+    expect(storageService.checkVideoDownloadByUrl).not.toHaveBeenCalled();
+  });
+
+  it("checkVideoDownloadStatus scopes the part lookup to the audio media type", async () => {
+    req.query = {
+      url: "https://www.bilibili.com/video/BV1x?p=2",
+      audioOnly: "true",
+    } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://www.bilibili.com/video/BV1x?p=2",
+      sourceVideoId: "BV1x",
+      platform: "bilibili",
+    } as any);
+    vi.mocked(isBilibiliUrl).mockReturnValue(true);
+    vi.mocked(isMissAVUrl).mockReturnValue(false);
+    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(true);
+    vi.mocked(storageService.checkVideoDownloadByUrl).mockReturnValue({
+      found: false,
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.checkVideoDownloadByUrl).toHaveBeenCalledWith(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "audio"
+    );
   });
 
   it("checkVideoDownloadStatus throws when url is missing", async () => {

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -482,16 +482,15 @@ describe("videoDownloadController extra coverage", () => {
 
     expect(
       storageService.getLatestDeletedHistoryItemBySourceUrl
-    ).toHaveBeenCalledWith("https://www.bilibili.com/video/BV1x?p=2");
+    ).toHaveBeenCalledWith("https://www.bilibili.com/video/BV1x?p=2", "video");
     expect(json).toHaveBeenCalledWith(
       expect.objectContaining({ found: true, status: "deleted" })
     );
   });
 
-  it("checkVideoDownloadStatus does not let a deleted video suppress a first audio request", async () => {
-    // History rows carry no media type, so a deleted video item would otherwise
-    // match an audio request for the same part. The tracking lookup is media
-    // scoped, and its absence means nothing audio was ever downloaded here.
+  it("checkVideoDownloadStatus scopes the deleted-part tombstone to the requested media type", async () => {
+    // A deleted video item must not suppress a first-time audio request for the
+    // same part, even when an audio tracking row exists via a sibling part.
     req.query = {
       url: "https://www.bilibili.com/video/BV1x?p=2",
       audioOnly: "true",
@@ -503,19 +502,24 @@ describe("videoDownloadController extra coverage", () => {
     } as any);
     vi.mocked(isBilibiliUrl).mockReturnValue(true);
     vi.mocked(isMissAVUrl).mockReturnValue(false);
+    // Audio part 1 survives, so the source-level audio row is found.
     vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
-      found: false,
+      found: true,
+      status: "exists",
+      videoId: "audio-part-1",
+      sourceUrl: "https://www.bilibili.com/video/BV1x?p=1",
     } as any);
     vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    // Only a video tombstone exists for part 2; the audio-scoped query misses.
     vi.mocked(
       storageService.getLatestDeletedHistoryItemBySourceUrl
-    ).mockReturnValue({ title: "Deleted video item" } as any);
+    ).mockReturnValue(undefined);
 
     await checkVideoDownloadStatus(req as Request, res as Response);
 
     expect(
       storageService.getLatestDeletedHistoryItemBySourceUrl
-    ).not.toHaveBeenCalled();
+    ).toHaveBeenCalledWith("https://www.bilibili.com/video/BV1x?p=2", "audio");
     expect(json).toHaveBeenCalledWith({ found: false });
   });
 

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -101,6 +101,12 @@ vi.mock("../../utils/helpers", () => ({
   isTwitchVideoUrl: vi.fn(),
   isYouTubeUrl: vi.fn(),
   isValidUrl: vi.fn(),
+  bilibiliPartSourceUrlAliases: vi.fn((url: string) => {
+    const base = url.split("?")[0];
+    const m = /[?&]p=(\d+)/.exec(url);
+    const part = m ? Number(m[1]) : 1;
+    return part === 1 ? [base, base + "?p=1"] : [base + "?p=" + part];
+  }),
   getBilibiliPartNumber: vi.fn((url: string) => {
     const match = /[?&]p=(\d+)/.exec(url);
     const part = match ? Number(match[1]) : 0;

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -343,13 +343,18 @@ describe("videoDownloadController extra coverage", () => {
       "https://www.bilibili.com/video/BV1x?p=1",
       "https://www.bilibili.com/video/BV1x?p=2"
     );
-    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue({
-      id: "part-1-video",
-      title: "Part One",
-      author: "Author",
-      sourceUrl: "https://www.bilibili.com/video/BV1x?p=1",
-      createdAt: "2024-01-01T00:00:00.000Z",
-    } as any);
+    vi.mocked(storageService.getVideoBySourceUrl).mockImplementation(
+      (url: string) =>
+        url === "https://www.bilibili.com/video/BV1x?p=1"
+          ? ({
+              id: "part-1-video",
+              title: "Part One",
+              author: "Author",
+              sourceUrl: "https://www.bilibili.com/video/BV1x?p=1",
+              createdAt: "2024-01-01T00:00:00.000Z",
+            } as any)
+          : undefined
+    );
     vi.mocked(storageService.verifyVideoExists).mockReturnValue({
       exists: true,
       video: { id: "part-1-video", title: "Part One" },
@@ -367,6 +372,79 @@ describe("videoDownloadController extra coverage", () => {
     expect(json).toHaveBeenCalledWith(
       expect.objectContaining({ found: true, videoId: "part-1-video" })
     );
+  });
+
+  it("checkVideoDownloadStatus does not trust the tracking row's representative videoId", async () => {
+    // persistDownloadedMediaIdentity keeps videoId on the lowest-numbered
+    // surviving part while sourceUrl follows the last saved one, so the row can
+    // read ?p=2 while pointing at part 1. Returning it would permanently skip
+    // re-downloading a deleted part 2.
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "https://www.bilibili.com/video/BV1x?p=2"
+    );
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "part-1-video",
+      sourceUrl: "https://www.bilibili.com/video/BV1x?p=2",
+    } as any);
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus still reports a deleted part from the tracking row", async () => {
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "https://www.bilibili.com/video/BV1x?p=2"
+    );
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: true,
+      status: "deleted",
+      title: "Part Two",
+      author: "Author",
+      sourceUrl: "https://www.bilibili.com/video/BV1x?p=2",
+    } as any);
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    // Nothing on disk to verify; the deleted status comes from the tracking row.
+    vi.mocked(storageService.verifyVideoExists).mockReturnValue({} as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ found: true, status: "deleted" })
+    );
+  });
+
+  it("checkVideoDownloadStatus matches part 1 stored under either canonical alias", async () => {
+    // Saved from a bare URL, later requested as ?p=1 (and vice versa).
+    for (const [requested, stored] of [
+      ["https://www.bilibili.com/video/BV1x?p=1", "https://www.bilibili.com/video/BV1x"],
+      ["https://www.bilibili.com/video/BV1x", "https://www.bilibili.com/video/BV1x?p=1"],
+    ]) {
+      vi.clearAllMocks();
+      arrangeBilibiliPartCheck(requested, "https://www.bilibili.com/video/BV1x?p=3");
+      vi.mocked(storageService.getVideoBySourceUrl).mockImplementation(
+        (url: string) =>
+          url === stored ? ({ id: "part-1-video", title: "One" } as any) : undefined
+      );
+      vi.mocked(storageService.verifyVideoExists).mockReturnValue({
+        exists: true,
+        video: { id: "part-1-video", title: "One" },
+      } as any);
+      vi.mocked(storageService.getVideoById).mockReturnValue({
+        id: "part-1-video",
+      } as any);
+
+      await checkVideoDownloadStatus(req as Request, res as Response);
+
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ found: true, videoId: "part-1-video" })
+      );
+    }
   });
 
   it("checkVideoDownloadStatus scopes the per-part fallback to the media type", async () => {

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -335,6 +335,59 @@ describe("videoDownloadController extra coverage", () => {
     expect(json).toHaveBeenCalledWith({ found: false });
   });
 
+  it("checkVideoDownloadStatus finds a part the tracking row has forgotten", async () => {
+    // The tracking row's sourceUrl is overwritten by whichever part was saved
+    // last, so after parts 1 and 2 it only remembers ?p=2. Part 1 still exists
+    // as its own video row and must not be re-downloaded.
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      "https://www.bilibili.com/video/BV1x?p=2"
+    );
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue({
+      id: "part-1-video",
+      title: "Part One",
+      author: "Author",
+      sourceUrl: "https://www.bilibili.com/video/BV1x?p=1",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    } as any);
+    vi.mocked(storageService.verifyVideoExists).mockReturnValue({
+      exists: true,
+      video: { id: "part-1-video", title: "Part One" },
+    } as any);
+    vi.mocked(storageService.getVideoById).mockReturnValue({
+      id: "part-1-video",
+    } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.getVideoBySourceUrl).toHaveBeenCalledWith(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      "video"
+    );
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ found: true, videoId: "part-1-video" })
+    );
+  });
+
+  it("checkVideoDownloadStatus scopes the per-part fallback to the media type", async () => {
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      "https://www.bilibili.com/video/BV1x?p=2"
+    );
+    req.query = {
+      url: "https://www.bilibili.com/video/BV1x?p=1",
+      audioOnly: "true",
+    } as any;
+    vi.mocked(isMissAVUrl).mockReturnValue(false);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(storageService.getVideoBySourceUrl).toHaveBeenCalledWith(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      "audio"
+    );
+  });
+
   it("checkVideoDownloadStatus treats a bare URL and ?p=1 as the same part", async () => {
     arrangeBilibiliPartCheck(
       "https://www.bilibili.com/video/BV1x?p=1",

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -482,6 +482,37 @@ describe("videoDownloadController extra coverage", () => {
     );
   });
 
+  it("checkVideoDownloadStatus does not let a deleted video suppress a first audio request", async () => {
+    // History rows carry no media type, so a deleted video item would otherwise
+    // match an audio request for the same part. The tracking lookup is media
+    // scoped, and its absence means nothing audio was ever downloaded here.
+    req.query = {
+      url: "https://www.bilibili.com/video/BV1x?p=2",
+      audioOnly: "true",
+    } as any;
+    vi.mocked(processVideoUrl).mockResolvedValue({
+      videoUrl: "https://www.bilibili.com/video/BV1x?p=2",
+      sourceVideoId: "BV1x",
+      platform: "bilibili",
+    } as any);
+    vi.mocked(isBilibiliUrl).mockReturnValue(true);
+    vi.mocked(isMissAVUrl).mockReturnValue(false);
+    vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+      found: false,
+    } as any);
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    vi.mocked(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).mockReturnValue({ title: "Deleted video item" } as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
   it("checkVideoDownloadStatus treats a part with no history as new", async () => {
     arrangeBilibiliPartCheck(
       "https://www.bilibili.com/video/BV1x?p=2",

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -60,6 +60,7 @@ vi.mock("../../services/storageService", () => ({
   addDownloadHistoryItem: vi.fn(),
   getActiveDownload: vi.fn(),
   getLatestRetryHistoryItemBySourceUrl: vi.fn(),
+  getLatestDeletedHistoryItemBySourceUrl: vi.fn(),
   updateActiveDownloadTitle: vi.fn(),
   addActiveDownload: vi.fn(),
   getVideoBySourceUrl: vi.fn(),
@@ -152,6 +153,10 @@ describe("videoDownloadController extra coverage", () => {
       title: "Parts Title",
     } as any);
     vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    // No per-item tombstone by default; tests opt into a deleted part.
+    vi.mocked(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).mockReturnValue(undefined);
     vi.mocked(storageService.getCollectionsByVideoId).mockReturnValue([]);
     vi.mocked(storageService.getCollectionById).mockReturnValue({
       id: "col-download",
@@ -447,6 +452,51 @@ describe("videoDownloadController extra coverage", () => {
     }
   });
 
+  it("checkVideoDownloadStatus reports a part deleted from history when the tracking row moved on", async () => {
+    // Deleting part 2 hands the shared tracking row to surviving part 1 and
+    // leaves it reading "exists", so only the per-item history row records that
+    // part 2 was downloaded and then deleted.
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "https://www.bilibili.com/video/BV1x?p=1"
+    );
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    vi.mocked(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).mockReturnValue({
+      title: "Part Two",
+      author: "Author",
+      videoId: "part-2-video",
+      downloadedAt: 1000,
+      deletedAt: 2000,
+    } as any);
+    vi.mocked(storageService.verifyVideoExists).mockReturnValue({} as any);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).toHaveBeenCalledWith("https://www.bilibili.com/video/BV1x?p=2");
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ found: true, status: "deleted" })
+    );
+  });
+
+  it("checkVideoDownloadStatus treats a part with no history as new", async () => {
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "https://www.bilibili.com/video/BV1x?p=1"
+    );
+    vi.mocked(storageService.getVideoBySourceUrl).mockReturnValue(undefined);
+    vi.mocked(
+      storageService.getLatestDeletedHistoryItemBySourceUrl
+    ).mockReturnValue(undefined);
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
   it("checkVideoDownloadStatus scopes the per-part fallback to the media type", async () => {
     arrangeBilibiliPartCheck(
       "https://www.bilibili.com/video/BV1x?p=1",
@@ -466,26 +516,8 @@ describe("videoDownloadController extra coverage", () => {
     );
   });
 
-  it("checkVideoDownloadStatus treats a bare URL and ?p=1 as the same part", async () => {
-    arrangeBilibiliPartCheck(
-      "https://www.bilibili.com/video/BV1x?p=1",
-      "https://www.bilibili.com/video/BV1x"
-    );
-    vi.mocked(storageService.verifyVideoExists).mockReturnValue({
-      found: true,
-      status: "exists",
-      videoId: "other-part-video",
-    } as any);
-    vi.mocked(storageService.getVideoById).mockReturnValue({
-      id: "other-part-video",
-    } as any);
-
-    await checkVideoDownloadStatus(req as Request, res as Response);
-
-    expect(json).toHaveBeenCalledWith(
-      expect.objectContaining({ found: true })
-    );
-  });
+  // The bare/?p=1 equivalence is covered by "matches part 1 stored under either
+  // canonical alias" above, which asserts both directions with explicit rows.
 
   it("checkVideoDownloadStatus leaves non-bilibili lookups untouched", async () => {
     req.query = { url: "https://youtube.com/watch?v=abc" } as any;

--- a/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
+++ b/backend/src/__tests__/controllers/videoDownloadController.extra.test.ts
@@ -26,7 +26,6 @@ import {
   isValidUrl,
   processVideoUrl,
   resolveShortUrl,
-  targetsNonFirstBilibiliPart,
   trimBilibiliUrl,
 } from "../../utils/helpers";
 import { validateUrl } from "../../utils/security";
@@ -101,9 +100,13 @@ vi.mock("../../utils/helpers", () => ({
   isTwitchVideoUrl: vi.fn(),
   isYouTubeUrl: vi.fn(),
   isValidUrl: vi.fn(),
+  getBilibiliPartNumber: vi.fn((url: string) => {
+    const match = /[?&]p=(\d+)/.exec(url);
+    const part = match ? Number(match[1]) : 0;
+    return part > 0 ? part : null;
+  }),
   processVideoUrl: vi.fn(),
   resolveShortUrl: vi.fn(),
-  targetsNonFirstBilibiliPart: vi.fn(() => false),
   trimBilibiliUrl: vi.fn((url: string) => url),
 }));
 
@@ -288,45 +291,79 @@ describe("videoDownloadController extra coverage", () => {
     expect(json).toHaveBeenCalledWith({ found: false });
   });
 
-  it("checkVideoDownloadStatus keys a multipart part on its part URL, not the BV id", async () => {
-    // Every part of a multipart video shares one source video id, so an
-    // id-keyed lookup would report part 2 as downloaded because part 1 exists.
-    req.query = { url: "https://www.bilibili.com/video/BV1x?p=2" } as any;
+  // Every part of a multipart Bilibili video shares one tracking row, so the
+  // id-keyed lookup alone cannot tell which part it matched.
+  const arrangeBilibiliPartCheck = (
+    requestedUrl: string,
+    matchedSourceUrl: string
+  ) => {
+    req.query = { url: requestedUrl } as any;
     vi.mocked(processVideoUrl).mockResolvedValue({
-      videoUrl: "https://www.bilibili.com/video/BV1x?p=2",
+      videoUrl: requestedUrl,
       sourceVideoId: "BV1x",
       platform: "bilibili",
     } as any);
     vi.mocked(isBilibiliUrl).mockReturnValue(true);
-    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(true);
-    vi.mocked(storageService.checkVideoDownloadByUrl).mockReturnValue({
-      found: false,
-    } as any);
     vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
       found: true,
       status: "exists",
-      videoId: "part-1-video",
+      videoId: "other-part-video",
+      sourceUrl: matchedSourceUrl,
+    } as any);
+  };
+
+  it("checkVideoDownloadStatus does not report part 2 as downloaded when only part 1 exists", async () => {
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      "https://www.bilibili.com/video/BV1x?p=1"
+    );
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus does not report part 1 as downloaded when only part 2 exists", async () => {
+    // The reverse direction: a bare URL is part 1, and the row is part 2.
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x",
+      "https://www.bilibili.com/video/BV1x?p=2"
+    );
+
+    await checkVideoDownloadStatus(req as Request, res as Response);
+
+    expect(json).toHaveBeenCalledWith({ found: false });
+  });
+
+  it("checkVideoDownloadStatus treats a bare URL and ?p=1 as the same part", async () => {
+    arrangeBilibiliPartCheck(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      "https://www.bilibili.com/video/BV1x"
+    );
+    vi.mocked(storageService.verifyVideoExists).mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "other-part-video",
+    } as any);
+    vi.mocked(storageService.getVideoById).mockReturnValue({
+      id: "other-part-video",
     } as any);
 
     await checkVideoDownloadStatus(req as Request, res as Response);
 
-    expect(storageService.checkVideoDownloadByUrl).toHaveBeenCalledWith(
-      "https://www.bilibili.com/video/BV1x?p=2",
-      "video"
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ found: true })
     );
-    expect(storageService.checkVideoDownloadBySourceId).not.toHaveBeenCalled();
-    expect(json).toHaveBeenCalledWith({ found: false });
   });
 
-  it("checkVideoDownloadStatus still keys a bare bilibili URL on the source id", async () => {
-    req.query = { url: "https://www.bilibili.com/video/BV1x" } as any;
+  it("checkVideoDownloadStatus leaves non-bilibili lookups untouched", async () => {
+    req.query = { url: "https://youtube.com/watch?v=abc" } as any;
     vi.mocked(processVideoUrl).mockResolvedValue({
-      videoUrl: "https://www.bilibili.com/video/BV1x",
-      sourceVideoId: "BV1x",
-      platform: "bilibili",
+      videoUrl: "https://youtube.com/watch?v=abc",
+      sourceVideoId: "abc",
+      platform: "youtube",
     } as any);
-    vi.mocked(isBilibiliUrl).mockReturnValue(true);
-    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(false);
+    vi.mocked(isBilibiliUrl).mockReturnValue(false);
     vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
       found: false,
     } as any);
@@ -334,36 +371,11 @@ describe("videoDownloadController extra coverage", () => {
     await checkVideoDownloadStatus(req as Request, res as Response);
 
     expect(storageService.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
-      "BV1x",
-      "bilibili",
+      "abc",
+      "youtube",
       "video"
     );
-    expect(storageService.checkVideoDownloadByUrl).not.toHaveBeenCalled();
-  });
-
-  it("checkVideoDownloadStatus scopes the part lookup to the audio media type", async () => {
-    req.query = {
-      url: "https://www.bilibili.com/video/BV1x?p=2",
-      audioOnly: "true",
-    } as any;
-    vi.mocked(processVideoUrl).mockResolvedValue({
-      videoUrl: "https://www.bilibili.com/video/BV1x?p=2",
-      sourceVideoId: "BV1x",
-      platform: "bilibili",
-    } as any);
-    vi.mocked(isBilibiliUrl).mockReturnValue(true);
-    vi.mocked(isMissAVUrl).mockReturnValue(false);
-    vi.mocked(targetsNonFirstBilibiliPart).mockReturnValue(true);
-    vi.mocked(storageService.checkVideoDownloadByUrl).mockReturnValue({
-      found: false,
-    } as any);
-
-    await checkVideoDownloadStatus(req as Request, res as Response);
-
-    expect(storageService.checkVideoDownloadByUrl).toHaveBeenCalledWith(
-      "https://www.bilibili.com/video/BV1x?p=2",
-      "audio"
-    );
+    expect(json).toHaveBeenCalledWith({ found: false });
   });
 
   it("checkVideoDownloadStatus throws when url is missing", async () => {

--- a/backend/src/__tests__/services/bilibiliDownloadTask.test.ts
+++ b/backend/src/__tests__/services/bilibiliDownloadTask.test.ts
@@ -110,6 +110,7 @@ describe("buildBilibiliDownloadTask multipart collection handling", () => {
       skippedCount: 0,
       failedPartNumbers: [],
       firstVideo: { id: "v2" },
+      downloadedVideos: [{ id: "v2" }],
     });
   });
 
@@ -125,6 +126,7 @@ describe("buildBilibiliDownloadTask multipart collection handling", () => {
     const result = await runMultipartTask();
 
     expect(result.success).toBe(true);
+    expect(result.downloadedVideos).toEqual([{ id: "v1" }, { id: "v2" }]);
     expect(mocks.saveCollection).toHaveBeenCalledTimes(1);
     expect(mocks.saveCollection).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/backend/src/__tests__/services/continuousDownload/videoUrlFetcher.test.ts
+++ b/backend/src/__tests__/services/continuousDownload/videoUrlFetcher.test.ts
@@ -415,7 +415,14 @@ describe('VideoUrlFetcher', () => {
         'https://www.bilibili.com/video/BV111',
         'https://www.bilibili.com/video/BV222',
       ]);
-      expect(bilibiliCollection.getCollectionVideos).toHaveBeenCalledWith(100, 200);
+      // Trailing args are the fetch options and the per-subscription config
+      // override, both absent here.
+      expect(bilibiliCollection.getCollectionVideos).toHaveBeenCalledWith(
+        100,
+        200,
+        undefined,
+        undefined,
+      );
     });
 
     it('should resolve series videos and apply incremental slicing', async () => {
@@ -440,7 +447,12 @@ describe('VideoUrlFetcher', () => {
       );
 
       expect(urls).toEqual(['https://www.bilibili.com/video/BV2']);
-      expect(bilibiliCollection.getSeriesVideos).toHaveBeenCalledWith(300, 400);
+      expect(bilibiliCollection.getSeriesVideos).toHaveBeenCalledWith(
+        300,
+        400,
+        undefined,
+        undefined,
+      );
     });
 
     it('should throw on unsupported collection type from bilibili metadata', async () => {

--- a/backend/src/__tests__/services/downloadManager.test.ts
+++ b/backend/src/__tests__/services/downloadManager.test.ts
@@ -953,6 +953,69 @@ describe('DownloadManager', () => {
       );
     });
 
+    it('should record history for parts saved before an aggregate task was cancelled', async () => {
+      // The parts already on disk are real library items. Only their success
+      // rows can later become deletion tombstones — the task-level row written
+      // on cancel is a "failed" one and never can.
+      // The cancel is finalized while the download is still running, so the
+      // partial result only arrives afterwards — hold it until then.
+      let finishAggregate: (value: unknown) => void = () => {};
+      const aggregateFn = vi.fn().mockImplementation((registerCancel: any) => {
+        registerCancel(() => {});
+        return new Promise((resolve) => {
+          finishAggregate = resolve;
+        });
+      });
+
+      const running = downloadManager.addDownload(
+        aggregateFn,
+        'cancel-aggregate',
+        'Cancelled collection',
+        'https://www.bilibili.com/video/BV1cc',
+        'bilibili',
+      );
+      await waitForQueue();
+
+      await downloadManager.cancelDownload('cancel-aggregate');
+      await expect(running).rejects.toThrow();
+
+      finishAggregate({
+        success: false,
+        partial: true,
+        error: 'Cancelled mid-collection',
+        downloadedVideos: [
+          {
+            id: 'saved-part-1',
+            title: 'Part 1',
+            sourceUrl: 'https://www.bilibili.com/video/BV1cc?p=1',
+            partNumber: 1,
+          },
+          {
+            id: 'saved-part-2',
+            title: 'Part 2',
+            sourceUrl: 'https://www.bilibili.com/video/BV1cc?p=2',
+            partNumber: 2,
+          },
+        ],
+      });
+      await waitForQueue();
+
+      for (const [id, videoId, sourceUrl] of [
+        ['cancel-aggregate:part-1', 'saved-part-1', 'https://www.bilibili.com/video/BV1cc?p=1'],
+        ['cancel-aggregate:part-2', 'saved-part-2', 'https://www.bilibili.com/video/BV1cc?p=2'],
+      ]) {
+        expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id,
+            videoId,
+            sourceUrl,
+            status: 'success',
+            mediaType: 'video',
+          }),
+        );
+      }
+    });
+
     it('should not record failure handling when a cancelled task later rejects', async () => {
       let rejectDownload: (error: Error) => void = () => {};
       const cancelCleanup = vi.fn().mockResolvedValue(undefined);

--- a/backend/src/__tests__/services/downloadManager.test.ts
+++ b/backend/src/__tests__/services/downloadManager.test.ts
@@ -305,6 +305,52 @@ describe('DownloadManager', () => {
       );
     });
 
+    it('should record history for every newly downloaded multipart video', async () => {
+      const part1 = {
+        id: 'video-part-1',
+        title: 'Series Episode 1',
+        sourceUrl: 'https://www.bilibili.com/video/BV1zz?p=1',
+        partNumber: 1,
+        totalParts: 2,
+      };
+      const part2 = {
+        id: 'video-part-2',
+        title: 'Series Episode 2',
+        sourceUrl: 'https://www.bilibili.com/video/BV1zz?p=2',
+        partNumber: 2,
+        totalParts: 2,
+      };
+
+      await downloadManager.addDownload(
+        vi.fn().mockResolvedValue({
+          success: true,
+          partial: false,
+          video: part1,
+          downloadedVideos: [part1, part2],
+        }),
+        'multipart-history',
+        'Multipart Bilibili',
+        'https://www.bilibili.com/video/BV1zz',
+        'bilibili',
+      );
+
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'multipart-history',
+          videoId: 'video-part-1',
+          status: 'success',
+        }),
+      );
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'multipart-history:part-2',
+          videoId: 'video-part-2',
+          sourceUrl: 'https://www.bilibili.com/video/BV1zz?p=2',
+          status: 'success',
+        }),
+      );
+    });
+
     it('should queue downloads when at max concurrent limit', async () => {
       // Create 4 downloads (default limit is 3)
       const downloads = Array.from({ length: 4 }, (_, i) => ({
@@ -1077,10 +1123,24 @@ describe('DownloadManager', () => {
             failedPartNumbers: [3],
             error: 'Bilibili multipart incomplete',
             video: {
-              id: 'video-partial',
+              id: 'video-partial-2',
               title: 'Bilibili Video',
-              sourceUrl: 'https://www.bilibili.com/video/BV1xx',
+              sourceUrl: 'https://www.bilibili.com/video/BV1xx?p=2',
             },
+            downloadedVideos: [
+              {
+                id: 'video-partial-1',
+                title: 'Part 1',
+                sourceUrl: 'https://www.bilibili.com/video/BV1xx?p=1',
+                partNumber: 1,
+              },
+              {
+                id: 'video-partial-2',
+                title: 'Part 2',
+                sourceUrl: 'https://www.bilibili.com/video/BV1xx?p=2',
+                partNumber: 2,
+              },
+            ],
           }),
           'partial-1',
           'Partial task',
@@ -1095,6 +1155,13 @@ describe('DownloadManager', () => {
           id: 'partial-1',
           status: 'partial',
           error: 'Bilibili multipart incomplete',
+        }),
+      );
+      expect(storageService.addDownloadHistoryItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'partial-1:part-2',
+          videoId: 'video-partial-2',
+          status: 'success',
         }),
       );
       expect(HookService.executeHook).toHaveBeenCalledWith(

--- a/backend/src/__tests__/services/downloadService.test.ts
+++ b/backend/src/__tests__/services/downloadService.test.ts
@@ -97,16 +97,25 @@ describe("downloadService", () => {
       expect(BilibiliDownloader.downloadVideo).toHaveBeenCalledWith(
         "u", "vp", "tp", "d1", undefined
       );
-      expect(BilibiliDownloader.checkVideoParts).toHaveBeenCalledWith("bv1");
-      expect(BilibiliDownloader.checkCollectionOrSeries).toHaveBeenCalledWith("bv1");
+      // Both forward an optional per-subscription config override, undefined here.
+      expect(BilibiliDownloader.checkVideoParts).toHaveBeenCalledWith(
+        "bv1",
+        undefined,
+      );
+      expect(BilibiliDownloader.checkCollectionOrSeries).toHaveBeenCalledWith(
+        "bv1",
+        undefined,
+      );
       expect(BilibiliDownloader.getCollectionVideos).toHaveBeenCalledWith(
         1,
         2,
+        undefined,
         undefined
       );
       expect(BilibiliDownloader.getSeriesVideos).toHaveBeenCalledWith(
         3,
         4,
+        undefined,
         undefined
       );
     });

--- a/backend/src/__tests__/services/downloaders/bilibiliCoreDownload.avatar.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCoreDownload.avatar.test.ts
@@ -51,8 +51,10 @@ vi.mock("../../../utils/security", () => ({
   statSafeSync: () => ({ size: 2048 }),
 }));
 
-vi.mock("../../../utils/ytDlpUtils", () => {
-  class InvalidProxyError extends Error {}
+vi.mock("../../../utils/ytDlpUtils", async () => {
+  // The real InvalidProxyError, so the `instanceof` check in the downloader
+  // behaves as it does in production.
+  const { InvalidProxyError } = await import("../../../utils/ytdlp/proxy");
   return {
     executeYtDlpJson: (...args: any[]) => mocks.executeYtDlpJson(...args),
     executeYtDlpSpawn: (...args: any[]) => mocks.executeYtDlpSpawn(...args),
@@ -120,6 +122,7 @@ vi.mock(
 );
 
 import { downloadVideo } from "../../../services/downloaders/bilibili/bilibiliCoreDownload";
+import { InvalidProxyError } from "../../../utils/ytdlp/proxy";
 
 const SHORT_URL = "https://b23.tv/zKTXLw5";
 const AVATAR_URL = "https://i2.hdslb.com/bfs/face/abc.jpg";
@@ -226,6 +229,81 @@ describe("bilibiliCoreDownload avatar lookup for short URLs", () => {
     expect(mocks.axiosGet).not.toHaveBeenCalled();
     expect(mocks.downloadAndProcessAvatar).not.toHaveBeenCalled();
     expect(result.authorAvatarSaved).toBe(false);
+  });
+
+  describe("proxy handling for side requests", () => {
+    it("routes the avatar API lookup through the configured proxy", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({
+        proxy: "socks5://127.0.0.1:1080",
+      });
+      mocks.getAxiosProxyConfig.mockReturnValue({
+        proxy: false,
+        httpsAgent: "agent",
+      });
+      mocks.executeYtDlpJson.mockResolvedValue(ytDlpInfo());
+
+      await downloadVideo(SHORT_URL, "/mock/videos/out.mp4", "/mock/images/out.jpg");
+
+      // Previously this request got only headers, so it bypassed the proxy and
+      // hit api.bilibili.com from the host.
+      expect(mocks.axiosGet).toHaveBeenCalledWith(
+        expect.stringContaining("api.bilibili.com"),
+        expect.objectContaining({ proxy: false, httpsAgent: "agent" }),
+      );
+      expect(mocks.downloadAndProcessAvatar).toHaveBeenCalledWith(
+        AVATAR_URL,
+        "bilibili",
+        "Mock Author",
+        expect.any(Function),
+        expect.objectContaining({ proxy: false, httpsAgent: "agent" }),
+      );
+    });
+
+    it("skips side requests entirely when the proxy is unusable", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+      mocks.getAxiosProxyConfig.mockImplementation(() => {
+        throw new InvalidProxyError("not-a-proxy");
+      });
+      mocks.executeYtDlpJson.mockResolvedValue(
+        ytDlpInfo({ thumbnail: "https://i0.hdslb.com/thumb.jpg" }),
+      );
+
+      const result = await downloadVideo(
+        SHORT_URL,
+        "/mock/videos/out.mp4",
+        "/mock/images/out.jpg",
+      );
+
+      // A direct request here would expose the user's real IP.
+      expect(mocks.axiosGet).not.toHaveBeenCalled();
+      expect(mocks.downloadThumbnail).not.toHaveBeenCalled();
+      expect(mocks.downloadAndProcessAvatar).not.toHaveBeenCalled();
+      // The video itself still downloaded; yt-dlp applies the proxy itself.
+      expect(result.error).toBeUndefined();
+      expect(result.authorAvatarSaved).toBe(false);
+      expect(result.thumbnailSaved).toBe(false);
+    });
+
+    it("still uses a yt-dlp-supplied avatar URL over an unusable proxy path", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+      mocks.getAxiosProxyConfig.mockImplementation(() => {
+        throw new InvalidProxyError("not-a-proxy");
+      });
+      mocks.executeYtDlpJson.mockResolvedValue(
+        ytDlpInfo({ uploader_avatar: AVATAR_URL }),
+      );
+
+      const result = await downloadVideo(
+        SHORT_URL,
+        "/mock/videos/out.mp4",
+        "/mock/images/out.jpg",
+      );
+
+      // The URL is known, but fetching the image would still leak the IP.
+      expect(mocks.downloadAndProcessAvatar).not.toHaveBeenCalled();
+      expect(result.authorAvatarUrl).toBe(AVATAR_URL);
+      expect(result.authorAvatarSaved).toBe(false);
+    });
   });
 
   it("uses the id in the URL directly when the short link was already resolved", async () => {

--- a/backend/src/__tests__/services/downloaders/bilibiliCoreDownload.avatar.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliCoreDownload.avatar.test.ts
@@ -1,0 +1,247 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  executeYtDlpJson: vi.fn(),
+  executeYtDlpSpawn: vi.fn(),
+  getUserYtDlpConfig: vi.fn(),
+  getNetworkConfigFromUserConfig: vi.fn(),
+  getAxiosProxyConfig: vi.fn(),
+  prepareBilibiliDownloadFlags: vi.fn(),
+  resolveResolutionPreference: vi.fn(),
+  resolveResolutionRetryTarget: vi.fn(),
+  getVideoHeight: vi.fn(),
+  createTempDir: vi.fn(),
+  cleanupTempDir: vi.fn(),
+  findVideoFileInTemp: vi.fn(),
+  moveVideoFile: vi.fn(),
+  cleanupFilesOnCancellation: vi.fn(),
+  downloadAndProcessAvatar: vi.fn(),
+  downloadThumbnail: vi.fn(),
+  updateActiveDownload: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("axios", () => ({
+  default: { get: (...args: any[]) => mocks.axiosGet(...args) },
+}));
+
+vi.mock("fs-extra", () => ({
+  default: { ensureDirSync: vi.fn() },
+}));
+
+vi.mock("../../../config/paths", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, VIDEOS_DIR: "/mock/videos", AVATARS_DIR: "/mock/avatars" };
+});
+
+vi.mock("../../../utils/logger", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, logger: mocks.logger };
+});
+
+// The real path guards resolve against the on-disk layout; these tests only care
+// about which URL the avatar lookup uses, so keep the filesystem out of it.
+vi.mock("../../../utils/security", () => ({
+  pathExistsSafeSync: () => true,
+  readdirSafeSync: () => ["video.mp4"],
+  removeSafe: vi.fn(),
+  resolveSafeChildPath: (dir: string, child: string) => `${dir}/${child}`,
+  statSafeSync: () => ({ size: 2048 }),
+}));
+
+vi.mock("../../../utils/ytDlpUtils", () => {
+  class InvalidProxyError extends Error {}
+  return {
+    executeYtDlpJson: (...args: any[]) => mocks.executeYtDlpJson(...args),
+    executeYtDlpSpawn: (...args: any[]) => mocks.executeYtDlpSpawn(...args),
+    getAxiosProxyConfig: (...args: any[]) => mocks.getAxiosProxyConfig(...args),
+    getNetworkConfigFromUserConfig: (...args: any[]) =>
+      mocks.getNetworkConfigFromUserConfig(...args),
+    getUserYtDlpConfig: (...args: any[]) => mocks.getUserYtDlpConfig(...args),
+    getEffectiveUserYtDlpConfig: (url: any) => mocks.getUserYtDlpConfig(url),
+    InvalidProxyError,
+  };
+});
+
+vi.mock("../../../services/storageService", () => ({
+  updateActiveDownload: (...args: any[]) => mocks.updateActiveDownload(...args),
+}));
+
+vi.mock("../../../utils/avatarUtils", () => ({
+  downloadAndProcessAvatar: (...args: any[]) =>
+    mocks.downloadAndProcessAvatar(...args),
+}));
+
+vi.mock(
+  "../../../services/downloaders/bilibili/bilibiliConfig",
+  async (importOriginal) => {
+    const actual = await importOriginal<any>();
+    return {
+      ...actual,
+      prepareBilibiliDownloadFlags: (...args: any[]) =>
+        mocks.prepareBilibiliDownloadFlags(...args),
+      resolveResolutionPreference: (...args: any[]) =>
+        mocks.resolveResolutionPreference(...args),
+      resolveResolutionRetryTarget: (...args: any[]) =>
+        mocks.resolveResolutionRetryTarget(...args),
+    };
+  },
+);
+
+vi.mock("../../../services/downloaders/bilibili/bilibiliFileManager", () => ({
+  cleanupFilesOnCancellation: (...args: any[]) =>
+    mocks.cleanupFilesOnCancellation(...args),
+  cleanupTempDir: (...args: any[]) => mocks.cleanupTempDir(...args),
+  createTempDir: (...args: any[]) => mocks.createTempDir(...args),
+  findVideoFileInTemp: (...args: any[]) => mocks.findVideoFileInTemp(...args),
+  moveVideoFile: (...args: any[]) => mocks.moveVideoFile(...args),
+}));
+
+vi.mock("../../../services/downloaders/bilibili/bilibiliMetadata", () => ({
+  getVideoHeight: (...args: any[]) => mocks.getVideoHeight(...args),
+}));
+
+vi.mock(
+  "../../../services/downloaders/bilibili/bilibiliVideoHelpers",
+  async (importOriginal) => {
+    const actual = await importOriginal<any>();
+    return {
+      ...actual,
+      BilibiliDownloaderHelper: class {
+        throwIfCancelledPublic() {}
+        async downloadThumbnailPublic(...args: any[]) {
+          return mocks.downloadThumbnail(...args);
+        }
+      },
+    };
+  },
+);
+
+import { downloadVideo } from "../../../services/downloaders/bilibili/bilibiliCoreDownload";
+
+const SHORT_URL = "https://b23.tv/zKTXLw5";
+const AVATAR_URL = "https://i2.hdslb.com/bfs/face/abc.jpg";
+
+/** yt-dlp metadata for a b23.tv download: no avatar field, but a canonical URL. */
+const ytDlpInfo = (overrides: Record<string, any> = {}) => ({
+  title: "Mock Title",
+  uploader: "Mock Author",
+  upload_date: "20240101",
+  thumbnail: null,
+  description: "",
+  id: "BV1xx411c7mD",
+  webpage_url: "https://www.bilibili.com/video/BV1xx411c7mD",
+  ...overrides,
+});
+
+describe("bilibiliCoreDownload avatar lookup for short URLs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const subprocess: any = Promise.resolve(undefined);
+    subprocess.stdout = { on: vi.fn() };
+    subprocess.stderr = { on: vi.fn() };
+    subprocess.kill = vi.fn();
+
+    mocks.createTempDir.mockReturnValue("/mock/videos/temp");
+    mocks.executeYtDlpSpawn.mockReturnValue(subprocess);
+    mocks.getUserYtDlpConfig.mockReturnValue({});
+    mocks.getNetworkConfigFromUserConfig.mockReturnValue({});
+    mocks.prepareBilibiliDownloadFlags.mockReturnValue({ flags: {} });
+    mocks.resolveResolutionPreference.mockReturnValue({
+      height: null,
+      strict: false,
+    });
+    mocks.findVideoFileInTemp.mockReturnValue("video.mp4");
+    mocks.downloadAndProcessAvatar.mockResolvedValue(
+      "/mock/avatars/bilibili_Mock Author.jpg",
+    );
+    mocks.axiosGet.mockResolvedValue({
+      data: { data: { owner: { face: AVATAR_URL } } },
+    });
+  });
+
+  it("derives the BV id from yt-dlp metadata when the URL is a b23.tv short link", async () => {
+    mocks.executeYtDlpJson.mockResolvedValue(ytDlpInfo());
+
+    const result = await downloadVideo(
+      SHORT_URL,
+      "/mock/videos/out.mp4",
+      "/mock/images/out.jpg",
+    );
+
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      "https://api.bilibili.com/x/web-interface/view?bvid=BV1xx411c7mD",
+      expect.anything(),
+    );
+    expect(mocks.downloadAndProcessAvatar).toHaveBeenCalledWith(
+      AVATAR_URL,
+      "bilibili",
+      "Mock Author",
+      expect.any(Function),
+      expect.anything(),
+    );
+    expect(result.authorAvatarSaved).toBe(true);
+    expect(result.authorAvatarPath).toBe("/avatars/bilibili_Mock Author.jpg");
+  });
+
+  it("falls back to the bare yt-dlp id when webpage_url is absent", async () => {
+    // Multipart downloads report the part suffix on the id.
+    mocks.executeYtDlpJson.mockResolvedValue(
+      ytDlpInfo({ webpage_url: undefined, id: "BV1xx411c7mD_p2" }),
+    );
+
+    await downloadVideo(SHORT_URL, "/mock/videos/out.mp4", "/mock/images/out.jpg");
+
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      "https://api.bilibili.com/x/web-interface/view?bvid=BV1xx411c7mD",
+      expect.anything(),
+    );
+  });
+
+  it("still prefers an avatar already present in the yt-dlp metadata", async () => {
+    mocks.executeYtDlpJson.mockResolvedValue(
+      ytDlpInfo({ uploader_avatar: AVATAR_URL }),
+    );
+
+    await downloadVideo(SHORT_URL, "/mock/videos/out.mp4", "/mock/images/out.jpg");
+
+    expect(mocks.axiosGet).not.toHaveBeenCalled();
+    expect(mocks.downloadAndProcessAvatar).toHaveBeenCalled();
+  });
+
+  it("skips the avatar lookup when no id can be recovered at all", async () => {
+    mocks.executeYtDlpJson.mockResolvedValue(
+      ytDlpInfo({ webpage_url: undefined, id: undefined }),
+    );
+
+    const result = await downloadVideo(
+      SHORT_URL,
+      "/mock/videos/out.mp4",
+      "/mock/images/out.jpg",
+    );
+
+    expect(mocks.axiosGet).not.toHaveBeenCalled();
+    expect(mocks.downloadAndProcessAvatar).not.toHaveBeenCalled();
+    expect(result.authorAvatarSaved).toBe(false);
+  });
+
+  it("uses the id in the URL directly when the short link was already resolved", async () => {
+    mocks.executeYtDlpJson.mockResolvedValue(
+      ytDlpInfo({ webpage_url: undefined, id: undefined }),
+    );
+
+    await downloadVideo(
+      "https://www.bilibili.com/video/av123456",
+      "/mock/videos/out.mp4",
+      "/mock/images/out.jpg",
+    );
+
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      "https://api.bilibili.com/x/web-interface/view?aid=123456",
+      expect.anything(),
+    );
+  });
+});

--- a/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
@@ -38,7 +38,10 @@ vi.mock("../../../utils/ytDlpUtils", async () => {
   };
 });
 
-import { checkVideoParts } from "../../../services/downloaders/bilibili/bilibiliApi";
+import {
+  checkCollectionOrSeries,
+  checkVideoParts,
+} from "../../../services/downloaders/bilibili/bilibiliApi";
 import { InvalidProxyError } from "../../../utils/ytdlp/proxy";
 
 const PROXY_AGENT = { proxy: false, httpsAgent: "agent" };
@@ -78,6 +81,34 @@ describe("checkVideoParts proxy handling", () => {
     await expect(checkVideoParts("BV1x")).resolves.toEqual({
       success: false,
       videosNumber: 1,
+    });
+    expect(mocks.axiosGet).not.toHaveBeenCalled();
+  });
+
+  it("routes the collection preflight through the configured proxy", async () => {
+    mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "socks5://127.0.0.1:1080" });
+    mocks.getAxiosProxyConfig.mockReturnValue(PROXY_AGENT);
+    mocks.axiosGet.mockResolvedValue({
+      data: { data: { owner: { mid: 42 } } },
+    });
+
+    await checkCollectionOrSeries("BV1x");
+
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      expect.stringContaining("api.bilibili.com"),
+      expect.objectContaining(PROXY_AGENT),
+    );
+  });
+
+  it("skips the collection preflight when the proxy is unusable", async () => {
+    mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+    mocks.getAxiosProxyConfig.mockImplementation(() => {
+      throw new InvalidProxyError("not-a-proxy");
+    });
+
+    await expect(checkCollectionOrSeries("BV1x")).resolves.toEqual({
+      success: false,
+      type: "none",
     });
     expect(mocks.axiosGet).not.toHaveBeenCalled();
   });

--- a/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
@@ -48,6 +48,7 @@ vi.mock("../../../services/downloaders/bilibili/bilibiliVideo", () => ({
 import {
   checkCollectionOrSeries,
   checkVideoParts,
+  getVideoInfo,
 } from "../../../services/downloaders/bilibili/bilibiliApi";
 import {
   getCollectionVideos,
@@ -122,6 +123,42 @@ describe("checkVideoParts proxy handling", () => {
       type: "none",
     });
     expect(mocks.axiosGet).not.toHaveBeenCalled();
+  });
+
+  // A resolved short link routes the queued title lookup through the Bilibili
+  // id-specific path, whose yt-dlp failure falls back to this API request.
+  describe("getVideoInfo API fallback", () => {
+    beforeEach(() => {
+      mocks.executeYtDlpJson.mockRejectedValue(new Error("yt-dlp unavailable"));
+    });
+
+    it("routes the fallback through the configured proxy", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "socks5://127.0.0.1:1080" });
+      mocks.getAxiosProxyConfig.mockReturnValue(PROXY_AGENT);
+      mocks.axiosGet.mockResolvedValue({
+        data: { data: { title: "T", owner: { name: "A" }, pubdate: 0 } },
+      });
+
+      await expect(getVideoInfo("BV1x")).resolves.toMatchObject({ title: "T" });
+      expect(mocks.axiosGet).toHaveBeenCalledWith(
+        expect.stringContaining("api.bilibili.com"),
+        expect.objectContaining(PROXY_AGENT),
+      );
+    });
+
+    it("skips the fallback when the proxy is unusable", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+      mocks.getAxiosProxyConfig.mockImplementation(() => {
+        throw new InvalidProxyError("not-a-proxy");
+      });
+
+      // Same placeholder a failed lookup produces, without any request.
+      await expect(getVideoInfo("BV1x")).resolves.toMatchObject({
+        title: "Bilibili Video",
+        author: "Bilibili User",
+      });
+      expect(mocks.axiosGet).not.toHaveBeenCalled();
+    });
   });
 
   // Selecting a collection from a resolved short link fetches its member pages,

--- a/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
@@ -33,15 +33,26 @@ vi.mock("../../../utils/ytDlpUtils", async () => {
     getNetworkConfigFromUserConfig: (...args: any[]) =>
       mocks.getNetworkConfigFromUserConfig(...args),
     getUserYtDlpConfig: (...args: any[]) => mocks.getUserYtDlpConfig(...args),
-    getEffectiveUserYtDlpConfig: (url: any) => mocks.getUserYtDlpConfig(url),
+    // Forwards both args so tests can assert a subscription override reached it.
+    getEffectiveUserYtDlpConfig: (...args: any[]) =>
+      mocks.getUserYtDlpConfig(...args),
     InvalidProxyError,
   };
 });
+
+// bilibiliCollection pulls in the whole single-part download chain otherwise.
+vi.mock("../../../services/downloaders/bilibili/bilibiliVideo", () => ({
+  downloadSinglePart: vi.fn(),
+}));
 
 import {
   checkCollectionOrSeries,
   checkVideoParts,
 } from "../../../services/downloaders/bilibili/bilibiliApi";
+import {
+  getCollectionVideos,
+  getSeriesVideos,
+} from "../../../services/downloaders/bilibili/bilibiliCollection";
 import { InvalidProxyError } from "../../../utils/ytdlp/proxy";
 
 const PROXY_AGENT = { proxy: false, httpsAgent: "agent" };
@@ -111,6 +122,67 @@ describe("checkVideoParts proxy handling", () => {
       type: "none",
     });
     expect(mocks.axiosGet).not.toHaveBeenCalled();
+  });
+
+  // Selecting a collection from a resolved short link fetches its member pages,
+  // so those have to be proxied too.
+  describe("collection member page fetches", () => {
+    const archivePage = {
+      data: {
+        code: 0,
+        data: {
+          archives: [{ bvid: "BV1a", title: "One", aid: 1 }],
+          page: { total: 1 },
+        },
+      },
+    };
+
+    it("routes collection and series pages through the configured proxy", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "socks5://127.0.0.1:1080" });
+      mocks.getAxiosProxyConfig.mockReturnValue(PROXY_AGENT);
+      mocks.axiosGet.mockResolvedValue(archivePage);
+
+      await expect(getCollectionVideos(42, 7)).resolves.toMatchObject({
+        success: true,
+      });
+      await expect(getSeriesVideos(42, 9)).resolves.toMatchObject({
+        success: true,
+      });
+
+      for (const call of mocks.axiosGet.mock.calls) {
+        expect(call[1]).toMatchObject(PROXY_AGENT);
+      }
+    });
+
+    it("skips the page fetches when the proxy is unusable", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+      mocks.getAxiosProxyConfig.mockImplementation(() => {
+        throw new InvalidProxyError("not-a-proxy");
+      });
+
+      await expect(getCollectionVideos(42, 7)).resolves.toEqual({
+        success: false,
+        videos: [],
+      });
+      await expect(getSeriesVideos(42, 9)).resolves.toEqual({
+        success: false,
+        videos: [],
+      });
+      expect(mocks.axiosGet).not.toHaveBeenCalled();
+    });
+
+    it("passes a subscription override to the config lookup", async () => {
+      mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "socks5://127.0.0.1:1080" });
+      mocks.getAxiosProxyConfig.mockReturnValue(PROXY_AGENT);
+      mocks.axiosGet.mockResolvedValue(archivePage);
+
+      await getCollectionVideos(42, 7, undefined, "--proxy socks5://sub:1080");
+
+      expect(mocks.getUserYtDlpConfig).toHaveBeenCalledWith(
+        "https://space.bilibili.com/42",
+        "--proxy socks5://sub:1080",
+      );
+    });
   });
 
   it("sends the lookup directly when no proxy is configured", async () => {

--- a/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliPartsCheck.proxy.test.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  axiosGet: vi.fn(),
+  getUserYtDlpConfig: vi.fn(),
+  getAxiosProxyConfig: vi.fn(),
+  getNetworkConfigFromUserConfig: vi.fn(),
+  executeYtDlpJson: vi.fn(),
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock("axios", () => ({
+  default: { get: (...args: any[]) => mocks.axiosGet(...args) },
+}));
+
+vi.mock("../../../utils/logger", async (importOriginal) => {
+  const actual = await importOriginal<any>();
+  return { ...actual, logger: mocks.logger };
+});
+
+vi.mock("../../../services/storageService", () => ({
+  getSettings: () => ({}),
+}));
+
+// resolveProxiedAxiosConfig itself is deliberately NOT mocked — this exercises
+// the real skip-vs-proxy decision. Only its inputs are stubbed.
+vi.mock("../../../utils/ytDlpUtils", async () => {
+  const { InvalidProxyError } = await import("../../../utils/ytdlp/proxy");
+  return {
+    executeYtDlpJson: (...args: any[]) => mocks.executeYtDlpJson(...args),
+    getAxiosProxyConfig: (...args: any[]) => mocks.getAxiosProxyConfig(...args),
+    getNetworkConfigFromUserConfig: (...args: any[]) =>
+      mocks.getNetworkConfigFromUserConfig(...args),
+    getUserYtDlpConfig: (...args: any[]) => mocks.getUserYtDlpConfig(...args),
+    getEffectiveUserYtDlpConfig: (url: any) => mocks.getUserYtDlpConfig(url),
+    InvalidProxyError,
+  };
+});
+
+import { checkVideoParts } from "../../../services/downloaders/bilibili/bilibiliApi";
+import { InvalidProxyError } from "../../../utils/ytdlp/proxy";
+
+const PROXY_AGENT = { proxy: false, httpsAgent: "agent" };
+
+describe("checkVideoParts proxy handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getUserYtDlpConfig.mockReturnValue({});
+    mocks.getAxiosProxyConfig.mockReturnValue({});
+  });
+
+  it("routes the parts lookup through the configured proxy", async () => {
+    mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "socks5://127.0.0.1:1080" });
+    mocks.getAxiosProxyConfig.mockReturnValue(PROXY_AGENT);
+    mocks.axiosGet.mockResolvedValue({
+      data: { data: { videos: 3, title: "Multipart" } },
+    });
+
+    await expect(checkVideoParts("BV1x")).resolves.toEqual({
+      success: true,
+      videosNumber: 3,
+      title: "Multipart",
+    });
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      expect.stringContaining("api.bilibili.com"),
+      expect.objectContaining(PROXY_AGENT),
+    );
+  });
+
+  it("skips the lookup rather than sending it directly when the proxy is unusable", async () => {
+    mocks.getUserYtDlpConfig.mockReturnValue({ proxy: "not-a-proxy" });
+    mocks.getAxiosProxyConfig.mockImplementation(() => {
+      throw new InvalidProxyError("not-a-proxy");
+    });
+
+    // Reported as a failed check, not as a bogus single-part answer.
+    await expect(checkVideoParts("BV1x")).resolves.toEqual({
+      success: false,
+      videosNumber: 1,
+    });
+    expect(mocks.axiosGet).not.toHaveBeenCalled();
+  });
+
+  it("sends the lookup directly when no proxy is configured", async () => {
+    mocks.axiosGet.mockResolvedValue({ data: { data: { videos: 1 } } });
+
+    await checkVideoParts("BV1x");
+
+    expect(mocks.getAxiosProxyConfig).not.toHaveBeenCalled();
+    expect(mocks.axiosGet).toHaveBeenCalledWith(
+      expect.stringContaining("api.bilibili.com"),
+      expect.objectContaining({ headers: expect.any(Object) }),
+    );
+  });
+});

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -370,6 +370,38 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(cleanupCalls).toEqual([]);
   });
 
+  it("repairs an explicit target on a multipart video instead of duplicating it", async () => {
+    // A ?p=N URL now resolves a real part count, so totalParts > 1 for a
+    // single-part repair. The explicit target must still be updated in place;
+    // otherwise collision repair adds a row beside the item it was fixing.
+    mocks.getVideoById.mockReturnValue(
+      buildExistingVideo({
+        id: "repair-target",
+        mediaType: "video",
+        sourceUrl: "https://www.bilibili.com/video/BV1x?p=2",
+      }),
+    );
+
+    const result = await downloadSinglePart(
+      "https://www.bilibili.com/video/BV1x?p=2",
+      2,
+      5,
+      "",
+      "download-repair",
+      undefined,
+      undefined,
+      undefined,
+      { existingLocalVideoId: "repair-target" } as any,
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.updateVideo).toHaveBeenCalled();
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
+    expect(mocks.persistDownloadedMediaIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({ trackingMode: "multipart_part" }),
+    );
+  });
+
   it("does not clean up a thumbnail destination it never created", async () => {
     // No thumbnail was saved, so thumbnail collision checks were disabled and
     // the planned path can belong to another row this download never touched.

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -370,6 +370,29 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(cleanupCalls).toEqual([]);
   });
 
+  it("reuses part 1's row when a forced download uses the other canonical alias", async () => {
+    // Stored bare by a single download, force-downloaded as ?p=1 (the all-parts
+    // spelling). Matching only the exact URL would add a second row for the
+    // same item.
+    mocks.getVideoBySourceUrl.mockImplementation((url: string) =>
+      url === "https://www.bilibili.com/video/BV1x"
+        ? buildExistingVideo({ id: "part-1-video", mediaType: "video" })
+        : undefined,
+    );
+
+    const result = await downloadSinglePart(
+      "https://www.bilibili.com/video/BV1x?p=1",
+      1,
+      4,
+      "",
+      "download-alias",
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.updateVideo).toHaveBeenCalled();
+    expect(mocks.saveVideo).not.toHaveBeenCalled();
+  });
+
   it("repairs an explicit target on a multipart video instead of duplicating it", async () => {
     // A ?p=N URL now resolves a real part count, so totalParts > 1 for a
     // single-part repair. The explicit target must still be updated in place;

--- a/backend/src/__tests__/services/ensureFavoritesTables.test.ts
+++ b/backend/src/__tests__/services/ensureFavoritesTables.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../services/storageService/migrations/legacyTwitchDownloads", () => 
   normalizeLegacyTwitchDownloads: vi.fn(),
 }));
 vi.mock("../../services/storageService/migrations/dataBackfill", () => ({
+  backfillDownloadHistoryMediaTypes: vi.fn(),
   backfillDownloadHistoryVideoIds: vi.fn(),
   populateVideoFileSizes: vi.fn(),
 }));

--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -362,6 +362,53 @@ describe('Helpers', () => {
       expect(axiosHeadMock).not.toHaveBeenCalled();
     });
 
+    it('should not retry a short URL that just failed to resolve', async () => {
+      // One paste hits /check-bilibili-collection, /check-bilibili-parts and
+      // /download in sequence; without this the same unreachable host burns the
+      // full timeout on each.
+      axiosHeadMock.mockRejectedValue(new Error('ETIMEDOUT'));
+
+      for (let i = 0; i < 3; i++) {
+        await expect(resolveShortUrl('https://b23.tv/slow')).resolves.toBe(
+          'https://b23.tv/slow'
+        );
+      }
+
+      expect(axiosHeadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry once a remembered failure has expired', async () => {
+      vi.useFakeTimers();
+      try {
+        axiosHeadMock.mockRejectedValueOnce(new Error('ETIMEDOUT'));
+        await resolveShortUrl('https://b23.tv/slow');
+
+        // Failures are remembered far more briefly than successes, so a
+        // shortener that recovers is not written off for the full TTL.
+        vi.advanceTimersByTime(61 * 1000);
+        mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
+
+        await expect(resolveShortUrl('https://b23.tv/slow')).resolves.toBe(
+          'https://www.bilibili.com/video/BV1xx411c7mD'
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should remember a chain that never reaches an allowed host', async () => {
+      mockRedirectChain(undefined);
+
+      await expect(resolveShortUrl('https://b23.tv/dead')).resolves.toBe(
+        'https://b23.tv/dead'
+      );
+      await expect(resolveShortUrl('https://b23.tv/dead')).resolves.toBe(
+        'https://b23.tv/dead'
+      );
+
+      expect(axiosHeadMock).toHaveBeenCalledTimes(1);
+    });
+
     it('should cache a resolved short URL instead of re-requesting it', async () => {
       mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
       const first = await resolveShortUrl('https://b23.tv/zKTXLw5');

--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -26,9 +26,31 @@ import {
     normalizeYouTubeAuthorUrl,
     processVideoUrl,
     resolveShortUrl,
+    resetShortUrlResolutionCacheForTests,
     sanitizeFilename,
     trimBilibiliUrl
 } from '../../utils/helpers';
+
+const axiosHeadMock = vi.fn();
+vi.mock('axios', () => ({
+  default: {
+    head: (...args: unknown[]) => axiosHeadMock(...args),
+  },
+}));
+
+// getUserYtDlpConfig pulls in the storage layer; the short-URL resolver only
+// needs the proxy field, so stub it to a proxy-less config.
+vi.mock('../../utils/ytdlp/config', () => ({
+  getUserYtDlpConfig: () => ({}),
+}));
+
+/** Queue a redirect chain for the mocked axios.head to walk through. */
+const mockRedirectChain = (...locations: (string | undefined)[]) => {
+  axiosHeadMock.mockReset();
+  for (const location of locations) {
+    axiosHeadMock.mockResolvedValueOnce({ headers: location ? { location } : {} });
+  }
+};
 
 describe('Helpers', () => {
   describe('isValidUrl', () => {
@@ -184,38 +206,130 @@ describe('Helpers', () => {
   describe('resolveShortUrl', () => {
     beforeEach(() => {
       vi.clearAllMocks();
+      axiosHeadMock.mockReset();
+      resetShortUrlResolutionCacheForTests();
     });
 
-    it('should normalize and return whitelisted short URL', async () => {
-      const result = await resolveShortUrl('https://b23.tv/example');
-      expect(result).toBe('https://b23.tv/example');
+    it('should follow the redirect to the canonical Bilibili video URL', async () => {
+      mockRedirectChain(
+        'https://www.bilibili.com/video/BV1xx411c7mD?share_source=copy_web'
+      );
+      await expect(resolveShortUrl('https://b23.tv/zKTXLw5')).resolves.toBe(
+        'https://www.bilibili.com/video/BV1xx411c7mD?share_source=copy_web'
+      );
+      expect(extractBilibiliVideoId(await resolveShortUrl('https://b23.tv/zKTXLw5')))
+        .toBe('BV1xx411c7mD');
     });
 
-    it('should return normalized short URL without outbound resolution', async () => {
-      const result = await resolveShortUrl('https://b23.tv/fail');
-      expect(result).toBe('https://b23.tv/fail');
+    it('should follow a multi-hop chain that stays on allowed hosts', async () => {
+      mockRedirectChain(
+        'https://bili2233.cn/hop',
+        'https://m.bilibili.com/video/BV1xx411c7mD'
+      );
+      await expect(resolveShortUrl('https://b23.tv/zKTXLw5')).resolves.toBe(
+        'https://m.bilibili.com/video/BV1xx411c7mD'
+      );
     });
 
-    it('should keep short URL path unchanged', async () => {
-      const result = await resolveShortUrl('https://b23.tv/example');
-      expect(result).toBe('https://b23.tv/example');
+    it('should preserve the subdomain a short link actually points at', async () => {
+      // Collapsing live./space. onto www. would silently point the download at
+      // an unrelated page.
+      mockRedirectChain('https://live.bilibili.com/1234');
+      await expect(resolveShortUrl('https://b23.tv/live')).resolves.toBe(
+        'https://live.bilibili.com/1234'
+      );
+    });
+
+    it('should fill out a bare bilibili.com host to www', async () => {
+      mockRedirectChain('https://bilibili.com/video/BV1xx411c7mD');
+      await expect(resolveShortUrl('https://b23.tv/bare')).resolves.toBe(
+        'https://www.bilibili.com/video/BV1xx411c7mD'
+      );
+    });
+
+    it('should reject a redirect that carries credentials', async () => {
+      mockRedirectChain('https://user:pass@www.bilibili.com/video/BV1xx411c7mD');
+      await expect(resolveShortUrl('https://b23.tv/creds')).resolves.toBe(
+        'https://b23.tv/creds'
+      );
+    });
+
+    it('should resolve a relative Location header against the current hop', async () => {
+      // A relative hop that stays on the shortener is joined against the
+      // current URL and then followed like any other hop.
+      mockRedirectChain(
+        '/s/zKTXLw5',
+        'https://www.bilibili.com/video/BV1xx411c7mD'
+      );
+      await expect(resolveShortUrl('https://b23.tv/zKTXLw5')).resolves.toBe(
+        'https://www.bilibili.com/video/BV1xx411c7mD'
+      );
+      expect(axiosHeadMock).toHaveBeenNthCalledWith(
+        2,
+        'https://b23.tv/s/zKTXLw5',
+        expect.objectContaining({ maxRedirects: 0 })
+      );
+    });
+
+    it('should never follow a redirect off the allow-list', async () => {
+      mockRedirectChain('http://169.254.169.254/latest/meta-data');
+      // The off-list hop is rejected before it is requested, so the caller is
+      // left on the short URL rather than being pointed at the internal host.
+      await expect(resolveShortUrl('https://b23.tv/evil')).resolves.toBe(
+        'https://b23.tv/evil'
+      );
+      expect(axiosHeadMock).toHaveBeenCalledTimes(1);
+      expect(axiosHeadMock).toHaveBeenCalledWith(
+        'https://b23.tv/evil',
+        expect.objectContaining({ maxRedirects: 0 })
+      );
+    });
+
+    it('should fall back to the short URL when resolution fails', async () => {
+      axiosHeadMock.mockRejectedValue(new Error('ENOTFOUND'));
+      await expect(resolveShortUrl('https://b23.tv/fail')).resolves.toBe(
+        'https://b23.tv/fail'
+      );
+    });
+
+    it('should fall back to the short URL when no redirect is returned', async () => {
+      mockRedirectChain(undefined);
+      await expect(resolveShortUrl('https://b23.tv/example')).resolves.toBe(
+        'https://b23.tv/example'
+      );
+    });
+
+    it('should give up on a redirect loop that never leaves the shorteners', async () => {
+      axiosHeadMock.mockResolvedValue({
+        headers: { location: 'https://b23.tv/loop' },
+      });
+      await expect(resolveShortUrl('https://b23.tv/loop')).resolves.toBe(
+        'https://b23.tv/loop'
+      );
+      expect(axiosHeadMock).toHaveBeenCalledTimes(5);
+    });
+
+    it('should cache a resolved short URL instead of re-requesting it', async () => {
+      mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
+      const first = await resolveShortUrl('https://b23.tv/zKTXLw5');
+      const second = await resolveShortUrl('https://b23.tv/zKTXLw5');
+      expect(second).toBe(first);
+      expect(axiosHeadMock).toHaveBeenCalledTimes(1);
     });
 
     it('should reject non-whitelisted short URL hosts', async () => {
       await expect(resolveShortUrl('https://example.com/test')).rejects.toThrow('Invalid URL');
+      expect(axiosHeadMock).not.toHaveBeenCalled();
     });
 
     it('should reject short URL with credentials', async () => {
       await expect(resolveShortUrl('https://user:pass@b23.tv/example')).rejects.toThrow('Invalid URL');
-    });
-
-    it('should return normalized short URL with explicit path', async () => {
-      const result = await resolveShortUrl('https://b23.tv/example');
-      expect(result).toBe('https://b23.tv/example');
+      expect(axiosHeadMock).not.toHaveBeenCalled();
     });
 
     it('should reject invalid protocol and normalize traversal paths', async () => {
       await expect(resolveShortUrl('ftp://b23.tv/test')).rejects.toThrow('Invalid URL');
+      mockRedirectChain(undefined);
       await expect(resolveShortUrl('https://b23.tv/../test')).resolves.toBe('https://b23.tv/test');
     });
   });
@@ -331,6 +445,21 @@ describe('Helpers', () => {
     });
 
     it('should process text-wrapped URLs and resolve bilibili short links', async () => {
+      resetShortUrlResolutionCacheForTests();
+      mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
+      await expect(
+        processVideoUrl('Title https://b23.tv/xyz')
+      ).resolves.toEqual({
+        videoUrl: 'https://www.bilibili.com/video/BV1xx411c7mD',
+        sourceVideoId: 'BV1xx411c7mD',
+        platform: 'bilibili',
+      });
+    });
+
+    it('should still classify a short link that cannot be resolved', async () => {
+      resetShortUrlResolutionCacheForTests();
+      axiosHeadMock.mockReset();
+      axiosHeadMock.mockRejectedValue(new Error('offline'));
       await expect(
         processVideoUrl('Title https://b23.tv/xyz')
       ).resolves.toEqual({

--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -27,6 +27,7 @@ import {
     processVideoUrl,
     resolveShortUrl,
     resetShortUrlResolutionCacheForTests,
+    getShortUrlResolutionCacheSizeForTests,
     sanitizeFilename,
     trimBilibiliUrl
 } from '../../utils/helpers';
@@ -39,9 +40,16 @@ vi.mock('axios', () => ({
 }));
 
 // getUserYtDlpConfig pulls in the storage layer; the short-URL resolver only
-// needs the proxy field, so stub it to a proxy-less config.
+// needs the proxy field, so stub it. Defaults to a proxy-less config.
+const userYtDlpConfigMock = vi.fn(() => ({}) as Record<string, unknown>);
 vi.mock('../../utils/ytdlp/config', () => ({
-  getUserYtDlpConfig: () => ({}),
+  getUserYtDlpConfig: (...args: unknown[]) => userYtDlpConfigMock(...(args as [])),
+}));
+
+const axiosProxyConfigMock = vi.fn(() => ({}) as Record<string, unknown>);
+vi.mock('../../utils/ytdlp/proxy', () => ({
+  getAxiosProxyConfig: (...args: unknown[]) =>
+    axiosProxyConfigMock(...(args as [])),
 }));
 
 /** Queue a redirect chain for the mocked axios.head to walk through. */
@@ -207,6 +215,10 @@ describe('Helpers', () => {
     beforeEach(() => {
       vi.clearAllMocks();
       axiosHeadMock.mockReset();
+      userYtDlpConfigMock.mockReset();
+      userYtDlpConfigMock.mockReturnValue({});
+      axiosProxyConfigMock.mockReset();
+      axiosProxyConfigMock.mockReturnValue({});
       resetShortUrlResolutionCacheForTests();
     });
 
@@ -309,12 +321,82 @@ describe('Helpers', () => {
       expect(axiosHeadMock).toHaveBeenCalledTimes(5);
     });
 
+    it('should carry a part selector through resolution and trimming', async () => {
+      // The controller feeds the resolved URL straight into trimBilibiliUrl, so
+      // a short link to part 2 must still name part 2 at the end of that chain.
+      mockRedirectChain(
+        'https://www.bilibili.com/video/BV1xx411c7mD?p=2&share_source=COPY&unique_k=zKTXLw5'
+      );
+      const resolved = await resolveShortUrl('https://b23.tv/zKTXLw5');
+      expect(trimBilibiliUrl(resolved)).toBe(
+        'https://www.bilibili.com/video/BV1xx411c7mD?p=2'
+      );
+    });
+
+    it('should route the request through a configured proxy', async () => {
+      userYtDlpConfigMock.mockReturnValue({ proxy: 'socks5://127.0.0.1:1080' });
+      axiosProxyConfigMock.mockReturnValue({ proxy: false, httpsAgent: 'agent' });
+      mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
+
+      await resolveShortUrl('https://b23.tv/zKTXLw5');
+
+      expect(axiosProxyConfigMock).toHaveBeenCalledWith('socks5://127.0.0.1:1080');
+      expect(axiosHeadMock).toHaveBeenCalledWith(
+        'https://b23.tv/zKTXLw5',
+        expect.objectContaining({ proxy: false, httpsAgent: 'agent' })
+      );
+    });
+
+    it('should never fall back to a direct request when the proxy is invalid', async () => {
+      // getAxiosProxyConfig throws precisely to stop a silent direct connection
+      // from exposing the user's real IP, so resolution must abort entirely.
+      userYtDlpConfigMock.mockReturnValue({ proxy: 'not-a-proxy' });
+      axiosProxyConfigMock.mockImplementation(() => {
+        throw new Error('Invalid proxy URL: not-a-proxy');
+      });
+
+      await expect(resolveShortUrl('https://b23.tv/zKTXLw5')).resolves.toBe(
+        'https://b23.tv/zKTXLw5'
+      );
+      expect(axiosHeadMock).not.toHaveBeenCalled();
+    });
+
     it('should cache a resolved short URL instead of re-requesting it', async () => {
       mockRedirectChain('https://www.bilibili.com/video/BV1xx411c7mD');
       const first = await resolveShortUrl('https://b23.tv/zKTXLw5');
       const second = await resolveShortUrl('https://b23.tv/zKTXLw5');
       expect(second).toBe(first);
       expect(axiosHeadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('should evict expired entries instead of growing forever', async () => {
+      vi.useFakeTimers();
+      try {
+        // One-off links are never requested a second time, so expiry-on-read
+        // alone would never reclaim them.
+        for (let i = 0; i < 3; i++) {
+          mockRedirectChain(`https://www.bilibili.com/video/BV100${i}`);
+          await resolveShortUrl(`https://b23.tv/oneoff${i}`);
+        }
+        expect(getShortUrlResolutionCacheSizeForTests()).toBe(3);
+
+        // Past the TTL, the next write sweeps every stale entry.
+        vi.advanceTimersByTime(11 * 60 * 1000);
+        mockRedirectChain('https://www.bilibili.com/video/BV2000');
+        await resolveShortUrl('https://b23.tv/fresh');
+
+        expect(getShortUrlResolutionCacheSizeForTests()).toBe(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should keep the cache bounded when entries have not expired', async () => {
+      for (let i = 0; i < 505; i++) {
+        mockRedirectChain(`https://www.bilibili.com/video/BV${i}`);
+        await resolveShortUrl(`https://b23.tv/bulk${i}`);
+      }
+      expect(getShortUrlResolutionCacheSizeForTests()).toBe(500);
     });
 
     it('should reject non-whitelisted short URL hosts', async () => {
@@ -343,6 +425,29 @@ describe('Helpers', () => {
     it('should trim bilibili URL with av ID', () => {
       const url = 'https://www.bilibili.com/video/av123456?spm_id_from=333.999.0.0';
       expect(trimBilibiliUrl(url)).toBe('https://www.bilibili.com/video/av123456');
+    });
+
+    it('should keep the part selector while dropping tracking params', () => {
+      // Dropping ?p= silently downloads part 1 of a multipart video instead of
+      // the part the link actually points at.
+      expect(
+        trimBilibiliUrl(
+          'https://www.bilibili.com/video/BV1xx411c7mD?p=2&spm_id_from=333.999.0.0&share_source=COPY'
+        )
+      ).toBe('https://www.bilibili.com/video/BV1xx411c7mD?p=2');
+      expect(
+        trimBilibiliUrl('https://www.bilibili.com/video/av123456?p=13')
+      ).toBe('https://www.bilibili.com/video/av123456?p=13');
+    });
+
+    it('should ignore a malformed part selector', () => {
+      for (const part of ['0', '-1', 'abc', '2; DROP TABLE', '']) {
+        expect(
+          trimBilibiliUrl(
+            `https://www.bilibili.com/video/BV1xx411c7mD?p=${encodeURIComponent(part)}`
+          )
+        ).toBe('https://www.bilibili.com/video/BV1xx411c7mD');
+      }
     });
 
     it('should remove query parameters if no video ID found', () => {

--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -29,7 +29,7 @@ import {
     resetShortUrlResolutionCacheForTests,
     getShortUrlResolutionCacheSizeForTests,
     sanitizeFilename,
-    targetsNonFirstBilibiliPart,
+    getBilibiliPartNumber,
     trimBilibiliUrl
 } from '../../utils/helpers';
 
@@ -456,22 +456,23 @@ describe('Helpers', () => {
       expect(trimBilibiliUrl(url)).toBe('https://www.bilibili.com/read/cv123456');
     });
 
-    it('should identify URLs that target a part other than the first', () => {
-      // p=1 and a bare URL are the same video, so only p>=2 needs the
-      // part-aware duplicate check.
+    it('should read the part number off a URL', () => {
       expect(
-        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=2')
-      ).toBe(true);
+        getBilibiliPartNumber('https://www.bilibili.com/video/BV1x?p=2')
+      ).toBe(2);
       expect(
-        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=1')
-      ).toBe(false);
+        getBilibiliPartNumber('https://www.bilibili.com/video/BV1x?p=1')
+      ).toBe(1);
+      // Absent or malformed selectors are not a part number; callers treat
+      // these as part 1.
+      expect(getBilibiliPartNumber('https://www.bilibili.com/video/BV1x')).toBeNull();
       expect(
-        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x')
-      ).toBe(false);
+        getBilibiliPartNumber('https://www.bilibili.com/video/BV1x?p=abc')
+      ).toBeNull();
       expect(
-        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=abc')
-      ).toBe(false);
-      expect(targetsNonFirstBilibiliPart('not-a-url')).toBe(false);
+        getBilibiliPartNumber('https://www.bilibili.com/video/BV1x?p=0')
+      ).toBeNull();
+      expect(getBilibiliPartNumber('not-a-url')).toBeNull();
     });
 
     it('should return original value when URL parsing fails', () => {

--- a/backend/src/__tests__/utils/helpers.test.ts
+++ b/backend/src/__tests__/utils/helpers.test.ts
@@ -29,6 +29,7 @@ import {
     resetShortUrlResolutionCacheForTests,
     getShortUrlResolutionCacheSizeForTests,
     sanitizeFilename,
+    targetsNonFirstBilibiliPart,
     trimBilibiliUrl
 } from '../../utils/helpers';
 
@@ -453,6 +454,24 @@ describe('Helpers', () => {
     it('should remove query parameters if no video ID found', () => {
       const url = 'https://www.bilibili.com/read/cv123456?from=search';
       expect(trimBilibiliUrl(url)).toBe('https://www.bilibili.com/read/cv123456');
+    });
+
+    it('should identify URLs that target a part other than the first', () => {
+      // p=1 and a bare URL are the same video, so only p>=2 needs the
+      // part-aware duplicate check.
+      expect(
+        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=2')
+      ).toBe(true);
+      expect(
+        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=1')
+      ).toBe(false);
+      expect(
+        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x')
+      ).toBe(false);
+      expect(
+        targetsNonFirstBilibiliPart('https://www.bilibili.com/video/BV1x?p=abc')
+      ).toBe(false);
+      expect(targetsNonFirstBilibiliPart('not-a-url')).toBe(false);
     });
 
     it('should return original value when URL parsing fails', () => {

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -20,6 +20,7 @@ import { isLoginRequired } from "../services/passwordService";
 import * as storageService from "../services/storageService";
 import {
   extractBilibiliVideoId,
+  getBilibiliPartNumber,
   getMissAVPlaceholderTitle,
   isBilibiliShortUrl,
   isBilibiliUrl,
@@ -29,7 +30,6 @@ import {
   isValidUrl,
   processVideoUrl,
   resolveShortUrl,
-  targetsNonFirstBilibiliPart,
   trimBilibiliUrl,
 } from "../utils/helpers";
 import { logger } from "../utils/logger";
@@ -82,12 +82,18 @@ export const searchVideos = async (
 /**
  * Look up a previous download for this request.
  *
- * Normally keyed on the source video id, but every part of a multipart Bilibili
- * video shares one source video id (the videoDownloads unique index is
- * sourceVideoId + platform + mediaType), so an id-keyed lookup reports part 2 as
- * already downloaded whenever any other part exists. When the URL names a part
- * other than the first, key on the trimmed part URL instead — the same `?p=N`
- * form the multipart download flow already records per part.
+ * Keyed on the source video id, but every part of a multipart Bilibili video
+ * shares one source video id (videoDownloads is unique on sourceVideoId +
+ * platform + mediaType), so that lookup answers "some part of this video was
+ * downloaded", not "this part was". Taken at face value it reports part 2 as
+ * already downloaded because part 1 exists — and equally reports part 1 as
+ * downloaded when only part 2 exists.
+ *
+ * So for Bilibili the matched row's own source URL is compared against the
+ * requested part, and a different part is treated as no match. Guarding the
+ * existing lookup rather than keying on the part URL keeps every match that
+ * works today (older rows whose stored URL predates a normalization still match
+ * on the id) while dropping only the cross-part false positives.
  */
 function checkPreviousDownload(
   videoUrl: string,
@@ -95,18 +101,30 @@ function checkPreviousDownload(
   platform: string,
   mediaType: "audio" | "video",
 ) {
-  if (isBilibiliUrl(videoUrl) && targetsNonFirstBilibiliPart(videoUrl)) {
-    return storageService.checkVideoDownloadByUrl(
-      trimBilibiliUrl(videoUrl),
-      mediaType,
-    );
-  }
-
-  return storageService.checkVideoDownloadBySourceId(
+  const downloadCheck = storageService.checkVideoDownloadBySourceId(
     sourceVideoId,
     platform,
     mediaType,
   );
+
+  if (!downloadCheck.found || !isBilibiliUrl(videoUrl)) {
+    return downloadCheck;
+  }
+
+  // A bare URL and ?p=1 are the same part, so both normalize to 1.
+  const requestedPart = getBilibiliPartNumber(videoUrl) ?? 1;
+  const matchedPart = downloadCheck.sourceUrl
+    ? (getBilibiliPartNumber(downloadCheck.sourceUrl) ?? 1)
+    : requestedPart;
+
+  if (matchedPart !== requestedPart) {
+    logger.info(
+      `Bilibili duplicate check matched part ${matchedPart} but part ${requestedPart} was requested; treating as a new download.`,
+    );
+    return { found: false };
+  }
+
+  return downloadCheck;
 }
 
 /**

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -90,24 +90,29 @@ export const searchVideos = async (
  * downloaded when only part 2 exists.
  *
  * So for Bilibili the matched row's own source URL is compared against the
- * requested part, and a different part is treated as no match. Guarding the
- * existing lookup rather than keying on the part URL keeps every match that
- * works today (older rows whose stored URL predates a normalization still match
- * on the id) while dropping only the cross-part false positives.
+ * requested part. Guarding the existing lookup rather than keying on the part
+ * URL keeps every match that works today (older rows whose stored URL predates
+ * a normalization still match on the id).
+ *
+ * When the row is about a different part it is not evidence either way: the
+ * tracking row's sourceUrl is overwritten by whichever part was written last
+ * (persistDownloadedMediaIdentity's onConflictDoUpdate), so it remembers one
+ * part, not the set. The per-video rows do have one entry per part, so they are
+ * what actually answers "does this part exist".
  */
 function checkPreviousDownload(
   videoUrl: string,
   sourceVideoId: string,
   platform: string,
   mediaType: "audio" | "video",
-) {
+): storageService.VideoDownloadCheckResult {
   const downloadCheck = storageService.checkVideoDownloadBySourceId(
     sourceVideoId,
     platform,
     mediaType,
   );
 
-  if (!downloadCheck.found || !isBilibiliUrl(videoUrl)) {
+  if (!isBilibiliUrl(videoUrl)) {
     return downloadCheck;
   }
 
@@ -117,14 +122,37 @@ function checkPreviousDownload(
     ? (getBilibiliPartNumber(downloadCheck.sourceUrl) ?? 1)
     : requestedPart;
 
-  if (matchedPart !== requestedPart) {
-    logger.info(
-      `Bilibili duplicate check matched part ${matchedPart} but part ${requestedPart} was requested; treating as a new download.`,
-    );
-    return { found: false };
+  if (downloadCheck.found && matchedPart === requestedPart) {
+    return downloadCheck;
   }
 
-  return downloadCheck;
+  // Either nothing was tracked, or the tracking row is about another part.
+  // Ask the per-part rows directly before concluding this part is missing.
+  const existingPart = storageService.getVideoBySourceUrl(
+    trimBilibiliUrl(videoUrl),
+    mediaType,
+  );
+
+  if (existingPart) {
+    const downloadedAt = Date.parse(existingPart.createdAt ?? "");
+    return {
+      found: true,
+      status: "exists" as const,
+      videoId: existingPart.id,
+      title: existingPart.title,
+      author: existingPart.author,
+      downloadedAt: Number.isNaN(downloadedAt) ? undefined : downloadedAt,
+      sourceUrl: existingPart.sourceUrl,
+    };
+  }
+
+  if (downloadCheck.found) {
+    logger.info(
+      `Bilibili duplicate check matched part ${matchedPart} but part ${requestedPart} was requested and has no saved item; treating as a new download.`,
+    );
+  }
+
+  return { found: false };
 }
 
 /**

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -19,6 +19,7 @@ import {
 import { isLoginRequired } from "../services/passwordService";
 import * as storageService from "../services/storageService";
 import {
+  bilibiliPartSourceUrlAliases,
   extractBilibiliVideoId,
   getBilibiliPartNumber,
   getMissAVPlaceholderTitle,
@@ -99,15 +100,6 @@ export const searchVideos = async (
  * existence. The tracking row is consulted only for the deleted state it alone
  * records, and only when it is about the requested part.
  */
-function bilibiliPartAliases(videoUrl: string, requestedPart: number): string[] {
-  const baseUrl = trimBilibiliUrl(videoUrl).split("?")[0];
-  // Part 1 has two canonical spellings and either may be what was stored: a
-  // single download saves the bare URL, the all-parts flow saves ?p=1.
-  return requestedPart === 1
-    ? [baseUrl, `${baseUrl}?p=1`]
-    : [`${baseUrl}?p=${requestedPart}`];
-}
-
 function checkPreviousDownload(
   videoUrl: string,
   sourceVideoId: string,
@@ -127,7 +119,7 @@ function checkPreviousDownload(
   // A bare URL and ?p=1 are the same part, so both normalize to 1.
   const requestedPart = getBilibiliPartNumber(videoUrl) ?? 1;
 
-  for (const candidateUrl of bilibiliPartAliases(videoUrl, requestedPart)) {
+  for (const candidateUrl of bilibiliPartSourceUrlAliases(videoUrl)) {
     const existingPart = storageService.getVideoBySourceUrl(
       candidateUrl,
       mediaType,
@@ -175,7 +167,7 @@ function checkPreviousDownload(
     return { found: false };
   }
 
-  for (const candidateUrl of bilibiliPartAliases(videoUrl, requestedPart)) {
+  for (const candidateUrl of bilibiliPartSourceUrlAliases(videoUrl)) {
     const deletedItem =
       storageService.getLatestDeletedHistoryItemBySourceUrl(candidateUrl);
     if (deletedItem) {

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -29,6 +29,7 @@ import {
   isValidUrl,
   processVideoUrl,
   resolveShortUrl,
+  targetsNonFirstBilibiliPart,
   trimBilibiliUrl,
 } from "../utils/helpers";
 import { logger } from "../utils/logger";
@@ -79,6 +80,36 @@ export const searchVideos = async (
 };
 
 /**
+ * Look up a previous download for this request.
+ *
+ * Normally keyed on the source video id, but every part of a multipart Bilibili
+ * video shares one source video id (the videoDownloads unique index is
+ * sourceVideoId + platform + mediaType), so an id-keyed lookup reports part 2 as
+ * already downloaded whenever any other part exists. When the URL names a part
+ * other than the first, key on the trimmed part URL instead — the same `?p=N`
+ * form the multipart download flow already records per part.
+ */
+function checkPreviousDownload(
+  videoUrl: string,
+  sourceVideoId: string,
+  platform: string,
+  mediaType: "audio" | "video",
+) {
+  if (isBilibiliUrl(videoUrl) && targetsNonFirstBilibiliPart(videoUrl)) {
+    return storageService.checkVideoDownloadByUrl(
+      trimBilibiliUrl(videoUrl),
+      mediaType,
+    );
+  }
+
+  return storageService.checkVideoDownloadBySourceId(
+    sourceVideoId,
+    platform,
+    mediaType,
+  );
+}
+
+/**
  * Check video download status
  * Errors are automatically handled by asyncHandler middleware
  */
@@ -120,7 +151,8 @@ export const checkVideoDownloadStatus = async (
   const effectiveAudioOnly = audioOnly && !isMissAVUrl(videoUrl);
 
   // Check if video was previously downloaded
-  const downloadCheck = storageService.checkVideoDownloadBySourceId(
+  const downloadCheck = checkPreviousDownload(
+    videoUrl,
     sourceVideoId,
     platform,
     effectiveAudioOnly ? "audio" : "video",
@@ -285,7 +317,8 @@ export const downloadVideo = async (
     // Scope the lookup to the requested media type so an existing video download
     // never masks a new audio-only request (and vice versa).
     if (sourceVideoId && !downloadAllParts && !downloadCollection) {
-      const downloadCheck = storageService.checkVideoDownloadBySourceId(
+      const downloadCheck = checkPreviousDownload(
+        resolvedUrl,
         sourceVideoId,
         platform,
         effectiveMediaType,

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -158,18 +158,14 @@ function checkPreviousDownload(
   // per-part deletion. History rows can: each carries its own item's source
   // URL, so the deleted part is still on file under its own ?p=N URL.
   //
-  // History rows carry no media type, so the tombstone is only consulted when a
-  // tracking row exists for the requested one. That row is media-type scoped,
-  // so its absence means nothing of this media type was ever downloaded here and
-  // any deleted entry under the same URL belongs to the other one — which would
-  // otherwise make a deleted video suppress a first-time audio request.
-  if (!downloadCheck.found) {
-    return { found: false };
-  }
-
+  // Scoped to the requested media type like every other lookup here: history
+  // rows carry their own, so a deleted video item cannot suppress a first-time
+  // audio request for the same part.
   for (const candidateUrl of bilibiliPartSourceUrlAliases(videoUrl)) {
-    const deletedItem =
-      storageService.getLatestDeletedHistoryItemBySourceUrl(candidateUrl);
+    const deletedItem = storageService.getLatestDeletedHistoryItemBySourceUrl(
+      candidateUrl,
+      mediaType,
+    );
     if (deletedItem) {
       return {
         found: true,

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -89,17 +89,25 @@ export const searchVideos = async (
  * already downloaded because part 1 exists — and equally reports part 1 as
  * downloaded when only part 2 exists.
  *
- * So for Bilibili the matched row's own source URL is compared against the
- * requested part. Guarding the existing lookup rather than keying on the part
- * URL keeps every match that works today (older rows whose stored URL predates
- * a normalization still match on the id).
+ * Neither field of that row can stand in for the requested part.
+ * persistDownloadedMediaIdentity overwrites sourceUrl with whichever part was
+ * saved last, while deliberately keeping videoId on the lowest-numbered
+ * surviving part — so the row can say "?p=2" while pointing at part 1's video.
+ * Trusting either would skip a part that is genuinely missing.
  *
- * When the row is about a different part it is not evidence either way: the
- * tracking row's sourceUrl is overwritten by whichever part was written last
- * (persistDownloadedMediaIdentity's onConflictDoUpdate), so it remembers one
- * part, not the set. The per-video rows do have one entry per part, so they are
- * what actually answers "does this part exist".
+ * The per-video rows do have one entry per part, so for Bilibili they decide
+ * existence. The tracking row is consulted only for the deleted state it alone
+ * records, and only when it is about the requested part.
  */
+function bilibiliPartAliases(videoUrl: string, requestedPart: number): string[] {
+  const baseUrl = trimBilibiliUrl(videoUrl).split("?")[0];
+  // Part 1 has two canonical spellings and either may be what was stored: a
+  // single download saves the bare URL, the all-parts flow saves ?p=1.
+  return requestedPart === 1
+    ? [baseUrl, `${baseUrl}?p=1`]
+    : [`${baseUrl}?p=${requestedPart}`];
+}
+
 function checkPreviousDownload(
   videoUrl: string,
   sourceVideoId: string,
@@ -118,37 +126,43 @@ function checkPreviousDownload(
 
   // A bare URL and ?p=1 are the same part, so both normalize to 1.
   const requestedPart = getBilibiliPartNumber(videoUrl) ?? 1;
+
+  for (const candidateUrl of bilibiliPartAliases(videoUrl, requestedPart)) {
+    const existingPart = storageService.getVideoBySourceUrl(
+      candidateUrl,
+      mediaType,
+    );
+    if (existingPart) {
+      const downloadedAt = Date.parse(existingPart.createdAt ?? "");
+      return {
+        found: true,
+        status: "exists" as const,
+        videoId: existingPart.id,
+        title: existingPart.title,
+        author: existingPart.author,
+        downloadedAt: Number.isNaN(downloadedAt) ? undefined : downloadedAt,
+        sourceUrl: existingPart.sourceUrl,
+      };
+    }
+  }
+
+  // No saved item for this part. Only the tracking row knows about a *deleted*
+  // one, and only counts when it is about this part rather than another.
   const matchedPart = downloadCheck.sourceUrl
     ? (getBilibiliPartNumber(downloadCheck.sourceUrl) ?? 1)
     : requestedPart;
 
-  if (downloadCheck.found && matchedPart === requestedPart) {
+  if (
+    downloadCheck.found &&
+    matchedPart === requestedPart &&
+    downloadCheck.status === "deleted"
+  ) {
     return downloadCheck;
-  }
-
-  // Either nothing was tracked, or the tracking row is about another part.
-  // Ask the per-part rows directly before concluding this part is missing.
-  const existingPart = storageService.getVideoBySourceUrl(
-    trimBilibiliUrl(videoUrl),
-    mediaType,
-  );
-
-  if (existingPart) {
-    const downloadedAt = Date.parse(existingPart.createdAt ?? "");
-    return {
-      found: true,
-      status: "exists" as const,
-      videoId: existingPart.id,
-      title: existingPart.title,
-      author: existingPart.author,
-      downloadedAt: Number.isNaN(downloadedAt) ? undefined : downloadedAt,
-      sourceUrl: existingPart.sourceUrl,
-    };
   }
 
   if (downloadCheck.found) {
     logger.info(
-      `Bilibili duplicate check matched part ${matchedPart} but part ${requestedPart} was requested and has no saved item; treating as a new download.`,
+      `Bilibili duplicate check matched part ${matchedPart} but part ${requestedPart} has no saved item; treating as a new download.`,
     );
   }
 

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -165,6 +165,16 @@ function checkPreviousDownload(
   // surviving part and leaves it reading "exists", so that row cannot record a
   // per-part deletion. History rows can: each carries its own item's source
   // URL, so the deleted part is still on file under its own ?p=N URL.
+  //
+  // History rows carry no media type, so the tombstone is only consulted when a
+  // tracking row exists for the requested one. That row is media-type scoped,
+  // so its absence means nothing of this media type was ever downloaded here and
+  // any deleted entry under the same URL belongs to the other one — which would
+  // otherwise make a deleted video suppress a first-time audio request.
+  if (!downloadCheck.found) {
+    return { found: false };
+  }
+
   for (const candidateUrl of bilibiliPartAliases(videoUrl, requestedPart)) {
     const deletedItem =
       storageService.getLatestDeletedHistoryItemBySourceUrl(candidateUrl);

--- a/backend/src/controllers/videoDownloadController.ts
+++ b/backend/src/controllers/videoDownloadController.ts
@@ -146,8 +146,9 @@ function checkPreviousDownload(
     }
   }
 
-  // No saved item for this part. Only the tracking row knows about a *deleted*
-  // one, and only counts when it is about this part rather than another.
+  // No saved item for this part, so the question becomes whether it was
+  // downloaded and then deleted. The tracking row answers that only when it is
+  // about this part rather than another.
   const matchedPart = downloadCheck.sourceUrl
     ? (getBilibiliPartNumber(downloadCheck.sourceUrl) ?? 1)
     : requestedPart;
@@ -158,6 +159,27 @@ function checkPreviousDownload(
     downloadCheck.status === "deleted"
   ) {
     return downloadCheck;
+  }
+
+  // Deleting one part of a multipart video hands the shared tracking row to a
+  // surviving part and leaves it reading "exists", so that row cannot record a
+  // per-part deletion. History rows can: each carries its own item's source
+  // URL, so the deleted part is still on file under its own ?p=N URL.
+  for (const candidateUrl of bilibiliPartAliases(videoUrl, requestedPart)) {
+    const deletedItem =
+      storageService.getLatestDeletedHistoryItemBySourceUrl(candidateUrl);
+    if (deletedItem) {
+      return {
+        found: true,
+        status: "deleted" as const,
+        videoId: deletedItem.videoId,
+        title: deletedItem.title,
+        author: deletedItem.author,
+        downloadedAt: deletedItem.downloadedAt ?? undefined,
+        deletedAt: deletedItem.deletedAt ?? undefined,
+        sourceUrl: candidateUrl,
+      };
+    }
   }
 
   if (downloadCheck.found) {

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -239,7 +239,7 @@ export const downloadHistory = sqliteTable(
     videoId: text("video_id"), // Reference to video for skipped items
     downloadedAt: integer("downloaded_at"), // Original download timestamp for deleted items
     deletedAt: integer("deleted_at"), // Deletion timestamp for deleted items
-    mediaType: text("media_type"), // "video" | "audio"; null on legacy rows = video
+    mediaType: text("media_type"), // "video" | "audio"; null only when no video reference can be recovered
     subscriptionId: text("subscription_id"), // Reference to subscription if downloaded via subscription
     taskId: text("task_id"), // Reference to continuous download task if downloaded via task
     platform: text("platform"), // canonical: youtube/bilibili/twitch/missav/local/cloud/unknown

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -239,6 +239,7 @@ export const downloadHistory = sqliteTable(
     videoId: text("video_id"), // Reference to video for skipped items
     downloadedAt: integer("downloaded_at"), // Original download timestamp for deleted items
     deletedAt: integer("deleted_at"), // Deletion timestamp for deleted items
+    mediaType: text("media_type"), // "video" | "audio"; null on legacy rows = video
     subscriptionId: text("subscription_id"), // Reference to subscription if downloaded via subscription
     taskId: text("task_id"), // Reference to continuous download task if downloaded via task
     platform: text("platform"), // canonical: youtube/bilibili/twitch/missav/local/cloud/unknown

--- a/backend/src/services/bilibiliDownloadTask.ts
+++ b/backend/src/services/bilibiliDownloadTask.ts
@@ -483,9 +483,15 @@ export function buildBilibiliDownloadTask(
     // saved metadata has to agree. Hardcoding 1/1 here recorded part N under
     // part 1's number and filename identity, which collides with a later real
     // part-1 download.
-    const selectedPart = getBilibiliPartNumber(downloadUrl) ?? 1;
+    //
+    // An explicit ?p=1 is not the same as no selector: it names a part of what
+    // may well be a multipart video, so it needs the real count too. Saving it
+    // as a standalone 1/1 would drop the multipart title and filename treatment
+    // and leave metadata that disagrees with a later all-parts download of the
+    // same source URL.
+    const selectedPart = getBilibiliPartNumber(downloadUrl);
     const { partNumber, totalParts } =
-      selectedPart > 1
+      selectedPart != null
         ? await resolveSelectedPartCounts(downloadUrl, selectedPart)
         : { partNumber: 1, totalParts: 1 };
 

--- a/backend/src/services/bilibiliDownloadTask.ts
+++ b/backend/src/services/bilibiliDownloadTask.ts
@@ -1,5 +1,6 @@
 import {
   extractBilibiliVideoId,
+  getBilibiliPartNumber,
   isBilibiliUrl,
   trimBilibiliUrl,
 } from "../utils/helpers";
@@ -14,6 +15,37 @@ import * as storageService from "./storageService";
 import { resolveAuthorOrganizationMode } from "../types/settings";
 import type { AudioFormat } from "../types/settings";
 import type { DownloadModeOptions } from "./downloaders/BaseDownloader";
+
+/**
+ * Resolve the part number and real part count for a URL that names a specific
+ * part.
+ *
+ * totalParts drives the filename suffix, the title prefix, and whether the row
+ * is tracked as a multipart part, so it has to reflect the actual video. If the
+ * parts lookup fails, fall back to the selected part as the count: an off-by-a
+ * few "N/N" label is far better than recording part N as a standalone 1/1.
+ */
+async function resolveSelectedPartCounts(
+  downloadUrl: string,
+  selectedPart: number,
+): Promise<{ partNumber: number; totalParts: number }> {
+  const videoId = extractBilibiliVideoId(downloadUrl);
+  if (videoId) {
+    try {
+      const partsInfo = await downloadService.checkBilibiliVideoParts(videoId);
+      if (partsInfo.success && (partsInfo.videosNumber ?? 0) >= selectedPart) {
+        return { partNumber: selectedPart, totalParts: partsInfo.videosNumber };
+      }
+    } catch (error) {
+      logger.warn(
+        "Could not resolve Bilibili part count for a part-specific URL:",
+        error,
+      );
+    }
+  }
+
+  return { partNumber: selectedPart, totalParts: selectedPart };
+}
 
 function buildAggregateError(result: BilibiliAggregateDownloadResult): string {
   if (result.error) {
@@ -447,16 +479,28 @@ export function buildBilibiliDownloadTask(
       };
     }
 
-    logger.info("Downloading single Bilibili video part");
+    // A URL that names a part (…?p=N) makes yt-dlp download that part, so the
+    // saved metadata has to agree. Hardcoding 1/1 here recorded part N under
+    // part 1's number and filename identity, which collides with a later real
+    // part-1 download.
+    const selectedPart = getBilibiliPartNumber(downloadUrl) ?? 1;
+    const { partNumber, totalParts } =
+      selectedPart > 1
+        ? await resolveSelectedPartCounts(downloadUrl, selectedPart)
+        : { partNumber: 1, totalParts: 1 };
+
+    logger.info(
+      `Downloading single Bilibili video part ${partNumber}/${totalParts}`,
+    );
     const modeOptions = buildDownloadModeOptions(options);
     const result = modeOptions
       ? await downloadService.downloadSingleBilibiliPart(
-          downloadUrl, 1, 1, "", options.downloadId, registerCancel,
+          downloadUrl, partNumber, totalParts, "", options.downloadId, registerCancel,
           undefined, undefined,
           modeOptions,
         )
       : await downloadService.downloadSingleBilibiliPart(
-          downloadUrl, 1, 1, "", options.downloadId, registerCancel,
+          downloadUrl, partNumber, totalParts, "", options.downloadId, registerCancel,
         );
 
     return {

--- a/backend/src/services/bilibiliDownloadTask.ts
+++ b/backend/src/services/bilibiliDownloadTask.ts
@@ -176,6 +176,9 @@ export function buildBilibiliDownloadTask(
       );
       let firstPartResult: downloadService.DownloadResult;
       let firstVideo = existingPart1;
+      const downloadedVideos: NonNullable<
+        BilibiliAggregateDownloadResult["downloadedVideos"]
+      > = [];
       let collectionId: string | null = null;
       const multipartCollectionName =
         options.collectionName ?? retryMetadata?.collectionName;
@@ -372,6 +375,7 @@ export function buildBilibiliDownloadTask(
         }
         if (firstPartResult.videoData) {
           firstVideo = firstPartResult.videoData;
+          downloadedVideos.push(firstPartResult.videoData);
         }
         if (retryMetadata?.shape === "bilibili_all_parts") {
           if (firstPartResult.success && firstPartResult.videoData) {
@@ -413,6 +417,7 @@ export function buildBilibiliDownloadTask(
         failedPartNumbers = failedPartNumbers.concat(
           remainingResult.failedPartNumbers,
         );
+        downloadedVideos.push(...(remainingResult.downloadedVideos ?? []));
         if (!firstVideo && remainingResult.firstVideo) {
           firstVideo = remainingResult.firstVideo;
         }
@@ -455,6 +460,7 @@ export function buildBilibiliDownloadTask(
         skippedCount,
         failedPartNumbers,
         firstVideo,
+        downloadedVideos,
         video: firstVideo,
         isMultiPart: true,
         totalParts: videosNumber,
@@ -471,6 +477,7 @@ export function buildBilibiliDownloadTask(
                 skippedCount,
                 failedPartNumbers,
                 firstVideo,
+                downloadedVideos,
                 collectionId: collectionId ?? undefined,
                 isMultiPart: true,
                 totalParts: videosNumber,

--- a/backend/src/services/continuousDownload/videoUrlFetcher.ts
+++ b/backend/src/services/continuousDownload/videoUrlFetcher.ts
@@ -608,7 +608,7 @@ export class VideoUrlFetcher {
     if (!mid) {
       const videoId = extractBilibiliVideoId(authorUrl);
       if (videoId) {
-        const collectionInfo = await checkBilibiliCollectionOrSeries(videoId);
+        const collectionInfo = await checkBilibiliCollectionOrSeries(videoId, subscriptionYtdlpConfig);
         if (
           collectionInfo.success &&
           collectionInfo.type !== "none" &&
@@ -621,9 +621,9 @@ export class VideoUrlFetcher {
 
           let videosResult;
           if (collectionInfo.type === "collection") {
-            videosResult = await getCollectionVideos(collectionInfo.mid, collectionInfo.id);
+            videosResult = await getCollectionVideos(collectionInfo.mid, collectionInfo.id, undefined, subscriptionYtdlpConfig);
           } else if (collectionInfo.type === "series") {
-            videosResult = await getSeriesVideos(collectionInfo.mid, collectionInfo.id);
+            videosResult = await getSeriesVideos(collectionInfo.mid, collectionInfo.id, undefined, subscriptionYtdlpConfig);
           } else {
             throw new Error(`Unsupported Bilibili type: ${collectionInfo.type}`);
           }
@@ -948,15 +948,15 @@ export class VideoUrlFetcher {
       const videoId = extractBilibiliVideoId(authorUrl);
       if (videoId) {
         // Check if this video belongs to a collection or series
-        const collectionInfo = await checkBilibiliCollectionOrSeries(videoId);
+        const collectionInfo = await checkBilibiliCollectionOrSeries(videoId, subscriptionYtdlpConfig);
         if (collectionInfo.success && collectionInfo.type !== "none" && collectionInfo.mid && collectionInfo.id) {
           // It's a collection or series, use the collection API
           logger.info(`Detected Bilibili ${collectionInfo.type} from video URL, using collection API`);
           let videosResult;
           if (collectionInfo.type === "collection") {
-            videosResult = await getCollectionVideos(collectionInfo.mid, collectionInfo.id);
+            videosResult = await getCollectionVideos(collectionInfo.mid, collectionInfo.id, undefined, subscriptionYtdlpConfig);
           } else if (collectionInfo.type === "series") {
-            videosResult = await getSeriesVideos(collectionInfo.mid, collectionInfo.id);
+            videosResult = await getSeriesVideos(collectionInfo.mid, collectionInfo.id, undefined, subscriptionYtdlpConfig);
           } else {
             throw new Error(`Unsupported Bilibili type: ${collectionInfo.type}`);
           }

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -650,6 +650,10 @@ class DownloadManager {
             author: videoData.author,
             videoId: videoData.id,
             totalSize: historyTotalSize,
+            // Carried so a later deletion leaves a tombstone that says which of
+            // audio/video went away, which the shared source-level tracking row
+            // cannot express for a multipart item.
+            mediaType: videoData.mediaType === "audio" ? "audio" : "video",
             platform: platformFromUrl(historySourceUrl),
             sourceKind: task.statistics?.sourceKind ?? "manual",
             downloadType: task.type,

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -665,6 +665,13 @@ class DownloadManager {
         task.cancelFn = cancel;
       });
       if (task.cancelled) {
+        // An aggregate download can have saved parts before the cancel landed,
+        // and this is the only point where that result is in hand — the
+        // cancellation is usually finalized earlier, while the download was
+        // still running. Record those parts before discarding the result:
+        // their success rows are the only ones a later deletion can turn into
+        // a tombstone, since the task-level cancel row is a "failed" one.
+        addAggregatePartHistory(task, result);
         throw DownloadCancelledError.create();
       }
 

--- a/backend/src/services/downloadManager.ts
+++ b/backend/src/services/downloadManager.ts
@@ -38,8 +38,81 @@ import {
   normalizeSurface,
 } from "./statistics";
 import type { DownloadHistoryItem } from "./storageService";
+import type { Video } from "./storageService";
 import * as storageService from "./storageService";
 import { logger } from "../utils/logger";
+
+function getAggregateDownloadedVideos(value: unknown): Video[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const downloadedVideos = (value as { downloadedVideos?: unknown })
+    .downloadedVideos;
+  if (!Array.isArray(downloadedVideos)) {
+    return [];
+  }
+
+  return downloadedVideos.filter(
+    (video): video is Video =>
+      Boolean(video) &&
+      typeof video === "object" &&
+      typeof (video as { id?: unknown }).id === "string" &&
+      (video as { id: string }).id.length > 0,
+  );
+}
+
+function addAggregatePartHistory(
+  task: DownloadTask,
+  value: unknown,
+  representativeVideoId?: string,
+): void {
+  if (task.options?.suppressHistory) {
+    return;
+  }
+
+  const downloadedVideos = getAggregateDownloadedVideos(value);
+  if (downloadedVideos.length === 0) {
+    return;
+  }
+
+  const seenVideoIds = new Set<string>();
+  downloadedVideos.forEach((video, index) => {
+    if (video.id === representativeVideoId || seenVideoIds.has(video.id)) {
+      return;
+    }
+    seenVideoIds.add(video.id);
+
+    const sourceUrl = video.sourceUrl || task.sourceUrl;
+    const partNumber =
+      typeof video.partNumber === "number" &&
+      Number.isInteger(video.partNumber) &&
+      video.partNumber > 0
+        ? video.partNumber
+        : index + 1;
+    const totalSize =
+      typeof video.fileSize === "string" || typeof video.fileSize === "number"
+        ? String(video.fileSize)
+        : undefined;
+
+    storageService.addDownloadHistoryItem({
+      id: `${task.id}:part-${partNumber}`,
+      title: video.title || task.title,
+      finishedAt: Date.now(),
+      status: "success",
+      videoPath: video.videoPath,
+      thumbnailPath: video.thumbnailPath,
+      sourceUrl,
+      author: video.author,
+      videoId: video.id,
+      totalSize,
+      mediaType: video.mediaType === "audio" ? "audio" : "video",
+      platform: platformFromUrl(sourceUrl),
+      sourceKind: task.statistics?.sourceKind ?? "manual",
+      downloadType: task.type,
+    });
+  });
+}
 
 class DownloadManager {
   private queue: DownloadTask[];
@@ -662,6 +735,7 @@ class DownloadManager {
                 ? serializeRetryMetadata(task.retryMetadata)
                 : undefined,
           });
+          addAggregatePartHistory(task, result, videoData.id);
         }
 
         // Record video download for future duplicate detection
@@ -774,6 +848,11 @@ class DownloadManager {
 
       // Download failed
       storageService.removeActiveDownload(task.id);
+      const structuredResult = getStructuredDownloadResult(error);
+      // The task-level history row is partial/failed here, so it cannot later
+      // become a deletion tombstone. Keep a success row for every part that
+      // was actually saved, including the part surfaced as `video`.
+      addAggregatePartHistory(task, structuredResult);
 
       // Add to history (unless already added by cancelDownload). Members-only
       // subscription skips are never retried — retrying can't succeed.
@@ -785,7 +864,6 @@ class DownloadManager {
       if (!task.cancelled && !retryScheduled) {
         this.clearRetryTimer(task.id);
         if (!task.options?.suppressHistory) {
-          const structuredResult = getStructuredDownloadResult(error);
           storageService.addDownloadHistoryItem({
             id: task.id,
             title: task.title,

--- a/backend/src/services/downloadService.ts
+++ b/backend/src/services/downloadService.ts
@@ -58,8 +58,9 @@ export async function downloadBilibiliVideo(
 // Helper function to check if a Bilibili video has multiple parts
 export async function checkBilibiliVideoParts(
   videoId: string,
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliPartsCheckResult> {
-  return BilibiliDownloader.checkVideoParts(videoId);
+  return BilibiliDownloader.checkVideoParts(videoId, subscriptionYtdlpConfig);
 }
 
 // Helper function to check if a YouTube URL is a playlist
@@ -127,8 +128,12 @@ export async function checkPlaylist(playlistUrl: string): Promise<{
 // Helper function to check if a Bilibili video belongs to a collection or series
 export async function checkBilibiliCollectionOrSeries(
   videoId: string,
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliCollectionCheckResult> {
-  return BilibiliDownloader.checkCollectionOrSeries(videoId);
+  return BilibiliDownloader.checkCollectionOrSeries(
+    videoId,
+    subscriptionYtdlpConfig,
+  );
 }
 
 // Helper function to get all videos from a Bilibili collection
@@ -136,8 +141,14 @@ export async function getBilibiliCollectionVideos(
   mid: number,
   seasonId: number,
   options?: { pageSize?: number; maxPages?: number },
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliVideosResult> {
-  return BilibiliDownloader.getCollectionVideos(mid, seasonId, options);
+  return BilibiliDownloader.getCollectionVideos(
+    mid,
+    seasonId,
+    options,
+    subscriptionYtdlpConfig,
+  );
 }
 
 // Helper function to get all videos from a Bilibili series
@@ -145,8 +156,14 @@ export async function getBilibiliSeriesVideos(
   mid: number,
   seriesId: number,
   options?: { pageSize?: number; maxPages?: number },
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliVideosResult> {
-  return BilibiliDownloader.getSeriesVideos(mid, seriesId, options);
+  return BilibiliDownloader.getSeriesVideos(
+    mid,
+    seriesId,
+    options,
+    subscriptionYtdlpConfig,
+  );
 }
 
 // Helper function to download a single Bilibili part

--- a/backend/src/services/downloaders/BilibiliDownloader.ts
+++ b/backend/src/services/downloaders/BilibiliDownloader.ts
@@ -108,34 +108,48 @@ export class BilibiliDownloader extends BaseDownloader {
 
   // Helper function to check if a Bilibili video has multiple parts
   static async checkVideoParts(
-    videoId: string
+    videoId: string,
+    subscriptionYtdlpConfig?: string | null
   ): Promise<BilibiliPartsCheckResult> {
-    return bilibiliApi.checkVideoParts(videoId);
+    return bilibiliApi.checkVideoParts(videoId, subscriptionYtdlpConfig);
   }
 
   // Helper function to check if a Bilibili video belongs to a collection or series
   static async checkCollectionOrSeries(
-    videoId: string
+    videoId: string,
+    subscriptionYtdlpConfig?: string | null
   ): Promise<BilibiliCollectionCheckResult> {
-    return bilibiliApi.checkCollectionOrSeries(videoId);
+    return bilibiliApi.checkCollectionOrSeries(videoId, subscriptionYtdlpConfig);
   }
 
   // Helper function to get all videos from a Bilibili collection
   static async getCollectionVideos(
     mid: number,
     seasonId: number,
-    options?: CollectionFetchOptions
+    options?: CollectionFetchOptions,
+    subscriptionYtdlpConfig?: string | null
   ): Promise<BilibiliVideosResult> {
-    return bilibiliCollection.getCollectionVideos(mid, seasonId, options);
+    return bilibiliCollection.getCollectionVideos(
+      mid,
+      seasonId,
+      options,
+      subscriptionYtdlpConfig
+    );
   }
 
   // Helper function to get all videos from a Bilibili series
   static async getSeriesVideos(
     mid: number,
     seriesId: number,
-    options?: CollectionFetchOptions
+    options?: CollectionFetchOptions,
+    subscriptionYtdlpConfig?: string | null
   ): Promise<BilibiliVideosResult> {
-    return bilibiliCollection.getSeriesVideos(mid, seriesId, options);
+    return bilibiliCollection.getSeriesVideos(
+      mid,
+      seriesId,
+      options,
+      subscriptionYtdlpConfig
+    );
   }
 
   // Helper function to download a single Bilibili part

--- a/backend/src/services/downloaders/bilibili/bilibiliApi.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliApi.ts
@@ -276,13 +276,29 @@ export async function checkVideoParts(
  * Check if a Bilibili video belongs to a collection or series
  */
 export async function checkCollectionOrSeries(
-  videoId: string
+  videoId: string,
+  subscriptionYtdlpConfig?: string | null
 ): Promise<BilibiliCollectionCheckResult> {
   try {
+    // Same reasoning as checkVideoParts: this is the other preflight the
+    // frontend runs before a Bilibili download, and resolving short links now
+    // lets it reach the API instead of failing ID extraction first.
+    const axiosConfig = resolveProxiedAxiosConfigForUrl(
+      `https://www.bilibili.com/video/${videoId}`,
+      subscriptionYtdlpConfig
+    );
+    if (!axiosConfig) {
+      logger.warn(
+        "Skipping Bilibili collection check: proxy is configured but unusable"
+      );
+      return { success: false, type: "none" };
+    }
+
     const apiUrl = `https://api.bilibili.com/x/web-interface/view?bvid=${videoId}`;
     logger.info("Checking if video belongs to collection/series:", apiUrl);
 
     const response = await axios.get(apiUrl, {
+      ...axiosConfig,
       headers: {
         Referer: "https://www.bilibili.com",
         "User-Agent":

--- a/backend/src/services/downloaders/bilibili/bilibiliApi.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliApi.ts
@@ -7,6 +7,7 @@ import {
   getUserYtDlpConfig,
 } from "../../../utils/ytDlpUtils";
 import { VideoInfo } from "../BaseDownloader";
+import { resolveProxiedAxiosConfigForUrl } from "./bilibiliConfig";
 import {
   BilibiliCollectionCheckResult,
   BilibiliPartsCheckResult,
@@ -213,9 +214,24 @@ export async function getLatestVideoUrl(
  * Check if a Bilibili video has multiple parts
  */
 export async function checkVideoParts(
-  videoId: string
+  videoId: string,
+  subscriptionYtdlpConfig?: string | null
 ): Promise<BilibiliPartsCheckResult> {
   try {
+    // No URL in scope, so the config is keyed off the video URL this lookup is
+    // about — which also applies the "proxy only for YouTube" setting the same
+    // way it applies to the yt-dlp call for that URL.
+    const axiosConfig = resolveProxiedAxiosConfigForUrl(
+      `https://www.bilibili.com/video/${videoId}`,
+      subscriptionYtdlpConfig
+    );
+    if (!axiosConfig) {
+      logger.warn(
+        "Skipping Bilibili parts check: proxy is configured but unusable"
+      );
+      return { success: false, videosNumber: 1 };
+    }
+
     // Try to get video info from Bilibili API
     // Handle both BV and av formats
     const isBvId = videoId.startsWith("BV");
@@ -228,6 +244,7 @@ export async function checkVideoParts(
     logger.info("Fetching video info from API to check parts:", apiUrl);
 
     const response = await axios.get(apiUrl, {
+      ...axiosConfig,
       headers: {
         Referer: "https://www.bilibili.com",
         "User-Agent":

--- a/backend/src/services/downloaders/bilibili/bilibiliApi.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliApi.ts
@@ -7,21 +7,40 @@ import {
   getUserYtDlpConfig,
 } from "../../../utils/ytDlpUtils";
 import { VideoInfo } from "../BaseDownloader";
-import { resolveProxiedAxiosConfigForUrl } from "./bilibiliConfig";
+import {
+  resolveProxiedAxiosConfig,
+  resolveProxiedAxiosConfigForUrl,
+} from "./bilibiliConfig";
 import {
   BilibiliCollectionCheckResult,
   BilibiliPartsCheckResult,
 } from "./types";
 
+const BILIBILI_API_HEADERS = {
+  Referer: "https://www.bilibili.com",
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+};
+
+function buildUnknownVideoInfo(): VideoInfo {
+  return {
+    title: "Bilibili Video",
+    author: "Bilibili User",
+    date: new Date().toISOString().slice(0, 10).replace(/-/g, ""),
+    thumbnailUrl: null,
+  };
+}
+
 /**
  * Get video info from Bilibili (tries yt-dlp first, falls back to API)
  */
 export async function getVideoInfo(videoId: string): Promise<VideoInfo> {
-  try {
-    const videoUrl = `https://www.bilibili.com/video/${videoId}`;
+  const videoUrl = `https://www.bilibili.com/video/${videoId}`;
+  // Get user config for network options. Resolved outside the try so the API
+  // fallback in the catch can route through the same proxy yt-dlp used.
+  const userConfig = getUserYtDlpConfig(videoUrl);
 
-    // Get user config for network options
-    const userConfig = getUserYtDlpConfig(videoUrl);
+  try {
     const networkConfig = getNetworkConfigFromUserConfig(userConfig);
     const info = await executeYtDlpJson(videoUrl, {
       ...networkConfig,
@@ -42,8 +61,19 @@ export async function getVideoInfo(videoId: string): Promise<VideoInfo> {
     logger.error("Error fetching Bilibili video info with yt-dlp:", error);
     // Fallback to API
     try {
+      const axiosConfig = resolveProxiedAxiosConfig(userConfig);
+      if (!axiosConfig) {
+        logger.warn(
+          "Skipping Bilibili video info API fallback: proxy is configured but unusable",
+        );
+        return buildUnknownVideoInfo();
+      }
+
       const apiUrl = `https://api.bilibili.com/x/web-interface/view?bvid=${videoId}`;
-      const response = await axios.get(apiUrl);
+      const response = await axios.get(apiUrl, {
+        ...axiosConfig,
+        headers: BILIBILI_API_HEADERS,
+      });
 
       if (response.data && response.data.data) {
         const videoInfo = response.data.data;
@@ -61,12 +91,7 @@ export async function getVideoInfo(videoId: string): Promise<VideoInfo> {
     } catch (apiError) {
       logger.error("Error fetching Bilibili video info from API:", apiError);
     }
-    return {
-      title: "Bilibili Video",
-      author: "Bilibili User",
-      date: new Date().toISOString().slice(0, 10).replace(/-/g, ""),
-      thumbnailUrl: null,
-    };
+    return buildUnknownVideoInfo();
   }
 }
 

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -13,6 +13,7 @@ import { downloadSinglePart } from "./bilibiliVideo";
 import {
   BILIBILI_COOKIE_REFRESH_HINT,
   isLikelyBilibiliAuthFailure,
+  resolveProxiedAxiosConfigForUrl,
 } from "./bilibiliConfig";
 import type { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import {
@@ -329,6 +330,7 @@ export async function getCollectionVideos(
   mid: number,
   seasonId: number,
   options?: BilibiliVideoFetchOptions,
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliVideosResult> {
   try {
     const allVideos: BilibiliVideoItem[] = [];
@@ -339,6 +341,19 @@ export async function getCollectionVideos(
     logger.info(
       `Fetching collection videos for mid=${mid}, season_id=${seasonId}`
     );
+
+    // Resolved once for the whole pagination loop; keyed off the owner's space
+    // URL since that is the source these archives belong to.
+    const axiosConfig = resolveProxiedAxiosConfigForUrl(
+      `https://space.bilibili.com/${mid}`,
+      subscriptionYtdlpConfig
+    );
+    if (!axiosConfig) {
+      logger.warn(
+        "Skipping Bilibili collection video fetch: proxy is configured but unusable"
+      );
+      return { success: false, videos: [] };
+    }
 
     while (hasMore && (maxPages === null || pageNum <= maxPages)) {
       const apiUrl = `https://api.bilibili.com/x/polymer/web-space/seasons_archives_list`;
@@ -353,6 +368,7 @@ export async function getCollectionVideos(
       logger.info(`Fetching page ${pageNum} of collection...`);
 
       const response = await axios.get(apiUrl, {
+        ...axiosConfig,
         params,
         headers: {
           Referer: "https://www.bilibili.com",
@@ -399,6 +415,7 @@ export async function getSeriesVideos(
   mid: number,
   seriesId: number,
   options?: BilibiliVideoFetchOptions,
+  subscriptionYtdlpConfig?: string | null,
 ): Promise<BilibiliVideosResult> {
   try {
     const allVideos: BilibiliVideoItem[] = [];
@@ -407,6 +424,19 @@ export async function getSeriesVideos(
     let hasMore = true;
 
     logger.info(`Fetching series videos for mid=${mid}, series_id=${seriesId}`);
+
+    // Resolved once for the whole pagination loop; keyed off the owner's space
+    // URL since that is the source these archives belong to.
+    const axiosConfig = resolveProxiedAxiosConfigForUrl(
+      `https://space.bilibili.com/${mid}`,
+      subscriptionYtdlpConfig
+    );
+    if (!axiosConfig) {
+      logger.warn(
+        "Skipping Bilibili series video fetch: proxy is configured but unusable"
+      );
+      return { success: false, videos: [] };
+    }
 
     while (hasMore && (maxPages === null || pageNum <= maxPages)) {
       const apiUrl = `https://api.bilibili.com/x/series/archives`;
@@ -420,6 +450,7 @@ export async function getSeriesVideos(
       logger.info(`Fetching page ${pageNum} of series...`);
 
       const response = await axios.get(apiUrl, {
+        ...axiosConfig,
         params,
         headers: {
           Referer: "https://www.bilibili.com",

--- a/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCollection.ts
@@ -887,6 +887,10 @@ export async function downloadRemainingParts(
   onStart?: (cancel: () => void) => void,
   retryMetadata?: DownloadRetryMetadata,
 ): Promise<BilibiliAggregateDownloadResult> {
+  let downloadedVideos: NonNullable<
+    BilibiliAggregateDownloadResult["downloadedVideos"]
+  > = [];
+
   try {
     logger.info(
       `Starting download of remaining parts: ${startPart} to ${totalParts} of "${seriesTitle}"`
@@ -985,6 +989,7 @@ export async function downloadRemainingParts(
 
       if (result.success && result.videoData) {
         successCount++;
+        downloadedVideos.push(result.videoData);
         if (retryPartsMetadata) {
           retryPartsMetadata.completedPartNumbers = Array.from(
             new Set([...(retryPartsMetadata.completedPartNumbers ?? []), part]),
@@ -1063,6 +1068,7 @@ export async function downloadRemainingParts(
       skippedCount,
       failedPartNumbers: failedParts,
       firstVideo,
+      downloadedVideos,
       collectionId: collectionId ?? undefined,
       isMultiPart: true,
       totalParts,
@@ -1078,6 +1084,7 @@ export async function downloadRemainingParts(
       downloadedCount: 0,
       skippedCount: 0,
       failedPartNumbers: [],
+      downloadedVideos,
       collectionId: collectionId ?? undefined,
       isMultiPart: true,
       totalParts,

--- a/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from "../../../utils/logger";
 import {
   getAxiosProxyConfig,
+  getEffectiveUserYtDlpConfig,
   getNetworkConfigFromUserConfig,
   getUserYtDlpConfig,
   InvalidProxyError,
@@ -42,6 +43,23 @@ export function resolveProxiedAxiosConfig(
     }
     throw error;
   }
+}
+
+/**
+ * resolveProxiedAxiosConfig for callers that hold a URL rather than a resolved
+ * config.
+ *
+ * The URL is passed through to the config lookup so the "proxy only for
+ * YouTube" setting is applied the same way it is for the yt-dlp call on the
+ * same URL, instead of the API request quietly taking a different route.
+ */
+export function resolveProxiedAxiosConfigForUrl(
+  url: string,
+  subscriptionYtdlpConfig?: string | null,
+): Record<string, unknown> | null {
+  return resolveProxiedAxiosConfig(
+    getEffectiveUserYtDlpConfig(url, subscriptionYtdlpConfig),
+  );
 }
 
 export interface BilibiliDownloadFlags {

--- a/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliConfig.ts
@@ -6,10 +6,43 @@ import {
 } from "../../../types/settings";
 import { logger } from "../../../utils/logger";
 import {
+  getAxiosProxyConfig,
   getNetworkConfigFromUserConfig,
   getUserYtDlpConfig,
+  InvalidProxyError,
 } from "../../../utils/ytDlpUtils";
 import { isAudioOnlyFormatSelector } from "../ytdlp/ytdlpConfig";
+
+/**
+ * Axios config for a Bilibili download's outbound side requests (API metadata
+ * lookups, thumbnails, avatars, subtitles), honoring the user's proxy.
+ *
+ * Returns null when a proxy is configured but unusable. getAxiosProxyConfig
+ * throws on a malformed proxy specifically so callers do not silently fall back
+ * to a direct connection and expose the user's real IP, so a null here means
+ * "skip the request", never "send it directly".
+ */
+export function resolveProxiedAxiosConfig(
+  userConfig: Record<string, any>,
+): Record<string, unknown> | null {
+  const proxy = userConfig?.proxy;
+  if (typeof proxy !== "string" || !proxy) {
+    return {};
+  }
+
+  try {
+    return getAxiosProxyConfig(proxy);
+  } catch (error) {
+    if (error instanceof InvalidProxyError) {
+      logger.warn(
+        "Invalid proxy configuration; skipping Bilibili side requests rather than sending them directly:",
+        error.message,
+      );
+      return null;
+    }
+    throw error;
+  }
+}
 
 export interface BilibiliDownloadFlags {
   [key: string]: string | number | boolean | string[] | undefined | null;

--- a/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
@@ -54,6 +54,37 @@ function extractBilibiliVideoIdFromYtDlpId(id: unknown): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Axios config for this download's outbound side requests, honoring the user's
+ * proxy.
+ *
+ * Returns null when a proxy is configured but unusable. getAxiosProxyConfig
+ * throws on a malformed proxy specifically so callers do not silently fall back
+ * to a direct connection and expose the user's real IP, so a null here means
+ * "skip the request", never "send it directly".
+ */
+function resolveProxiedAxiosConfig(
+  userConfig: Record<string, any>,
+): Record<string, unknown> | null {
+  const proxy = userConfig?.proxy;
+  if (typeof proxy !== "string" || !proxy) {
+    return {};
+  }
+
+  try {
+    return getAxiosProxyConfig(proxy);
+  } catch (error) {
+    if (error instanceof InvalidProxyError) {
+      logger.warn(
+        "Invalid proxy configuration; skipping Bilibili side requests rather than sending them directly:",
+        error.message,
+      );
+      return null;
+    }
+    throw error;
+  }
+}
+
 function resolveDownloadedVideoDestination(
   plannedVideoPath: string,
   downloadedVideoFile: string,
@@ -174,12 +205,17 @@ export async function downloadVideo(
       });
     }
 
+    // Resolved once for every outbound side request in this download (avatar
+    // API lookup, thumbnail, avatar image). null means the configured proxy is
+    // unusable, so these requests are skipped rather than sent directly.
+    const proxiedAxiosConfig = resolveProxiedAxiosConfig(userConfig);
+
     // Try to get avatar URL from yt-dlp info first
     let authorAvatarUrl =
       metaSource.channel_avatar || metaSource.uploader_avatar || null;
 
     // If not in yt-dlp info, get it from Bilibili API
-    if (!authorAvatarUrl) {
+    if (!authorAvatarUrl && proxiedAxiosConfig) {
       try {
         const { extractBilibiliVideoId } = await import(
           "../../../utils/helpers"
@@ -208,6 +244,7 @@ export async function downloadVideo(
               )}`;
 
           const response = await axios.get(apiUrl, {
+            ...proxiedAxiosConfig,
             headers: {
               Referer: "https://www.bilibili.com",
               "User-Agent":
@@ -510,28 +547,13 @@ export async function downloadVideo(
 
     // Download thumbnail if available
     let thumbnailSaved = false;
-    if (thumbnailUrl) {
+    if (thumbnailUrl && proxiedAxiosConfig) {
       // Use base class method via temporary instance
-      let axiosConfig = {};
-      if (userConfig.proxy) {
-        try {
-          axiosConfig = getAxiosProxyConfig(userConfig.proxy);
-        } catch (error) {
-          if (error instanceof InvalidProxyError) {
-            logger.warn(
-              "Invalid proxy configuration for thumbnail download, proceeding without proxy:",
-              error.message
-            );
-          } else {
-            throw error;
-          }
-        }
-      }
       const downloader = new BilibiliDownloaderHelper();
       thumbnailSaved = await downloader.downloadThumbnailPublic(
         thumbnailUrl,
         thumbnailPath,
-        axiosConfig
+        proxiedAxiosConfig
       );
     }
 
@@ -542,28 +564,12 @@ export async function downloadVideo(
     const platform = "bilibili";
     let authorAvatarPathResult: string | null = null;
 
-    if (authorAvatarUrl) {
+    if (authorAvatarUrl && proxiedAxiosConfig) {
       logger.info("Downloading Bilibili author avatar from URL:", {
         url: authorAvatarUrl,
         author: videoAuthor,
         platform: platform,
       });
-
-      let axiosConfig = {};
-      if (userConfig.proxy) {
-        try {
-          axiosConfig = getAxiosProxyConfig(userConfig.proxy);
-        } catch (error) {
-          if (error instanceof InvalidProxyError) {
-            logger.warn(
-              "Invalid proxy configuration for avatar download, proceeding without proxy:",
-              error.message
-            );
-          } else {
-            throw error;
-          }
-        }
-      }
 
       const downloader = new BilibiliDownloaderHelper();
       authorAvatarPathResult = await downloadAndProcessAvatar(
@@ -571,10 +577,10 @@ export async function downloadVideo(
         platform,
         videoAuthor,
         downloader.downloadThumbnailPublic.bind(downloader),
-        axiosConfig
+        proxiedAxiosConfig
       );
       authorAvatarSaved = authorAvatarPathResult !== null;
-    } else {
+    } else if (!authorAvatarUrl) {
       logger.info(
         "No Bilibili author avatar URL available, skipping avatar download"
       );

--- a/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
@@ -44,6 +44,16 @@ import {
   formatYtDlpFailureMessage,
 } from "./bilibiliVideoHelpers";
 
+/**
+ * yt-dlp reports the Bilibili id bare (no /video/ prefix) and suffixes the part
+ * for multipart videos, e.g. "BV1xx411c7mD_p2". Pull the bare BV/av id out.
+ */
+function extractBilibiliVideoIdFromYtDlpId(id: unknown): string | null {
+  if (typeof id !== "string") return null;
+  const match = id.match(/^(BV[0-9A-Za-z]+|av\d+)/i);
+  return match ? match[1] : null;
+}
+
 function resolveDownloadedVideoDestination(
   plannedVideoPath: string,
   downloadedVideoFile: string,
@@ -174,7 +184,18 @@ export async function downloadVideo(
         const { extractBilibiliVideoId } = await import(
           "../../../utils/helpers"
         );
-        const videoId = extractBilibiliVideoId(url);
+        // A b23.tv short URL carries no BV/av id. Resolution of the shortener is
+        // best-effort (it can fail behind a proxy or an offline network), but
+        // yt-dlp followed the redirect itself, so its metadata still knows the
+        // canonical URL — fall back to that rather than skipping the avatar.
+        const videoId =
+          extractBilibiliVideoId(url) ??
+          extractBilibiliVideoId(
+            typeof metaSource.webpage_url === "string"
+              ? metaSource.webpage_url
+              : ""
+          ) ??
+          extractBilibiliVideoIdFromYtDlpId(metaSource.id);
         if (videoId) {
           logger.info("Fetching Bilibili avatar from API for video:", videoId);
           const axios = (await import("axios")).default;

--- a/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliCoreDownload.ts
@@ -24,6 +24,7 @@ import {
 import * as storageService from "../../storageService";
 import {
   prepareBilibiliDownloadFlags,
+  resolveProxiedAxiosConfig,
   resolveResolutionPreference,
   resolveResolutionRetryTarget,
 } from "./bilibiliConfig";
@@ -52,37 +53,6 @@ function extractBilibiliVideoIdFromYtDlpId(id: unknown): string | null {
   if (typeof id !== "string") return null;
   const match = id.match(/^(BV[0-9A-Za-z]+|av\d+)/i);
   return match ? match[1] : null;
-}
-
-/**
- * Axios config for this download's outbound side requests, honoring the user's
- * proxy.
- *
- * Returns null when a proxy is configured but unusable. getAxiosProxyConfig
- * throws on a malformed proxy specifically so callers do not silently fall back
- * to a direct connection and expose the user's real IP, so a null here means
- * "skip the request", never "send it directly".
- */
-function resolveProxiedAxiosConfig(
-  userConfig: Record<string, any>,
-): Record<string, unknown> | null {
-  const proxy = userConfig?.proxy;
-  if (typeof proxy !== "string" || !proxy) {
-    return {};
-  }
-
-  try {
-    return getAxiosProxyConfig(proxy);
-  } catch (error) {
-    if (error instanceof InvalidProxyError) {
-      logger.warn(
-        "Invalid proxy configuration; skipping Bilibili side requests rather than sending them directly:",
-        error.message,
-      );
-      return null;
-    }
-    throw error;
-  }
 }
 
 function resolveDownloadedVideoDestination(

--- a/backend/src/services/downloaders/bilibili/bilibiliMetadata.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliMetadata.ts
@@ -36,12 +36,22 @@ export async function extractPartMetadata(
   partNumber: number,
   totalParts: number,
   seriesTitle: string,
-  bilibiliInfo: BilibiliVideoInfo
+  bilibiliInfo: BilibiliVideoInfo,
+  // null means a configured proxy is unusable: skip the lookup rather than
+  // reach api.bilibili.com directly and expose the user's real IP.
+  axiosConfig: Record<string, unknown> | null = {}
 ): Promise<PartMetadata> {
   let channelUrl: string | undefined;
   let partTitle = bilibiliInfo.title || "Bilibili Video";
 
   try {
+    if (!axiosConfig) {
+      logger.warn(
+        "Skipping Bilibili part metadata lookup: proxy is configured but unusable"
+      );
+      return { partTitle, channelUrl };
+    }
+
     const videoId = extractBilibiliVideoId(url);
     if (!videoId) {
       logger.warn("Could not extract video ID from URL, using yt-dlp title");
@@ -57,6 +67,7 @@ export async function extractPartMetadata(
         )}`;
 
     const response = await axios.get<BilibiliViewResponse>(apiUrl, {
+      ...axiosConfig,
       headers: {
         Referer: "https://www.bilibili.com",
         "User-Agent":

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -141,8 +141,12 @@ export async function downloadSinglePart(
     const timestamp = Date.now();
     const downloadedAtIso = new Date(timestamp).toISOString();
     const sourceVideoId = extractBilibiliVideoId(url) || undefined;
+    // An explicit target (collision repair, redownload) names the row to update,
+    // so it is honored whatever the video's aggregate part count is: a URL that
+    // selects one part of a multipart video still repairs that one row. Only the
+    // implicit same-URL reuse stays limited to single-part videos.
     const existingLocalVideoForRedownload =
-      totalParts === 1
+      totalParts === 1 || modeOptions?.existingLocalVideoId
         ? resolveExistingVideoForRedownload(
             url,
             audioOnly ? "audio" : "video",
@@ -444,8 +448,10 @@ export async function downloadSinglePart(
       : undefined;
 
     // For multi-part videos, always create a new video entry (each part is separate)
-    // For single videos, check if video with same sourceUrl already exists
-    if (totalParts === 1) {
+    // For single videos, check if video with same sourceUrl already exists.
+    // An explicit repair/redownload target overrides that: it updates its own
+    // row rather than adding a duplicate alongside the item it was meant to fix.
+    if (totalParts === 1 || existingLocalVideoForRedownload) {
       // Scope by media type so an audio-only download becomes its own library
       // item instead of overwriting the existing video row for the same URL.
       const existingVideo = existingLocalVideoForRedownload;

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -3,6 +3,7 @@ import { getErrorMessage } from "../../../utils/errors";
 import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 import { isCancellationError } from "../../../utils/downloadUtils";
 import {
+  bilibiliPartSourceUrlAliases,
   extractBilibiliVideoId,
   formatVideoFilename,
   getBilibiliPartNumber,
@@ -67,7 +68,19 @@ function resolveExistingVideoForRedownload(
   existingLocalVideoId?: string
 ): Video | null {
   if (!existingLocalVideoId) {
-    return storageService.getVideoBySourceUrl(url, mediaType) ?? null;
+    // Check every spelling of this part, not just the incoming one: part 1 may
+    // have been stored bare or as ?p=1, and matching only the exact URL would
+    // add a duplicate beside the item a forced download meant to replace.
+    for (const candidateUrl of bilibiliPartSourceUrlAliases(url)) {
+      const existing = storageService.getVideoBySourceUrl(
+        candidateUrl,
+        mediaType
+      );
+      if (existing) {
+        return existing;
+      }
+    }
+    return null;
   }
 
   const selectedVideo = storageService.getVideoById(existingLocalVideoId);

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -33,6 +33,7 @@ import {
   BILIBILI_COOKIE_REFRESH_HINT,
   isLikelyBilibiliAuthFailure,
   resolveBilibiliMergeOutputFormat,
+  resolveProxiedAxiosConfig,
 } from "./bilibiliConfig";
 import {
   cleanupFilesOnCancellation,
@@ -119,6 +120,10 @@ export async function downloadSinglePart(
     const mergeOutputFormat = audioOnly
       ? audioFormat
       : resolveBilibiliMergeOutputFormat(userConfig);
+    // Shared by every outbound side request below (part metadata lookup,
+    // subtitles). null means the configured proxy is unusable, so those
+    // requests are skipped rather than sent directly.
+    const proxiedAxiosConfig = resolveProxiedAxiosConfig(userConfig);
     // Overlay any per-subscription filename-template override onto the global
     // naming settings so renameFilesWithMetadata and the legacy/template branch
     // below use it consistently (issue #368). When no override is present the
@@ -218,7 +223,8 @@ export async function downloadSinglePart(
       partNumber,
       totalParts,
       seriesTitle,
-      bilibiliInfo
+      bilibiliInfo,
+      proxiedAxiosConfig
     );
 
     // For multi-part videos, include the part number in the title
@@ -332,29 +338,20 @@ export async function downloadSinglePart(
         const subtitlePathPrefix =
           renameResult.subtitleWebBaseDir ||
           (moveSubtitlesToVideoFolder ? `/videos` : `/subtitles`);
-        let axiosConfig = {};
-        if (userConfig.proxy) {
-          try {
-            axiosConfig = getAxiosProxyConfig(userConfig.proxy);
-          } catch (error) {
-            if (error instanceof InvalidProxyError) {
-              logger.warn(
-                "Invalid proxy configuration for subtitle download, proceeding without proxy:",
-                error.message
-              );
-            } else {
-              throw error;
-            }
-          }
+        if (proxiedAxiosConfig) {
+          subtitles = await downloadSubtitles(
+            url,
+            newSafeBaseFilename,
+            subtitleDir,
+            subtitlePathPrefix,
+            proxiedAxiosConfig
+          );
+          logger.info(`Downloaded ${subtitles.length} subtitles`);
+        } else {
+          logger.warn(
+            "Skipping subtitle download: proxy is configured but unusable"
+          );
         }
-        subtitles = await downloadSubtitles(
-          url,
-          newSafeBaseFilename,
-          subtitleDir,
-          subtitlePathPrefix,
-          axiosConfig
-        );
-        logger.info(`Downloaded ${subtitles.length} subtitles`);
       } catch (e) {
         // If it's a cancellation error, re-throw it
         downloader.handleCancellationErrorPublic(e);

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -2,7 +2,11 @@ import { IMAGES_DIR, VIDEOS_DIR } from "../../../config/paths";
 import { getErrorMessage } from "../../../utils/errors";
 import { DownloadCancelledError } from "../../../errors/DownloadErrors";
 import { isCancellationError } from "../../../utils/downloadUtils";
-import { extractBilibiliVideoId, formatVideoFilename } from "../../../utils/helpers";
+import {
+  extractBilibiliVideoId,
+  formatVideoFilename,
+  getBilibiliPartNumber,
+} from "../../../utils/helpers";
 import { FilenameTemplateSourceOptions } from "../../filenameTemplate/types";
 import { applySubscriptionFilenameTemplateOverride } from "../../filenameTemplate";
 import { resolveAuthorOrganizationMode } from "../../../types/settings";
@@ -141,12 +145,17 @@ export async function downloadSinglePart(
     const timestamp = Date.now();
     const downloadedAtIso = new Date(timestamp).toISOString();
     const sourceVideoId = extractBilibiliVideoId(url) || undefined;
-    // An explicit target (collision repair, redownload) names the row to update,
-    // so it is honored whatever the video's aggregate part count is: a URL that
-    // selects one part of a multipart video still repairs that one row. Only the
-    // implicit same-URL reuse stays limited to single-part videos.
+    // Reuse an existing row whenever this download refers to exactly one item.
+    // That holds for a single-part video, for an explicit target (collision
+    // repair, redownload), and for a URL naming a part — ?p=N identifies one
+    // row, so same-URL reuse is well defined and a forced redownload replaces
+    // that part instead of adding a duplicate beside it. The aggregate part
+    // count is irrelevant to all three.
+    const selectsSpecificPart = getBilibiliPartNumber(url) != null;
     const existingLocalVideoForRedownload =
-      totalParts === 1 || modeOptions?.existingLocalVideoId
+      totalParts === 1 ||
+      selectsSpecificPart ||
+      modeOptions?.existingLocalVideoId
         ? resolveExistingVideoForRedownload(
             url,
             audioOnly ? "audio" : "video",

--- a/backend/src/services/downloaders/bilibili/types.ts
+++ b/backend/src/services/downloaders/bilibili/types.ts
@@ -58,6 +58,8 @@ export interface BilibiliAggregateDownloadResult {
   skippedCount: number;
   failedPartNumbers: number[];
   firstVideo?: Video;
+  /** Videos newly saved by an all-parts task, excluding skipped existing rows. */
+  downloadedVideos?: Video[];
   collectionId?: string;
   videosDownloaded?: number;
   isMultiPart?: boolean;

--- a/backend/src/services/storageService/__tests__/dataBackfill.test.ts
+++ b/backend/src/services/storageService/__tests__/dataBackfill.test.ts
@@ -33,6 +33,7 @@ describe("download history data backfills", () => {
         id TEXT PRIMARY KEY,
         video_id TEXT,
         media_type TEXT,
+        video_path TEXT,
         status TEXT NOT NULL
       );
     `);
@@ -77,6 +78,44 @@ describe("download history data backfills", () => {
       { id: "audio-history", mediaType: "audio" },
       { id: "unknown-history", mediaType: null },
       { id: "video-history", mediaType: "video" },
+    ]);
+  });
+
+  it("types legacy tombstones from their saved file when the video is gone", () => {
+    // The join above cannot reach a deleted row: its video is already removed.
+    // The path it saved is the remaining evidence of which of the two it was.
+    sqlite.prepare("DELETE FROM download_history").run();
+    sqlite
+      .prepare(
+        "INSERT INTO download_history (id, video_id, media_type, video_path, status) VALUES (?, NULL, NULL, ?, ?), (?, NULL, NULL, ?, ?), (?, NULL, NULL, ?, ?), (?, NULL, NULL, NULL, ?)"
+      )
+      .run(
+        "gone-audio",
+        "/uploads/videos/Song.m4a",
+        "deleted",
+        "gone-audio-upper",
+        "/uploads/videos/Song.MP3",
+        "deleted",
+        "gone-video",
+        "/uploads/videos/Movie.mp4",
+        "deleted",
+        "gone-pathless",
+        "deleted",
+      );
+
+    backfillDownloadHistoryMediaTypes();
+
+    expect(
+      sqlite
+        .prepare(
+          "SELECT id, media_type AS mediaType FROM download_history ORDER BY id"
+        )
+        .all()
+    ).toEqual([
+      { id: "gone-audio", mediaType: "audio" },
+      { id: "gone-audio-upper", mediaType: "audio" },
+      { id: "gone-pathless", mediaType: null },
+      { id: "gone-video", mediaType: "video" },
     ]);
   });
 });

--- a/backend/src/services/storageService/__tests__/dataBackfill.test.ts
+++ b/backend/src/services/storageService/__tests__/dataBackfill.test.ts
@@ -1,0 +1,82 @@
+import Database from "better-sqlite3";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ sqlite: undefined as any }));
+
+vi.mock("../../../db", () => ({
+  get sqlite() {
+    return mocks.sqlite;
+  },
+  db: {},
+}));
+
+vi.mock("../../../utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("download history data backfills", () => {
+  let sqlite: Database.Database;
+  let backfillDownloadHistoryMediaTypes: typeof import("../migrations/dataBackfill").backfillDownloadHistoryMediaTypes;
+
+  beforeAll(async () => {
+    sqlite = new Database(":memory:");
+    sqlite.exec(`
+      CREATE TABLE videos (
+        id TEXT PRIMARY KEY,
+        media_type TEXT
+      );
+      CREATE TABLE download_history (
+        id TEXT PRIMARY KEY,
+        video_id TEXT,
+        media_type TEXT,
+        status TEXT NOT NULL
+      );
+    `);
+    mocks.sqlite = sqlite;
+    ({ backfillDownloadHistoryMediaTypes } = await import(
+      "../migrations/dataBackfill"
+    ));
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  it("copies audio/video type from the referenced video and leaves unknown rows untyped", () => {
+    sqlite
+      .prepare("INSERT INTO videos (id, media_type) VALUES (?, ?), (?, ?)")
+      .run("audio-video", "audio", "video-video", "video");
+    sqlite
+      .prepare(
+        "INSERT INTO download_history (id, video_id, media_type, status) VALUES (?, ?, NULL, ?), (?, ?, NULL, ?), (?, NULL, NULL, ?)"
+      )
+      .run(
+        "audio-history",
+        "audio-video",
+        "deleted",
+        "video-history",
+        "video-video",
+        "deleted",
+        "unknown-history",
+        "deleted",
+      );
+
+    backfillDownloadHistoryMediaTypes();
+
+    expect(
+      sqlite
+        .prepare(
+          "SELECT id, media_type AS mediaType FROM download_history ORDER BY id"
+        )
+        .all()
+    ).toEqual([
+      { id: "audio-history", mediaType: "audio" },
+      { id: "unknown-history", mediaType: null },
+      { id: "video-history", mediaType: "video" },
+    ]);
+  });
+});

--- a/backend/src/services/storageService/__tests__/downloadHistory.test.ts
+++ b/backend/src/services/storageService/__tests__/downloadHistory.test.ts
@@ -19,6 +19,11 @@ vi.mock("../../../db/schema", () => ({
     nextRetryAt: "nextRetryAt",
     sourceUrl: "sourceUrl",
     downloadType: "downloadType",
+    mediaType: "mediaType",
+  },
+  videos: {
+    id: "id",
+    mediaType: "mediaType",
   },
 }));
 
@@ -26,6 +31,7 @@ vi.mock("../../../db", () => ({
   db: {
     insert: vi.fn(),
     select: vi.fn(),
+    update: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -47,6 +53,7 @@ import {
   getDownloadHistoryItem,
   getLatestRetryHistoryItemBySourceUrl,
   getPendingRetryHistoryItems,
+  markDownloadHistoryDeletedByVideoId,
   removeDownloadHistoryItem,
 } from "../downloadHistory";
 
@@ -349,5 +356,42 @@ describe("downloadHistory", () => {
       "Error clearing download history",
       expect.any(Error)
     );
+  });
+
+  it("stamps a legacy history row with the referenced video's media type when deleted", () => {
+    const get = vi.fn().mockReturnValue({ mediaType: "audio" });
+    const whereSelect = vi.fn(() => ({ get }));
+    const fromSelect = vi.fn(() => ({ where: whereSelect }));
+    vi.mocked(db.select).mockReturnValue({ from: fromSelect } as any);
+
+    const run = vi.fn();
+    const whereUpdate = vi.fn(() => ({ run }));
+    const set = vi.fn(() => ({ where: whereUpdate }));
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+
+    markDownloadHistoryDeletedByVideoId("audio-video", 123);
+
+    expect(set).toHaveBeenCalledWith({
+      status: "deleted",
+      deletedAt: 123,
+      mediaType: "audio",
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not infer video for a deleted history row whose video reference is gone", () => {
+    const get = vi.fn().mockReturnValue(undefined);
+    const whereSelect = vi.fn(() => ({ get }));
+    const fromSelect = vi.fn(() => ({ where: whereSelect }));
+    vi.mocked(db.select).mockReturnValue({ from: fromSelect } as any);
+
+    const run = vi.fn();
+    const whereUpdate = vi.fn(() => ({ run }));
+    const set = vi.fn(() => ({ where: whereUpdate }));
+    vi.mocked(db.update).mockReturnValue({ set } as any);
+
+    markDownloadHistoryDeletedByVideoId("missing-video", 456);
+
+    expect(set).toHaveBeenCalledWith({ status: "deleted", deletedAt: 456 });
   });
 });

--- a/backend/src/services/storageService/downloadHistory.ts
+++ b/backend/src/services/storageService/downloadHistory.ts
@@ -1,10 +1,10 @@
-import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, ne, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, lt, ne } from "drizzle-orm";
 import { DatabaseError } from "../../errors/DownloadErrors";
 import { db } from "../../db";
-import { downloadHistory, subscriptions } from "../../db/schema";
+import { downloadHistory, subscriptions, videos } from "../../db/schema";
 import { logger } from "../../utils/logger";
 import { getSettings } from "./settings";
-import { DownloadHistoryItem, MediaType } from "./types";
+import { DownloadHistoryItem, MediaType, normalizeMediaType } from "./types";
 import { PARTIAL_STATUS, PENDING_RETRY_STATUS } from "./downloadHistoryStatus";
 
 function mapDownloadHistoryRow(row: typeof downloadHistory.$inferSelect): DownloadHistoryItem {
@@ -160,17 +160,6 @@ export function getLatestDeletedHistoryItemBySourceUrl(
   mediaType: MediaType = "video",
 ): DownloadHistoryItem | undefined {
   try {
-    // Audio and video of one item are distinct rows, so the tombstone has to be
-    // scoped like every other lookup. Rows written before media_type existed
-    // read as video, matching the convention on the videos table.
-    const mediaTypeCondition =
-      mediaType === "audio"
-        ? eq(downloadHistory.mediaType, "audio")
-        : or(
-            eq(downloadHistory.mediaType, "video"),
-            isNull(downloadHistory.mediaType),
-          )!;
-
     const item = db
       .select()
       .from(downloadHistory)
@@ -178,7 +167,7 @@ export function getLatestDeletedHistoryItemBySourceUrl(
         and(
           eq(downloadHistory.sourceUrl, sourceUrl),
           eq(downloadHistory.status, "deleted"),
-          mediaTypeCondition,
+          eq(downloadHistory.mediaType, mediaType),
         ),
       )
       .orderBy(desc(downloadHistory.finishedAt))
@@ -252,8 +241,23 @@ export function markDownloadHistoryDeletedByVideoId(
   deletedAt: number = Date.now()
 ): void {
   try {
+    // This is the last reliable point at which the referenced video is still
+    // present. It also repairs a legacy success row before it becomes a
+    // per-item tombstone; rows with no surviving reference remain untyped and
+    // are intentionally ignored by media-scoped tombstone lookups.
+    const video = db
+      .select({ mediaType: videos.mediaType })
+      .from(videos)
+      .where(eq(videos.id, videoId))
+      .get();
+    const mediaType = video ? normalizeMediaType(video.mediaType) : undefined;
+
     db.update(downloadHistory)
-      .set({ status: "deleted", deletedAt })
+      .set({
+        status: "deleted",
+        deletedAt,
+        ...(mediaType ? { mediaType } : {}),
+      })
       .where(
         and(
           eq(downloadHistory.videoId, videoId),

--- a/backend/src/services/storageService/downloadHistory.ts
+++ b/backend/src/services/storageService/downloadHistory.ts
@@ -1,10 +1,10 @@
-import { and, asc, desc, eq, inArray, isNotNull, lt, ne } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, ne, or } from "drizzle-orm";
 import { DatabaseError } from "../../errors/DownloadErrors";
 import { db } from "../../db";
 import { downloadHistory, subscriptions } from "../../db/schema";
 import { logger } from "../../utils/logger";
 import { getSettings } from "./settings";
-import { DownloadHistoryItem } from "./types";
+import { DownloadHistoryItem, MediaType } from "./types";
 import { PARTIAL_STATUS, PENDING_RETRY_STATUS } from "./downloadHistoryStatus";
 
 function mapDownloadHistoryRow(row: typeof downloadHistory.$inferSelect): DownloadHistoryItem {
@@ -20,6 +20,7 @@ function mapDownloadHistoryRow(row: typeof downloadHistory.$inferSelect): Downlo
     videoId: row.videoId || undefined,
     downloadedAt: row.downloadedAt || undefined,
     deletedAt: row.deletedAt || undefined,
+    mediaType: (row.mediaType as DownloadHistoryItem["mediaType"]) || undefined,
     subscriptionId: row.subscriptionId || undefined,
     taskId: row.taskId || undefined,
     platform: row.platform || undefined,
@@ -49,6 +50,7 @@ export function addDownloadHistoryItem(item: DownloadHistoryItem): void {
       videoId: item.videoId ?? null,
       downloadedAt: item.downloadedAt ?? null,
       deletedAt: item.deletedAt ?? null,
+      mediaType: item.mediaType ?? null,
       subscriptionId: item.subscriptionId ?? null,
       taskId: item.taskId ?? null,
       platform: item.platform ?? null,
@@ -155,8 +157,20 @@ export function getLatestRetryHistoryItemBySourceUrl(
  */
 export function getLatestDeletedHistoryItemBySourceUrl(
   sourceUrl: string,
+  mediaType: MediaType = "video",
 ): DownloadHistoryItem | undefined {
   try {
+    // Audio and video of one item are distinct rows, so the tombstone has to be
+    // scoped like every other lookup. Rows written before media_type existed
+    // read as video, matching the convention on the videos table.
+    const mediaTypeCondition =
+      mediaType === "audio"
+        ? eq(downloadHistory.mediaType, "audio")
+        : or(
+            eq(downloadHistory.mediaType, "video"),
+            isNull(downloadHistory.mediaType),
+          )!;
+
     const item = db
       .select()
       .from(downloadHistory)
@@ -164,6 +178,7 @@ export function getLatestDeletedHistoryItemBySourceUrl(
         and(
           eq(downloadHistory.sourceUrl, sourceUrl),
           eq(downloadHistory.status, "deleted"),
+          mediaTypeCondition,
         ),
       )
       .orderBy(desc(downloadHistory.finishedAt))

--- a/backend/src/services/storageService/downloadHistory.ts
+++ b/backend/src/services/storageService/downloadHistory.ts
@@ -143,6 +143,43 @@ export function getLatestRetryHistoryItemBySourceUrl(
   }
 }
 
+/**
+ * Latest deleted-history entry for an exact source URL.
+ *
+ * Acts as the per-item tombstone that the source-level tracking row cannot
+ * provide: videoDownloads keeps one row per (sourceVideoId, platform,
+ * mediaType), so deleting one part of a multipart video reassigns that row to a
+ * surviving part and leaves its status as "exists". History rows, by contrast,
+ * carry the individual item's own source URL, so a deleted part is still
+ * recorded here under its own ?p=N URL.
+ */
+export function getLatestDeletedHistoryItemBySourceUrl(
+  sourceUrl: string,
+): DownloadHistoryItem | undefined {
+  try {
+    const item = db
+      .select()
+      .from(downloadHistory)
+      .where(
+        and(
+          eq(downloadHistory.sourceUrl, sourceUrl),
+          eq(downloadHistory.status, "deleted"),
+        ),
+      )
+      .orderBy(desc(downloadHistory.finishedAt))
+      .limit(1)
+      .get();
+
+    return item ? mapDownloadHistoryRow(item) : undefined;
+  } catch (error) {
+    logger.error(
+      "Error getting latest deleted history item by source URL",
+      error instanceof Error ? error : new Error(String(error))
+    );
+    return undefined;
+  }
+}
+
 export function getPendingRetryHistoryItems(): DownloadHistoryItem[] {
   try {
     const items = db

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -24,6 +24,7 @@ export {
     clearDownloadHistory,
     getDownloadHistory,
     getDownloadHistoryItem,
+    getLatestDeletedHistoryItemBySourceUrl,
     getLatestRetryHistoryItemBySourceUrl,
     pruneDownloadHistory,
     getPendingRetryHistoryItems,

--- a/backend/src/services/storageService/migrations/dataBackfill.ts
+++ b/backend/src/services/storageService/migrations/dataBackfill.ts
@@ -91,6 +91,42 @@ export function backfillDownloadHistoryVideoIds(): void {
   }
 }
 
+// Backfill media_type for legacy history rows that point at a local video.
+// The column is nullable because an old row may not have a surviving video
+// reference, but a referenced video gives us an authoritative answer — unlike
+// treating every NULL as video, which misclassifies legacy audio tombstones.
+export function backfillDownloadHistoryMediaTypes(): void {
+  try {
+    const result = sqlite
+      .prepare(
+        `
+            UPDATE download_history
+            SET media_type = (
+              SELECT CASE WHEN v.media_type = 'audio' THEN 'audio' ELSE 'video' END
+              FROM videos v
+              WHERE v.id = download_history.video_id
+            )
+            WHERE media_type IS NULL
+              AND video_id IS NOT NULL
+              AND EXISTS (
+                SELECT 1 FROM videos v WHERE v.id = download_history.video_id
+              )
+        `
+      )
+      .run();
+    if (result && result.changes > 0) {
+      logger.info(
+        `Backfilled media_type for ${result.changes} download history items.`
+      );
+    }
+  } catch (error) {
+    logger.error(
+      "Error backfilling media_type in download history",
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+}
+
 export function backfillDownloadHistoryDimensions(): void {
   try {
     // Backfill platform from videos.source where joinable via video_id

--- a/backend/src/services/storageService/migrations/dataBackfill.ts
+++ b/backend/src/services/storageService/migrations/dataBackfill.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { VIDEOS_DIR } from "../../../config/paths";
 import { db, sqlite } from "../../../db";
 import { videos } from "../../../db/schema";
+import { AUDIO_FORMATS } from "../../../types/settings";
 import { logger } from "../../../utils/logger";
 import {
   pathExistsSafeSync,
@@ -117,6 +118,47 @@ export function backfillDownloadHistoryMediaTypes(): void {
     if (result && result.changes > 0) {
       logger.info(
         `Backfilled media_type for ${result.changes} download history items.`
+      );
+    }
+
+    // A deleted row is exactly the case the join above cannot reach: its video
+    // is gone, so it stays NULL and the media-type-scoped tombstone lookup
+    // never returns it. Deletion only flips status and deleted_at, so the row
+    // still carries the path of the file it saved — enough to tell the two
+    // apart without assuming every legacy tombstone was a video.
+    const audioExtensionMatch = AUDIO_FORMATS.map(
+      (format) => `lower(video_path) LIKE '%.${format}'`
+    ).join(" OR ");
+
+    const audioResult = sqlite
+      .prepare(
+        `
+            UPDATE download_history
+            SET media_type = 'audio'
+            WHERE media_type IS NULL
+              AND video_path IS NOT NULL
+              AND (${audioExtensionMatch})
+        `
+      )
+      .run();
+
+    // Whatever is left with a saved file is a video: audio-only is an explicit
+    // opt-in and its containers are enumerated above.
+    const videoResult = sqlite
+      .prepare(
+        `
+            UPDATE download_history
+            SET media_type = 'video'
+            WHERE media_type IS NULL
+              AND video_path IS NOT NULL
+        `
+      )
+      .run();
+
+    const fromPath = (audioResult?.changes ?? 0) + (videoResult?.changes ?? 0);
+    if (fromPath > 0) {
+      logger.info(
+        `Backfilled media_type from the saved file path for ${fromPath} download history items whose video is gone.`
       );
     }
   } catch (error) {

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -8,6 +8,7 @@ import {
   normalizeLegacyTwitchDownloads,
 } from "./legacyTwitchDownloads";
 import {
+  backfillDownloadHistoryMediaTypes,
   backfillDownloadHistoryVideoIds,
   populateVideoFileSizes,
 } from "./dataBackfill";
@@ -954,8 +955,8 @@ export function migrateColumnsAndTables(): void {
     // Media type on history rows: audio and video of the same source are
     // separate library items, and a deleted-history row is the only per-item
     // record of a deleted multipart part. Without this the two cannot be told
-    // apart. Left nullable; existing rows read as video, matching how a null
-    // media_type is treated on the videos table.
+    // apart. Keep it nullable for legacy rows that have no surviving video
+    // reference; referenced rows are backfilled below.
     if (!downloadHistoryColumns.includes("media_type")) {
       logger.info(
         "Migrating database: Adding media_type column to download_history table..."
@@ -1000,6 +1001,10 @@ export function migrateColumnsAndTables(): void {
 
     // Backfill video_id in download_history for existing records
     backfillDownloadHistoryVideoIds();
+
+    // Backfill media_type after video_id so legacy audio history remains an
+    // audio tombstone instead of being inferred as video.
+    backfillDownloadHistoryMediaTypes();
 
     // Ensure performance indexes exist on existing databases.
     migratePerformanceIndexes();

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -951,6 +951,24 @@ export function migrateColumnsAndTables(): void {
       downloadHistoryColumns.push("deleted_at");
     }
 
+    // Media type on history rows: audio and video of the same source are
+    // separate library items, and a deleted-history row is the only per-item
+    // record of a deleted multipart part. Without this the two cannot be told
+    // apart. Left nullable; existing rows read as video, matching how a null
+    // media_type is treated on the videos table.
+    if (!downloadHistoryColumns.includes("media_type")) {
+      logger.info(
+        "Migrating database: Adding media_type column to download_history table..."
+      );
+      sqlite
+        .prepare("ALTER TABLE download_history ADD COLUMN media_type TEXT")
+        .run();
+      logger.info(
+        "Migration successful: media_type added to download_history."
+      );
+      downloadHistoryColumns.push("media_type");
+    }
+
     if (
       downloadHistoryColumns.includes("subscription_id") &&
       downloadHistoryColumns.includes("status") &&

--- a/backend/src/services/storageService/types.ts
+++ b/backend/src/services/storageService/types.ts
@@ -74,6 +74,10 @@ export interface DownloadHistoryItem {
   videoId?: string; // Reference to the video for skipped items
   downloadedAt?: number; // Original download timestamp for deleted items
   deletedAt?: number; // Deletion timestamp for deleted items
+  // Audio and video of one source are separate items. A deleted-history row is
+  // the only per-item record of a deleted multipart part, so it has to say
+  // which of the two it was. Absent on legacy rows, which read as video.
+  mediaType?: MediaType;
   subscriptionId?: string; // Reference to subscription if downloaded via subscription
   taskId?: string; // Reference to continuous download task if downloaded via task
   platform?: string; // canonical lowercase, statistics-friendly bucket

--- a/backend/src/services/storageService/types.ts
+++ b/backend/src/services/storageService/types.ts
@@ -107,6 +107,12 @@ export interface VideoDownloadCheckResult {
   author?: string;
   downloadedAt?: number;
   deletedAt?: number;
+  /**
+   * Source URL of the matched tracking row. Lets callers tell *which* item the
+   * shared source video id actually matched — needed for multipart Bilibili
+   * videos, where every part collapses onto one tracking row.
+   */
+  sourceUrl?: string;
 }
 
 export interface DownloadStatus {

--- a/backend/src/services/storageService/videoDownloadTracking.ts
+++ b/backend/src/services/storageService/videoDownloadTracking.ts
@@ -95,13 +95,22 @@ export function checkVideoDownloadBySourceId(
  * Check if a video has been downloaded before by its source URL
  */
 export function checkVideoDownloadByUrl(
-  sourceUrl: string
+  sourceUrl: string,
+  mediaType: MediaType = "video"
 ): VideoDownloadCheckResult {
   try {
+    // Scoped to the media type for the same reason the source-id lookup is: an
+    // audio row and a video row for one URL are distinct library items, so an
+    // audio request must not match the video row.
     const record = db
       .select()
       .from(videoDownloads)
-      .where(eq(videoDownloads.sourceUrl, sourceUrl))
+      .where(
+        and(
+          eq(videoDownloads.sourceUrl, sourceUrl),
+          eq(videoDownloads.mediaType, mediaType)
+        )
+      )
       .get();
 
     if (record) {

--- a/backend/src/services/storageService/videoDownloadTracking.ts
+++ b/backend/src/services/storageService/videoDownloadTracking.ts
@@ -13,6 +13,7 @@ type DownloadTrackingRow = {
   author?: string | null;
   downloadedAt?: number | null;
   deletedAt?: number | null;
+  sourceUrl?: string | null;
 };
 
 function buildSourceVideoQueryCondition(
@@ -57,6 +58,7 @@ function toDownloadCheckResult(record: DownloadTrackingRow): VideoDownloadCheckR
     author: record.author || undefined,
     downloadedAt: record.downloadedAt ?? undefined,
     deletedAt: record.deletedAt ?? undefined,
+    sourceUrl: record.sourceUrl || undefined,
   };
 }
 
@@ -95,22 +97,13 @@ export function checkVideoDownloadBySourceId(
  * Check if a video has been downloaded before by its source URL
  */
 export function checkVideoDownloadByUrl(
-  sourceUrl: string,
-  mediaType: MediaType = "video"
+  sourceUrl: string
 ): VideoDownloadCheckResult {
   try {
-    // Scoped to the media type for the same reason the source-id lookup is: an
-    // audio row and a video row for one URL are distinct library items, so an
-    // audio request must not match the video row.
     const record = db
       .select()
       .from(videoDownloads)
-      .where(
-        and(
-          eq(videoDownloads.sourceUrl, sourceUrl),
-          eq(videoDownloads.mediaType, mediaType)
-        )
-      )
+      .where(eq(videoDownloads.sourceUrl, sourceUrl))
       .get();
 
     if (record) {

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -209,6 +209,7 @@ const shortUrlResolutionCache = new Map<
   { resolvedUrl: string; expiresAt: number }
 >();
 const SHORT_URL_CACHE_TTL_MS = 10 * 60 * 1000;
+const SHORT_URL_CACHE_MAX_ENTRIES = 500;
 
 function getCachedShortUrlResolution(safeShortUrl: string): string | null {
   const cached = shortUrlResolutionCache.get(safeShortUrl);
@@ -221,10 +222,49 @@ function getCachedShortUrlResolution(safeShortUrl: string): string | null {
 }
 
 /**
+ * Store a resolution, keeping the cache bounded.
+ *
+ * A long-running server sees a stream of one-off links that are never requested
+ * a second time, so lazy expiry-on-read alone would let the map grow forever.
+ * Every write sweeps expired entries, and if that is not enough the oldest
+ * entries are dropped — Map preserves insertion order, so those are the ones
+ * closest to expiring anyway.
+ */
+function setCachedShortUrlResolution(
+  safeShortUrl: string,
+  resolvedUrl: string,
+): void {
+  const now = Date.now();
+  for (const [key, entry] of shortUrlResolutionCache) {
+    if (entry.expiresAt <= now) {
+      shortUrlResolutionCache.delete(key);
+    }
+  }
+
+  shortUrlResolutionCache.set(safeShortUrl, {
+    resolvedUrl,
+    expiresAt: now + SHORT_URL_CACHE_TTL_MS,
+  });
+
+  while (shortUrlResolutionCache.size > SHORT_URL_CACHE_MAX_ENTRIES) {
+    const oldestKey = shortUrlResolutionCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    shortUrlResolutionCache.delete(oldestKey);
+  }
+}
+
+/**
  * @internal Test helper to clear the short-URL resolution cache between cases.
  */
 export function resetShortUrlResolutionCacheForTests(): void {
   shortUrlResolutionCache.clear();
+}
+
+/**
+ * @internal Test helper to assert the cache stays bounded.
+ */
+export function getShortUrlResolutionCacheSizeForTests(): number {
+  return shortUrlResolutionCache.size;
 }
 
 /**
@@ -239,21 +279,22 @@ export function resetShortUrlResolutionCacheForTests(): void {
  * reachability, an off-allow-list hop), leaving the caller on the short URL.
  */
 async function followBilibiliShortUrl(safeShortUrl: string): Promise<string | null> {
+  // Dynamic imports: both modules reach back into helpers, so a static import
+  // would close an initialization cycle. getUserYtDlpConfig swallows its own
+  // read errors and returns {}, so a throw here means the module itself is
+  // unavailable — treat that as "proxy state unknown" and give up rather than
+  // guess that a direct connection is acceptable.
+  const { getUserYtDlpConfig } = await import("./ytdlp/config");
+  const proxy = getUserYtDlpConfig(safeShortUrl)?.proxy;
+
   let axiosConfig: Record<string, unknown> = {};
-  try {
-    // Dynamic imports: both modules reach back into helpers, so a static import
-    // would close an initialization cycle.
-    const { getUserYtDlpConfig } = await import("./ytdlp/config");
-    const proxy = getUserYtDlpConfig(safeShortUrl)?.proxy;
-    if (typeof proxy === "string" && proxy) {
-      const { getAxiosProxyConfig } = await import("./ytdlp/proxy");
-      axiosConfig = getAxiosProxyConfig(proxy);
-    }
-  } catch (error: unknown) {
-    logger.warn(
-      `Could not apply proxy config while resolving short URL, continuing direct: ${getErrorMessage(error)}`,
-    );
-    axiosConfig = {};
+  if (typeof proxy === "string" && proxy) {
+    // getAxiosProxyConfig throws on a malformed proxy precisely so callers do
+    // not silently fall back to a direct connection and expose the user's real
+    // IP. Let it propagate: the caller keeps the short URL, and the download
+    // still works because yt-dlp follows the redirect over the same proxy.
+    const { getAxiosProxyConfig } = await import("./ytdlp/proxy");
+    axiosConfig = getAxiosProxyConfig(proxy);
   }
 
   const axios = (await import("axios")).default;
@@ -311,10 +352,7 @@ export async function resolveShortUrl(url: string): Promise<string> {
       const resolvedUrl = await followBilibiliShortUrl(safeShortUrl);
       if (resolvedUrl) {
         logger.info(`Resolved shortened URL to: ${resolvedUrl}`);
-        shortUrlResolutionCache.set(safeShortUrl, {
-          resolvedUrl,
-          expiresAt: Date.now() + SHORT_URL_CACHE_TTL_MS,
-        });
+        setCachedShortUrlResolution(safeShortUrl, resolvedUrl);
         return resolvedUrl;
       }
       logger.warn(
@@ -340,6 +378,22 @@ export async function resolveShortUrl(url: string): Promise<string> {
   }
 }
 
+/**
+ * Read the `p` (part) selector off a Bilibili URL.
+ *
+ * `p` is the one query parameter that changes *which* video is downloaded, so it
+ * has to survive trimming; everything else is share/tracking noise. Only a plain
+ * positive integer is accepted, so a junk value cannot ride along.
+ */
+function getBilibiliPartParam(url: string): string | null {
+  try {
+    const part = new URL(url).searchParams.get("p");
+    return part && /^\d+$/.test(part) && Number(part) > 0 ? part : null;
+  } catch {
+    return null;
+  }
+}
+
 // Helper function to trim Bilibili URL by removing query parameters
 export function trimBilibiliUrl(url: string): string {
   try {
@@ -348,10 +402,13 @@ export function trimBilibiliUrl(url: string): string {
 
     if (videoIdMatch && videoIdMatch[1]) {
       const videoId = videoIdMatch[1];
-      // Construct a clean URL with just the video ID
-      const cleanUrl = videoId.startsWith("BV")
-        ? `https://www.bilibili.com/video/${videoId}`
-        : `https://www.bilibili.com/video/${videoId}`;
+      // Keep the part selector: dropping it silently redirects a shared link
+      // for part N to part 1. Matches the `?p=N` form the multipart download
+      // flow already uses as a part's canonical source URL.
+      const partParam = getBilibiliPartParam(url);
+      const cleanUrl =
+        `https://www.bilibili.com/video/${videoId}` +
+        (partParam ? `?p=${partParam}` : "");
 
       logger.info(`Trimmed Bilibili URL from "${url}" to "${cleanUrl}"`);
       return cleanUrl;

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -25,6 +25,18 @@ const TWITTER_HOSTNAMES = ["x.com", "twitter.com"] as const;
 const TWITCH_HOSTNAMES = ["twitch.tv"] as const;
 
 const ALLOWED_BILIBILI_SHORTENER_HOSTNAMES = ["b23.tv", "bili2233.cn"] as const;
+// Hosts a shortener hop may legally land on. Kept separate from the shortener
+// list so a redirect can only ever move within the shorteners or onto Bilibili
+// proper — never to an arbitrary host the shortener happens to point at.
+const ALLOWED_BILIBILI_REDIRECT_HOSTNAMES = [
+  "bilibili.com",
+  "b23.tv",
+  "bili2233.cn",
+] as const;
+const MAX_SHORT_URL_REDIRECTS = 5;
+const SHORT_URL_RESOLVE_TIMEOUT_MS = 10000;
+const SHORT_URL_RESOLVE_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36";
 const REQUEST_HOST_OUTPUT_MAP: Record<string, string> = {
   "bilibili.com": "www.bilibili.com",
 };
@@ -147,6 +159,135 @@ export function extractUrlFromText(text: string): string {
   return text; // Return original text if no URL found
 }
 
+/**
+ * Validate a shortener redirect target.
+ *
+ * Deliberately not buildSafeRequestUrl: that helper canonicalizes every
+ * `*.bilibili.com` host to `www.bilibili.com`, which is right for a URL the user
+ * typed but wrong for a redirect target — a short link to `live.bilibili.com/123`
+ * would be rewritten into a completely different `www.bilibili.com/123` page.
+ * Here the host is validated and preserved, and only a bare `bilibili.com` is
+ * filled out to `www`.
+ */
+function buildSafeRedirectUrl(url: string): string {
+  const parsedUrl = new URL(url);
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error(
+      `Invalid redirect protocol: ${parsedUrl.protocol}. Only http and https are allowed.`,
+    );
+  }
+  if (parsedUrl.username || parsedUrl.password || parsedUrl.port) {
+    throw new Error(
+      "SSRF protection: redirects with credentials or explicit ports are not allowed.",
+    );
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const isAllowed = ALLOWED_BILIBILI_REDIRECT_HOSTNAMES.some(
+    (allowedHost) =>
+      hostname === allowedHost || hostname.endsWith(`.${allowedHost}`),
+  );
+  if (!isAllowed) {
+    throw new Error(
+      `SSRF protection: redirect target ${parsedUrl.hostname} is not in the allow-list.`,
+    );
+  }
+
+  if (parsedUrl.pathname.split("/").some((segment) => segment === "..")) {
+    throw new Error("SSRF protection: path traversal is not allowed in a redirect.");
+  }
+
+  const outputHost = hostname === "bilibili.com" ? "www.bilibili.com" : hostname;
+  return `https://${outputHost}${parsedUrl.pathname || "/"}${parsedUrl.search}`;
+}
+
+// A single download resolves the same short URL several times (download-status
+// check, then the download itself, then any retry), so cache the redirect target
+// briefly to keep one paste from fanning out into repeated outbound requests.
+const shortUrlResolutionCache = new Map<
+  string,
+  { resolvedUrl: string; expiresAt: number }
+>();
+const SHORT_URL_CACHE_TTL_MS = 10 * 60 * 1000;
+
+function getCachedShortUrlResolution(safeShortUrl: string): string | null {
+  const cached = shortUrlResolutionCache.get(safeShortUrl);
+  if (!cached) return null;
+  if (cached.expiresAt <= Date.now()) {
+    shortUrlResolutionCache.delete(safeShortUrl);
+    return null;
+  }
+  return cached.resolvedUrl;
+}
+
+/**
+ * @internal Test helper to clear the short-URL resolution cache between cases.
+ */
+export function resetShortUrlResolutionCacheForTests(): void {
+  shortUrlResolutionCache.clear();
+}
+
+/**
+ * Follow a Bilibili shortener redirect chain one hop at a time.
+ *
+ * Every hop is validated against the allow-list before it is requested, which is
+ * why redirects are followed manually instead of by axios: axios' own follower
+ * would happily request an intermediate Location pointing at an internal host
+ * before we ever see the final URL.
+ *
+ * Returns null when the chain could not be followed (network failure, proxy-only
+ * reachability, an off-allow-list hop), leaving the caller on the short URL.
+ */
+async function followBilibiliShortUrl(safeShortUrl: string): Promise<string | null> {
+  let axiosConfig: Record<string, unknown> = {};
+  try {
+    // Dynamic imports: both modules reach back into helpers, so a static import
+    // would close an initialization cycle.
+    const { getUserYtDlpConfig } = await import("./ytdlp/config");
+    const proxy = getUserYtDlpConfig(safeShortUrl)?.proxy;
+    if (typeof proxy === "string" && proxy) {
+      const { getAxiosProxyConfig } = await import("./ytdlp/proxy");
+      axiosConfig = getAxiosProxyConfig(proxy);
+    }
+  } catch (error: unknown) {
+    logger.warn(
+      `Could not apply proxy config while resolving short URL, continuing direct: ${getErrorMessage(error)}`,
+    );
+    axiosConfig = {};
+  }
+
+  const axios = (await import("axios")).default;
+  let currentUrl = safeShortUrl;
+
+  for (let hop = 0; hop < MAX_SHORT_URL_REDIRECTS; hop++) {
+    const response = await axios.head(currentUrl, {
+      ...axiosConfig,
+      maxRedirects: 0, // every hop is validated here, not by axios
+      validateStatus: null,
+      timeout: SHORT_URL_RESOLVE_TIMEOUT_MS,
+      headers: { "User-Agent": SHORT_URL_RESOLVE_USER_AGENT },
+    });
+
+    const location = response.headers?.location;
+    if (typeof location !== "string" || !location) {
+      // No further redirect: this is as far as the chain goes.
+      return isBilibiliShortUrl(currentUrl) ? null : currentUrl;
+    }
+
+    // Relative Location headers are resolved against the current hop.
+    const nextUrl = new URL(location, currentUrl).toString();
+    currentUrl = buildSafeRedirectUrl(nextUrl);
+
+    if (!isBilibiliShortUrl(currentUrl)) {
+      return currentUrl;
+    }
+  }
+
+  throw new Error(
+    `Short URL exceeded ${MAX_SHORT_URL_REDIRECTS} redirects without reaching bilibili.com`,
+  );
+}
+
 // Helper function to resolve shortened URLs (like b23.tv)
 export async function resolveShortUrl(url: string): Promise<string> {
   try {
@@ -156,9 +297,37 @@ export async function resolveShortUrl(url: string): Promise<string> {
       url,
       ALLOWED_BILIBILI_SHORTENER_HOSTNAMES,
     );
-    logger.info(
-      `Short URL host is allowed. Returning normalized URL without outbound resolution: ${safeShortUrl}`,
-    );
+
+    const cachedUrl = getCachedShortUrlResolution(safeShortUrl);
+    if (cachedUrl) {
+      logger.info(`Resolved shortened URL from cache to: ${cachedUrl}`);
+      return cachedUrl;
+    }
+
+    // The short URL carries no BV/av id, so everything keyed off the source
+    // video id (avatar lookup, duplicate detection, multipart/collection
+    // detection, filename templates) needs the redirect target.
+    try {
+      const resolvedUrl = await followBilibiliShortUrl(safeShortUrl);
+      if (resolvedUrl) {
+        logger.info(`Resolved shortened URL to: ${resolvedUrl}`);
+        shortUrlResolutionCache.set(safeShortUrl, {
+          resolvedUrl,
+          expiresAt: Date.now() + SHORT_URL_CACHE_TTL_MS,
+        });
+        return resolvedUrl;
+      }
+      logger.warn(
+        `Short URL ${safeShortUrl} did not redirect to an allowed Bilibili host; keeping the short URL.`,
+      );
+    } catch (resolveError: unknown) {
+      // Resolution is best-effort: yt-dlp follows the redirect itself, so a
+      // failure here degrades metadata rather than breaking the download.
+      logger.warn(
+        `Could not follow shortened URL ${safeShortUrl}, keeping it as-is: ${getErrorMessage(resolveError)}`,
+      );
+    }
+
     return safeShortUrl;
   } catch (error: unknown) {
     logger.error(`Error resolving shortened URL: ${getErrorMessage(error)}`);

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -385,13 +385,28 @@ export async function resolveShortUrl(url: string): Promise<string> {
  * has to survive trimming; everything else is share/tracking noise. Only a plain
  * positive integer is accepted, so a junk value cannot ride along.
  */
-function getBilibiliPartParam(url: string): string | null {
+export function getBilibiliPartNumber(url: string): number | null {
   try {
     const part = new URL(url).searchParams.get("p");
-    return part && /^\d+$/.test(part) && Number(part) > 0 ? part : null;
+    if (!part || !/^\d+$/.test(part)) return null;
+    const partNumber = Number(part);
+    return partNumber > 0 ? partNumber : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether a Bilibili URL names a part other than the first.
+ *
+ * The bare video URL and `?p=1` are the same thing, so only `p >= 2` makes the
+ * request refer to something the bare BV/av id cannot identify — which matters
+ * for duplicate detection, since every part of a multipart video shares one
+ * source video id.
+ */
+export function targetsNonFirstBilibiliPart(url: string): boolean {
+  const partNumber = getBilibiliPartNumber(url);
+  return partNumber != null && partNumber > 1;
 }
 
 // Helper function to trim Bilibili URL by removing query parameters
@@ -405,10 +420,10 @@ export function trimBilibiliUrl(url: string): string {
       // Keep the part selector: dropping it silently redirects a shared link
       // for part N to part 1. Matches the `?p=N` form the multipart download
       // flow already uses as a part's canonical source URL.
-      const partParam = getBilibiliPartParam(url);
+      const partNumber = getBilibiliPartNumber(url);
       const cleanUrl =
         `https://www.bilibili.com/video/${videoId}` +
-        (partParam ? `?p=${partParam}` : "");
+        (partNumber != null ? `?p=${partNumber}` : "");
 
       logger.info(`Trimmed Bilibili URL from "${url}" to "${cleanUrl}"`);
       return cleanUrl;

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -396,19 +396,6 @@ export function getBilibiliPartNumber(url: string): number | null {
   }
 }
 
-/**
- * Whether a Bilibili URL names a part other than the first.
- *
- * The bare video URL and `?p=1` are the same thing, so only `p >= 2` makes the
- * request refer to something the bare BV/av id cannot identify — which matters
- * for duplicate detection, since every part of a multipart video shares one
- * source video id.
- */
-export function targetsNonFirstBilibiliPart(url: string): boolean {
-  const partNumber = getBilibiliPartNumber(url);
-  return partNumber != null && partNumber > 1;
-}
-
 // Helper function to trim Bilibili URL by removing query parameters
 export function trimBilibiliUrl(url: string): string {
   try {

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -396,6 +396,22 @@ export function getBilibiliPartNumber(url: string): number | null {
   }
 }
 
+/**
+ * Every source URL that can denote the part a Bilibili URL selects.
+ *
+ * Part 1 has two canonical spellings and either may be what was stored: a single
+ * download saves the bare URL, the all-parts flow saves `?p=1`. Every other part
+ * has exactly one. Shared so duplicate detection and the downloader's reuse
+ * lookup cannot disagree about what counts as the same item.
+ */
+export function bilibiliPartSourceUrlAliases(url: string): string[] {
+  const baseUrl = trimBilibiliUrl(url).split("?")[0];
+  const partNumber = getBilibiliPartNumber(url) ?? 1;
+  return partNumber === 1
+    ? [baseUrl, `${baseUrl}?p=1`]
+    : [`${baseUrl}?p=${partNumber}`];
+}
+
 // Helper function to trim Bilibili URL by removing query parameters
 export function trimBilibiliUrl(url: string): string {
   try {

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -206,19 +206,32 @@ function buildSafeRedirectUrl(url: string): string {
 // briefly to keep one paste from fanning out into repeated outbound requests.
 const shortUrlResolutionCache = new Map<
   string,
-  { resolvedUrl: string; expiresAt: number }
+  // resolvedUrl null = a remembered failure.
+  { resolvedUrl: string | null; expiresAt: number }
 >();
 const SHORT_URL_CACHE_TTL_MS = 10 * 60 * 1000;
+const SHORT_URL_FAILURE_CACHE_TTL_MS = 60 * 1000;
 const SHORT_URL_CACHE_MAX_ENTRIES = 500;
 
-function getCachedShortUrlResolution(safeShortUrl: string): string | null {
+/**
+ * Cached resolution, or undefined when nothing is cached.
+ *
+ * A cached entry with a null resolvedUrl is a remembered failure, which is not
+ * the same as a cache miss: one paste hits /check-bilibili-collection,
+ * /check-bilibili-parts and /download in sequence, and each resolves the same
+ * URL, so an unreachable shortener would otherwise burn the full timeout three
+ * times before the download is even queued.
+ */
+function getCachedShortUrlResolution(
+  safeShortUrl: string,
+): { resolvedUrl: string | null } | undefined {
   const cached = shortUrlResolutionCache.get(safeShortUrl);
-  if (!cached) return null;
+  if (!cached) return undefined;
   if (cached.expiresAt <= Date.now()) {
     shortUrlResolutionCache.delete(safeShortUrl);
-    return null;
+    return undefined;
   }
-  return cached.resolvedUrl;
+  return cached;
 }
 
 /**
@@ -232,7 +245,7 @@ function getCachedShortUrlResolution(safeShortUrl: string): string | null {
  */
 function setCachedShortUrlResolution(
   safeShortUrl: string,
-  resolvedUrl: string,
+  resolvedUrl: string | null,
 ): void {
   const now = Date.now();
   for (const [key, entry] of shortUrlResolutionCache) {
@@ -243,7 +256,14 @@ function setCachedShortUrlResolution(
 
   shortUrlResolutionCache.set(safeShortUrl, {
     resolvedUrl,
-    expiresAt: now + SHORT_URL_CACHE_TTL_MS,
+    // Failures expire far sooner than successes: they are remembered only to
+    // spare the rest of one paste's request flow, not to keep a shortener
+    // marked unreachable after it recovers.
+    expiresAt:
+      now +
+      (resolvedUrl === null
+        ? SHORT_URL_FAILURE_CACHE_TTL_MS
+        : SHORT_URL_CACHE_TTL_MS),
   });
 
   while (shortUrlResolutionCache.size > SHORT_URL_CACHE_MAX_ENTRIES) {
@@ -339,10 +359,18 @@ export async function resolveShortUrl(url: string): Promise<string> {
       ALLOWED_BILIBILI_SHORTENER_HOSTNAMES,
     );
 
-    const cachedUrl = getCachedShortUrlResolution(safeShortUrl);
-    if (cachedUrl) {
-      logger.info(`Resolved shortened URL from cache to: ${cachedUrl}`);
-      return cachedUrl;
+    const cached = getCachedShortUrlResolution(safeShortUrl);
+    if (cached) {
+      if (cached.resolvedUrl) {
+        logger.info(
+          `Resolved shortened URL from cache to: ${cached.resolvedUrl}`,
+        );
+        return cached.resolvedUrl;
+      }
+      logger.warn(
+        `Short URL ${safeShortUrl} failed to resolve recently; keeping it as-is without retrying.`,
+      );
+      return safeShortUrl;
     }
 
     // The short URL carries no BV/av id, so everything keyed off the source
@@ -358,9 +386,11 @@ export async function resolveShortUrl(url: string): Promise<string> {
       logger.warn(
         `Short URL ${safeShortUrl} did not redirect to an allowed Bilibili host; keeping the short URL.`,
       );
+      setCachedShortUrlResolution(safeShortUrl, null);
     } catch (resolveError: unknown) {
       // Resolution is best-effort: yt-dlp follows the redirect itself, so a
       // failure here degrades metadata rather than breaking the download.
+      setCachedShortUrlResolution(safeShortUrl, null);
       logger.warn(
         `Could not follow shortened URL ${safeShortUrl}, keeping it as-is: ${getErrorMessage(resolveError)}`,
       );


### PR DESCRIPTION
## Problem

Downloading a Bilibili video from a `b23.tv` short link (e.g. `https://b23.tv/zKTXLw5`) saves the video correctly but never downloads the author's avatar.

## Root cause

`resolveShortUrl` was not resolving anything. A previous security refactor (e2a49adc) removed the redirect-following and left it returning the normalized short URL unchanged:

> Short URL host is allowed. Returning normalized URL without outbound resolution

So the short URL stayed a `b23.tv` URL through the entire pipeline. yt-dlp follows the redirect internally, which is why the video itself downloaded fine and only the avatar looked broken.

`extractBilibiliVideoId()` matches `/video/(BV…|av…)` against the URL, and a short link has no such segment, so it returned `null`. In `bilibiliCoreDownload.ts`, a null id skips the Bilibili API call that supplies `owner.face` — and since yt-dlp does not populate `uploader_avatar` for Bilibili, no avatar URL was left to download.

## Other short-URL issues found

The null `sourceVideoId` silently degraded everything keyed off it:

- **Duplicate detection skipped** — the dedupe branch is gated on `if (sourceVideoId && …)`, so re-pasting the same short link always re-downloaded.
- **Multipart / collection prompts never appeared** — `checkBilibiliParts` and `checkBilibiliCollection` threw a 400, which the frontend catches and swallows to continue with a normal download.
- **Filename templates** using the video id resolved to an empty string; media identity and collision-audit records lost their id.

## Fix

Two layers, so the avatar survives even when the network does not cooperate.

**1. Restored resolution, addressing the SSRF concern directly** instead of by disabling the feature. Redirects are followed one hop at a time with `maxRedirects: 0`, validating each hop against an allow-list *before* requesting it — axios' own follower would fetch an intermediate `Location` pointing at an internal host before we ever see the final URL. Best-effort with a 10s timeout, proxy support, and a 10-minute cache (one paste resolves the same URL 2–3 times).

**2. Metadata fallback in the downloader** — derive the id from yt-dlp's `webpage_url`, then its bare `id` (stripping the `_p2` multipart suffix), when the URL has none. Covers proxy-only or offline hosts where the shortener cannot be reached.

Redirect targets get their own validator rather than reusing `buildSafeRequestUrl`, which canonicalizes *any* `*.bilibili.com` host to `www.bilibili.com`. That is right for a URL the user typed but wrong for a redirect target: a short link to `live.bilibili.com/1234` would have been rewritten into an unrelated `www.bilibili.com/1234` page.

## Verification

Confirmed against the real URL — `https://b23.tv/zKTXLw5` resolves in one hop to `BV1cEur6yEYb`, and a live run of the resolver produced that id. That run also exercised the graceful-degradation path, since the scratch environment had no settings DB and the proxy lookup fell through cleanly.

New test coverage: multi-hop chains, relative `Location` headers, an off-allow-list hop rejected before it is requested, credentialed redirect targets, subdomain preservation, redirect loops, caching, and the downloader's metadata fallback.

Full backend suite: **2748 passing**. Six failures remain in `ytdlpHelpers`, `favoriteMigration`, and `sourceVideoIdMigration` — verified pre-existing by stashing and re-running on a clean tree (identical 6 failures, all cwd/DB-setup related and untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
