### PR TITLE
fix(frontend): walk a cover fallback chain before the placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fix
 
+- Stop a single unreachable cover URL from emptying the whole library: video covers now walk an ordered candidate list (backend origin, then page origin; `/images-small` mirror, then the original image; finally the remote thumbnail) before falling back to the "No Thumbnail" placeholder. Covers were the only media addressed through the absolute `VITE_BACKEND_URL` origin, so a deployment whose backend origin is not reachable from the browser lost every cover while avatars and playback kept working. Refs #405
 - Skip members-only YouTube uploads in subscription checks instead of failing and retrying them every cycle: detect yt-dlp's members-only error, record the upload as skipped, log it informationally, and advance the subscription cursor so the same video isn't re-attempted. Closes #393
 
 ## v1.10.16 (2026-07-13)

--- a/frontend/src/components/CollectionCard.tsx
+++ b/frontend/src/components/CollectionCard.tsx
@@ -12,13 +12,11 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router';
 import { overlay } from '../theme/colors';
-import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
+import { useThumbnailCandidates } from '../hooks/useThumbnailCandidates';
 import { useFavoriteCollections } from '../hooks/useFavoriteCollections';
 import { Collection, Video } from '../types';
-import { getBackendUrl } from '../utils/apiUrl';
 import { formatDisplayDate } from '../utils/formatUtils';
