### PR TITLE
fix(docker): default frontend runtime urls to same-origin paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fix
 
+- Default the frontend container's browser-facing URLs to same-origin paths instead of the `backend:5551` compose service name. nginx already proxies `/api` and every media route, and the service name only resolves inside the container network, so a stack that omitted `VITE_BACKEND_URL` baked an unreachable origin into the bundle and lost all video covers — the only media addressed through it — while the API, avatars and playback kept working. Refs #405
 - Stop a single unreachable cover URL from emptying the whole library: video covers now walk an ordered candidate list (backend origin, then page origin; `/images-small` mirror, then the original image; finally the remote thumbnail) before falling back to the "No Thumbnail" placeholder. Covers were the only media addressed through the absolute `VITE_BACKEND_URL` origin, so a deployment whose backend origin is not reachable from the browser lost every cover while avatars and playback kept working. Refs #405
 - Skip members-only YouTube uploads in subscription checks instead of failing and retrying them every cycle: detect yt-dlp's members-only error, record the upload as skipped, log it informationally, and advance the subscription cursor so the same video isn't re-attempted. Closes #393
 

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -26,9 +26,17 @@ else
   echo "Using default backend service name: backend:5551"
 fi
 
-# Runtime values from docker-compose environment variables for JavaScript
-DOCKER_API_URL="${VITE_API_URL-http://backend:5551/api}"
-DOCKER_BACKEND_URL="${VITE_BACKEND_URL-http://backend:5551}"
+# Runtime values from docker-compose environment variables for JavaScript.
+#
+# These end up in the browser, so they default to same-origin paths rather than
+# to the compose service name: nginx already proxies /api, /videos, /images,
+# /images-small, /avatars and /subtitles to $NGINX_BACKEND, and "backend:5551"
+# only resolves inside the container network. A stack that omits VITE_BACKEND_URL
+# used to bake that unreachable origin into the bundle, which broke video covers
+# (the only media addressed through it) while everything else kept working.
+# Set them explicitly to serve media from a different host than the page.
+DOCKER_API_URL="${VITE_API_URL-/api}"
+DOCKER_BACKEND_URL="${VITE_BACKEND_URL-}"
 
 # If API_HOST is provided, override JavaScript URLs
 if [ ! -z "$API_HOST" ]; then


### PR DESCRIPTION
Refs #405. Follow-up to #409, which made covers survive this misconfiguration; this removes the misconfiguration itself.

## Problem

The reporter in #405 confirmed the split: covers render when the UI is opened on the backend port (5551) and stay blank on the frontend port (5556). The backend image ships its own copy of the frontend built with `VITE_BACKEND_URL=` (empty), so those pages use same-origin URLs. The nginx frontend image bakes `http://localhost:5551` into the bundle at build time and rewrites it at container start from:

```sh
DOCKER_API_URL="${VITE_API_URL-http://backend:5551/api}"
DOCKER_BACKEND_URL="${VITE_BACKEND_URL-http://backend:5551}"
```

These values are consumed by the **browser**, but the fallback is the compose service name, which only resolves inside the container network. A hand-written stack that sets `VITE_API_URL=/api` and omits `VITE_BACKEND_URL` (exactly the reporter's case) ends up with `http://backend:5551` in the bundle. Covers are the only media the frontend addresses through that origin — the API, avatars, playback and subtitles are all same-origin — so covers alone fail, which is why this reads as a thumbnail bug rather than a networking one.

## Change

Default both to same-origin paths. nginx already proxies `/api`, `/videos`, `/images`, `/images-small`, `/avatars` and `/subtitles` to `$NGINX_BACKEND`, so the browser needs no absolute origin by default:

```sh
DOCKER_API_URL="${VITE_API_URL-/api}"
DOCKER_BACKEND_URL="${VITE_BACKEND_URL-}"
```

This is what `stacks/docker-compose*.yml` and the docker guide already set explicitly, so shipped deployments are unaffected — only stacks that omit the variables change, and they change from "broken" to "works". `NGINX_BACKEND` (the proxy target, container-side) still defaults to `http://backend:5551`, and `API_HOST` / `NGINX_BACKEND_URL` / explicit `VITE_*` overrides keep their current precedence.

## Verification

Ran the real script against a temp root, checking the resolved values and the resulting bundle for four env combinations:

| env | API URL (JS) | Backend URL (JS) | Backend URL (nginx) |
|---|---|---|---|
| none set (reporter's case) | `/api` | *(empty)* | `http://backend:5551` |
| shipped compose (`VITE_API_URL=/api`, `VITE_BACKEND_URL=`) | `/api` | *(empty)* | `http://backend:5551` |
| `API_HOST=192.168.1.10` | `http://192.168.1.10:5551/api` | `http://192.168.1.10:5551` | `http://192.168.1.10:5551` |
| explicit remote origin | `https://api.example.com/api` | `https://api.example.com` | `https://api.example.com` |

The first two now agree, which is the point of the change. Also replayed both `sed` passes on a sample bundle to confirm the empty-string replacement rewrites `const b="http://localhost:5551"` to `const b=""` (`getBackendUrl()` then returns `""`, i.e. relative URLs).
