### PR TITLE
fix(auth): remove public default JWT secret and bearer token auth path (GHSA-rm8x-hmvr-qgp3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 - Replace the high-saturation cyan/red UI palette with a calmer teal-led color scheme and a mode-aware secondary purple (softer violet in light mode, stronger contrast in dark), updating favorite-page gradient accents, the browser theme color, and the web manifest without changing logo assets (#366)
 
+### Security
+
+- Remove the publicly known fallback JWT signing secret that allowed forged tokens in default deployments (GHSA-rm8x-hmvr-qgp3). An unset or empty `JWT_SECRET` now produces a random per-process key, and explicitly configuring the compromised historical default prevents the backend from starting.
+
+### Changed
+
+- **Breaking for legacy API clients:** `Authorization: Bearer <jwt>` is no longer accepted for authentication. Browser users continue to authenticate with the HTTP-only session cookie and are unaffected; external clients must use `X-API-Key` or `Authorization: ApiKey <key>` instead.
+
 ### Fix
 
 - Harden Bilibili source enumeration so a truncated listing fails loudly and retryably instead of being frozen as a complete plan. The space, collection, and series readers previously treated a short page as end-of-list, so a risk-controlled response that returned fewer rows than requested was silently accepted as the whole source; the collection reader could also loop forever when the API returned empty pages while still advertising more. All three now require a valid advertised total, reject a short page before that total is reached, and stop at a 100-page ceiling. Failed collection and series reads are also reported as structured, retryable planning failures rather than a bare error message, matching what the space path already produced.

--- a/backend/src/__tests__/middleware/authMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/authMiddleware.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { authMiddleware } from "../../middleware/authMiddleware";
 import {
   deleteSession,
   getAuthCookieName,
   getUserPayloadFromSession,
-  verifyToken,
 } from "../../services/authService";
 import { getSettings } from "../../services/storageService";
 import { isUserSessionPayloadValid } from "../../services/userService";
@@ -15,7 +15,6 @@ vi.mock("../../services/authService", () => ({
   deleteSession: vi.fn(),
   getAuthCookieName: vi.fn(),
   getUserPayloadFromSession: vi.fn(),
-  verifyToken: vi.fn(),
 }));
 
 vi.mock("../../services/userService", () => ({
@@ -52,7 +51,6 @@ describe("authMiddleware", () => {
     authMiddleware(req as Request, res as Response, next);
 
     expect(getUserPayloadFromSession).toHaveBeenCalledWith("sid-1");
-    expect(verifyToken).not.toHaveBeenCalled();
     expect((req as Request).user).toEqual(payload);
     expect(next).toHaveBeenCalledTimes(1);
   });
@@ -75,46 +73,32 @@ describe("authMiddleware", () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to bearer token when session cookie is missing", () => {
-    const payload = { role: "visitor", id: "u2" } as const;
-    req.headers = { authorization: "Bearer token-123" };
+  it("rejects a forged admin bearer token (GHSA-rm8x-hmvr-qgp3)", () => {
+    // A JWT signed with a leaked or default key must not authenticate anything:
+    // bearer tokens are no longer an auth path at all.
+    req.headers = {
+      authorization: `Bearer ${jwt.sign({ role: "admin" }, "default_development_secret_do_not_use_in_production")}`,
+    };
     vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
-    vi.mocked(verifyToken).mockReturnValue(payload as any);
-
-    authMiddleware(req as Request, res as Response, next);
-
-    expect(verifyToken).toHaveBeenCalledWith("token-123");
-    expect((req as Request).user).toEqual(payload);
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it("ignores stale user-backed bearer tokens", () => {
-    const payload = {
-      role: "visitor",
-      id: "login-1",
-      userId: "user-1",
-      sessionVersion: 1,
-    } as const;
-    req.headers = { authorization: "Bearer token-123" };
-    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
-    vi.mocked(verifyToken).mockReturnValue(payload as any);
-    vi.mocked(isUserSessionPayloadValid).mockReturnValue(false);
 
     authMiddleware(req as Request, res as Response, next);
 
     expect((req as Request).user).toBeUndefined();
-    expect(deleteSession).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
   });
 
-  it("continues when bearer token is invalid", () => {
-    req.headers = { authorization: "Bearer invalid" };
+  it("ignores a bearer token even when the session cookie is unresolvable", () => {
+    req.cookies = { mytube_auth_session: "expired-or-missing" };
+    req.headers = {
+      authorization: `Bearer ${jwt.sign({ role: "admin" }, "any-key")}`,
+    };
     vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
-    vi.mocked(verifyToken).mockReturnValue(null);
 
     authMiddleware(req as Request, res as Response, next);
 
-    expect(verifyToken).toHaveBeenCalledWith("invalid");
+    expect(getUserPayloadFromSession).toHaveBeenCalledWith(
+      "expired-or-missing"
+    );
     expect((req as Request).user).toBeUndefined();
     expect(next).toHaveBeenCalledTimes(1);
   });
@@ -124,25 +108,7 @@ describe("authMiddleware", () => {
 
     authMiddleware(req as Request, res as Response, next);
 
-    expect(verifyToken).not.toHaveBeenCalled();
     expect((req as Request).user).toBeUndefined();
-    expect(next).toHaveBeenCalledTimes(1);
-  });
-
-  it("tries bearer token if session exists but is not resolvable", () => {
-    const payload = { role: "admin", id: "u3" } as const;
-    req.cookies = { mytube_auth_session: "expired-or-missing" };
-    req.headers = { authorization: "Bearer t2" };
-    vi.mocked(getUserPayloadFromSession).mockReturnValue(null);
-    vi.mocked(verifyToken).mockReturnValue(payload as any);
-
-    authMiddleware(req as Request, res as Response, next);
-
-    expect(getUserPayloadFromSession).toHaveBeenCalledWith(
-      "expired-or-missing"
-    );
-    expect(verifyToken).toHaveBeenCalledWith("t2");
-    expect((req as Request).user).toEqual(payload);
     expect(next).toHaveBeenCalledTimes(1);
   });
 
@@ -158,7 +124,6 @@ describe("authMiddleware", () => {
     expect((req as Request).user).toBeUndefined();
     expect((req as Request).apiKeyAuthenticated).toBe(true);
     expect(getUserPayloadFromSession).not.toHaveBeenCalled();
-    expect(verifyToken).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
   });
 

--- a/backend/src/__tests__/services/authServiceSecret.test.ts
+++ b/backend/src/__tests__/services/authServiceSecret.test.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import jwt from "jsonwebtoken";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const LEGACY_SECRET = "default_development_secret_do_not_use_in_production";
+
+/**
+ * Regression coverage for GHSA-rm8x-hmvr-qgp3: the signing key must never fall
+ * back to the publicly known constant that shipped in earlier versions.
+ */
+describe("authService JWT secret resolution", () => {
+  const originalSecret = process.env.JWT_SECRET;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = originalSecret;
+    }
+  });
+
+  it("rejects tokens signed with the historical default when JWT_SECRET is unset", async () => {
+    delete process.env.JWT_SECRET;
+    const { verifyToken } = await import("../../services/authService");
+
+    const forged = jwt.sign({ role: "admin" }, LEGACY_SECRET, {
+      expiresIn: "24h",
+    });
+
+    expect(verifyToken(forged)).toBeNull();
+  });
+
+  it("rejects tokens signed with the historical default when JWT_SECRET is empty", async () => {
+    // An orchestrator-set empty value must fail closed, not select the default.
+    process.env.JWT_SECRET = "";
+    const { verifyToken } = await import("../../services/authService");
+
+    expect(verifyToken(jwt.sign({ role: "admin" }, LEGACY_SECRET))).toBeNull();
+  });
+
+  it("still round-trips its own tokens with a generated key", async () => {
+    delete process.env.JWT_SECRET;
+    const { generateToken, verifyToken } = await import(
+      "../../services/authService"
+    );
+
+    const decoded = verifyToken(generateToken({ role: "admin" }));
+    expect(decoded?.role).toBe("admin");
+  });
+
+  it("uses a configured JWT_SECRET when one is provided", async () => {
+    process.env.JWT_SECRET = "a-unique-operator-supplied-key";
+    const { verifyToken } = await import("../../services/authService");
+
+    const token = jwt.sign({ role: "admin" }, "a-unique-operator-supplied-key");
+    expect(verifyToken(token)?.role).toBe("admin");
+  });
+
+  it("refuses to start when JWT_SECRET is pinned to the compromised default", async () => {
+    process.env.JWT_SECRET = LEGACY_SECRET;
+
+    await expect(import("../../services/authService")).rejects.toThrow(
+      /publicly known default/
+    );
+  });
+});

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -4,7 +4,6 @@ import {
   getAuthCookieName,
   getUserPayloadFromSession,
   UserPayload,
-  verifyToken,
 } from "../services/authService";
 import { isUserSessionPayloadValid } from "../services/userService";
 import { isApiKeyAuthorized } from "../utils/apiKeyAuth";
@@ -21,7 +20,7 @@ declare global {
 
 /**
  * Middleware to resolve authenticated user and attach user to request
- * Checks HTTP-only session cookie first, then Authorization header JWT for backward compatibility.
+ * Resolves identity from the HTTP-only session cookie, then from the API key path.
  * Does NOT block requests if token is missing/invalid, just leaves req.user undefined
  * Blocking logic should be handled by specific route guards or role-based middleware
  */
@@ -48,21 +47,11 @@ export const authMiddleware = (
     }
   }
 
-  // Fallback to Authorization header for backward compatibility
-  // Security: Similar to above - authHeader is user-controlled, but security decision
-  // is based on verifyToken() which performs server-side JWT signature verification.
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith("Bearer ")) {
-    const token = authHeader.split(" ")[1];
-    const decoded = verifyToken(token);
-
-    // Only set req.user if token is valid and still valid for user-backed sessions.
-    if (decoded && isUserSessionPayloadValid(decoded)) {
-      req.user = decoded;
-      next();
-      return;
-    }
-  }
+  // NOTE: `Authorization: Bearer <jwt>` is deliberately NOT an authentication
+  // path. JWTs are an internal login -> session handoff detail and are never
+  // handed to a client, so no legitimate caller sends one. Accepting them only
+  // gave anyone who learned the signing key a way to mint a `{ role: "admin" }`
+  // token with no bound user record. Automation uses the API key path below.
 
   // API key is an alternate auth path for automation clients that do not use session login.
   if (isApiKeyAuthorized(req)) {

--- a/backend/src/services/authService.ts
+++ b/backend/src/services/authService.ts
@@ -1,14 +1,52 @@
+import crypto from "crypto";
 import { Response } from "express";
 import jwt from "jsonwebtoken";
 import { v4 as uuidv4 } from "uuid";
 import { logger } from "../utils/logger";
 
-// Warn if JWT_SECRET is not set in production
-if (!process.env.JWT_SECRET && process.env.NODE_ENV === "production") {
-  logger.error("WARNING: JWT_SECRET is not set in production environment. This is a security risk!");
+/**
+ * The signing key that shipped as a fallback before this was fixed. It is public
+ * (it lived in the repository), so any token signed with it must be treated as
+ * attacker-controlled. Kept here only so we can refuse to use it.
+ */
+export const COMPROMISED_LEGACY_JWT_SECRET =
+  "default_development_secret_do_not_use_in_production";
+
+/**
+ * Resolve the JWT signing key, failing safe when none is configured.
+ *
+ * JWTs never leave this process: login mints one, `setAuthCookie` immediately
+ * exchanges it for an opaque server-side session id, and no response body
+ * returns a token. Sessions live in an in-memory Map, so nothing has to survive
+ * a restart either. That means an unconfigured deployment can safely get a
+ * random per-process key rather than a shared constant — no shipped compose file
+ * sets JWT_SECRET, so refusing to boot would break every default install while
+ * a random key breaks nothing.
+ */
+function resolveJwtSecret(): string {
+  const configured = process.env.JWT_SECRET?.trim();
+
+  if (configured === COMPROMISED_LEGACY_JWT_SECRET) {
+    const message =
+      "JWT_SECRET is set to the publicly known default that shipped with older " +
+      "MyTube versions. Anyone can forge admin tokens with it. Unset JWT_SECRET " +
+      "or replace it with a unique random value before starting.";
+    logger.error(message);
+    throw new Error(message);
+  }
+
+  if (configured) {
+    return configured;
+  }
+
+  logger.warn(
+    "JWT_SECRET is not set; generating a random per-process signing key. " +
+      "Auth sessions are in-memory and do not survive a restart either way."
+  );
+  return crypto.randomBytes(64).toString("hex");
 }
 
-const JWT_SECRET = process.env.JWT_SECRET || "default_development_secret_do_not_use_in_production";
+const JWT_SECRET = resolveJwtSecret();
 const JWT_EXPIRES_IN = "24h";
 const SESSION_COOKIE_NAME = "mytube_auth_session";
 const SESSION_MAX_AGE_MS = 24 * 60 * 60 * 1000;

--- a/documents/en/api-endpoints.md
+++ b/documents/en/api-endpoints.md
@@ -4,7 +4,7 @@ All API routes are mounted under `/api` unless noted otherwise.
 
 ## Auth & Access Notes
 
-- Auth is cookie-based (HTTP-only JWT cookie). Authorization header is also accepted for backward compatibility.
+- Browser authentication uses an HTTP-only cookie containing an opaque server-side session ID. Bearer JWTs are not accepted.
 - When password login is enabled, unauthenticated users can only access login-related public endpoints.
 - Visitor role is read-only for most resources.
 - API key auth is supported via `X-API-Key` or `Authorization: ApiKey <key>` when `apiKeyEnabled` is true.
@@ -22,7 +22,7 @@ All API routes are mounted under `/api` unless noted otherwise.
   - Query params: `query` (required), `limit` (optional, default: `8`), `offset` (optional, default: `1`)
 - `POST /api/download` - Queue a video download
   - Body: `{ youtubeUrl: string, downloadAllParts?: boolean, collectionName?: string, downloadCollection?: boolean, collectionInfo?: object, forceDownload?: boolean }`
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
   - Supports: YouTube, Bilibili, Twitch VODs, MissAV and other yt-dlp supported sites
 - `GET /api/check-video-download` - Check whether a source URL was downloaded before
   - Query params: `url` (required)
@@ -49,11 +49,11 @@ All API routes are mounted under `/api` unless noted otherwise.
     - Folder uploads import supported video files only; subdirectory structure is not preserved.
     - Duplicate uploads are skipped by content hash.
 - `GET /api/videos` - Get all videos (no server-side pagination/filtering in current implementation)
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `GET /api/videos/:id` - Get one video by ID
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `GET /api/mount-video/:id` - Stream a mount-directory video by video ID (supports Range)
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `PUT /api/videos/:id` - Update video metadata
   - Body allows: `{ title?, tags?, visibility?, subtitles? }`
 - `POST /api/videos/:id/subtitles` - Upload subtitle file for a video
@@ -88,7 +88,7 @@ All API routes are mounted under `/api` unless noted otherwise.
 ## Collections
 
 - `GET /api/collections` - Get all collections
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `POST /api/collections` - Create collection
   - Body: `{ name: string, videoId?: string }`
 - `PUT /api/collections/:id` - Update collection
@@ -306,7 +306,7 @@ WebSocket stream (mounted under `/api`, upgraded — not a JSON route):
 
 - `GET /api/system/version` - Get version/update info
   - Returns: `{ currentVersion, latestVersion, releaseUrl, hasUpdate, ... }`
-  - Auth: accepts session cookie/Bearer JWT, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - Auth: accepts a session cookie, or API key (`X-API-Key` / `Authorization: ApiKey <key>`)
 
 ## Non-API Routes (Not Under `/api`)
 

--- a/documents/en/deployment-security-model.md
+++ b/documents/en/deployment-security-model.md
@@ -172,3 +172,18 @@ Use:
 - `host` only if admin should be treated as a host-scoped deployment operator
 
 If you are unsure, start with `container` only when you need hooks or raw yt-dlp passthrough. Otherwise prefer `application`.
+
+## Session Signing Key (`JWT_SECRET`)
+
+`JWT_SECRET` is optional. When it is unset or empty, the backend generates a
+random signing key at startup rather than falling back to a shared constant.
+
+This is safe because signed tokens never leave the process: login mints one, the
+server immediately exchanges it for an opaque session id stored in memory, and
+no response body returns a token. Auth sessions do not survive a restart in
+either configuration, so a per-process key costs nothing.
+
+Do not set `JWT_SECRET` to
+`default_development_secret_do_not_use_in_production`. That value was published
+in earlier releases, so anyone can forge tokens with it. The backend refuses to
+start if it is configured.

--- a/documents/zh/api-endpoints.md
+++ b/documents/zh/api-endpoints.md
@@ -4,7 +4,7 @@
 
 ## 认证与访问说明
 
-- 认证基于 Cookie (HTTP-only JWT Cookie)。同时也接受 Authorization 标头以保证向后兼容性。
+- 浏览器认证使用 HTTP-only Cookie，其中保存不透明的服务端会话 ID。不支持 Bearer JWT。
 - 启用密码登录后，未认证用户只能访问与登录相关的公开端点。
 - 访客角色对大多数资源仅有只读权限。
 - 当 `apiKeyEnabled` 为 true 时，支持通过 `X-API-Key` 或 `Authorization: ApiKey <key>` 进行 API Key 认证。
@@ -22,7 +22,7 @@
   - 查询参数: `query` (必需), `limit` (可选, 默认: `8`), `offset` (可选, 默认: `1`)
 - `POST /api/download` - 添加视频下载任务
   - 请求体: `{ youtubeUrl: string, downloadAllParts?: boolean, collectionName?: string, downloadCollection?: boolean, collectionInfo?: object, forceDownload?: boolean }`
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
   - 支持: YouTube、Bilibili、Twitch VOD、MissAV 以及其他 yt-dlp 支持的网站
 - `GET /api/check-video-download` - 检查源 URL 是否已被下载过
   - 查询参数: `url` (必需)
@@ -49,11 +49,11 @@
     - 文件夹上传只导入受支持的视频文件，不保留子目录结构。
     - 重复内容会按内容哈希跳过。
 - `GET /api/videos` - 获取所有视频 (当前实现无服务器端分页/过滤)
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `GET /api/videos/:id` -通过 ID 获取单个视频
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `GET /api/mount-video/:id` - 通过视频 ID 流式传输挂载目录视频 (支持 Range)
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `PUT /api/videos/:id` - 更新视频元数据
   - 请求体允许: `{ title?, tags?, visibility?, subtitles? }`
 - `POST /api/videos/:id/subtitles` - 为视频上传字幕文件
@@ -88,7 +88,7 @@
 ## 收藏夹
 
 - `GET /api/collections` - 获取所有收藏夹
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
 - `POST /api/collections` - 创建收藏夹
   - 请求体: `{ name: string, videoId?: string }`
 - `PUT /api/collections/:id` - 更新收藏夹
@@ -291,7 +291,7 @@ WebSocket 流（挂载在 `/api` 下，通过升级建立——非 JSON 路由�
 
 - `GET /api/system/version` - 获取版本/更新信息
   - 返回: `{ currentVersion, latestVersion, releaseUrl, hasUpdate, ... }`
-  - 认证: 支持会话 Cookie/Bearer JWT，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
+  - 认证: 支持会话 Cookie，或 API Key (`X-API-Key` / `Authorization: ApiKey <key>`)
 
 ## 非 API 路由 (不在 `/api` 下)
 


### PR DESCRIPTION
Fixes GHSA-rm8x-hmvr-qgp3.

## The vulnerability

The advisory is valid, and more severe than its `medium` rating suggests. Confirmed chain on `master` @ `3cbb5fdd`:

1. `authService.ts` fell back to the public string `default_development_secret_do_not_use_in_production` when `JWT_SECRET` was falsy.
2. `authMiddleware` accepted `Authorization: Bearer <jwt>` verified with that key.
3. `isUserSessionPayloadValid()` returns `true` for any payload with no `userId`, skipping the user-record check.
4. `requireAdmin` passes on `req.user?.role === "admin"`.

So a JWT of `{ role: "admin" }` signed with the published key authenticated as admin with no user record behind it. I verified this end to end against the real middleware chain: `req.user` was set to admin and `requireAdmin` called `next()`. The reporter explicitly declined to claim this ("HTTP confirmation ... was not obtained"), so the practical impact is unauthenticated admin takeover.

**The report also understates the trigger.** It attributes exposure to a dotenv-16 empty-value quirk. In fact `JWT_SECRET` appears nowhere outside `authService.ts` — not in any compose file, Dockerfile, or doc. The public key was the live signing key in **every default deployment**; no edge case was required.

## The fix

**Signing key resolution.** I did not take the advisory's "refuse to start when unset" recommendation — since no shipped config sets `JWT_SECRET`, that would break every existing install on upgrade for no security gain. Instead:

- A trimmed, non-empty `JWT_SECRET` is used when configured.
- Otherwise a random per-process key is generated. This is sound because JWTs never leave the process: login mints one, `setAuthCookie` immediately exchanges it for an opaque in-memory session id, and no response body returns a token. Sessions already die on restart, so a per-process key costs nothing.
- Empty/whitespace values fail safe rather than selecting a constant, which covers the dotenv case the report describes.
- Booting with `JWT_SECRET` pinned to the compromised constant is now a hard startup failure.

**Bearer path removed.** The frontend authenticates by cookie (`apiClient.ts` says so explicitly), the extension sends no auth headers, and automation uses the API key path. The bearer branch was unused code serving only as forgery surface, so it is gone — this kills the vector even if a key leaks later.

`isUserSessionPayloadValid` is deliberately unchanged: admin logins legitimately carry no `userId` (shared-password admin has no user record), and with the bearer path removed its only caller is the server's own in-memory session state.

## Breaking change

`Authorization: Bearer <jwt>` is no longer accepted. Browser users are unaffected. Any external client relying on it must move to `X-API-Key` / `Authorization: ApiKey <key>`. EN/ZH endpoint docs are corrected accordingly.

## Verification

- `tsc --noEmit` clean.
- Full backend suite: **212 files / 2848 tests pass**.
- 5 new regression tests in `authServiceSecret.test.ts` (unset / empty / configured / round-trip / compromised-value refusal).
- The 4 stale bearer-acceptance tests in `authMiddleware.test.ts` were rewritten as rejection tests, including a forged-admin-token case tagged with the GHSA id.

## Follow-up

Cut a patched release, then publish the advisory — and consider correcting its severity to critical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)