-import { buildSmallThumbnailAbsoluteUrl } from '../utils/imageOptimization';
-import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../utils/thumbnailPlaceholder';
+import { handleThumbnailError } from '../utils/thumbnailPlaceholder';
 
 interface CollectionCardProps {
     collection: Collection;
@@ -171,18 +169,7 @@ const CollectionCard: React.FC<CollectionCardProps> = ({ collection, videos }) =
 
 // Component for individual thumbnail with cloud storage support
 const CollectionThumbnail: React.FC<{ video: Video; index: number }> = ({ video, index }) => {
-    // Only load thumbnail from cloud if the video itself is in cloud storage
-    const isVideoInCloud = video.videoPath?.startsWith('cloud:') ?? false;
-    const thumbnailPathForCloud = isVideoInCloud ? video.thumbnailPath : null;
-    const thumbnailUrl = useCloudStorageUrl(thumbnailPathForCloud, 'thumbnail');
-    const localThumbnailUrl = !isVideoInCloud
-        ? buildSmallThumbnailAbsoluteUrl(
-            getBackendUrl(),
-            video.thumbnailPath,
-            video.thumbnailUrl,
-        )
-        : undefined;
-    const src = thumbnailUrl || localThumbnailUrl || video.thumbnailUrl || THUMBNAIL_PLACEHOLDER_SRC;
+    const { src, candidates } = useThumbnailCandidates(video);
 
     return (
         <Box
@@ -209,7 +196,7 @@ const CollectionThumbnail: React.FC<{ video: Video; index: number }> = ({ video,
                     objectFit: 'cover'
                 }}
                 onError={(e) => {
-                    setThumbnailPlaceholder(e.currentTarget);
+                    handleThumbnailError(e.currentTarget, candidates);
                 }}
             />
         </Box>

--- a/frontend/src/components/LCPImagePreloader.tsx
+++ b/frontend/src/components/LCPImagePreloader.tsx
@@ -1,7 +1,7 @@
 import { useLayoutEffect } from 'react';
 import { Video } from '../types';
 import { getBackendUrl } from '../utils/apiUrl';
-import { buildSmallThumbnailAbsoluteUrl } from '../utils/imageOptimization';
+import { buildThumbnailCandidates } from '../utils/imageOptimization';
 
 /**
  * Component that preloads the first video thumbnail for better LCP
@@ -33,11 +33,11 @@ export const LCPImagePreloader: React.FC<LCPImagePreloaderProps> = ({ videos }) 
 
         // For local videos, construct the URL immediately
         if (firstVideo.thumbnailPath) {
-            thumbnailUrl = buildSmallThumbnailAbsoluteUrl(
+            thumbnailUrl = buildThumbnailCandidates(
                 getBackendUrl(),
                 firstVideo.thumbnailPath,
                 firstVideo.thumbnailUrl,
-            );
+            )[0];
         } else if (firstVideo.thumbnailUrl) {
             thumbnailUrl = firstVideo.thumbnailUrl;
         }

--- a/frontend/src/components/ManagePage/VideosTable.tsx
+++ b/frontend/src/components/ManagePage/VideosTable.tsx
@@ -40,7 +40,7 @@ import { useCollection } from '../../contexts/CollectionContext';
 import { useDownload } from '../../contexts/DownloadContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useVideo } from '../../contexts/VideoContext';
-import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
+import { useThumbnailCandidates } from '../../hooks/useThumbnailCandidates';
 import { Video } from '../../types';
 import type { TranslationKey } from '../../utils/translations';
 import { formatDuration, formatSize } from '../../utils/formatUtils';
@@ -48,13 +48,10 @@ import CollectionModal from '../CollectionModal';
 import ConfirmationModal from '../ConfirmationModal';
 import UploadThumbnailModal from '../UploadThumbnailModal';
 
-import { getBackendUrl } from '../../utils/apiUrl';
 import { neutral, overlay } from '../../theme/colors';
-import { buildSmallThumbnailAbsoluteUrl } from '../../utils/imageOptimization';
-import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../../utils/thumbnailPlaceholder';
+import { handleThumbnailError } from '../../utils/thumbnailPlaceholder';
 import { useVideoReDownload } from './hooks/useVideoReDownload';
 
-const BACKEND_URL = getBackendUrl();
 const thumbnailActionButtonSx = {
     bgcolor: overlay.black50,
     color: neutral.white,
@@ -69,32 +66,9 @@ const thumbnailActionButtonSx = {
     height: 24
 } as const;
 
-const appendCacheBust = (url: string | undefined, cacheBust?: number): string | undefined => {
-    if (!url || !cacheBust) {
-        return url;
-    }
-
-    const separator = url.includes('?') ? '&' : '?';
-    return `${url}${separator}cb=${cacheBust}`;
-};
-
 // Component for thumbnail with cloud storage support
 const ThumbnailImage: React.FC<{ video: Video; cacheBust?: number }> = ({ video, cacheBust }) => {
-    // Only load thumbnail from cloud if the video itself is in cloud storage
-    const isVideoInCloud = video.videoPath?.startsWith('cloud:') ?? false;
-    const thumbnailPathForCloud = isVideoInCloud ? video.thumbnailPath : null;
-    const thumbnailUrl = useCloudStorageUrl(thumbnailPathForCloud, 'thumbnail');
-    const localThumbnailUrl = !isVideoInCloud
-        ? buildSmallThumbnailAbsoluteUrl(
-            BACKEND_URL,
-            video.thumbnailPath,
-            video.thumbnailUrl,
-        )
-        : undefined;
-    const src = appendCacheBust(
-        thumbnailUrl || localThumbnailUrl || video.thumbnailUrl,
-        cacheBust,
-    ) || THUMBNAIL_PLACEHOLDER_SRC;
+    const { src, candidates } = useThumbnailCandidates(video, cacheBust);
 
     return (
         <Box
@@ -102,7 +76,7 @@ const ThumbnailImage: React.FC<{ video: Video; cacheBust?: number }> = ({ video,
             src={src}
             alt={video.title}
             sx={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: 1 }}
-            onError={(e) => setThumbnailPlaceholder(e.currentTarget)}
+            onError={(e) => handleThumbnailError(e.currentTarget, candidates)}
         />
     );
 };

--- a/frontend/src/components/VideoCard.tsx
+++ b/frontend/src/components/VideoCard.tsx
@@ -138,6 +138,7 @@ const VideoCardBase: React.FC<VideoCardProps> = ({
                 <VideoCardThumbnail
                     video={video}
                     thumbnailSrc={metadata.thumbnailSrc}
+                    thumbnailCandidates={metadata.thumbnailCandidates}
                     thumbnailSrcSet={metadata.thumbnailSrcSet}
                     thumbnailSizes={metadata.thumbnailSizes}
                     videoUrl={metadata.videoUrl}

--- a/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
+++ b/frontend/src/components/VideoCard/VideoCardThumbnail.tsx
@@ -5,12 +5,14 @@ import { useLanguage } from '../../contexts/LanguageContext';
 import { mask, neutral, overlay, shadow } from '../../theme/colors';
 import { Video } from '../../types';
 import { formatDuration, parseDuration } from '../../utils/formatUtils';
-import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../../utils/thumbnailPlaceholder';
+import { THUMBNAIL_PLACEHOLDER_SRC, handleThumbnailError } from '../../utils/thumbnailPlaceholder';
 import { VideoCardCollectionInfo } from '../../utils/videoCardUtils';
 
 interface VideoCardThumbnailProps {
     video: Video;
     thumbnailSrc?: string;
+    /** Ordered cover URLs to try before giving up on the placeholder. */
+    thumbnailCandidates?: string[];
     thumbnailSrcSet?: string;
     thumbnailSizes?: string;
     videoUrl?: string;
@@ -31,6 +33,7 @@ interface VideoCardThumbnailProps {
 const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
     video,
     thumbnailSrc,
+    thumbnailCandidates,
     thumbnailSrcSet,
     thumbnailSizes,
     videoUrl,
@@ -151,7 +154,7 @@ const VideoCardThumbnailView: React.FC<VideoCardThumbnailProps> = ({
                 }}
                 onError={(e) => {
                     setIsImageLoaded(true);
-                    setThumbnailPlaceholder(e.currentTarget);
+                    handleThumbnailError(e.currentTarget, thumbnailCandidates ?? []);
                 }}
             />
 

--- a/frontend/src/components/VideoPlayer/AudioUpNextSidebar.tsx
+++ b/frontend/src/components/VideoPlayer/AudioUpNextSidebar.tsx
@@ -14,13 +14,11 @@ import {
 import React, { useState } from 'react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
-import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
+import { useThumbnailCandidates } from '../../hooks/useThumbnailCandidates';
 import { Video } from '../../types';
-import { getBackendUrl } from '../../utils/apiUrl';
 import { formatDuration } from '../../utils/formatUtils';
-import { buildSmallThumbnailAbsoluteUrl } from '../../utils/imageOptimization';
 import { overlay, neutral, brand } from '../../theme/colors';
-import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../../utils/thumbnailPlaceholder';
+import { handleThumbnailError } from '../../utils/thumbnailPlaceholder';
 
 interface AudioUpNextSidebarProps {
   relatedVideos: Video[];
@@ -32,19 +30,15 @@ interface AudioUpNextSidebarProps {
 }
 
 const AudioTrackThumbnail: React.FC<{ video: Video }> = ({ video }) => {
-  const isCloud = video.videoPath?.startsWith('cloud:') ?? false;
-  const cloudUrl = useCloudStorageUrl(isCloud ? video.thumbnailPath : null, 'thumbnail');
-  const localUrl = !isCloud
-    ? buildSmallThumbnailAbsoluteUrl(getBackendUrl(), video.thumbnailPath, video.thumbnailUrl)
-    : undefined;
+  const { src, candidates } = useThumbnailCandidates(video);
 
   return (
     <CardMedia
       component="img"
       loading="lazy"
-      image={cloudUrl || localUrl || video.thumbnailUrl || THUMBNAIL_PLACEHOLDER_SRC}
+      image={src}
       alt=""
-      onError={(event) => setThumbnailPlaceholder(event.currentTarget)}
+      onError={(event) => handleThumbnailError(event.currentTarget, candidates)}
       sx={{ width: 56, height: 56, flexShrink: 0, borderRadius: 1.5, objectFit: 'cover' }}
     />
   );

--- a/frontend/src/components/VideoPlayer/UpNextSidebar.tsx
+++ b/frontend/src/components/VideoPlayer/UpNextSidebar.tsx
@@ -22,12 +22,10 @@ import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { neutral, overlay } from '../../theme/colors';
 import { useAuth } from '../../contexts/AuthContext';
-import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
+import { useThumbnailCandidates } from '../../hooks/useThumbnailCandidates';
 import { Video } from '../../types';
-import { getBackendUrl } from '../../utils/apiUrl';
 import { formatDate, formatDuration } from '../../utils/formatUtils';
-import { buildSmallThumbnailAbsoluteUrl } from '../../utils/imageOptimization';
-import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../../utils/thumbnailPlaceholder';
+import { handleThumbnailError } from '../../utils/thumbnailPlaceholder';
 
 interface UpNextSidebarProps {
     relatedVideos: Video[];
@@ -39,17 +37,7 @@ interface UpNextSidebarProps {
 
 const SidebarThumbnail: React.FC<{ video: Video }> = ({ video }) => {
     const [isImageLoaded, setIsImageLoaded] = useState(false);
-    // Only load thumbnail from cloud if the video itself is in cloud storage
-    const isVideoInCloud = video.videoPath?.startsWith('cloud:') ?? false;
-    const thumbnailPathForCloud = isVideoInCloud ? video.thumbnailPath : null;
-    const thumbnailUrl = useCloudStorageUrl(thumbnailPathForCloud, 'thumbnail');
-    const localThumbnailUrl = !isVideoInCloud
-        ? buildSmallThumbnailAbsoluteUrl(
-            getBackendUrl(),
-            video.thumbnailPath,
-            video.thumbnailUrl,
-        )
-        : undefined;
+    const { src, candidates } = useThumbnailCandidates(video);
 
     return (
         <Box sx={{ width: 180, minWidth: 180, position: 'relative', borderRadius: 2, overflow: 'hidden' }}>
@@ -80,11 +68,11 @@ const SidebarThumbnail: React.FC<{ video: Video }> = ({ video }) => {
                     // The image is always rendered but hidden until loaded
                 }}
                 onLoad={() => setIsImageLoaded(true)}
-                image={thumbnailUrl || localThumbnailUrl || video.thumbnailUrl || THUMBNAIL_PLACEHOLDER_SRC}
+                image={src}
                 alt={video.title}
                 onError={(e) => {
                     setIsImageLoaded(true);
-                    setThumbnailPlaceholder(e.currentTarget);
+                    handleThumbnailError(e.currentTarget, candidates);
                 }}
             />
             {video.duration && (

--- a/frontend/src/hooks/__tests__/useVideoCardMetadata.test.ts
+++ b/frontend/src/hooks/__tests__/useVideoCardMetadata.test.ts
@@ -113,6 +113,24 @@ describe('useVideoCardMetadata', () => {
         await expect(result.current.getVideoUrl()).resolves.toBe(`${window.location.origin}/videos/local.mp4`);
     });
 
+    it('exposes the original image as a fallback candidate behind the small mirror', () => {
+        const mockVideo = {
+            id: '4b',
+            videoPath: 'videos/local.mp4',
+            thumbnailPath: '/images/thumb.jpg'
+        };
+
+        const { result } = renderHook(() => useVideoCardMetadata({ video: mockVideo as any }));
+
+        // A failing /images-small request must not drop the card to the
+        // placeholder while the original cover is still servable (issue #405).
+        expect(
+            result.current.thumbnailCandidates.map((candidate) =>
+                candidate.replace(/^https?:\/\/[^/]+/, ''),
+            ),
+        ).toEqual(['/images-small/thumb.jpg', '/images/thumb.jpg']);
+    });
+
     it('should fallback to sourceUrl and then empty string when videoPath is missing', async () => {
         mockIsNewVideo.mockReturnValue(false);
 

--- a/frontend/src/hooks/useThumbnailCandidates.ts
+++ b/frontend/src/hooks/useThumbnailCandidates.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { Video } from '../types';
+import { getBackendUrl } from '../utils/apiUrl';
+import { buildThumbnailCandidates } from '../utils/imageOptimization';
+import { THUMBNAIL_PLACEHOLDER_SRC } from '../utils/thumbnailPlaceholder';
+import { useCloudStorageUrl } from './useCloudStorageUrl';
+
+type ThumbnailVideo = Pick<Video, 'videoPath' | 'thumbnailPath' | 'thumbnailUrl'>;
+
+export interface ThumbnailSource {
+    /** URL to render first (never empty: falls back to the placeholder). */
+    src: string;
+    /** Ordered candidates for `handleThumbnailError` to walk on load failure. */
+    candidates: string[];
+}
+
+const appendCacheBust = (url: string, cacheBust?: number): string => {
+    if (!cacheBust) {
+        return url;
+    }
+
+    const separator = url.includes('?') ? '&' : '?';
+    return `${url}${separator}cb=${cacheBust}`;
+};
+
+/**
+ * Resolve every URL a video cover can be loaded from, best first.
+ *
+ * Cloud-stored covers keep their signed URL as the first candidate; local covers
+ * fall back from the /images-small mirror to the original image and from the
+ * backend origin to the page origin, so a single unreachable URL no longer drops
+ * the card straight to the "No Thumbnail" placeholder (issue #405).
+ */
+export const useThumbnailCandidates = (
+    video?: ThumbnailVideo | null,
+    cacheBust?: number,
+): ThumbnailSource => {
+    // Only load a cover from cloud storage if the video itself lives there.
+    const isVideoInCloud = video?.videoPath?.startsWith('cloud:') ?? false;
+    const cloudThumbnailUrl = useCloudStorageUrl(
+        isVideoInCloud ? video?.thumbnailPath : null,
+        'thumbnail',
+    );
+
+    const thumbnailPath = video?.thumbnailPath;
+    const thumbnailUrl = video?.thumbnailUrl;
+
+    return useMemo(() => {
+        const candidates = [
+            ...(cloudThumbnailUrl ? [cloudThumbnailUrl] : []),
+            ...(isVideoInCloud
+                ? []
+                : buildThumbnailCandidates(getBackendUrl(), thumbnailPath, thumbnailUrl)),
+            ...(isVideoInCloud && thumbnailUrl ? [thumbnailUrl] : []),
+        ]
+            .map((candidate) => appendCacheBust(candidate, cacheBust))
+            .filter((candidate, index, all) => all.indexOf(candidate) === index);
+
+        return {
+            src: candidates[0] ?? THUMBNAIL_PLACEHOLDER_SRC,
+            candidates,
+        };
+    }, [cloudThumbnailUrl, isVideoInCloud, thumbnailPath, thumbnailUrl, cacheBust]);
+};

--- a/frontend/src/hooks/useVideoCardMetadata.ts
+++ b/frontend/src/hooks/useVideoCardMetadata.ts
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 import { Video } from '../types';
-import { getBackendUrl } from '../utils/apiUrl';
-import { buildSmallThumbnailAbsoluteUrl } from '../utils/imageOptimization';
 import { isNewVideo } from '../utils/videoCardUtils';
 import { useCloudStorageUrl } from './useCloudStorageUrl';
+import { useThumbnailCandidates } from './useThumbnailCandidates';
 
 interface UseVideoCardMetadataProps {
     video: Video;
@@ -13,21 +12,10 @@ interface UseVideoCardMetadataProps {
  * Hook to manage video card metadata: thumbnails, URLs, new video detection
  */
 export const useVideoCardMetadata = ({ video }: UseVideoCardMetadataProps) => {
-    // Use cloud storage hook for thumbnail URL only if video is in cloud storage
-    // Only load thumbnail from cloud if the video itself is in cloud storage
-    const isVideoInCloud = video.videoPath?.startsWith('cloud:') ?? false;
-    const thumbnailPathForCloud = isVideoInCloud ? video.thumbnailPath : null;
-    const thumbnailUrl = useCloudStorageUrl(thumbnailPathForCloud, 'thumbnail');
-    const localThumbnailUrl = !isVideoInCloud
-        ? buildSmallThumbnailAbsoluteUrl(
-            getBackendUrl(),
-            video.thumbnailPath,
-            video.thumbnailUrl,
-        )
-        : undefined;
-    const thumbnailSrc = thumbnailUrl
-        || localThumbnailUrl
-        || video.thumbnailUrl;
+    // Cover URLs, best first: cloud signed URL (cloud videos only), then the
+    // local /images-small mirror and its fallbacks.
+    const { src: thumbnailSrc, candidates: thumbnailCandidates } =
+        useThumbnailCandidates(video);
 
     // Use cloud storage hook for video URL
     const isAudioOnly = video.mediaType === 'audio';
@@ -66,6 +54,7 @@ export const useVideoCardMetadata = ({ video }: UseVideoCardMetadataProps) => {
 
     return {
         thumbnailSrc,
+        thumbnailCandidates,
         thumbnailSrcSet: undefined,
         thumbnailSizes: undefined,
         // Audio-only cards have no video frames, so feeding this URL into the

--- a/frontend/src/pages/favorite/useFavoriteThumbnail.ts
+++ b/frontend/src/pages/favorite/useFavoriteThumbnail.ts
@@ -1,20 +1,10 @@
-import { useCloudStorageUrl } from '../../hooks/useCloudStorageUrl';
+import { useThumbnailCandidates } from '../../hooks/useThumbnailCandidates';
 import type { Video } from '../../types';
-import { getBackendUrl } from '../../utils/apiUrl';
-import { buildSmallThumbnailAbsoluteUrl } from '../../utils/imageOptimization';
-import { THUMBNAIL_PLACEHOLDER_SRC } from '../../utils/thumbnailPlaceholder';
 
-export const useFavoriteThumbnail = (video?: Video): string => {
-    const cloudThumbnailPath = video?.videoPath?.startsWith('cloud:')
-        ? video.thumbnailPath
-        : null;
-    const cloudThumbnailUrl = useCloudStorageUrl(cloudThumbnailPath, 'thumbnail');
-
-    // Resolve local thumbnails against the backend origin so covers still load
-    // when the frontend is served from a different host (VITE_BACKEND_URL),
-    // matching VideoCard/CollectionCard.
-    return cloudThumbnailUrl
-        || buildSmallThumbnailAbsoluteUrl(getBackendUrl(), video?.thumbnailPath, video?.thumbnailUrl)
-        || video?.thumbnailUrl
-        || THUMBNAIL_PLACEHOLDER_SRC;
-};
+/**
+ * Favorite rails render covers mostly as CSS backgrounds, which have no
+ * load-error event to walk a fallback chain with, so they take the best
+ * candidate only. The candidate order itself comes from the shared resolver.
+ */
+export const useFavoriteThumbnail = (video?: Video): string =>
+    useThumbnailCandidates(video).src;

--- a/frontend/src/utils/__tests__/imageOptimization.test.ts
+++ b/frontend/src/utils/__tests__/imageOptimization.test.ts
@@ -1,7 +1,9 @@
 import {
     buildSmallThumbnailAbsoluteUrl,
     buildSmallThumbnailUrl,
+    buildThumbnailCandidates,
     extractThumbnailCacheSuffix,
+    toOriginalThumbnailPath,
     toSmallThumbnailPath,
 } from '../imageOptimization';
 
@@ -26,5 +28,45 @@ describe('imageOptimization', () => {
     it('returns undefined for non-local thumbnail paths', () => {
         expect(toSmallThumbnailPath('cloud:thumb.jpg')).toBeUndefined();
         expect(buildSmallThumbnailAbsoluteUrl('http://localhost:3000', 'cloud:thumb.jpg')).toBeUndefined();
+        expect(toOriginalThumbnailPath('cloud:thumb.jpg')).toBeUndefined();
+    });
+
+    describe('buildThumbnailCandidates', () => {
+        it('falls back from the small mirror to the original image on the page origin', () => {
+            expect(buildThumbnailCandidates('', '/images/folder/thumb.jpg')).toEqual([
+                '/images-small/folder/thumb.jpg',
+                '/images/folder/thumb.jpg',
+            ]);
+        });
+
+        it('tries the backend origin first, then the page origin, for every path', () => {
+            expect(
+                buildThumbnailCandidates('http://backend:5551', '/images/thumb.jpg'),
+            ).toEqual([
+                'http://backend:5551/images-small/thumb.jpg',
+                '/images-small/thumb.jpg',
+                'http://backend:5551/images/thumb.jpg',
+                '/images/thumb.jpg',
+            ]);
+        });
+
+        it('keeps the cache-busting suffix on every local candidate and drops duplicates', () => {
+            expect(
+                buildThumbnailCandidates('', '/videos/thumb.jpg', '/videos/thumb.jpg?t=9'),
+            ).toEqual([
+                '/images-small/thumb.jpg?t=9',
+                '/videos/thumb.jpg?t=9',
+            ]);
+        });
+
+        it('offers only the remote url for cloud-stored thumbnails', () => {
+            expect(
+                buildThumbnailCandidates('', 'cloud:thumb.jpg', 'https://cdn.example/thumb.jpg'),
+            ).toEqual(['https://cdn.example/thumb.jpg']);
+        });
+
+        it('returns nothing when there is no thumbnail at all', () => {
+            expect(buildThumbnailCandidates('', undefined, undefined)).toEqual([]);
+        });
     });
 });

--- a/frontend/src/utils/__tests__/thumbnailPlaceholder.test.ts
+++ b/frontend/src/utils/__tests__/thumbnailPlaceholder.test.ts
@@ -1,0 +1,71 @@
+import {
+    THUMBNAIL_PLACEHOLDER_SRC,
+    handleThumbnailError,
+} from '../thumbnailPlaceholder';
+
+const createImage = (src: string): HTMLImageElement => {
+    const image = document.createElement('img');
+    image.src = src;
+    return image;
+};
+
+describe('handleThumbnailError', () => {
+    it('advances to the next candidate instead of giving up on the first failure', () => {
+        const candidates = ['/images-small/thumb.jpg', '/images/thumb.jpg'];
+        const image = createImage(candidates[0]);
+
+        handleThumbnailError(image, candidates);
+
+        expect(image.src).toBe(`${window.location.origin}/images/thumb.jpg`);
+    });
+
+    it('walks an absolute backend candidate down to the same-origin one', () => {
+        const candidates = [
+            'http://backend:5551/images-small/thumb.jpg',
+            '/images-small/thumb.jpg',
+        ];
+        const image = createImage(candidates[0]);
+
+        handleThumbnailError(image, candidates);
+
+        expect(image.src).toBe(`${window.location.origin}/images-small/thumb.jpg`);
+    });
+
+    it('falls back to the placeholder once the last candidate fails', () => {
+        const candidates = ['/images-small/thumb.jpg', '/images/thumb.jpg'];
+        const image = createImage(candidates[1]);
+
+        handleThumbnailError(image, candidates);
+
+        expect(image.src).toBe(THUMBNAIL_PLACEHOLDER_SRC);
+    });
+
+    it('uses the placeholder when there are no candidates', () => {
+        const image = createImage('/images-small/thumb.jpg');
+
+        handleThumbnailError(image, []);
+
+        expect(image.src).toBe(THUMBNAIL_PLACEHOLDER_SRC);
+    });
+
+    it('never re-tries the url that just failed', () => {
+        const candidates = ['/images-small/thumb.jpg', '/images-small/thumb.jpg'];
+        const image = createImage(candidates[0]);
+
+        handleThumbnailError(image, candidates);
+
+        expect(image.src).toBe(THUMBNAIL_PLACEHOLDER_SRC);
+    });
+
+    it('clears srcset/sizes so the failed candidate cannot be re-selected', () => {
+        const candidates = ['/images-small/thumb.jpg', '/images/thumb.jpg'];
+        const image = createImage(candidates[0]);
+        image.srcset = '/images-small/thumb.jpg 480w';
+        image.sizes = '480px';
+
+        handleThumbnailError(image, candidates);
+
+        expect(image.hasAttribute('srcset')).toBe(false);
+        expect(image.hasAttribute('sizes')).toBe(false);
+    });
+});

--- a/frontend/src/utils/__tests__/thumbnailPlaceholder.test.ts
+++ b/frontend/src/utils/__tests__/thumbnailPlaceholder.test.ts
@@ -57,6 +57,25 @@ describe('handleThumbnailError', () => {
         expect(image.src).toBe(THUMBNAIL_PLACEHOLDER_SRC);
     });
 
+    it('skips past candidates that resolve to the failed url instead of stopping', () => {
+        // VITE_BACKEND_URL pointing at the page's own origin makes the absolute
+        // and relative form of a path collapse to the same URL; the full-size
+        // candidates behind them must still be reached.
+        const candidates = [
+            `${window.location.origin}/images-small/thumb.jpg`,
+            '/images-small/thumb.jpg',
+            `${window.location.origin}/images/thumb.jpg`,
+            '/images/thumb.jpg',
+        ];
+        const image = createImage(candidates[0]);
+
+        handleThumbnailError(image, candidates);
+        expect(image.src).toBe(`${window.location.origin}/images/thumb.jpg`);
+
+        handleThumbnailError(image, candidates);
+        expect(image.src).toBe(THUMBNAIL_PLACEHOLDER_SRC);
+    });
+
     it('clears srcset/sizes so the failed candidate cannot be re-selected', () => {
         const candidates = ['/images-small/thumb.jpg', '/images/thumb.jpg'];
         const image = createImage(candidates[0]);

--- a/frontend/src/utils/imageOptimization.ts
+++ b/frontend/src/utils/imageOptimization.ts
@@ -51,6 +51,23 @@ export const extractThumbnailCacheSuffix = (
     }
 };
 
+/**
+ * Web path of the original (full size) managed thumbnail, used as the fallback
+ * when the /images-small mirror cannot be served.
+ */
+export const toOriginalThumbnailPath = (
+    thumbnailPath?: string | null,
+): string | undefined => {
+    if (!thumbnailPath) {
+        return undefined;
+    }
+
+    const normalizedPath = normalizePath(thumbnailPath);
+    return normalizedPath.startsWith('/images/') || normalizedPath.startsWith('/videos/')
+        ? normalizedPath
+        : undefined;
+};
+
 export const buildSmallThumbnailUrl = (
     thumbnailPath?: string | null,
     thumbnailUrl?: string,
@@ -74,4 +91,46 @@ export const buildSmallThumbnailAbsoluteUrl = (
     }
 
     return `${backendUrl}${smallThumbnailUrl}`;
+};
+
+/**
+ * Ordered list of URLs to try for a video cover, best first.
+ *
+ * Covers are the only media the frontend addresses through an absolute backend
+ * origin (`VITE_BACKEND_URL`); avatars, videos and subtitles are served from the
+ * page origin through the nginx proxy. A deployment whose backend origin is not
+ * reachable from the browser therefore loses every cover while the rest of the
+ * page keeps working (issue #405), and a missing /images-small mirror used to be
+ * fatal as well. Trying, in order, the backend origin then the page origin, and
+ * the small mirror then the original image, makes both failures self-healing.
+ */
+export const buildThumbnailCandidates = (
+    backendUrl: string,
+    thumbnailPath?: string | null,
+    thumbnailUrl?: string,
+): string[] => {
+    const cacheSuffix = extractThumbnailCacheSuffix(thumbnailPath, thumbnailUrl);
+    // Same-origin first when there is no configured backend origin to try.
+    const origins = backendUrl ? [backendUrl, ''] : [''];
+    const candidates: string[] = [];
+
+    for (const mediaPath of [
+        toSmallThumbnailPath(thumbnailPath),
+        toOriginalThumbnailPath(thumbnailPath),
+    ]) {
+        if (!mediaPath) {
+            continue;
+        }
+        for (const origin of origins) {
+            candidates.push(`${origin}${mediaPath}${cacheSuffix}`);
+        }
+    }
+
+    if (thumbnailUrl) {
+        candidates.push(thumbnailUrl);
+    }
+
+    return candidates.filter(
+        (candidate, index) => candidates.indexOf(candidate) === index,
+    );
 };

--- a/frontend/src/utils/thumbnailPlaceholder.ts
+++ b/frontend/src/utils/thumbnailPlaceholder.ts
@@ -9,3 +9,41 @@ export const setThumbnailPlaceholder = (image: HTMLImageElement): void => {
   image.removeAttribute("sizes");
   image.src = THUMBNAIL_PLACEHOLDER_SRC;
 };
+
+const resolveAgainstPage = (value: string): string => {
+  try {
+    return new URL(value, window.location.href).href;
+  } catch {
+    return value;
+  }
+};
+
+/**
+ * Move an <img> to the next cover candidate after a load error, and only fall
+ * back to the placeholder once every candidate has failed.
+ *
+ * The current position is derived from the element's resolved `src` rather than
+ * from component state, so a re-render that resets `src` cannot strand the image
+ * mid-chain. Advancing to a URL the element already failed on is treated as the
+ * end of the chain, which keeps the walk finite.
+ */
+export const handleThumbnailError = (
+  image: HTMLImageElement,
+  candidates: readonly string[]
+): void => {
+  const currentIndex = candidates.findIndex(
+    (candidate) => resolveAgainstPage(candidate) === image.src
+  );
+  const nextSrc = candidates[currentIndex + 1];
+
+  if (!nextSrc || resolveAgainstPage(nextSrc) === image.src) {
+    setThumbnailPlaceholder(image);
+    return;
+  }
+
+  image.srcset = "";
+  image.sizes = "";
+  image.removeAttribute("srcset");
+  image.removeAttribute("sizes");
+  image.src = nextSrc;
+};

--- a/frontend/src/utils/thumbnailPlaceholder.ts
+++ b/frontend/src/utils/thumbnailPlaceholder.ts
@@ -24,19 +24,32 @@ const resolveAgainstPage = (value: string): string => {
  *
  * The current position is derived from the element's resolved `src` rather than
  * from component state, so a re-render that resets `src` cannot strand the image
- * mid-chain. Advancing to a URL the element already failed on is treated as the
- * end of the chain, which keeps the walk finite.
+ * mid-chain. Candidates that resolve to the URL that just failed are skipped
+ * rather than ending the walk: when the backend origin is the page's own origin,
+ * the absolute and relative form of a path collapse to the same URL, and treating
+ * that duplicate as the end would drop the still-untried full-size candidates.
+ *
+ * Anchoring on the *last* match makes the position strictly increase on every
+ * call, so the walk is finite whatever the candidate list looks like.
  */
 export const handleThumbnailError = (
   image: HTMLImageElement,
   candidates: readonly string[]
 ): void => {
-  const currentIndex = candidates.findIndex(
-    (candidate) => resolveAgainstPage(candidate) === image.src
-  );
-  const nextSrc = candidates[currentIndex + 1];
+  const resolvedCandidates = candidates.map(resolveAgainstPage);
+  let currentIndex = -1;
+  for (let index = 0; index < resolvedCandidates.length; index += 1) {
+    if (resolvedCandidates[index] === image.src) {
+      currentIndex = index;
+    }
+  }
 
-  if (!nextSrc || resolveAgainstPage(nextSrc) === image.src) {
+  const nextIndex = resolvedCandidates.findIndex(
+    (resolvedCandidate, index) =>
+      index > currentIndex && resolvedCandidate !== image.src
+  );
+
+  if (nextIndex === -1) {
     setThumbnailPlaceholder(image);
     return;
   }
@@ -45,5 +58,5 @@ export const handleThumbnailError = (
   image.sizes = "";
   image.removeAttribute("srcset");
   image.removeAttribute("sizes");
-  image.src = nextSrc;
+  image.src = candidates[nextIndex];
 };


### PR DESCRIPTION
Refs #405.

## Problem

A user reports that covers never render even though `uploads/images/` and `uploads/images-small/` both hold the files. Their screenshots show author avatars loading fine while every cover falls back to the "No Thumbnail" placeholder — and that split is the clue:

| resource | url |
|---|---|
| avatars, playback, subtitles | page origin (relative path, proxied by nginx) |
| **covers** | **absolute backend origin** (`getBackendUrl()` / `VITE_BACKEND_URL`) |

Covers are the only media addressed through the absolute origin, so a deployment whose backend origin is not reachable from the browser (or is cross-origin, dropping the `SameSite` login cookie on `<img>` requests) loses every cover while everything else keeps working. On top of that, the `<img>` `onError` handler went straight to the placeholder, so a single failing url was fatal — a missing `/images-small` mirror had no path back to the original image either.

The root cause on the reporter's side is not confirmed yet (diagnostics requested in the issue), but the fragility is real regardless and this makes both failure modes self-healing.

## Change

`buildThumbnailCandidates()` resolves an ordered list instead of a single url:

```
backend origin + /images-small → page origin + /images-small
→ backend origin + /images     → page origin + /images
→ remote thumbnailUrl          → placeholder
```

`handleThumbnailError()` walks that list on load errors. It derives the current position from the element's resolved `src` rather than from component state, so a re-render cannot strand an image mid-chain, and a url the element already failed on is treated as the end of the chain — the walk always terminates.

The absolute backend origin stays first, so deployments that legitimately serve the frontend from a different host than the backend are unaffected.

`useThumbnailCandidates` also collapses the cloud/local/remote resolution that was copy-pasted across VideoCard, the manage table, collection cards, both player sidebars and the favorites rails.

## Verification

- Reproduced the suspected deployment fault by pointing `getBackendUrl()` at an unreachable `http://backend:5551`: before the change all covers rendered as placeholders; after it, all four fell back to the same-origin `/images-small` and loaded (verified in the browser via `naturalWidth`/`naturalHeight` and the network log). Baseline restored afterwards and re-checked on the home page, manage table and player page.
- Frontend suite: 1789 existing tests pass, plus 13 new ones covering candidate ordering/dedupe and the fallback walker (advance, terminate, no-candidates, srcset clearing).
- `tsc --noEmit` and eslint clean on the touched files.
