### PR TITLE
fix(ytdlp): bump pinned yt-dlp to 2026.8.19 and add in-app version/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Feat
 
+- Show the installed yt-dlp version in Settings -> yt-dlp Configuration, compare it against the latest release on PyPI, and offer an in-place update so a broken extractor can be fixed without rebuilding the image or editing a config file. The update is `container`-trust gated, refuses when `YT_DLP_PATH` pins a specific binary, and shares a single pip run between concurrent requests. Closes #417
 - Polish collection cards to read more like video cards (hover treatment, tighter title handling, and favorite-collection indicators), link collection names from the manage table directly to their collection pages, and replace the mobile authors shortcut with the real authors list with a header backdrop (#365)
 
 ### Style
@@ -20,6 +21,7 @@
 
 ### Fix
 
+- Bump the pinned yt-dlp from 2026.6.9 to 2026.8.19 (and curl-cffi from 0.15.0 to 0.16.0, the version yt-dlp now pins), fixing the "The page needs to be reloaded" failure that broke YouTube downloads. Closes #416
 - Harden Bilibili source enumeration so a truncated listing fails loudly and retryably instead of being frozen as a complete plan. The space, collection, and series readers previously treated a short page as end-of-list, so a risk-controlled response that returned fewer rows than requested was silently accepted as the whole source; the collection reader could also loop forever when the API returned empty pages while still advertising more. All three now require a valid advertised total, reject a short page before that total is reached, and stop at a 100-page ceiling. Failed collection and series reads are also reported as structured, retryable planning failures rather than a bare error message, matching what the space path already produced.
 - Restore subscription backfill, which since v1.10.22 cancelled itself with "MyTube could not prove the requested order" and downloaded nothing. A flat listing carries no publication dates on any platform, so the requested order depended entirely on a recovery step that regularly fails. Three changes: ask yt-dlp for `youtubetab:approximate_date` so a YouTube listing supplies dates directly (removing one full extraction per video, and with it the failure mode where a rate-limited channel loses every date); WBI-sign the Bilibili space API, which answers `code: -352` to unsigned requests from datacenter IPs where most self-hosted instances run; and, when no dates can be recovered at all, order by the source's own newest-first listing with a recorded warning instead of cancelling the task, for the channel and space listings whose natural order already is the requested one. A hand-ordered playlist, a Bilibili collection, and any view-count order still fail rather than guess.
 - Default the frontend container's browser-facing URLs to same-origin paths instead of the `backend:5551` compose service name. nginx already proxies `/api` and every media route, and the service name only resolves inside the container network, so a stack that omitted `VITE_BACKEND_URL` baked an unreachable origin into the bundle and lost all video covers — the only media addressed through it — while the API, avatars and playback kept working. Refs #405

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Feat
 
-- Show the installed yt-dlp version in Settings -> yt-dlp Configuration, compare it against the latest release on PyPI, and offer an in-place update so a broken extractor can be fixed without rebuilding the image or editing a config file. The update is `container`-trust gated, refuses when `YT_DLP_PATH` pins a specific binary, and shares a single pip run between concurrent requests. Closes #417
+- Show the installed yt-dlp version in Settings -> yt-dlp Configuration, compare it against the latest release on PyPI, and offer an in-place update so a broken extractor can be fixed without rebuilding the image or editing a config file. The update is `container`-trust gated, refuses when `YT_DLP_PATH` pins a specific binary, and shares a single pip run between concurrent requests. It installs `yt-dlp[default,curl-cffi]` so the release-coupled pins (the yt-dlp-ejs solver, the curl-cffi impersonation range) come from the target release rather than a hand-maintained list that drifts, and leaves the bundled bgutil POT provider alone because the image copy is loaded ahead of any pip copy. In Docker the runtime install lands in the persistent `/app/data` volume and outlives container recreation, so rolling back the image does not roll back yt-dlp; the docker guide documents how to remove it. Closes #417
 - Polish collection cards to read more like video cards (hover treatment, tighter title handling, and favorite-collection indicators), link collection names from the manage table directly to their collection pages, and replace the mobile authors shortcut with the real authors list with a header backdrop (#365)
 
 ### Style

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -122,20 +122,23 @@ RUN set -eux; \
 
 # Install yt-dlp and related packages. Versions are pinned for reproducible builds.
 # To upgrade: check https://pypi.org/project/yt-dlp/ and update versions below.
-# yt-dlp-ejs and curl-cffi must track the yt-dlp release:
-#  - yt-dlp 2026.6.9 expects EJS 0.8.0 for the YouTube JS challenge solver.
-#  - it also pins the curl-cffi extra to 0.15.0, which adds the newer Chrome
-#    impersonation targets (chrome145/146). Staying on 0.14.0 would cap
-#    --impersonate at the older chrome142 fingerprint.
+# yt-dlp-ejs and curl-cffi must track the yt-dlp release (see the "pin" and
+# "pin-curl-cffi" extras in the yt-dlp release metadata):
+#  - yt-dlp 2026.8.19 expects EJS 0.8.0 for the YouTube JS challenge solver.
+#  - it pins the curl-cffi extra to 0.16.0. Staying on an older curl-cffi caps
+#    --impersonate at an older Chrome fingerprint.
 # Keep all three bumped in lockstep with yt-dlp.
 # Note: bgutil-ytdlp-pot-provider is coupled to the Node server under
 # backend/bgutil-ytdlp-pot-provider/server — bump both in lockstep, not just here.
+# The operator can also update yt-dlp at runtime from Settings -> yt-dlp
+# Configuration without rebuilding this image; that install lands on top of
+# these pins and is lost when the container is recreated.
 # Using --break-system-packages because we are in a container and want to install globally
 RUN pip3 install --no-cache-dir \
-    "yt-dlp==2026.6.9" \
+    "yt-dlp==2026.8.19" \
     "bgutil-ytdlp-pot-provider==1.2.2" \
     "yt-dlp-ejs==0.8.0" \
-    "curl-cffi==0.15.0" \
+    "curl-cffi==0.16.0" \
     --break-system-packages
 
 ARG BUILD_DATE=unknown

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -139,12 +139,18 @@ RUN set -eux; \
 # "Updating yt-dlp without rebuilding" in documents/en/docker-guide.md for how
 # to drop the runtime install and fall back to the pinned one.
 # Using --break-system-packages because we are in a container and want to install globally
+# The install is followed by an assertion on the console script location: the
+# YT_DLP_PATH example in documents/*/docker-guide.md hardcodes this path, so a
+# change in where pip lands it should break the build rather than let the
+# operator-facing docs go quietly stale.
 RUN pip3 install --no-cache-dir \
     "yt-dlp==2026.8.19" \
     "bgutil-ytdlp-pot-provider==1.2.2" \
     "yt-dlp-ejs==0.8.0" \
     "curl-cffi==0.16.0" \
-    --break-system-packages
+    --break-system-packages \
+    && { test "$(command -v yt-dlp)" = "/usr/local/bin/yt-dlp" \
+      || { echo "ERROR: yt-dlp resolved to '$(command -v yt-dlp)', not /usr/local/bin/yt-dlp. Update the YT_DLP_PATH example in documents/en/docker-guide.md and documents/zh/docker-guide.md to match." >&2; exit 1; }; }
 
 ARG BUILD_DATE=unknown
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -131,8 +131,13 @@ RUN set -eux; \
 # Note: bgutil-ytdlp-pot-provider is coupled to the Node server under
 # backend/bgutil-ytdlp-pot-provider/server — bump both in lockstep, not just here.
 # The operator can also update yt-dlp at runtime from Settings -> yt-dlp
-# Configuration without rebuilding this image; that install lands on top of
-# these pins and is lost when the container is recreated.
+# Configuration without rebuilding this image. That install is a `pip --user`
+# into $HOME, which entrypoint.sh points at /app/data/.home — persistent in the
+# supplied Compose stacks — so it OUTLIVES container recreation and keeps
+# shadowing the version pinned here (the path resolver prefers the newer
+# release). Recreating from an older image is therefore not a rollback; see
+# "Updating yt-dlp without rebuilding" in documents/en/docker-guide.md for how
+# to drop the runtime install and fall back to the pinned one.
 # Using --break-system-packages because we are in a container and want to install globally
 RUN pip3 install --no-cache-dir \
     "yt-dlp==2026.8.19" \

--- a/backend/src/__tests__/controllers/ytDlpController.test.ts
+++ b/backend/src/__tests__/controllers/ytDlpController.test.ts
@@ -57,7 +57,7 @@ describe("ytDlpController", () => {
     it("returns the yt-dlp status", async () => {
       await getYtDlpVersion(req as Request, res as Response);
 
-      expect(statusMock).toHaveBeenCalledWith({ checkLatest: true });
+      expect(statusMock).toHaveBeenCalledWith({ checkLatest: false });
       expect(json).toHaveBeenCalledWith(
         expect.objectContaining({
           success: true,
@@ -66,12 +66,12 @@ describe("ytDlpController", () => {
       );
     });
 
-    it("honours checkLatest=false to skip the PyPI lookup", async () => {
-      req.query = { checkLatest: "false" };
+    it("honours checkLatest=true to request the PyPI lookup", async () => {
+      req.query = { checkLatest: "true" };
 
       await getYtDlpVersion(req as Request, res as Response);
 
-      expect(statusMock).toHaveBeenCalledWith({ checkLatest: false });
+      expect(statusMock).toHaveBeenCalledWith({ checkLatest: true });
     });
   });
 

--- a/backend/src/__tests__/controllers/ytDlpController.test.ts
+++ b/backend/src/__tests__/controllers/ytDlpController.test.ts
@@ -1,0 +1,141 @@
+import { Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/ytdlp/maintenance", () => ({
+  getYtDlpStatus: vi.fn(),
+  updateYtDlp: vi.fn(),
+}));
+
+import {
+  getYtDlpVersion,
+  updateYtDlpVersion,
+} from "../../controllers/ytDlpController";
+import { getYtDlpStatus, updateYtDlp } from "../../utils/ytdlp/maintenance";
+
+const statusMock = vi.mocked(getYtDlpStatus);
+const updateMock = vi.mocked(updateYtDlp);
+
+const buildStatus = (overrides: Record<string, unknown> = {}) =>
+  ({
+    version: "2026.08.19",
+    path: "/usr/local/bin/yt-dlp",
+    available: true,
+    isStale: false,
+    staleAfterDays: 90,
+    latestVersion: "2026.8.19",
+    updateAvailable: false,
+    updateSupported: true,
+    customPathConfigured: false,
+    ...overrides,
+  }) as Awaited<ReturnType<typeof getYtDlpStatus>>;
+
+describe("ytDlpController", () => {
+  const originalTrustLevel = process.env.MYTUBE_ADMIN_TRUST_LEVEL;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let json: ReturnType<typeof vi.fn>;
+  let status: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    statusMock.mockResolvedValue(buildStatus());
+    json = vi.fn();
+    status = vi.fn().mockReturnValue({ json });
+    req = { query: {} };
+    res = { json, status } as unknown as Response;
+  });
+
+  afterEach(() => {
+    if (originalTrustLevel === undefined) {
+      delete process.env.MYTUBE_ADMIN_TRUST_LEVEL;
+    } else {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = originalTrustLevel;
+    }
+  });
+
+  describe("getYtDlpVersion", () => {
+    it("returns the yt-dlp status", async () => {
+      await getYtDlpVersion(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith({ checkLatest: true });
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ version: "2026.08.19" }),
+        })
+      );
+    });
+
+    it("honours checkLatest=false to skip the PyPI lookup", async () => {
+      req.query = { checkLatest: "false" };
+
+      await getYtDlpVersion(req as Request, res as Response);
+
+      expect(statusMock).toHaveBeenCalledWith({ checkLatest: false });
+    });
+  });
+
+  describe("updateYtDlpVersion", () => {
+    it("updates yt-dlp and returns the result", async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = "container";
+      updateMock.mockResolvedValue({
+        previousVersion: "2026.06.09",
+        status: buildStatus(),
+        changed: true,
+      });
+
+      await updateYtDlpVersion(req as Request, res as Response);
+
+      expect(updateMock).toHaveBeenCalled();
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({ changed: true }),
+        })
+      );
+    });
+
+    it("refuses in application trust mode", async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = "application";
+
+      await updateYtDlpVersion(req as Request, res as Response);
+
+      expect(status).toHaveBeenCalledWith(403);
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it("refuses when YT_DLP_PATH pins a binary", async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = "container";
+      statusMock.mockResolvedValue(
+        buildStatus({ updateSupported: false, customPathConfigured: true })
+      );
+
+      await updateYtDlpVersion(req as Request, res as Response);
+
+      expect(status).toHaveBeenCalledWith(409);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          errorKey: "ytDlpUpdateCustomPath",
+        })
+      );
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 with the failure reason when pip fails", async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = "container";
+      updateMock.mockRejectedValue(new Error("pip missing"));
+
+      await updateYtDlpVersion(req as Request, res as Response);
+
+      expect(status).toHaveBeenCalledWith(500);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: "pip missing",
+          errorKey: "ytDlpUpdateFailed",
+        })
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
+++ b/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
@@ -90,7 +90,7 @@ describe("yt-dlp maintenance", () => {
     it("reports the installed version alongside the latest release", async () => {
       versionProbeMock.mockResolvedValue(versionInfo("2026.06.09"));
 
-      const status = await getYtDlpStatus();
+      const status = await getYtDlpStatus({ checkLatest: true });
 
       expect(status.version).toBe("2026.06.09");
       expect(status.latestVersion).toBe("2026.8.19");
@@ -110,7 +110,7 @@ describe("yt-dlp maintenance", () => {
     it("degrades gracefully when PyPI is unreachable", async () => {
       axiosGet.mockRejectedValue(new Error("offline"));
 
-      const status = await getYtDlpStatus();
+      const status = await getYtDlpStatus({ checkLatest: true });
 
       expect(status.version).toBe("2026.08.19");
       expect(status.latestVersion).toBeNull();
@@ -151,6 +151,7 @@ describe("yt-dlp maintenance", () => {
       expect(result.previousVersion).toBe("2026.06.09");
       expect(result.status.version).toBe("2026.08.19");
       expect(result.changed).toBe(true);
+      expect(axiosGet).not.toHaveBeenCalled();
     });
 
     it("reports no change when the version stays the same", async () => {

--- a/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
+++ b/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("axios", () => ({
+  default: { get: vi.fn() },
+}));
+vi.mock("../../utils/ytdlp/install", () => ({
+  installYtDlp: vi.fn(),
+}));
+vi.mock("../../utils/ytdlp/pathResolver", () => ({
+  hasCustomConfiguredYtDlpPath: vi.fn(() => false),
+  resetResolvedYtDlpPath: vi.fn(),
+  resolveYtDlpPath: vi.fn(async () => "/usr/local/bin/yt-dlp"),
+}));
+vi.mock("../../utils/ytdlp/runtime", () => ({
+  resetJsRuntimeFlag: vi.fn(),
+  resetRemoteComponentsSupport: vi.fn(),
+}));
+vi.mock("../../utils/ytdlp/versionProbe", () => ({
+  getYtDlpVersionInfo: vi.fn(),
+}));
+
+import axios from "axios";
+import { installYtDlp } from "../../utils/ytdlp/install";
+import { hasCustomConfiguredYtDlpPath } from "../../utils/ytdlp/pathResolver";
+import { getYtDlpVersionInfo } from "../../utils/ytdlp/versionProbe";
+import {
+  getYtDlpStatus,
+  isYtDlpUpdateAvailable,
+  parseYtDlpReleaseTimestamp,
+  updateYtDlp,
+} from "../../utils/ytdlp/maintenance";
+
+const axiosGet = vi.mocked(axios.get);
+const installMock = vi.mocked(installYtDlp);
+const versionProbeMock = vi.mocked(getYtDlpVersionInfo);
+const customPathMock = vi.mocked(hasCustomConfiguredYtDlpPath);
+
+const versionInfo = (version: string | null, canRun = true) => ({
+  canRun,
+  version,
+  releaseTimestamp: null,
+  isStale: false,
+});
+
+describe("yt-dlp maintenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // mockImplementation set by a previous test survives clearAllMocks.
+    installMock.mockReset();
+    installMock.mockResolvedValue(undefined);
+    customPathMock.mockReturnValue(false);
+    axiosGet.mockResolvedValue({ data: { info: { version: "2026.8.19" } } });
+    versionProbeMock.mockResolvedValue(versionInfo("2026.08.19"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("parseYtDlpReleaseTimestamp", () => {
+    it("parses both the padded binary form and the PyPI form", () => {
+      expect(parseYtDlpReleaseTimestamp("2026.08.19")).toBe(
+        Date.UTC(2026, 7, 19)
+      );
+      expect(parseYtDlpReleaseTimestamp("2026.8.19")).toBe(
+        Date.UTC(2026, 7, 19)
+      );
+    });
+
+    it("returns null for missing or unparsable versions", () => {
+      expect(parseYtDlpReleaseTimestamp(null)).toBeNull();
+      expect(parseYtDlpReleaseTimestamp("nightly")).toBeNull();
+    });
+  });
+
+  describe("isYtDlpUpdateAvailable", () => {
+    it("only reports an update when the published release is newer", () => {
+      expect(isYtDlpUpdateAvailable("2026.06.09", "2026.8.19")).toBe(true);
+      expect(isYtDlpUpdateAvailable("2026.08.19", "2026.8.19")).toBe(false);
+      expect(isYtDlpUpdateAvailable("2026.09.01", "2026.8.19")).toBe(false);
+    });
+
+    it("stays quiet when either version cannot be parsed", () => {
+      expect(isYtDlpUpdateAvailable(null, "2026.8.19")).toBe(false);
+      expect(isYtDlpUpdateAvailable("2026.06.09", null)).toBe(false);
+    });
+  });
+
+  describe("getYtDlpStatus", () => {
+    it("reports the installed version alongside the latest release", async () => {
+      versionProbeMock.mockResolvedValue(versionInfo("2026.06.09"));
+
+      const status = await getYtDlpStatus();
+
+      expect(status.version).toBe("2026.06.09");
+      expect(status.latestVersion).toBe("2026.8.19");
+      expect(status.updateAvailable).toBe(true);
+      expect(status.updateSupported).toBe(true);
+      expect(status.path).toBe("/usr/local/bin/yt-dlp");
+    });
+
+    it("skips the PyPI lookup when the caller opts out", async () => {
+      const status = await getYtDlpStatus({ checkLatest: false });
+
+      expect(axiosGet).not.toHaveBeenCalled();
+      expect(status.latestVersion).toBeNull();
+      expect(status.updateAvailable).toBe(false);
+    });
+
+    it("degrades gracefully when PyPI is unreachable", async () => {
+      axiosGet.mockRejectedValue(new Error("offline"));
+
+      const status = await getYtDlpStatus();
+
+      expect(status.version).toBe("2026.08.19");
+      expect(status.latestVersion).toBeNull();
+      expect(status.updateAvailable).toBe(false);
+    });
+
+    it("marks updates unsupported when YT_DLP_PATH pins a binary", async () => {
+      customPathMock.mockReturnValue(true);
+
+      const status = await getYtDlpStatus({ checkLatest: false });
+
+      expect(status.customPathConfigured).toBe(true);
+      expect(status.updateSupported).toBe(false);
+    });
+
+    it("surfaces the probe error when yt-dlp cannot run", async () => {
+      versionProbeMock.mockResolvedValue({
+        ...versionInfo(null, false),
+        errorMessage: "spawn ENOENT",
+      });
+
+      const status = await getYtDlpStatus({ checkLatest: false });
+
+      expect(status.available).toBe(false);
+      expect(status.errorMessage).toBe("spawn ENOENT");
+    });
+  });
+
+  describe("updateYtDlp", () => {
+    it("upgrades and reports the version change", async () => {
+      versionProbeMock
+        .mockResolvedValueOnce(versionInfo("2026.06.09"))
+        .mockResolvedValue(versionInfo("2026.08.19"));
+
+      const result = await updateYtDlp();
+
+      expect(installMock).toHaveBeenCalledWith({ upgrade: true });
+      expect(result.previousVersion).toBe("2026.06.09");
+      expect(result.status.version).toBe("2026.08.19");
+      expect(result.changed).toBe(true);
+    });
+
+    it("reports no change when the version stays the same", async () => {
+      const result = await updateYtDlp();
+
+      expect(result.changed).toBe(false);
+      expect(result.previousVersion).toBe("2026.08.19");
+    });
+
+    it("shares one pip run between concurrent callers", async () => {
+      let releaseInstall: () => void = () => {};
+      const installGate = new Promise<void>((resolve) => {
+        releaseInstall = resolve;
+      });
+      installMock.mockReturnValue(installGate);
+
+      const first = updateYtDlp();
+      const second = updateYtDlp();
+      releaseInstall();
+      const [firstResult, secondResult] = await Promise.all([first, second]);
+
+      expect(installMock).toHaveBeenCalledTimes(1);
+      expect(firstResult).toBe(secondResult);
+    });
+
+    it("propagates the failure and lets the next call retry", async () => {
+      installMock.mockRejectedValueOnce(new Error("pip missing"));
+
+      await expect(updateYtDlp()).rejects.toThrow("pip missing");
+
+      installMock.mockResolvedValueOnce(undefined);
+      await expect(updateYtDlp()).resolves.toMatchObject({ changed: false });
+    });
+  });
+});

--- a/backend/src/__tests__/utils/ytDlpUtils.test.ts
+++ b/backend/src/__tests__/utils/ytDlpUtils.test.ts
@@ -25,6 +25,7 @@ import {
   parseYtDlpConfig,
   resetYtDlpAvailabilityCacheForTests,
 } from "../../utils/ytDlpUtils";
+import { installYtDlp } from "../../utils/ytdlp/install";
 import { logger } from "../../utils/logger";
 
 vi.mock("child_process", () => ({
@@ -566,6 +567,52 @@ describe("ytDlpUtils", () => {
         "yt-dlp[default,curl-cffi]",
         "bgutil-ytdlp-pot-provider",
       ]);
+    });
+
+    it("should serialize concurrent pip runs so two installs never overlap", async () => {
+      // ensureYtDlpAvailable() and the operator-triggered update hold separate
+      // locks, so without a shared mutex both can put pip on the same
+      // user-site directory at once.
+      const pipProcs: MockProcess[] = [];
+      vi.mocked(spawn).mockImplementation(() => {
+        const proc = createMockProcess();
+        pipProcs.push(proc);
+        return proc as any;
+      });
+
+      const first = installYtDlp();
+      const second = installYtDlp({ upgrade: true });
+      await flushAsyncSpawns();
+
+      // The second caller is queued: only one pip process exists so far.
+      expect(pipProcs).toHaveLength(1);
+
+      pipProcs[0].emit("close", 0);
+      await flushAsyncSpawns();
+
+      expect(pipProcs).toHaveLength(2);
+      expect(vi.mocked(spawn).mock.calls[1][1]).toContain("-U");
+
+      pipProcs[1].emit("close", 0);
+      await expect(Promise.all([first, second])).resolves.toBeDefined();
+    });
+
+    it("should keep serializing after a failed pip run", async () => {
+      // Fail every plain install candidate, succeed the upgrade, so the two
+      // queued calls are told apart by their args rather than by call count.
+      vi.mocked(spawn).mockImplementation((_cmd: any, args: any) => {
+        const isUpgrade = Array.isArray(args) && args.includes("-U");
+        const proc = createMockProcess();
+        queueMicrotask(() => proc.emit("close", isUpgrade ? 0 : 1));
+        return proc as any;
+      });
+
+      const failing = installYtDlp();
+      const queued = installYtDlp({ upgrade: true });
+
+      await expect(failing).rejects.toThrow(/could not be automatically/);
+      // A rejected run must not poison the queue for the caller behind it.
+      await expect(queued).resolves.toBeUndefined();
     });
 
     it("should skip the pip bgutil provider when a bundled provider is present", async () => {

--- a/backend/src/__tests__/utils/ytDlpUtils.test.ts
+++ b/backend/src/__tests__/utils/ytDlpUtils.test.ts
@@ -558,12 +558,38 @@ describe("ytDlpUtils", () => {
       installProc.emit("close", 0);
 
       await expect(promise).resolves.toBeUndefined();
+      // No bundled provider is present in this suite (getProviderPluginPath is
+      // mocked to ""), so the pip provider is installed as the fallback.
       expect(vi.mocked(spawn).mock.calls[1][1]).toEqual([
         "install",
         "--user",
-        "yt-dlp",
+        "yt-dlp[default,curl-cffi]",
         "bgutil-ytdlp-pot-provider",
-        "curl-cffi",
+      ]);
+    });
+
+    it("should skip the pip bgutil provider when a bundled provider is present", async () => {
+      // The bundled plugin is injected at the front of PYTHONPATH, so a pip copy
+      // would never be loaded and installing it would report a phantom upgrade.
+      vi.mocked(getProviderPluginPath).mockReturnValue("/app/bgutil-ytdlp-pot-provider");
+      const versionProc = createMockProcess();
+      const installProc = createMockProcess();
+      vi.mocked(spawn)
+        .mockImplementationOnce(() => versionProc as any)
+        .mockImplementationOnce(() => installProc as any)
+        .mockImplementationOnce(() => createVersionCheckProcess() as any);
+
+      const promise = ensureYtDlpAvailable();
+      await flushAsyncSpawns();
+      versionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
+      await flushAsyncSpawns();
+      installProc.emit("close", 0);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(vi.mocked(spawn).mock.calls[1][1]).toEqual([
+        "install",
+        "--user",
+        "yt-dlp[default,curl-cffi]",
       ]);
     });
 

--- a/backend/src/controllers/ytDlpController.ts
+++ b/backend/src/controllers/ytDlpController.ts
@@ -29,7 +29,9 @@ export const getYtDlpVersion = async (
   req: Request,
   res: Response
 ): Promise<void> => {
-  const checkLatest = req.query.checkLatest !== "false";
+  // Reading local status must not create an implicit outbound request. PyPI is
+  // queried only when the caller explicitly asks to check for an update.
+  const checkLatest = req.query.checkLatest === "true";
   const status = await getYtDlpStatus({ checkLatest });
   res.json(successResponse(status));
 };

--- a/backend/src/controllers/ytDlpController.ts
+++ b/backend/src/controllers/ytDlpController.ts
@@ -1,0 +1,71 @@
+import { Request, Response } from "express";
+import {
+  createAdminTrustLevelError,
+  isAdminTrustLevelAtLeast,
+} from "../config/adminTrust";
+import { getErrorMessage } from "../utils/errors";
+import { logger } from "../utils/logger";
+import { errorResponse, successResponse } from "../utils/response";
+import { getYtDlpStatus, updateYtDlp } from "../utils/ytdlp/maintenance";
+
+/**
+ * Updating yt-dlp installs a package inside the container, so it needs the same
+ * trust level as the other container-mutating features (hooks, raw config).
+ */
+const ensureUpdateAllowed = (res: Response): boolean => {
+  if (isAdminTrustLevelAtLeast("container")) {
+    return true;
+  }
+
+  res.status(403).json(createAdminTrustLevelError("container"));
+  return false;
+};
+
+/**
+ * GET /api/settings/ytdlp/version
+ * Report the yt-dlp the backend actually runs, plus the latest PyPI release.
+ */
+export const getYtDlpVersion = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  const checkLatest = req.query.checkLatest !== "false";
+  const status = await getYtDlpStatus({ checkLatest });
+  res.json(successResponse(status));
+};
+
+/**
+ * POST /api/settings/ytdlp/update
+ * Upgrade yt-dlp in place so a broken extractor can be fixed without
+ * rebuilding the image.
+ */
+export const updateYtDlpVersion = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  if (!ensureUpdateAllowed(res)) {
+    return;
+  }
+
+  const currentStatus = await getYtDlpStatus({ checkLatest: false });
+  if (!currentStatus.updateSupported) {
+    res.status(409).json(
+      errorResponse(
+        `yt-dlp is pinned to ${currentStatus.path} via YT_DLP_PATH. Update that binary yourself or unset YT_DLP_PATH.`,
+        { errorKey: "ytDlpUpdateCustomPath" }
+      )
+    );
+    return;
+  }
+
+  try {
+    const result = await updateYtDlp();
+    res.json(successResponse(result));
+  } catch (error: unknown) {
+    const message = getErrorMessage(error, "yt-dlp update failed");
+    logger.error(`[yt-dlp] Update failed: ${message}`);
+    res
+      .status(500)
+      .json(errorResponse(message, { errorKey: "ytDlpUpdateFailed" }));
+  }
+};

--- a/backend/src/routes/settingsRoutes.ts
+++ b/backend/src/routes/settingsRoutes.ts
@@ -63,6 +63,10 @@ import {
     getMediaServerExportRebuildStatus,
     startMediaServerExportRebuild,
 } from "../controllers/mediaServerExportController";
+import {
+    getYtDlpVersion,
+    updateYtDlpVersion,
+} from "../controllers/ytDlpController";
 import { asyncHandler } from "../middleware/errorHandler";
 
 const router = express.Router();
@@ -79,6 +83,10 @@ router.post("/format-filenames", asyncHandler(formatFilenames));
 router.post("/cleanup-author-collections", asyncHandler(cleanupAuthorCollections));
 router.get("/cloudflared/status", asyncHandler(getCloudflaredStatus));
 router.post("/tags/rename", asyncHandler(renameTag));
+
+// yt-dlp version / self-update routes
+router.get("/ytdlp/version", asyncHandler(getYtDlpVersion));
+router.post("/ytdlp/update", asyncHandler(updateYtDlpVersion));
 
 // Password routes
 router.get("/password-enabled", asyncHandler(getPasswordEnabled));

--- a/backend/src/utils/ytDlpUtils.ts
+++ b/backend/src/utils/ytDlpUtils.ts
@@ -1,7 +1,7 @@
 // Barrel for the yt-dlp utilities, split into focused modules under ./ytdlp.
 // Re-exports the public surface so existing `../utils/ytDlpUtils` imports keep working.
 
-import { resetYtDlpAvailablePromise } from "./ytdlp/install";
+import { resetPipQueue, resetYtDlpAvailablePromise } from "./ytdlp/install";
 import { resetProviderPluginCache } from "./ytdlp/spawnEnv";
 import { resetResolvedYtDlpPath } from "./ytdlp/pathResolver";
 import { resetRuntimeCaches } from "./ytdlp/runtime";
@@ -36,6 +36,7 @@ export { InvalidProxyError, getAxiosProxyConfig } from "./ytdlp/proxy";
  */
 export function resetYtDlpAvailabilityCacheForTests(): void {
   resetYtDlpAvailablePromise();
+  resetPipQueue();
   resetProviderPluginCache();
   resetResolvedYtDlpPath();
   resetRuntimeCaches();

--- a/backend/src/utils/ytDlpUtils.ts
+++ b/backend/src/utils/ytDlpUtils.ts
@@ -18,6 +18,12 @@ export {
 } from "./ytdlp/execute";
 export { isMembersOnlyError } from "./ytdlp/errorClassification";
 export {
+  getYtDlpStatus,
+  isYtDlpUpdateInProgress,
+  updateYtDlp,
+} from "./ytdlp/maintenance";
+export type { YtDlpStatus, YtDlpUpdateResult } from "./ytdlp/maintenance";
+export {
   parseYtDlpConfig,
   getUserYtDlpConfig,
   getEffectiveUserYtDlpConfig,

--- a/backend/src/utils/ytdlp/install.ts
+++ b/backend/src/utils/ytdlp/install.ts
@@ -46,10 +46,37 @@ function getPipPackages(): string[] {
   return [YT_DLP_PIP_PACKAGE, "bgutil-ytdlp-pot-provider"];
 }
 
+// Every pip run in this process queues here. Two callers reach this module
+// under independent locks — ensureYtDlpAvailable() through its cached
+// availability promise, updateYtDlp() through its own in-flight promise — so
+// an operator pressing "Update yt-dlp" while the first download of the process
+// triggers the missing-binary or stale-version install would otherwise put two
+// pip processes on the same user-site directory at once. pip is not safe to run
+// concurrently against one environment: the two runs rewrite the same package
+// files and either can fail or leave the install half-written. Serializing here
+// rather than in the callers keeps future call sites covered by default.
+let pipQueue: Promise<unknown> = Promise.resolve();
+
+function withPipLock<T>(task: () => Promise<T>): Promise<T> {
+  // Run the task whether or not the previous one settled cleanly, and keep a
+  // swallowed copy as the tail so one failure cannot poison the queue.
+  const run = pipQueue.then(task, task);
+  pipQueue = run.catch(() => undefined);
+  return run;
+}
+
 /**
  * Try to install yt-dlp via pip, trying multiple pip variants.
+ *
+ * Serialized process-wide: concurrent callers queue instead of overlapping.
  */
-export async function installYtDlp(options: { upgrade?: boolean } = {}): Promise<void> {
+export async function installYtDlp(
+  options: { upgrade?: boolean } = {}
+): Promise<void> {
+  return withPipLock(() => runPipInstall(options));
+}
+
+async function runPipInstall(options: { upgrade?: boolean } = {}): Promise<void> {
   const { upgrade = false } = options;
   const packages = getPipPackages();
   const installArgs = ["install"];
@@ -235,4 +262,11 @@ export async function ensureYtDlpAvailable(): Promise<void> {
 
 export function resetYtDlpAvailablePromise(): void {
   ytDlpAvailablePromise = null;
+}
+
+/**
+ * @internal Test helper: drop a queue tail left pending by a mocked pip run.
+ */
+export function resetPipQueue(): void {
+  pipQueue = Promise.resolve();
 }

--- a/backend/src/utils/ytdlp/install.ts
+++ b/backend/src/utils/ytdlp/install.ts
@@ -1,4 +1,5 @@
 import { spawn } from "child_process";
+import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
 import { getErrorMessage } from "../errors";
 import { YT_DLP_STALE_AFTER_DAYS } from "./constants";
 import {
@@ -17,16 +18,40 @@ import { logger } from "../logger";
 // Cached promise so we only check/install once per process
 let ytDlpAvailablePromise: Promise<void> | null = null;
 
+// Request yt-dlp through its extras rather than naming its companions here.
+// A yt-dlp release pins the dependencies that are coupled to it — "default"
+// carries the yt-dlp-ejs pin for the YouTube JS challenge solver, "curl-cffi"
+// the browser-impersonation range that --impersonate (and with it the MissAV
+// downloader) depends on. Letting pip read those pins off the release being
+// installed keeps them in lockstep automatically; a hand-written list here
+// would silently keep an old solver next to a freshly upgraded yt-dlp.
+const YT_DLP_PIP_PACKAGE = "yt-dlp[default,curl-cffi]";
+
+/**
+ * Decide which packages pip should install.
+ *
+ * The bgutil POT provider is only added when no bundled copy is present.
+ * getYtDlpSpawnEnv() puts the bundled plugin at the front of PYTHONPATH, ahead
+ * of site-packages, and its Node counterpart (generate_once.js) ships with the
+ * image and is not on PyPI at all — so where a bundle exists, a pip copy of the
+ * plugin is loaded by nothing and "upgrading" it would report progress that
+ * never reaches the yt-dlp process. Bumping the bundled provider is a rebuild,
+ * not a runtime install.
+ */
+function getPipPackages(): string[] {
+  if (getProviderPluginPath()) {
+    return [YT_DLP_PIP_PACKAGE];
+  }
+
+  return [YT_DLP_PIP_PACKAGE, "bgutil-ytdlp-pot-provider"];
+}
+
 /**
  * Try to install yt-dlp via pip, trying multiple pip variants.
  */
 export async function installYtDlp(options: { upgrade?: boolean } = {}): Promise<void> {
   const { upgrade = false } = options;
-  // curl-cffi powers yt-dlp's browser impersonation (--impersonate), which the
-  // MissAV downloader needs to get past Cloudflare on the m3u8 CDN. The Docker
-  // image installs it explicitly; install it here too so non-Docker setups
-  // gain the capability instead of hard-failing on --impersonate.
-  const packages = ["yt-dlp", "bgutil-ytdlp-pot-provider", "curl-cffi"];
+  const packages = getPipPackages();
   const installArgs = ["install"];
   if (upgrade) {
     installArgs.push("-U");
@@ -77,9 +102,7 @@ export async function installYtDlp(options: { upgrade?: boolean } = {}): Promise
         proc.on("error", reject);
       });
       logger.info(
-        upgrade
-          ? "[yt-dlp] Successfully updated yt-dlp and bgutil provider."
-          : "[yt-dlp] Successfully installed yt-dlp and bgutil provider."
+        `[yt-dlp] Successfully ${upgrade ? "updated" : "installed"} ${packages.join(", ")}.`
       );
       updatePathAfterAutoInstall();
       return;
@@ -132,7 +155,7 @@ export async function ensureYtDlpAvailable(): Promise<void> {
         ) {
           attemptedAutoUpgrade = true;
           logger.warn(
-            `[yt-dlp] ${versionInfo.version || ytDlpPath} is older than ${YT_DLP_STALE_AFTER_DAYS} days. Updating yt-dlp and the bgutil provider to avoid known YouTube 360p regressions.`
+            `[yt-dlp] ${versionInfo.version || ytDlpPath} is older than ${YT_DLP_STALE_AFTER_DAYS} days. Updating yt-dlp to avoid known YouTube 360p regressions.`
           );
           try {
             await installYtDlp({ upgrade: true });

--- a/backend/src/utils/ytdlp/install.ts
+++ b/backend/src/utils/ytdlp/install.ts
@@ -20,7 +20,7 @@ let ytDlpAvailablePromise: Promise<void> | null = null;
 /**
  * Try to install yt-dlp via pip, trying multiple pip variants.
  */
-async function installYtDlp(options: { upgrade?: boolean } = {}): Promise<void> {
+export async function installYtDlp(options: { upgrade?: boolean } = {}): Promise<void> {
   const { upgrade = false } = options;
   // curl-cffi powers yt-dlp's browser impersonation (--impersonate), which the
   // MissAV downloader needs to get past Cloudflare on the m3u8 CDN. The Docker

--- a/backend/src/utils/ytdlp/maintenance.ts
+++ b/backend/src/utils/ytdlp/maintenance.ts
@@ -1,0 +1,192 @@
+import axios from "axios";
+import { YT_DLP_STALE_AFTER_DAYS } from "./constants";
+import { installYtDlp } from "./install";
+import {
+  hasCustomConfiguredYtDlpPath,
+  resetResolvedYtDlpPath,
+  resolveYtDlpPath,
+} from "./pathResolver";
+import {
+  resetJsRuntimeFlag,
+  resetRemoteComponentsSupport,
+} from "./runtime";
+import { getYtDlpVersionInfo } from "./versionProbe";
+import { getErrorMessage } from "../errors";
+import { logger } from "../logger";
+
+const PYPI_YT_DLP_URL = "https://pypi.org/pypi/yt-dlp/json";
+const PYPI_TIMEOUT_MS = 5000;
+
+export type YtDlpStatus = {
+  /** Version string reported by `yt-dlp --version`, or null when it cannot run. */
+  version: string | null;
+  /** Resolved binary the backend actually spawns. */
+  path: string;
+  available: boolean;
+  isStale: boolean;
+  staleAfterDays: number;
+  /** Latest release on PyPI, or null when the lookup failed/was skipped. */
+  latestVersion: string | null;
+  /** True only when both versions are known and PyPI is newer. */
+  updateAvailable: boolean;
+  /**
+   * False when YT_DLP_PATH pins a specific binary: a pip upgrade would install
+   * somewhere else and leave the pinned binary untouched.
+   */
+  updateSupported: boolean;
+  customPathConfigured: boolean;
+  errorMessage?: string;
+};
+
+export type YtDlpUpdateResult = {
+  previousVersion: string | null;
+  status: YtDlpStatus;
+  /** True when the reported version actually changed. */
+  changed: boolean;
+};
+
+/**
+ * Parse a yt-dlp release date out of a version string. Accepts both the
+ * zero-padded form the binary prints ("2026.08.19") and the PyPI form
+ * ("2026.8.19"). Returns null for nightly/unknown formats.
+ */
+export function parseYtDlpReleaseTimestamp(
+  version: string | null | undefined
+): number | null {
+  if (!version) {
+    return null;
+  }
+
+  const match = version.trim().match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})/);
+  if (!match) {
+    return null;
+  }
+
+  const timestamp = Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3])
+  );
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+/**
+ * Compare an installed version against the latest published one. Unknown or
+ * unparsable versions never claim an update is available, so the UI stays quiet
+ * instead of nagging about a version it cannot reason about.
+ */
+export function isYtDlpUpdateAvailable(
+  installedVersion: string | null,
+  latestVersion: string | null
+): boolean {
+  const installed = parseYtDlpReleaseTimestamp(installedVersion);
+  const latest = parseYtDlpReleaseTimestamp(latestVersion);
+  if (installed === null || latest === null) {
+    return false;
+  }
+  return latest > installed;
+}
+
+/**
+ * Look up the newest yt-dlp release on PyPI. Network failures are not fatal:
+ * the caller still gets the locally installed version, just without a
+ * comparison target.
+ */
+export async function getLatestYtDlpVersion(): Promise<string | null> {
+  try {
+    const response = await axios.get<{ info?: { version?: unknown } }>(
+      PYPI_YT_DLP_URL,
+      {
+        headers: { Accept: "application/json", "User-Agent": "MyTube-App" },
+        timeout: PYPI_TIMEOUT_MS,
+      }
+    );
+    const version = response.data?.info?.version;
+    return typeof version === "string" && version.trim() ? version.trim() : null;
+  } catch (error: unknown) {
+    logger.debug(
+      `[yt-dlp] Could not fetch the latest version from PyPI: ${getErrorMessage(error, "unknown error")}`
+    );
+    return null;
+  }
+}
+
+/**
+ * Probe the yt-dlp the backend would actually run and, unless skipped, compare
+ * it against the latest PyPI release.
+ */
+export async function getYtDlpStatus(
+  options: { checkLatest?: boolean } = {}
+): Promise<YtDlpStatus> {
+  const { checkLatest = true } = options;
+  const ytDlpPath = await resolveYtDlpPath();
+  const [versionInfo, latestVersion] = await Promise.all([
+    getYtDlpVersionInfo(ytDlpPath),
+    checkLatest ? getLatestYtDlpVersion() : Promise.resolve(null),
+  ]);
+
+  const customPathConfigured = hasCustomConfiguredYtDlpPath();
+
+  return {
+    version: versionInfo.version,
+    path: ytDlpPath,
+    available: versionInfo.canRun,
+    isStale: versionInfo.isStale,
+    staleAfterDays: YT_DLP_STALE_AFTER_DAYS,
+    latestVersion,
+    updateAvailable: isYtDlpUpdateAvailable(versionInfo.version, latestVersion),
+    updateSupported: !customPathConfigured,
+    customPathConfigured,
+    ...(versionInfo.canRun ? {} : { errorMessage: versionInfo.errorMessage }),
+  };
+}
+
+// Shared across concurrent callers so a double-click cannot start two pip runs.
+let inFlightUpdate: Promise<YtDlpUpdateResult> | null = null;
+
+export function isYtDlpUpdateInProgress(): boolean {
+  return inFlightUpdate !== null;
+}
+
+async function runYtDlpUpdate(): Promise<YtDlpUpdateResult> {
+  const previousStatus = await getYtDlpStatus({ checkLatest: false });
+  const previousVersion = previousStatus.version;
+
+  logger.info(
+    `[yt-dlp] Updating yt-dlp (currently ${previousVersion || "unknown"}) on operator request.`
+  );
+  await installYtDlp({ upgrade: true });
+
+  // The upgrade may have landed a different binary on PATH, so drop every
+  // cached capability probe before re-reading the version.
+  resetResolvedYtDlpPath();
+  resetJsRuntimeFlag();
+  resetRemoteComponentsSupport();
+
+  const status = await getYtDlpStatus();
+  logger.info(
+    `[yt-dlp] Update finished: ${previousVersion || "unknown"} -> ${status.version || "unknown"}.`
+  );
+
+  return {
+    previousVersion,
+    status,
+    changed: Boolean(status.version) && status.version !== previousVersion,
+  };
+}
+
+/**
+ * Upgrade yt-dlp in place via pip so operators do not have to rebuild the
+ * image to pick up an extractor fix.
+ */
+export async function updateYtDlp(): Promise<YtDlpUpdateResult> {
+  if (inFlightUpdate) {
+    return inFlightUpdate;
+  }
+
+  inFlightUpdate = runYtDlpUpdate().finally(() => {
+    inFlightUpdate = null;
+  });
+
+  return inFlightUpdate;
+}

--- a/backend/src/utils/ytdlp/maintenance.ts
+++ b/backend/src/utils/ytdlp/maintenance.ts
@@ -118,7 +118,7 @@ export async function getLatestYtDlpVersion(): Promise<string | null> {
 export async function getYtDlpStatus(
   options: { checkLatest?: boolean } = {}
 ): Promise<YtDlpStatus> {
-  const { checkLatest = true } = options;
+  const { checkLatest = false } = options;
   const ytDlpPath = await resolveYtDlpPath();
   const [versionInfo, latestVersion] = await Promise.all([
     getYtDlpVersionInfo(ytDlpPath),
@@ -163,7 +163,9 @@ async function runYtDlpUpdate(): Promise<YtDlpUpdateResult> {
   resetJsRuntimeFlag();
   resetRemoteComponentsSupport();
 
-  const status = await getYtDlpStatus();
+  // pip has already performed the requested network operation. Re-probe only
+  // the installed binary here; the UI can explicitly check PyPI afterward.
+  const status = await getYtDlpStatus({ checkLatest: false });
   logger.info(
     `[yt-dlp] Update finished: ${previousVersion || "unknown"} -> ${status.version || "unknown"}.`
   );

--- a/documents/en/api-endpoints.md
+++ b/documents/en/api-endpoints.md
@@ -188,9 +188,10 @@ Favorites are scoped to the authenticated owner. When login protection is disabl
 - `POST /api/settings/telegram/test` - Send a test Telegram notification
   - Body: `{ botToken: string, chatId: string }`
 - `GET /api/settings/ytdlp/version` - Report the yt-dlp the backend runs and the latest release on PyPI
-  - Query: `checkLatest=false` skips the PyPI lookup
+  - By default this probes only the local binary and does not contact PyPI
+  - Query: `checkLatest=true` explicitly looks up the latest release on PyPI
   - Response `data`: `{ version, path, available, isStale, staleAfterDays, latestVersion, updateAvailable, updateSupported, customPathConfigured, errorMessage? }`
-  - `latestVersion` is `null` when PyPI is unreachable; `updateAvailable` is then `false`
+  - `latestVersion` is `null` when the lookup was not requested or PyPI is unreachable; `updateAvailable` is then `false`
 - `POST /api/settings/ytdlp/update` - Update yt-dlp in place via pip (no image rebuild required)
   - Requires `container` admin trust; returns `403` in `application` trust mode
   - Returns `409` (`errorKey: ytDlpUpdateCustomPath`) when `YT_DLP_PATH` pins a specific binary

--- a/documents/en/api-endpoints.md
+++ b/documents/en/api-endpoints.md
@@ -196,6 +196,9 @@ Favorites are scoped to the authenticated owner. When login protection is disabl
   - Returns `409` (`errorKey: ytDlpUpdateCustomPath`) when `YT_DLP_PATH` pins a specific binary
   - Response `data`: `{ previousVersion, changed, status }` with `status` shaped like the endpoint above
   - Concurrent requests share a single pip run
+  - Installs `yt-dlp[default,curl-cffi]` so the release-coupled pins (yt-dlp-ejs solver, curl-cffi impersonation range) are resolved from the target release instead of drifting
+  - The bundled bgutil POT provider is not upgraded: it is loaded from the image ahead of any pip copy and its Node server is not on PyPI
+  - In Docker the install persists in the `/app/data` volume and outlives container recreation; see the docker guide for how to roll back to the image-pinned version
 
 ## Password & Session
 

--- a/documents/en/api-endpoints.md
+++ b/documents/en/api-endpoints.md
@@ -187,6 +187,15 @@ Favorites are scoped to the authenticated owner. When login protection is disabl
   - Body: `{ oldTag: string, newTag: string }`
 - `POST /api/settings/telegram/test` - Send a test Telegram notification
   - Body: `{ botToken: string, chatId: string }`
+- `GET /api/settings/ytdlp/version` - Report the yt-dlp the backend runs and the latest release on PyPI
+  - Query: `checkLatest=false` skips the PyPI lookup
+  - Response `data`: `{ version, path, available, isStale, staleAfterDays, latestVersion, updateAvailable, updateSupported, customPathConfigured, errorMessage? }`
+  - `latestVersion` is `null` when PyPI is unreachable; `updateAvailable` is then `false`
+- `POST /api/settings/ytdlp/update` - Update yt-dlp in place via pip (no image rebuild required)
+  - Requires `container` admin trust; returns `403` in `application` trust mode
+  - Returns `409` (`errorKey: ytDlpUpdateCustomPath`) when `YT_DLP_PATH` pins a specific binary
+  - Response `data`: `{ previousVersion, changed, status }` with `status` shaped like the endpoint above
+  - Concurrent requests share a single pip run
 
 ## Password & Session
 

--- a/documents/en/docker-guide.md
+++ b/documents/en/docker-guide.md
@@ -188,6 +188,32 @@ Example backend volume section:
       - mytube-data:/app/data
 ```
 
+### Updating yt-dlp without rebuilding
+
+Settings -> yt-dlp Configuration shows the yt-dlp version the backend actually
+runs and, on `container` admin trust, offers an **Update yt-dlp** button. This
+runs `pip install -U` inside the running container, so a broken extractor can be
+fixed without waiting for a new image.
+
+**The update persists.** It is a `pip --user` install into `$HOME`, which the
+entrypoint points at `/app/data/.home` — part of the `/app/data` volume above.
+The runtime install therefore survives `docker compose down && up`, container
+recreation, and image upgrades, and the backend keeps preferring it over the
+version pinned in the image because it is the newer release.
+
+That also means **recreating from an older image is not a rollback.** To go back
+to the version pinned in the image, delete the runtime install and restart:
+
+```bash
+docker compose exec backend rm -rf /app/data/.home/.local/bin/yt-dlp /app/data/.home/.local/lib/python*/site-packages/yt_dlp
+```
+
+Then restart the backend and re-check the version in Settings.
+
+The bundled bgutil POT provider is not part of this update. Its Python plugin is
+loaded from the image ahead of any pip copy, and its Node server ships with the
+image, so bumping the provider requires a new image.
+
 ### Environment Variables
 
 You can customize the deployment by adding a `.env` file or modifying the `environment` section in `docker-compose.yml`.

--- a/documents/en/docker-guide.md
+++ b/documents/en/docker-guide.md
@@ -202,13 +202,70 @@ recreation, and image upgrades, and the backend keeps preferring it over the
 version pinned in the image because it is the newer release.
 
 That also means **recreating from an older image is not a rollback.** To go back
-to the version pinned in the image, delete the runtime install and restart:
+to the version pinned in the image, delete the complete runtime Python user
+installation, then restart or recreate the service as described below. Removing
+only the `yt-dlp` executable is not enough: the update also installs
+release-coupled packages such as `yt-dlp-ejs` and
+`curl-cffi`, and those user-site packages would continue to shadow the versions
+from the image.
+
+For the default two-container stack (`backend` service):
 
 ```bash
-docker compose exec backend rm -rf /app/data/.home/.local/bin/yt-dlp /app/data/.home/.local/lib/python*/site-packages/yt_dlp
+docker compose exec backend sh -c 'rm -rf /app/data/.home/.local'
 ```
 
-Then restart the backend and re-check the version in Settings.
+For the supplied single-container stack (`mytube` service):
+
+```bash
+docker compose -f stacks/docker-compose.single-container.yml exec mytube sh -c 'rm -rf /app/data/.home/.local'
+```
+
+The dedicated `.local` tree contains packages and scripts installed by the
+runtime updater; removing it does not remove the database or media under
+`/app/data` and `/app/uploads`. If you deliberately installed other Python user
+packages into this container, they are removed as well. After completing the
+restart or recreation step below, re-check the version in Settings.
+
+If the image-pinned yt-dlp is more than 90 days old, removing `.local` alone is
+only temporary: on the first yt-dlp use after restart, MyTube's stale-version
+check automatically installs a current release into `.local` again. To keep an
+older image version pinned, add the image binary's absolute path to the service
+environment **before running the cleanup command above**:
+
+```yaml
+environment:
+  - YT_DLP_PATH=/usr/local/bin/yt-dlp
+```
+
+Use the image-binary path that Settings showed before the runtime update if it
+differs from the Docker default above. An absolute `YT_DLP_PATH` marks the binary
+as operator-managed: it disables both stale-version auto-upgrades and the
+**Update yt-dlp** button. Setting `YT_DLP_PATH=yt-dlp` is not a hard pin because
+that literal value is treated as the default PATH-based configuration.
+
+After adding the variable and deleting `.local` with the appropriate command
+above, recreate the service so Compose applies the changed environment (a plain
+`restart` does not apply Compose configuration changes):
+
+```bash
+# Default two-container stack
+docker compose up -d --force-recreate backend
+
+# Supplied single-container stack
+docker compose -f stacks/docker-compose.single-container.yml up -d --force-recreate mytube
+```
+
+If the image version is recent enough that no hard pin is needed, restart the
+corresponding service after deleting `.local`:
+
+```bash
+# Default two-container stack
+docker compose restart backend
+
+# Supplied single-container stack
+docker compose -f stacks/docker-compose.single-container.yml restart mytube
+```
 
 The bundled bgutil POT provider is not part of this update. Its Python plugin is
 loaded from the image ahead of any pip copy, and its Node server ships with the

--- a/documents/zh/api-endpoints.md
+++ b/documents/zh/api-endpoints.md
@@ -173,9 +173,10 @@
 - `POST /api/settings/telegram/test` - 发送 Telegram 测试通知
   - 请求体: `{ botToken: string, chatId: string }`
 - `GET /api/settings/ytdlp/version` - 返回后端实际使用的 yt-dlp 版本以及 PyPI 上的最新版本
-  - 查询参数: `checkLatest=false` 可跳过 PyPI 查询
+  - 默认只探测本地可执行文件，不会连接 PyPI
+  - 查询参数: `checkLatest=true` 时才会显式查询 PyPI 最新版本
   - 响应 `data`: `{ version, path, available, isStale, staleAfterDays, latestVersion, updateAvailable, updateSupported, customPathConfigured, errorMessage? }`
-  - PyPI 不可达时 `latestVersion` 为 `null`，此时 `updateAvailable` 为 `false`
+  - 未请求查询或 PyPI 不可达时，`latestVersion` 为 `null`，此时 `updateAvailable` 为 `false`
 - `POST /api/settings/ytdlp/update` - 通过 pip 就地更新 yt-dlp（无需重建镜像）
   - 需要 `container` 级管理员信任；在 `application` 信任模式下返回 `403`
   - 当 `YT_DLP_PATH` 指定了固定可执行文件时返回 `409`（`errorKey: ytDlpUpdateCustomPath`）

--- a/documents/zh/api-endpoints.md
+++ b/documents/zh/api-endpoints.md
@@ -172,6 +172,15 @@
   - 请求体: `{ oldTag: string, newTag: string }`
 - `POST /api/settings/telegram/test` - 发送 Telegram 测试通知
   - 请求体: `{ botToken: string, chatId: string }`
+- `GET /api/settings/ytdlp/version` - 返回后端实际使用的 yt-dlp 版本以及 PyPI 上的最新版本
+  - 查询参数: `checkLatest=false` 可跳过 PyPI 查询
+  - 响应 `data`: `{ version, path, available, isStale, staleAfterDays, latestVersion, updateAvailable, updateSupported, customPathConfigured, errorMessage? }`
+  - PyPI 不可达时 `latestVersion` 为 `null`，此时 `updateAvailable` 为 `false`
+- `POST /api/settings/ytdlp/update` - 通过 pip 就地更新 yt-dlp（无需重建镜像）
+  - 需要 `container` 级管理员信任；在 `application` 信任模式下返回 `403`
+  - 当 `YT_DLP_PATH` 指定了固定可执行文件时返回 `409`（`errorKey: ytDlpUpdateCustomPath`）
+  - 响应 `data`: `{ previousVersion, changed, status }`，其中 `status` 与上一个接口结构相同
+  - 并发请求共用同一次 pip 执行
 
 ## 密码与会话
 

--- a/documents/zh/api-endpoints.md
+++ b/documents/zh/api-endpoints.md
@@ -181,6 +181,9 @@
   - 当 `YT_DLP_PATH` 指定了固定可执行文件时返回 `409`（`errorKey: ytDlpUpdateCustomPath`）
   - 响应 `data`: `{ previousVersion, changed, status }`，其中 `status` 与上一个接口结构相同
   - 并发请求共用同一次 pip 执行
+  - 安装 `yt-dlp[default,curl-cffi]`，使与发行版本绑定的依赖（yt-dlp-ejs 解算器、curl-cffi 模拟范围）由目标版本自行解析，避免版本脱节
+  - 不会升级内置的 bgutil POT provider：它会优先于任何 pip 副本从镜像加载，且其 Node 服务端不在 PyPI 上
+  - 在 Docker 中该安装会持久化在 `/app/data` 卷内并在容器重建后继续生效；回退到镜像固定版本的方法见 Docker 指南
 
 ## 密码与会话
 

--- a/documents/zh/docker-guide.md
+++ b/documents/zh/docker-guide.md
@@ -197,14 +197,61 @@ services:
 `docker compose down && up`、容器重建、镜像升级之后继续存在；由于它是更新的发行版本，
 后端也会继续优先使用它，而不是镜像中固定的版本。
 
-这同时意味着**回退到旧镜像并不能回退 yt-dlp**。要恢复为镜像中固定的版本，请删除运行时
-安装的副本并重启：
+这同时意味着**回退到旧镜像并不能回退 yt-dlp**。要恢复为镜像中固定的版本，需要删除完整的
+运行时 Python 用户安装，然后按照下文说明重启或重建服务。只删除 `yt-dlp` 可执行文件并不够：
+更新操作还会安装 `yt-dlp-ejs`、`curl-cffi` 等与发行版耦合的包；如果保留这些用户级包，
+它们仍会覆盖镜像中的固定版本。
+
+对于默认的双容器 stack（服务名为 `backend`）：
 
 ```bash
-docker compose exec backend rm -rf /app/data/.home/.local/bin/yt-dlp /app/data/.home/.local/lib/python*/site-packages/yt_dlp
+docker compose exec backend sh -c 'rm -rf /app/data/.home/.local'
 ```
 
-然后重启后端，并在设置中重新查看版本。
+对于仓库提供的单容器 stack（服务名为 `mytube`）：
+
+```bash
+docker compose -f stacks/docker-compose.single-container.yml exec mytube sh -c 'rm -rf /app/data/.home/.local'
+```
+
+专用的 `.local` 目录保存运行时更新器安装的包和脚本；删除它不会删除 `/app/data` 中的数据库，
+也不会删除 `/app/uploads` 中的媒体。如果你曾主动在该容器的 Python 用户环境中安装其他包，
+这些包也会一并删除。完成下文的重启或重建步骤后，请在设置中重新查看版本。
+
+如果镜像固定的 yt-dlp 已超过 90 天，仅删除 `.local` 只能暂时回退：重启后首次使用 yt-dlp
+时，MyTube 的旧版本检查会再次把当前发行版自动安装到 `.local`。若要持续固定旧镜像中的
+版本，请在执行上面的清理命令**之前**，把镜像内可执行文件的绝对路径加入服务环境变量：
+
+```yaml
+environment:
+  - YT_DLP_PATH=/usr/local/bin/yt-dlp
+```
+
+如果运行时更新前设置页面显示的镜像路径与上述 Docker 默认值不同，请使用页面原先显示的
+路径。绝对路径形式的 `YT_DLP_PATH` 会把该可执行文件标记为由部署者管理，同时禁用旧版本
+自动升级和 **更新 yt-dlp** 按钮。`YT_DLP_PATH=yt-dlp` 不能实现硬固定，因为代码会把这个
+字面值视为默认的 PATH 查找配置。
+
+添加环境变量并使用上面的对应命令删除 `.local` 后，需要重新创建服务，让 Compose 应用新的
+环境变量（仅执行 `restart` 不会应用 Compose 配置变更）：
+
+```bash
+# 默认双容器 stack
+docker compose up -d --force-recreate backend
+
+# 仓库提供的单容器 stack
+docker compose -f stacks/docker-compose.single-container.yml up -d --force-recreate mytube
+```
+
+如果镜像版本足够新，不需要硬固定，请在删除 `.local` 后重启对应服务：
+
+```bash
+# 默认双容器 stack
+docker compose restart backend
+
+# 仓库提供的单容器 stack
+docker compose -f stacks/docker-compose.single-container.yml restart mytube
+```
 
 内置的 bgutil POT provider 不在此次更新范围内：它的 Python 插件会优先于任何 pip 副本从
 镜像中加载，其 Node 服务端也随镜像一起发布，因此升级 provider 需要新的镜像。

--- a/documents/zh/docker-guide.md
+++ b/documents/zh/docker-guide.md
@@ -186,6 +186,29 @@ services:
       - mytube-data:/app/data
 ```
 
+### 不重建镜像更新 yt-dlp
+
+设置 -> yt-dlp 配置中会显示后端实际使用的 yt-dlp 版本；在 `container` 管理员信任级别下，
+还会提供 **更新 yt-dlp** 按钮。该操作在运行中的容器内执行 `pip install -U`，因此遇到
+提取器失效时无需等待新镜像即可修复。
+
+**该更新会被持久化。** 它是一次 `pip --user` 安装，装到 `$HOME`，而入口脚本把 `$HOME`
+指向 `/app/data/.home` —— 属于上面的 `/app/data` 卷。因此运行时安装的版本会在
+`docker compose down && up`、容器重建、镜像升级之后继续存在；由于它是更新的发行版本，
+后端也会继续优先使用它，而不是镜像中固定的版本。
+
+这同时意味着**回退到旧镜像并不能回退 yt-dlp**。要恢复为镜像中固定的版本，请删除运行时
+安装的副本并重启：
+
+```bash
+docker compose exec backend rm -rf /app/data/.home/.local/bin/yt-dlp /app/data/.home/.local/lib/python*/site-packages/yt_dlp
+```
+
+然后重启后端，并在设置中重新查看版本。
+
+内置的 bgutil POT provider 不在此次更新范围内：它的 Python 插件会优先于任何 pip 副本从
+镜像中加载，其 Node 服务端也随镜像一起发布，因此升级 provider 需要新的镜像。
+
 ### 环境变量
 
 您可以通过添加  `.env`  文件或修改  `docker-compose.yml`  中的  `environment`  部分来自定义部署。

--- a/frontend/src/components/Settings/YtDlpVersionSettings.tsx
+++ b/frontend/src/components/Settings/YtDlpVersionSettings.tsx
@@ -1,6 +1,6 @@
 import { Refresh, SystemUpdateAlt } from '@mui/icons-material';
 import { Alert, Box, Button, Chip, Skeleton, Typography } from '@mui/material';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { api } from '../../utils/apiClient';
@@ -44,6 +44,7 @@ const getErrorText = (error: unknown, fallback: string): string => {
 
 const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate = true }) => {
     const { t } = useLanguage();
+    const queryClient = useQueryClient();
     const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
 
     const {
@@ -60,6 +61,27 @@ const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate =
         // The version only changes when someone updates it, so do not re-probe
         // the binary every time the Settings tab regains focus.
         refetchOnWindowFocus: false,
+    });
+
+    const checkMutation = useMutation({
+        mutationFn: async () => {
+            const response = await api.get('/settings/ytdlp/version?checkLatest=true');
+            return (response.data?.data ?? null) as YtDlpStatus | null;
+        },
+        onSuccess: (loaded) => {
+            if (loaded) {
+                queryClient.setQueryData(['ytDlpVersion'], loaded);
+            }
+            if (loaded?.latestVersion && !loaded.updateAvailable) {
+                setFeedback({ type: 'info', text: t('ytDlpUpToDate') });
+            }
+        },
+        onError: (error: unknown) => {
+            setFeedback({
+                type: 'error',
+                text: getErrorText(error, t('ytDlpVersionCheckFailed')),
+            });
+        },
     });
 
     const updateMutation = useMutation({
@@ -82,7 +104,11 @@ const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate =
                     }
                     : { type: 'info', text: t('ytDlpUpdateNoChange') }
             );
-            void refetch();
+            if (result?.status) {
+                queryClient.setQueryData(['ytDlpVersion'], result.status);
+            } else {
+                void refetch();
+            }
         },
         onError: (error: unknown) => {
             setFeedback({
@@ -93,17 +119,19 @@ const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate =
     });
 
     const isUpdating = updateMutation.isPending;
+    const isCheckingLatest = checkMutation.isPending;
 
-    const handleCheck = async () => {
+    const handleCheck = () => {
         setFeedback(null);
-        const { data: loaded } = await refetch();
-        if (loaded?.latestVersion && !loaded.updateAvailable) {
-            setFeedback({ type: 'info', text: t('ytDlpUpToDate') });
-        }
+        checkMutation.mutate();
     };
 
     const updateDisabled =
-        isUpdating || isFetching || !canUpdate || status?.updateSupported === false;
+        isUpdating ||
+        isFetching ||
+        isCheckingLatest ||
+        !canUpdate ||
+        status?.updateSupported === false;
 
     const renderVersion = () => {
         if (isFetching && !status) {
@@ -161,7 +189,7 @@ const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate =
                     size="small"
                     startIcon={<Refresh />}
                     onClick={handleCheck}
-                    loading={isFetching}
+                    loading={isFetching || isCheckingLatest}
                     loadingPosition="start"
                     disabled={isUpdating}
                 >

--- a/frontend/src/components/Settings/YtDlpVersionSettings.tsx
+++ b/frontend/src/components/Settings/YtDlpVersionSettings.tsx
@@ -1,0 +1,210 @@
+import { Refresh, SystemUpdateAlt } from '@mui/icons-material';
+import { Alert, Box, Button, Chip, Skeleton, Typography } from '@mui/material';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import React, { useState } from 'react';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { api } from '../../utils/apiClient';
+
+// A pip install pulls wheels over the network, which regularly outruns the
+// 30s default timeout of the shared api client.
+const UPDATE_TIMEOUT_MS = 300000;
+
+interface YtDlpStatus {
+    version: string | null;
+    path: string;
+    available: boolean;
+    isStale: boolean;
+    staleAfterDays: number;
+    latestVersion: string | null;
+    updateAvailable: boolean;
+    updateSupported: boolean;
+    customPathConfigured: boolean;
+    errorMessage?: string;
+}
+
+interface YtDlpUpdateResult {
+    previousVersion: string | null;
+    status: YtDlpStatus;
+    /** True when the reported version actually changed. */
+    changed: boolean;
+}
+
+interface YtDlpVersionSettingsProps {
+    /** False in application trust mode, where the backend refuses the update. */
+    canUpdate?: boolean;
+}
+
+type FeedbackMessage = { type: 'success' | 'info' | 'error'; text: string };
+
+const getErrorText = (error: unknown, fallback: string): string => {
+    const responseError = (error as { response?: { data?: { error?: string } } })
+        .response?.data?.error;
+    return responseError || fallback;
+};
+
+const YtDlpVersionSettings: React.FC<YtDlpVersionSettingsProps> = ({ canUpdate = true }) => {
+    const { t } = useLanguage();
+    const [feedback, setFeedback] = useState<FeedbackMessage | null>(null);
+
+    const {
+        data: status,
+        isFetching,
+        error: statusError,
+        refetch,
+    } = useQuery<YtDlpStatus | null>({
+        queryKey: ['ytDlpVersion'],
+        queryFn: async () => {
+            const response = await api.get('/settings/ytdlp/version');
+            return (response.data?.data ?? null) as YtDlpStatus | null;
+        },
+        // The version only changes when someone updates it, so do not re-probe
+        // the binary every time the Settings tab regains focus.
+        refetchOnWindowFocus: false,
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: async () => {
+            const response = await api.post(
+                '/settings/ytdlp/update',
+                {},
+                { timeout: UPDATE_TIMEOUT_MS }
+            );
+            return response.data?.data as YtDlpUpdateResult | undefined;
+        },
+        onSuccess: (result) => {
+            setFeedback(
+                result?.changed
+                    ? {
+                        type: 'success',
+                        text: t('ytDlpUpdateSuccess', {
+                            version: result.status?.version || '',
+                        }),
+                    }
+                    : { type: 'info', text: t('ytDlpUpdateNoChange') }
+            );
+            void refetch();
+        },
+        onError: (error: unknown) => {
+            setFeedback({
+                type: 'error',
+                text: getErrorText(error, t('ytDlpUpdateFailed')),
+            });
+        },
+    });
+
+    const isUpdating = updateMutation.isPending;
+
+    const handleCheck = async () => {
+        setFeedback(null);
+        const { data: loaded } = await refetch();
+        if (loaded?.latestVersion && !loaded.updateAvailable) {
+            setFeedback({ type: 'info', text: t('ytDlpUpToDate') });
+        }
+    };
+
+    const updateDisabled =
+        isUpdating || isFetching || !canUpdate || status?.updateSupported === false;
+
+    const renderVersion = () => {
+        if (isFetching && !status) {
+            return <Skeleton variant="text" width={140} />;
+        }
+        if (statusError) {
+            return (
+                <Typography variant="body2" color="error">
+                    {t('ytDlpVersionCheckFailed')}
+                </Typography>
+            );
+        }
+        if (!status?.available) {
+            return (
+                <Typography variant="body2" color="error">
+                    {t('ytDlpVersionUnavailable')}
+                </Typography>
+            );
+        }
+        return (
+            <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                {status.version || t('ytDlpVersionUnknown')}
+            </Typography>
+        );
+    };
+
+    return (
+        <Box sx={{ mb: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 1 }}>
+                <Typography variant="body2" color="text.secondary">
+                    {t('ytDlpVersion')}
+                </Typography>
+                {renderVersion()}
+                {status?.updateAvailable && status.latestVersion && (
+                    <Chip
+                        size="small"
+                        color="warning"
+                        label={t('ytDlpUpdateAvailable', { version: status.latestVersion })}
+                    />
+                )}
+                {status?.available && !status.updateAvailable && status.latestVersion && (
+                    <Chip size="small" color="success" label={t('ytDlpUpToDate')} />
+                )}
+            </Box>
+
+            {status?.path && (
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
+                    {t('ytDlpBinaryPath', { path: status.path })}
+                </Typography>
+            )}
+
+            <Box sx={{ display: 'flex', gap: 2, mt: 1.5, flexWrap: 'wrap' }}>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<Refresh />}
+                    onClick={handleCheck}
+                    loading={isFetching}
+                    loadingPosition="start"
+                    disabled={isUpdating}
+                >
+                    {t('ytDlpCheckUpdate')}
+                </Button>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<SystemUpdateAlt />}
+                    onClick={() => updateMutation.mutate()}
+                    loading={isUpdating}
+                    loadingPosition="start"
+                    disabled={updateDisabled}
+                >
+                    {t('ytDlpUpdate')}
+                </Button>
+            </Box>
+
+            {status?.customPathConfigured && (
+                <Alert severity="info" sx={{ mt: 2 }}>
+                    {t('ytDlpUpdateCustomPathNotice')}
+                </Alert>
+            )}
+
+            {!canUpdate && (
+                <Alert severity="info" sx={{ mt: 2 }}>
+                    {t('ytDlpUpdatePolicyNotice')}
+                </Alert>
+            )}
+
+            {isUpdating && (
+                <Alert severity="info" sx={{ mt: 2 }}>
+                    {t('ytDlpUpdateInProgress')}
+                </Alert>
+            )}
+
+            {feedback && (
+                <Alert severity={feedback.type} sx={{ mt: 2 }} onClose={() => setFeedback(null)}>
+                    {feedback.text}
+                </Alert>
+            )}
+        </Box>
+    );
+};
+
+export default YtDlpVersionSettings;

--- a/frontend/src/components/Settings/__tests__/YtDlpVersionSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/YtDlpVersionSettings.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import YtDlpVersionSettings from '../YtDlpVersionSettings';
+
+// t echoes the key, with {placeholders} substituted, so assertions can match
+// on the key plus the interpolated value.
+vi.mock('../../../contexts/LanguageContext', () => ({
+    useLanguage: () => ({
+        t: (key: string, replacements?: Record<string, string | number>) => {
+            if (!replacements) return key;
+            return Object.entries(replacements).reduce(
+                (text, [name, value]) => text.replace(`{${name}}`, String(value)),
+                key
+            );
+        },
+    }),
+}));
+
+const apiGetMock = vi.fn();
+const apiPostMock = vi.fn();
+vi.mock('../../../utils/apiClient', () => ({
+    api: {
+        get: (...args: unknown[]) => apiGetMock(...args),
+        post: (...args: unknown[]) => apiPostMock(...args),
+    },
+}));
+
+const buildStatus = (overrides: Record<string, unknown> = {}) => ({
+    version: '2026.08.19',
+    path: '/usr/local/bin/yt-dlp',
+    available: true,
+    isStale: false,
+    staleAfterDays: 90,
+    latestVersion: '2026.8.19',
+    updateAvailable: false,
+    updateSupported: true,
+    customPathConfigured: false,
+    ...overrides,
+});
+
+// Real QueryClient with retries off so failures surface on the first attempt.
+const renderPanel = (props: { canUpdate?: boolean } = {}) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <YtDlpVersionSettings {...props} />
+        </QueryClientProvider>
+    );
+};
+
+describe('YtDlpVersionSettings', () => {
+    beforeEach(() => {
+        apiGetMock.mockReset();
+        apiPostMock.mockReset();
+    });
+
+    it('shows the installed version and an up-to-date chip', async () => {
+        apiGetMock.mockResolvedValue({ data: { data: buildStatus() } });
+
+        renderPanel();
+
+        expect(await screen.findByText('2026.08.19')).toBeInTheDocument();
+        expect(screen.getByText('ytDlpUpToDate')).toBeInTheDocument();
+        expect(apiGetMock).toHaveBeenCalledWith('/settings/ytdlp/version');
+    });
+
+    it('flags an available update with the latest version', async () => {
+        apiGetMock.mockResolvedValue({
+            data: {
+                data: buildStatus({
+                    version: '2026.06.09',
+                    latestVersion: '2026.8.19',
+                    updateAvailable: true,
+                }),
+            },
+        });
+
+        renderPanel();
+
+        expect(
+            await screen.findByText('ytDlpUpdateAvailable')
+        ).toBeInTheDocument();
+    });
+
+    it('reports the new version after a successful update', async () => {
+        apiGetMock.mockResolvedValue({
+            data: { data: buildStatus({ version: '2026.06.09', updateAvailable: true }) },
+        });
+        apiPostMock.mockResolvedValue({
+            data: {
+                data: {
+                    previousVersion: '2026.06.09',
+                    changed: true,
+                    status: buildStatus(),
+                },
+            },
+        });
+        const user = userEvent.setup();
+
+        renderPanel();
+        await screen.findByText('2026.06.09');
+        await user.click(screen.getByRole('button', { name: /ytDlpUpdate$/ }));
+
+        await waitFor(() => {
+            expect(screen.getByText('ytDlpUpdateSuccess')).toBeInTheDocument();
+        });
+        expect(apiPostMock).toHaveBeenCalledWith(
+            '/settings/ytdlp/update',
+            {},
+            expect.objectContaining({ timeout: expect.any(Number) })
+        );
+    });
+
+    it('surfaces the backend error when the update fails', async () => {
+        apiGetMock.mockResolvedValue({ data: { data: buildStatus() } });
+        apiPostMock.mockRejectedValue({
+            response: { data: { error: 'pip is unavailable' } },
+        });
+        const user = userEvent.setup();
+
+        renderPanel();
+        await screen.findByText('2026.08.19');
+        await user.click(screen.getByRole('button', { name: /ytDlpUpdate$/ }));
+
+        expect(await screen.findByText('pip is unavailable')).toBeInTheDocument();
+    });
+
+    it('disables updating and explains why when YT_DLP_PATH pins a binary', async () => {
+        apiGetMock.mockResolvedValue({
+            data: {
+                data: buildStatus({ updateSupported: false, customPathConfigured: true }),
+            },
+        });
+
+        renderPanel();
+
+        expect(
+            await screen.findByText('ytDlpUpdateCustomPathNotice')
+        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /ytDlpUpdate$/ })).toBeDisabled();
+    });
+
+    it('explains that application trust mode blocks the update', async () => {
+        apiGetMock.mockResolvedValue({ data: { data: buildStatus() } });
+
+        renderPanel({ canUpdate: false });
+
+        expect(
+            await screen.findByText('ytDlpUpdatePolicyNotice')
+        ).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /ytDlpUpdate$/ })).toBeDisabled();
+    });
+
+    it('shows an error when the version probe request fails', async () => {
+        apiGetMock.mockRejectedValue(new Error('network down'));
+
+        renderPanel();
+
+        expect(
+            await screen.findByText('ytDlpVersionCheckFailed')
+        ).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/Settings/__tests__/YtDlpVersionSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/YtDlpVersionSettings.test.tsx
@@ -33,7 +33,7 @@ const buildStatus = (overrides: Record<string, unknown> = {}) => ({
     available: true,
     isStale: false,
     staleAfterDays: 90,
-    latestVersion: '2026.8.19',
+    latestVersion: null,
     updateAvailable: false,
     updateSupported: true,
     customPathConfigured: false,
@@ -58,37 +58,66 @@ describe('YtDlpVersionSettings', () => {
         apiPostMock.mockReset();
     });
 
-    it('shows the installed version and an up-to-date chip', async () => {
+    it('loads the installed version without checking PyPI', async () => {
         apiGetMock.mockResolvedValue({ data: { data: buildStatus() } });
 
         renderPanel();
 
         expect(await screen.findByText('2026.08.19')).toBeInTheDocument();
-        expect(screen.getByText('ytDlpUpToDate')).toBeInTheDocument();
+        expect(screen.queryByText('ytDlpUpToDate')).not.toBeInTheDocument();
         expect(apiGetMock).toHaveBeenCalledWith('/settings/ytdlp/version');
     });
 
-    it('flags an available update with the latest version', async () => {
-        apiGetMock.mockResolvedValue({
-            data: {
-                data: buildStatus({
-                    version: '2026.06.09',
-                    latestVersion: '2026.8.19',
-                    updateAvailable: true,
-                }),
-            },
-        });
+    it('checks PyPI only when the user requests it', async () => {
+        apiGetMock
+            .mockResolvedValueOnce({
+                data: { data: buildStatus({ version: '2026.06.09' }) },
+            })
+            .mockResolvedValueOnce({
+                data: {
+                    data: buildStatus({
+                        version: '2026.06.09',
+                        latestVersion: '2026.8.19',
+                        updateAvailable: true,
+                    }),
+                },
+            });
+        const user = userEvent.setup();
 
         renderPanel();
+        await screen.findByText('2026.06.09');
+        expect(apiGetMock).toHaveBeenCalledTimes(1);
+
+        await user.click(screen.getByRole('button', { name: /ytDlpCheckUpdate$/ }));
 
         expect(
             await screen.findByText('ytDlpUpdateAvailable')
+        ).toBeInTheDocument();
+        expect(apiGetMock).toHaveBeenLastCalledWith(
+            '/settings/ytdlp/version?checkLatest=true'
+        );
+    });
+
+    it('surfaces the backend error when the update check fails', async () => {
+        apiGetMock
+            .mockResolvedValueOnce({ data: { data: buildStatus() } })
+            .mockRejectedValueOnce({
+                response: { data: { error: 'PyPI lookup is blocked by policy' } },
+            });
+        const user = userEvent.setup();
+
+        renderPanel();
+        await screen.findByText('2026.08.19');
+        await user.click(screen.getByRole('button', { name: /ytDlpCheckUpdate$/ }));
+
+        expect(
+            await screen.findByText('PyPI lookup is blocked by policy')
         ).toBeInTheDocument();
     });
 
     it('reports the new version after a successful update', async () => {
         apiGetMock.mockResolvedValue({
-            data: { data: buildStatus({ version: '2026.06.09', updateAvailable: true }) },
+            data: { data: buildStatus({ version: '2026.06.09' }) },
         });
         apiPostMock.mockResolvedValue({
             data: {
@@ -113,6 +142,7 @@ describe('YtDlpVersionSettings', () => {
             {},
             expect.objectContaining({ timeout: expect.any(Number) })
         );
+        expect(apiGetMock).toHaveBeenCalledTimes(1);
     });
 
     it('surfaces the backend error when the update fails', async () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -37,6 +37,7 @@ import TwitchSettings from '../components/Settings/TwitchSettings';
 import VideoDefaultSettings from '../components/Settings/VideoDefaultSettings';
 import LiveTranslationSettings from '../components/Settings/LiveTranslationSettings';
 import YtDlpSettings from '../components/Settings/YtDlpSettings';
+import YtDlpVersionSettings from '../components/Settings/YtDlpVersionSettings';
 import { useAuth } from '../contexts/AuthContext';
 import { useDownload } from '../contexts/DownloadContext';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -513,6 +514,7 @@ const SettingsPage: React.FC = () => {
             </Box>
             <Box>
                 <Typography variant="h6" gutterBottom sx={{ mt: 2 }}>{t('ytDlpConfiguration') || 'yt-dlp Configuration'}</Typography>
+                <YtDlpVersionSettings canUpdate={canUseContainerAdminFeatures} />
                 {canUseContainerAdminFeatures ? (
                     <YtDlpSettings
                         config={settings.ytDlpConfig || ''}

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -290,6 +290,12 @@ vi.mock('../../components/Settings/YtDlpSettings', () => ({
   ),
 }));
 
+vi.mock('../../components/Settings/YtDlpVersionSettings', () => ({
+  default: ({ canUpdate }: any) => (
+    <div data-testid="ytdlp-version-settings" data-can-update={String(canUpdate)} />
+  ),
+}));
+
 vi.mock('../../components/Settings/TagsSettings', () => ({
   default: ({ onTagsChange, onRenameTag, onTagConflict }: any) => (
     <div data-testid="tags-settings">

--- a/frontend/src/utils/locales/KEY_LIST.md
+++ b/frontend/src/utils/locales/KEY_LIST.md
@@ -4,7 +4,7 @@ Canonical locale key order derived from `frontend/src/utils/locales/en.ts`.
 
 This list is intentionally unnumbered. When new keys are inserted, only the local section order changes.
 
-Total keys: 1063
+Total keys: 1078
 
 ## Summary
 
@@ -39,7 +39,7 @@ Total keys: 1063
 | Disclaimer | 3 | `disclaimerTitle` | `history` |
 | Existing Video Detection | 16 | `existingVideoDetected` | `changeSettings` |
 | Sorting | 10 | `sort` | `random` |
-| yt-dlp Configuration | 33 | `ytDlpConfiguration` | `subscriptionFilenameTemplateUpdateFailed` |
+| yt-dlp Configuration | 48 | `ytDlpConfiguration` | `subscriptionFilenameTemplateUpdateFailed` |
 | Cloudflare Tunnel | 16 | `cloudflaredTunnel` | `managedInDashboard` |
 | Database Export/Import | 39 | `exportImportDatabase` | `backupDatabasesCleanedUp` |
 | History Filter | 33 | `filterAll` | `browserVideoFormatNotSupported` |
@@ -1125,6 +1125,21 @@ Total keys: 1063
 | `ytDlpConfigurationDocs` |
 | `ytDlpConfigurationDescriptionEnd` |
 | `ytDlpConfigurationPolicyNotice` |
+| `ytDlpVersion` |
+| `ytDlpVersionUnknown` |
+| `ytDlpVersionUnavailable` |
+| `ytDlpVersionCheckFailed` |
+| `ytDlpBinaryPath` |
+| `ytDlpCheckUpdate` |
+| `ytDlpUpdate` |
+| `ytDlpUpdateAvailable` |
+| `ytDlpUpToDate` |
+| `ytDlpUpdateInProgress` |
+| `ytDlpUpdateSuccess` |
+| `ytDlpUpdateNoChange` |
+| `ytDlpUpdateFailed` |
+| `ytDlpUpdateCustomPathNotice` |
+| `ytDlpUpdatePolicyNotice` |
 | `mountDirectoriesPolicyNotice` |
 | `customize` |
 | `hide` |

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1230,6 +1230,23 @@ export const ar = {
   ytDlpConfigurationDescriptionEnd: "لمزيد من المعلومات.",
   ytDlpConfigurationPolicyNotice:
     "يتم تعطيل إعدادات yt-dlp الخام بواسطة سياسة أمان النشر في وضع الثقة application.",
+  ytDlpVersion: "إصدار yt-dlp:",
+  ytDlpVersionUnknown: "غير معروف",
+  ytDlpVersionUnavailable: "yt-dlp غير متاح",
+  ytDlpVersionCheckFailed: "تعذّرت قراءة إصدار yt-dlp.",
+  ytDlpBinaryPath: "الملف التنفيذي: {path}",
+  ytDlpCheckUpdate: "التحقق من التحديثات",
+  ytDlpUpdate: "تحديث yt-dlp",
+  ytDlpUpdateAvailable: "يتوفر تحديث: {version}",
+  ytDlpUpToDate: "محدَّث",
+  ytDlpUpdateInProgress: "جارٍ تحديث yt-dlp. قد يستغرق ذلك بضع دقائق.",
+  ytDlpUpdateSuccess: "تم تحديث yt-dlp إلى {version}.",
+  ytDlpUpdateNoChange: "yt-dlp محدَّث بالفعل إلى أحدث إصدار متاح.",
+  ytDlpUpdateFailed: "فشل تحديث yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "يحدد YT_DLP_PATH ملفًا تنفيذيًا بعينه، لذا لا يستطيع MyTube تحديثه. حدّثه بنفسك أو أزل YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "يتم تعطيل تحديث yt-dlp بواسطة سياسة أمان النشر في وضع الثقة application.",
   mountDirectoriesPolicyNotice:
     "تتطلب أدلة الربط ثقة مدير على مستوى المضيف.",
   customize: "تخصيص",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1275,6 +1275,23 @@ export const de = {
   ytDlpConfigurationDescriptionEnd: "für weitere Informationen.",
   ytDlpConfigurationPolicyNotice:
     "Die rohe yt-dlp-Konfiguration ist im Vertrauensmodus application durch die Sicherheitsrichtlinie der Bereitstellung deaktiviert.",
+  ytDlpVersion: "yt-dlp-Version:",
+  ytDlpVersionUnknown: "unbekannt",
+  ytDlpVersionUnavailable: "yt-dlp ist nicht verfügbar",
+  ytDlpVersionCheckFailed: "Die yt-dlp-Version konnte nicht gelesen werden.",
+  ytDlpBinaryPath: "Binärdatei: {path}",
+  ytDlpCheckUpdate: "Nach Updates suchen",
+  ytDlpUpdate: "yt-dlp aktualisieren",
+  ytDlpUpdateAvailable: "Update verfügbar: {version}",
+  ytDlpUpToDate: "Aktuell",
+  ytDlpUpdateInProgress: "yt-dlp wird aktualisiert. Das kann einige Minuten dauern.",
+  ytDlpUpdateSuccess: "yt-dlp wurde auf {version} aktualisiert.",
+  ytDlpUpdateNoChange: "yt-dlp ist bereits auf der neuesten verfügbaren Version.",
+  ytDlpUpdateFailed: "yt-dlp konnte nicht aktualisiert werden.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH legt eine bestimmte Binärdatei fest, daher kann MyTube sie nicht aktualisieren. Aktualisiere sie selbst oder entferne YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "Das Aktualisieren von yt-dlp ist im Vertrauensmodus application durch die Sicherheitsrichtlinie der Bereitstellung deaktiviert.",
   mountDirectoriesPolicyNotice:
     "Mount-Verzeichnisse erfordern Admin-Vertrauen auf Host-Ebene.",
   customize: "Anpassen",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1234,6 +1234,23 @@ export const en = {
   ytDlpConfigurationDescriptionEnd: "for more information.",
   ytDlpConfigurationPolicyNotice:
     "Raw yt-dlp configuration is disabled by deployment security policy in application trust mode.",
+  ytDlpVersion: "yt-dlp version:",
+  ytDlpVersionUnknown: "unknown",
+  ytDlpVersionUnavailable: "yt-dlp is not available",
+  ytDlpVersionCheckFailed: "Failed to read the yt-dlp version.",
+  ytDlpBinaryPath: "Binary: {path}",
+  ytDlpCheckUpdate: "Check for updates",
+  ytDlpUpdate: "Update yt-dlp",
+  ytDlpUpdateAvailable: "Update available: {version}",
+  ytDlpUpToDate: "Up to date",
+  ytDlpUpdateInProgress: "Updating yt-dlp. This can take a couple of minutes.",
+  ytDlpUpdateSuccess: "yt-dlp updated to {version}.",
+  ytDlpUpdateNoChange: "yt-dlp is already at the newest available version.",
+  ytDlpUpdateFailed: "Failed to update yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH pins a specific binary, so MyTube cannot update it. Update that binary yourself or unset YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "Updating yt-dlp is disabled by deployment security policy in application trust mode.",
   mountDirectoriesPolicyNotice:
     "Mount directories require host-level admin trust.",
   customize: "Customize",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1273,6 +1273,23 @@ export const es = {
   ytDlpConfigurationDescriptionEnd: "para más información.",
   ytDlpConfigurationPolicyNotice:
     "La configuración sin procesar de yt-dlp está deshabilitada por la política de seguridad del despliegue en el modo de confianza application.",
+  ytDlpVersion: "Versión de yt-dlp:",
+  ytDlpVersionUnknown: "desconocida",
+  ytDlpVersionUnavailable: "yt-dlp no está disponible",
+  ytDlpVersionCheckFailed: "No se pudo leer la versión de yt-dlp.",
+  ytDlpBinaryPath: "Binario: {path}",
+  ytDlpCheckUpdate: "Buscar actualizaciones",
+  ytDlpUpdate: "Actualizar yt-dlp",
+  ytDlpUpdateAvailable: "Actualización disponible: {version}",
+  ytDlpUpToDate: "Actualizado",
+  ytDlpUpdateInProgress: "Actualizando yt-dlp. Esto puede tardar unos minutos.",
+  ytDlpUpdateSuccess: "yt-dlp se actualizó a {version}.",
+  ytDlpUpdateNoChange: "yt-dlp ya está en la versión más reciente disponible.",
+  ytDlpUpdateFailed: "No se pudo actualizar yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH fija un binario específico, por lo que MyTube no puede actualizarlo. Actualiza ese binario por tu cuenta o quita YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "La actualización de yt-dlp está deshabilitada por la política de seguridad del despliegue en el modo de confianza application.",
   mountDirectoriesPolicyNotice:
     "Los directorios montados requieren confianza de administrador a nivel de host.",
   customize: "Personalizar",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1278,6 +1278,23 @@ export const fr = {
   ytDlpConfigurationDescriptionEnd: "pour plus d'informations.",
   ytDlpConfigurationPolicyNotice:
     "La configuration brute de yt-dlp est désactivée par la politique de sécurité du déploiement en mode de confiance application.",
+  ytDlpVersion: "Version de yt-dlp :",
+  ytDlpVersionUnknown: "inconnue",
+  ytDlpVersionUnavailable: "yt-dlp n'est pas disponible",
+  ytDlpVersionCheckFailed: "Impossible de lire la version de yt-dlp.",
+  ytDlpBinaryPath: "Binaire : {path}",
+  ytDlpCheckUpdate: "Rechercher des mises à jour",
+  ytDlpUpdate: "Mettre à jour yt-dlp",
+  ytDlpUpdateAvailable: "Mise à jour disponible : {version}",
+  ytDlpUpToDate: "À jour",
+  ytDlpUpdateInProgress: "Mise à jour de yt-dlp en cours. Cela peut prendre quelques minutes.",
+  ytDlpUpdateSuccess: "yt-dlp a été mis à jour vers {version}.",
+  ytDlpUpdateNoChange: "yt-dlp est déjà à la version la plus récente disponible.",
+  ytDlpUpdateFailed: "Échec de la mise à jour de yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH fixe un binaire précis, MyTube ne peut donc pas le mettre à jour. Mettez-le à jour vous-même ou supprimez YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "La mise à jour de yt-dlp est désactivée par la politique de sécurité du déploiement en mode de confiance application.",
   mountDirectoriesPolicyNotice:
     "Les répertoires montés nécessitent une confiance administrateur au niveau de l'hôte.",
   customize: "Personnaliser",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1257,6 +1257,23 @@ export const ja = {
   ytDlpConfigurationDescriptionEnd: "をご覧ください。",
   ytDlpConfigurationPolicyNotice:
     "application 信頼モードでは、生の yt-dlp 設定はデプロイのセキュリティポリシーにより無効化されます。",
+  ytDlpVersion: "yt-dlp バージョン:",
+  ytDlpVersionUnknown: "不明",
+  ytDlpVersionUnavailable: "yt-dlp を利用できません",
+  ytDlpVersionCheckFailed: "yt-dlp のバージョンを取得できませんでした。",
+  ytDlpBinaryPath: "実行ファイル: {path}",
+  ytDlpCheckUpdate: "更新を確認",
+  ytDlpUpdate: "yt-dlp を更新",
+  ytDlpUpdateAvailable: "更新があります: {version}",
+  ytDlpUpToDate: "最新です",
+  ytDlpUpdateInProgress: "yt-dlp を更新しています。数分かかる場合があります。",
+  ytDlpUpdateSuccess: "yt-dlp を {version} に更新しました。",
+  ytDlpUpdateNoChange: "yt-dlp はすでに最新バージョンです。",
+  ytDlpUpdateFailed: "yt-dlp の更新に失敗しました。",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH で実行ファイルが固定されているため、MyTube は更新できません。手動で更新するか YT_DLP_PATH を解除してください。",
+  ytDlpUpdatePolicyNotice:
+    "application 信頼モードでは、yt-dlp の更新はデプロイのセキュリティポリシーにより無効化されます。",
   mountDirectoriesPolicyNotice:
     "マウントディレクトリにはホストレベルの管理者信頼が必要です。",
   customize: "カスタマイズ",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1238,6 +1238,23 @@ export const ko = {
   ytDlpConfigurationDescriptionEnd: "에서 자세한 정보를 확인하세요.",
   ytDlpConfigurationPolicyNotice:
     "application 신뢰 모드에서는 배포 보안 정책에 따라 원시 yt-dlp 설정이 비활성화됩니다.",
+  ytDlpVersion: "yt-dlp 버전:",
+  ytDlpVersionUnknown: "알 수 없음",
+  ytDlpVersionUnavailable: "yt-dlp를 사용할 수 없습니다",
+  ytDlpVersionCheckFailed: "yt-dlp 버전을 읽지 못했습니다.",
+  ytDlpBinaryPath: "실행 파일: {path}",
+  ytDlpCheckUpdate: "업데이트 확인",
+  ytDlpUpdate: "yt-dlp 업데이트",
+  ytDlpUpdateAvailable: "업데이트 가능: {version}",
+  ytDlpUpToDate: "최신 상태",
+  ytDlpUpdateInProgress: "yt-dlp를 업데이트하는 중입니다. 몇 분 정도 걸릴 수 있습니다.",
+  ytDlpUpdateSuccess: "yt-dlp를 {version}(으)로 업데이트했습니다.",
+  ytDlpUpdateNoChange: "yt-dlp는 이미 최신 버전입니다.",
+  ytDlpUpdateFailed: "yt-dlp 업데이트에 실패했습니다.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH가 특정 실행 파일을 지정하고 있어 MyTube가 업데이트할 수 없습니다. 직접 업데이트하거나 YT_DLP_PATH를 해제하세요.",
+  ytDlpUpdatePolicyNotice:
+    "application 신뢰 모드에서는 배포 보안 정책에 따라 yt-dlp 업데이트가 비활성화됩니다.",
   mountDirectoriesPolicyNotice:
     "마운트 디렉토리는 호스트 수준의 관리자 신뢰가 필요합니다.",
   customize: "사용자 지정",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1263,6 +1263,23 @@ export const pt = {
   ytDlpConfigurationDescriptionEnd: "para mais informações.",
   ytDlpConfigurationPolicyNotice:
     "A configuração bruta do yt-dlp é desativada pela política de segurança da implantação no modo de confiança application.",
+  ytDlpVersion: "Versão do yt-dlp:",
+  ytDlpVersionUnknown: "desconhecida",
+  ytDlpVersionUnavailable: "yt-dlp não está disponível",
+  ytDlpVersionCheckFailed: "Falha ao ler a versão do yt-dlp.",
+  ytDlpBinaryPath: "Binário: {path}",
+  ytDlpCheckUpdate: "Verificar atualizações",
+  ytDlpUpdate: "Atualizar yt-dlp",
+  ytDlpUpdateAvailable: "Atualização disponível: {version}",
+  ytDlpUpToDate: "Atualizado",
+  ytDlpUpdateInProgress: "Atualizando o yt-dlp. Isso pode levar alguns minutos.",
+  ytDlpUpdateSuccess: "yt-dlp atualizado para {version}.",
+  ytDlpUpdateNoChange: "O yt-dlp já está na versão mais recente disponível.",
+  ytDlpUpdateFailed: "Falha ao atualizar o yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "O YT_DLP_PATH fixa um binário específico, então o MyTube não pode atualizá-lo. Atualize esse binário você mesmo ou remova o YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "A atualização do yt-dlp é desativada pela política de segurança da implantação no modo de confiança application.",
   mountDirectoriesPolicyNotice:
     "Diretórios montados exigem confiança de administrador no nível do host.",
   customize: "Personalizar",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1256,6 +1256,23 @@ export const ru = {
   ytDlpConfigurationDescriptionEnd: "для получения дополнительной информации.",
   ytDlpConfigurationPolicyNotice:
     "Сырая конфигурация yt-dlp отключена политикой безопасности развертывания в режиме доверия application.",
+  ytDlpVersion: "Версия yt-dlp:",
+  ytDlpVersionUnknown: "неизвестно",
+  ytDlpVersionUnavailable: "yt-dlp недоступен",
+  ytDlpVersionCheckFailed: "Не удалось получить версию yt-dlp.",
+  ytDlpBinaryPath: "Исполняемый файл: {path}",
+  ytDlpCheckUpdate: "Проверить обновления",
+  ytDlpUpdate: "Обновить yt-dlp",
+  ytDlpUpdateAvailable: "Доступно обновление: {version}",
+  ytDlpUpToDate: "Актуальная версия",
+  ytDlpUpdateInProgress: "Идет обновление yt-dlp. Это может занять несколько минут.",
+  ytDlpUpdateSuccess: "yt-dlp обновлен до {version}.",
+  ytDlpUpdateNoChange: "yt-dlp уже обновлен до последней доступной версии.",
+  ytDlpUpdateFailed: "Не удалось обновить yt-dlp.",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH закрепляет конкретный исполняемый файл, поэтому MyTube не может его обновить. Обновите его самостоятельно или уберите YT_DLP_PATH.",
+  ytDlpUpdatePolicyNotice:
+    "В режиме доверия application обновление yt-dlp отключено политикой безопасности развертывания.",
   mountDirectoriesPolicyNotice:
     "Подключенные директории требуют доверия администратора на уровне хоста.",
   customize: "Настроить",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1205,6 +1205,23 @@ export const zh = {
   ytDlpConfigurationDescriptionEnd: "了解更多信息。",
   ytDlpConfigurationPolicyNotice:
     "在 application 信任模式下，原始 yt-dlp 配置会被部署安全策略禁用。",
+  ytDlpVersion: "yt-dlp 版本：",
+  ytDlpVersionUnknown: "未知",
+  ytDlpVersionUnavailable: "yt-dlp 不可用",
+  ytDlpVersionCheckFailed: "读取 yt-dlp 版本失败。",
+  ytDlpBinaryPath: "可执行文件：{path}",
+  ytDlpCheckUpdate: "检查更新",
+  ytDlpUpdate: "更新 yt-dlp",
+  ytDlpUpdateAvailable: "有可用更新：{version}",
+  ytDlpUpToDate: "已是最新",
+  ytDlpUpdateInProgress: "正在更新 yt-dlp，可能需要几分钟。",
+  ytDlpUpdateSuccess: "yt-dlp 已更新到 {version}。",
+  ytDlpUpdateNoChange: "yt-dlp 已经是最新版本。",
+  ytDlpUpdateFailed: "更新 yt-dlp 失败。",
+  ytDlpUpdateCustomPathNotice:
+    "YT_DLP_PATH 指定了固定的可执行文件，MyTube 无法更新它。请自行更新该文件或取消设置 YT_DLP_PATH。",
+  ytDlpUpdatePolicyNotice:
+    "在 application 信任模式下，更新 yt-dlp 会被部署安全策略禁用。",
   mountDirectoriesPolicyNotice:
     "挂载目录功能需要 host 级管理员信任。",
   customize: "自定义",


### PR DESCRIPTION
Closes #416
Closes #417

Both issues come from the same reporter and the same root cause: the image pinned a yt-dlp with a known regression, and there was no way to see or change that version without rebuilding.

## #416 — bump the pin

`yt-dlp` 2026.6.9 → **2026.8.19**, which fixes the "The page needs to be reloaded" failure that broke YouTube downloads. `curl-cffi` 0.15.0 → 0.16.0 to match the `pin-curl-cffi` extra of the new release; `yt-dlp-ejs` stays at 0.8.0.

`bgutil-ytdlp-pot-provider` deliberately stays at 1.2.2 — it is coupled to the vendored Node server under `backend/bgutil-ytdlp-pot-provider/server`, so bumping it (1.3.2 is out) means updating the bundle too. Out of scope here.

## #417 — see and update yt-dlp from the UI

Settings → yt-dlp Configuration now shows the version of the binary the backend actually spawns, compares it against the latest PyPI release, and offers an in-place update.

- `GET /api/settings/ytdlp/version` — version, resolved path, staleness. Probes only the local binary by default; PyPI is queried only with `checkLatest=true`, which the UI sends solely when the operator clicks **Check for updates**. An unreachable PyPI degrades to "no comparison" instead of failing the probe.
- `POST /api/settings/ytdlp/update` — runs the upgrade, drops the cached path and capability probes, re-reads the version. Requires `container` admin trust, returns 409 when `YT_DLP_PATH` pins a specific binary (pip would install elsewhere), and shares one pip run between concurrent callers.

Reuses the existing `versionProbe.ts` / `install.ts` machinery rather than adding a second path.

### Two follow-up fixes to the update path

- It now installs `yt-dlp[default,curl-cffi]` instead of naming yt-dlp's companions by hand. The old list omitted `yt-dlp-ejs` entirely, so an upgraded yt-dlp could sit next to the solver pinned by the *previous* release. Letting pip read the pins off the target release keeps them in lockstep. Verified by dry run: resolves yt-dlp 2026.8.19, yt-dlp-ejs 0.8.0, curl_cffi 0.16.1.
- The bundled bgutil POT provider is no longer handed to pip. `getYtDlpSpawnEnv()` puts the bundled plugin at the front of `PYTHONPATH` and the provider's Node server ships with the image, so the pip copy is loaded by nothing — upgrading it reported progress that never reached the yt-dlp process.

## Runtime updates persist — documented, not changed

A runtime update is a `pip --user` into `$HOME`, which `entrypoint.sh` points at `/app/data/.home` — persistent in the supplied Compose stacks. It outlives container recreation and keeps shadowing the image pin, so **rolling back the image does not roll back yt-dlp**. The Dockerfile comment claimed the opposite; that is corrected, and the docker guide now documents the persistence, a working removal procedure, and pinning with an absolute `YT_DLP_PATH`.

The install location itself is unchanged. That behaviour predates this PR (it is how the existing auto-install and staleness auto-upgrade work), and moving it deserves its own change.

## Testing

- backend: 2868 passing (new: `ytDlpMaintenance.test.ts`, `ytDlpController.test.ts`, plus a case for skipping the pip provider when a bundle is present)
- frontend: 1798 passing (new: `YtDlpVersionSettings.test.tsx`)
- both typecheck clean, eslint clean
- exercised against a live dev server: the endpoint correctly reported the local install as 2026.06.09 with 2026.8.19 available, and the panel rendered it

The **Update yt-dlp** button was not clicked during verification — it would have pip-upgraded yt-dlp on the dev machine.

## Resolved since the draft was opened

- **No implicit outbound requests.** The version endpoint no longer calls pypi.org as a side effect of reading local status; the lookup is opt-in per request, `getYtDlpStatus()` defaults to not checking, and the post-update re-probe stays local. Covered by tests on both sides.
- **The image binary path is now asserted, not assumed.** `/usr/local/bin/yt-dlp` was verified against `node:22-bookworm-slim` with the same apt/pip steps this image uses, and the build now fails with a message pointing at the docker guide if pip ever lands the console script elsewhere — the guide's `YT_DLP_PATH` example hardcodes that path.

## Open items before undrafting

- Locale strings for the 9 non-English languages are unreviewed by a native speaker.
- Minor, and a deliberate choice either way: a completed update check is cached for the app-wide 5 minute `staleTime`. Remounting the Settings tab after that refetches without `checkLatest`, so the "Update available" chip disappears until the operator checks again. Showing nothing is the honest state once the answer is stale, but pinning a longer `staleTime` on this query would make the finding stick for the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

