### PR TITLE
feat(ytdlp): publish yt-dlp updates as immutable managed releases

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -103,3 +103,48 @@ jobs:
           -r frontend/coverage/lcov.info
 
         bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+
+  # The managed yt-dlp release store publishes by atomic rename and builds an
+  # explicit `<python> -m yt_dlp` command line. Both behave differently on
+  # Windows (MoveFileEx replace semantics, sharing violations from an open
+  # reader, `;` as the PYTHONPATH delimiter), so this subset runs on all three
+  # platforms. The full backend suite stays on Linux only.
+  ytdlp-release-store:
+    name: yt-dlp release store (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      # This subset never touches media tooling, Chromium, or the POT provider.
+      SKIP_FFMPEG_AUTO_INSTALL: '1'
+      SKIP_PROVIDER_BUILD: '1'
+      PUPPETEER_SKIP_DOWNLOAD: '1'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js 22.22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.22.x
+        cache: 'npm'
+        cache-dependency-path: backend/package-lock.json
+
+    - name: Install Backend Dependencies
+      working-directory: backend
+      run: npm ci
+
+    - name: Test yt-dlp Release Store
+      working-directory: backend
+      run: >-
+        npx vitest run
+        src/__tests__/utils/ytdlpManagedRelease.test.ts
+        src/__tests__/utils/ytdlpReleaseConcurrency.test.ts
+        src/__tests__/utils/ytdlpReleaseFailureInjection.test.ts
+        src/__tests__/utils/ytdlpReleaseIntegration.test.ts
+        src/__tests__/utils/ytdlpReleaseValidation.test.ts
+        src/__tests__/utils/ytdlpSpawnBoundary.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ codeql-reports/
 # Reports
 reports/*
 .lighthouseci/
+
+# Codacy CLI local snapshots (auto-generated; the shared config is .codacy/codacy.yaml)
+.codacy/codacy.config.json
+.codacy/codacy.config.baseline.json

--- a/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
+++ b/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
@@ -1,5 +1,6 @@
 
 import { spawn } from 'child_process';
+import { EventEmitter } from 'events';
 import fs from 'fs-extra';
 import puppeteer from 'puppeteer';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -43,14 +44,7 @@ vi.mock('../../../utils/security', async (importOriginal) => {
   };
 });
 vi.mock('child_process', () => ({
-  spawn: vi.fn().mockReturnValue({
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
-    on: vi.fn((event: string, cb: (code: number) => void) => {
-      if (event === 'close') cb(1); // immediate non-zero exit; caught by .catch(() => {})
-    }),
-    kill: vi.fn(),
-  }),
+  spawn: vi.fn(),
 }));
 vi.mock('fs-extra', () => ({
   default: {
@@ -71,6 +65,36 @@ vi.mock('fs-extra', () => ({
   },
 }));
 
+
+function createAutoClosingSpawnProc(code = 1): any {
+  const proc: {
+    stdout: { on: ReturnType<typeof vi.fn> };
+    stderr: { on: ReturnType<typeof vi.fn> };
+    killed: boolean;
+    exitCode: number;
+    kill: ReturnType<typeof vi.fn>;
+    on: ReturnType<typeof vi.fn>;
+    once: ReturnType<typeof vi.fn>;
+  } = {
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    killed: false,
+    exitCode: code,
+    kill: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+  };
+  proc.on.mockImplementation((event: string, cb: (code: number) => void) => {
+    if (event === 'close') queueMicrotask(() => cb(code));
+    return proc;
+  });
+  proc.once.mockImplementation((event: string, cb: (code: number) => void) => {
+    if (event === 'close') queueMicrotask(() => cb(code));
+    return proc;
+  });
+  return proc;
+}
+
 describe('MissAVDownloader', () => {
   const expectedChromeFallbackPath =
     process.platform === 'darwin'
@@ -80,6 +104,7 @@ describe('MissAVDownloader', () => {
         : '/usr/bin/google-chrome-stable';
 
   beforeEach(() => {
+    vi.mocked(spawn).mockImplementation(() => createAutoClosingSpawnProc(1));
     vi.mocked(fs.existsSync).mockReturnValue(false);
     vi.mocked(security.pathExistsTrustedSync).mockReturnValue(false);
     vi.mocked(storageService.getSettings).mockReturnValue({} as any);
@@ -88,6 +113,7 @@ describe('MissAVDownloader', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.mocked(spawn).mockImplementation(() => createAutoClosingSpawnProc(1));
     delete process.env.PUPPETEER_EXECUTABLE_PATH;
     delete process.env.PUPPETEER_HEADLESS;
   });
@@ -414,10 +440,11 @@ describe('MissAVDownloader', () => {
       await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
 
       // The URL resolved by waitForResponse must have been selected and forwarded to yt-dlp
-      expect(spawn).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.arrayContaining(['https://surrit.com/playlist.m3u8']),
-      );
+      expect(
+        vi.mocked(spawn).mock.calls.some(
+          ([, args]) => Array.isArray(args) && args.includes('https://surrit.com/playlist.m3u8'),
+        ),
+      ).toBe(true);
     });
 
     it('uses the global --impersonate flag (not the generic extractor-arg) to bypass the Cloudflare CDN block', async () => {
@@ -540,19 +567,53 @@ describe('MissAVDownloader', () => {
       (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
       (isCancellationError as ReturnType<typeof vi.fn>).mockReturnValueOnce(true);
 
-      let closeHandler: ((code: number | null, signal: NodeJS.Signals | null) => void) | null = null;
-      const mockChild: any = {
-        stdout: { on: vi.fn() },
-        stderr: { on: vi.fn() },
-        on: vi.fn((event: string, cb: (code: number | null, signal: NodeJS.Signals | null) => void) => {
-          if (event === 'close') closeHandler = cb;
-        }),
-        kill: vi.fn(() => {
-          closeHandler?.(null, 'SIGTERM');
-          return true;
-        }),
+      const mockChild = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+        killed: boolean;
+        exitCode: number | null;
+        pid: number;
+        kill: ReturnType<typeof vi.fn>;
       };
-      (spawn as ReturnType<typeof vi.fn>).mockReturnValueOnce(mockChild);
+      mockChild.stdout = new EventEmitter();
+      mockChild.stderr = new EventEmitter();
+      mockChild.killed = false;
+      mockChild.exitCode = null;
+      mockChild.pid = 4242;
+      mockChild.kill = vi.fn((signal?: NodeJS.Signals) => {
+        mockChild.killed = true;
+        mockChild.emit('close', null, signal ?? 'SIGTERM');
+        return true;
+      });
+      (spawn as ReturnType<typeof vi.fn>).mockImplementation((command: string, args?: string[]) => {
+        const list = Array.isArray(args) ? args : [];
+        if (
+          list.includes('--version') ||
+          list.includes('--help') ||
+          list.includes('--list-impersonate-targets')
+        ) {
+          const probe: any = {
+            stdout: { on: vi.fn() },
+            stderr: { on: vi.fn() },
+            killed: false,
+            exitCode: 0,
+            kill: vi.fn(),
+            on: vi.fn(),
+            once: vi.fn(),
+          };
+          const finish = (cb: (code: number) => void) => queueMicrotask(() => cb(0));
+          probe.on.mockImplementation((event: string, cb: (code: number) => void) => {
+            if (event === 'close') finish(cb);
+            return probe;
+          });
+          probe.once.mockImplementation((event: string, cb: (code: number) => void) => {
+            if (event === 'close') finish(cb);
+            return probe;
+          });
+          return probe;
+        }
+        return mockChild;
+      });
 
       let cancelDownload: (() => void | Promise<void>) | undefined;
       const downloadPromise = MissAVDownloader.downloadVideo(
@@ -563,7 +624,11 @@ describe('MissAVDownloader', () => {
         },
       );
 
-      await new Promise((resolve) => setImmediate(resolve));
+      await vi.waitFor(() => {
+        if (!cancelDownload) {
+          throw new Error('cancel callback not registered yet');
+        }
+      });
       await cancelDownload?.();
 
       await expect(downloadPromise).rejects.toThrow('Download cancelled by user');
@@ -606,10 +671,11 @@ describe('MissAVDownloader', () => {
       await MissAVDownloader.downloadVideo('https://missav.com/test-video').catch(() => {});
 
       expect(mockPage.waitForResponse).not.toHaveBeenCalled();
-      expect(spawn).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.arrayContaining(['https://surrit.com/playlist.m3u8']),
-      );
+      expect(
+        vi.mocked(spawn).mock.calls.some(
+          ([, args]) => Array.isArray(args) && args.includes('https://surrit.com/playlist.m3u8'),
+        ),
+      ).toBe(true);
       expect(mockBrowser.close).toHaveBeenCalled();
     });
 

--- a/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
+++ b/backend/src/__tests__/utils/ytDlpMaintenance.test.ts
@@ -47,7 +47,7 @@ describe("yt-dlp maintenance", () => {
     vi.clearAllMocks();
     // mockImplementation set by a previous test survives clearAllMocks.
     installMock.mockReset();
-    installMock.mockResolvedValue(undefined);
+    installMock.mockResolvedValue({ published: true });
     customPathMock.mockReturnValue(false);
     axiosGet.mockResolvedValue({ data: { info: { version: "2026.8.19" } } });
     versionProbeMock.mockResolvedValue(versionInfo("2026.08.19"));
@@ -147,7 +147,7 @@ describe("yt-dlp maintenance", () => {
 
       const result = await updateYtDlp();
 
-      expect(installMock).toHaveBeenCalledWith({ upgrade: true });
+      expect(installMock).toHaveBeenCalledWith({ upgrade: true, currentIsUsable: true });
       expect(result.previousVersion).toBe("2026.06.09");
       expect(result.status.version).toBe("2026.08.19");
       expect(result.changed).toBe(true);
@@ -163,8 +163,8 @@ describe("yt-dlp maintenance", () => {
 
     it("shares one pip run between concurrent callers", async () => {
       let releaseInstall: () => void = () => {};
-      const installGate = new Promise<void>((resolve) => {
-        releaseInstall = resolve;
+      const installGate = new Promise<{ published: boolean }>((resolve) => {
+        releaseInstall = () => resolve({ published: true });
       });
       installMock.mockReturnValue(installGate);
 
@@ -182,7 +182,7 @@ describe("yt-dlp maintenance", () => {
 
       await expect(updateYtDlp()).rejects.toThrow("pip missing");
 
-      installMock.mockResolvedValueOnce(undefined);
+      installMock.mockResolvedValueOnce({ published: true });
       await expect(updateYtDlp()).resolves.toMatchObject({ changed: false });
     });
   });

--- a/backend/src/__tests__/utils/ytDlpUtils.test.ts
+++ b/backend/src/__tests__/utils/ytDlpUtils.test.ts
@@ -26,6 +26,7 @@ import {
   resetYtDlpAvailabilityCacheForTests,
 } from "../../utils/ytDlpUtils";
 import { installYtDlp } from "../../utils/ytdlp/install";
+import { installManagedRelease } from "../../utils/ytdlp/release";
 import { logger } from "../../utils/logger";
 
 vi.mock("child_process", () => ({
@@ -47,6 +48,30 @@ vi.mock("socks-proxy-agent", () => ({
     };
   }),
 }));
+function publishOutcome(
+  releaseId: string,
+  generation: number,
+  previousReleaseId: string | null = null
+) {
+  return {
+    published: true,
+    current: {
+      schemaVersion: 1 as const,
+      generation,
+      releaseId,
+      previousReleaseId,
+      publishedAt: new Date().toISOString(),
+    },
+  };
+}
+
+vi.mock("../../utils/ytdlp/release", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../utils/ytdlp/release")>();
+  return {
+    ...actual,
+    installManagedRelease: vi.fn(async () => publishOutcome("rel-test", 1)),
+  };
+});
 
 type MockProcess = EventEmitter & {
   stdout: PassThrough | null;
@@ -102,59 +127,129 @@ const createHelpCheckProcess = (flagStyle: JsRuntimeFlagStyle = "plural"): MockP
   return proc;
 };
 
+const createImpersonateCheckProcess = (): MockProcess => {
+  const proc = createMockProcess();
+  queueMicrotask(() => {
+    proc.stdout?.emit(
+      "data",
+      Buffer.from("chrome        curl_cffi\n")
+    );
+    proc.emit("close", 0);
+  });
+  return proc;
+};
+
+const isProbeArgs = (
+  args: readonly string[] | undefined,
+  flag: string
+): boolean => Array.isArray(args) && args.length === 1 && args[0] === flag;
+
+const mockRoutedYtDlpSpawn = (
+  options: {
+    helpStyle?: JsRuntimeFlagStyle;
+    version?: string;
+    denoProc?: MockProcess;
+  },
+  ...commandProcesses: MockProcess[]
+) => {
+  const queue = [...commandProcesses];
+  vi.mocked(spawn).mockImplementation((command: string, args?: readonly string[]) => {
+    if (command === "deno") {
+      return (options.denoProc ?? createDenoCheckProcess()) as any;
+    }
+    if (isProbeArgs(args, "--version")) {
+      return createVersionCheckProcess(options.version) as any;
+    }
+    if (isProbeArgs(args, "--help")) {
+      return createHelpCheckProcess(options.helpStyle ?? "plural") as any;
+    }
+    if (Array.isArray(args) && args.includes("--list-impersonate-targets")) {
+      return createImpersonateCheckProcess() as any;
+    }
+    const next = queue.shift();
+    return (next ?? createMockProcess()) as any;
+  });
+};
+
 const mockSpawnWithVersionCheck = (...processes: MockProcess[]) => {
-  vi.mocked(spawn).mockImplementationOnce(() => createVersionCheckProcess() as any);
-  for (const proc of processes) {
-    vi.mocked(spawn).mockImplementationOnce(() => proc as any);
-  }
+  mockRoutedYtDlpSpawn({ helpStyle: "none" }, ...processes);
 };
 
 const mockSpawnWithVersionAndHelpCheck = (
   flagStyle: JsRuntimeFlagStyle = "plural",
   ...processes: MockProcess[]
 ) => {
-  vi.mocked(spawn).mockImplementationOnce(() => createVersionCheckProcess() as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  for (const proc of processes) {
-    vi.mocked(spawn).mockImplementationOnce(() => proc as any);
-  }
+  mockRoutedYtDlpSpawn({ helpStyle: flagStyle }, ...processes);
 };
 
 const mockSpawnWithVersionHelpAndDenoCheck = (
   flagStyle: JsRuntimeFlagStyle = "plural",
   ...processes: MockProcess[]
 ) => {
-  vi.mocked(spawn).mockImplementationOnce(() => createVersionCheckProcess() as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createDenoCheckProcess() as any);
-  for (const proc of processes) {
-    vi.mocked(spawn).mockImplementationOnce(() => proc as any);
-  }
+  mockRoutedYtDlpSpawn({ helpStyle: flagStyle }, ...processes);
 };
 
 const mockSpawnWithVersionYouTubeHelpAndDenoCheck = (
   flagStyle: JsRuntimeFlagStyle = "plural",
   ...processes: MockProcess[]
 ) => {
-  vi.mocked(spawn).mockImplementationOnce(() => createVersionCheckProcess() as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createDenoCheckProcess() as any);
-  for (const proc of processes) {
-    vi.mocked(spawn).mockImplementationOnce(() => proc as any);
-  }
+  mockRoutedYtDlpSpawn({ helpStyle: flagStyle }, ...processes);
 };
 
 const mockSpawnWithVersionYouTubeHelpCheck = (
   flagStyle: JsRuntimeFlagStyle = "plural",
   ...processes: MockProcess[]
 ) => {
-  vi.mocked(spawn).mockImplementationOnce(() => createVersionCheckProcess() as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  vi.mocked(spawn).mockImplementationOnce(() => createHelpCheckProcess(flagStyle) as any);
-  for (const proc of processes) {
-    vi.mocked(spawn).mockImplementationOnce(() => proc as any);
-  }
+  mockRoutedYtDlpSpawn({ helpStyle: flagStyle }, ...processes);
+};
+
+const mockPathCandidateSpawn = (
+  candidates: Array<{
+    binDir: string;
+    version?: string;
+    helpStyle?: JsRuntimeFlagStyle;
+    versionProc?: MockProcess;
+    helpProc?: MockProcess;
+  }>,
+  commandProc: MockProcess
+) => {
+  vi.mocked(spawn).mockImplementation((command: string, args?: readonly string[]) => {
+    const list = Array.isArray(args) ? args : [];
+    if (command === "deno") {
+      return createDenoCheckProcess() as any;
+    }
+    const candidate = candidates.find(
+      (entry) => command === path.join(entry.binDir, "yt-dlp")
+    );
+    if (candidate) {
+      if (list.includes("--version")) {
+        if (candidate.versionProc) {
+          return candidate.versionProc as any;
+        }
+        return createVersionCheckProcess(candidate.version) as any;
+      }
+      if (list.includes("--help")) {
+        if (candidate.helpProc) {
+          return candidate.helpProc as any;
+        }
+        return createHelpCheckProcess(candidate.helpStyle ?? "none") as any;
+      }
+      if (list.includes("--list-impersonate-targets")) {
+        return createImpersonateCheckProcess() as any;
+      }
+      return commandProc as any;
+    }
+    if (isProbeArgs(list, "--version")) {
+      return createVersionCheckProcess() as any;
+    }
+    if (isProbeArgs(list, "--help")) {
+      return createHelpCheckProcess("plural") as any;
+    }
+    if (list.includes("--list-impersonate-targets")) {
+      return createImpersonateCheckProcess() as any;
+    }
+    return commandProc as any;
+  });
 };
 
 const flushAsyncSpawns = async () => {
@@ -546,112 +641,76 @@ describe("ytDlpUtils", () => {
 
     it("should auto-install when yt-dlp is missing", async () => {
       const versionProc = createMockProcess();
-      const installProc = createMockProcess();
       vi.mocked(spawn)
         .mockImplementationOnce(() => versionProc as any)
-        .mockImplementationOnce(() => installProc as any)
         .mockImplementationOnce(() => createVersionCheckProcess() as any);
 
       const promise = ensureYtDlpAvailable();
       await flushAsyncSpawns();
       versionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
-      await flushAsyncSpawns();
-      installProc.emit("close", 0);
 
       await expect(promise).resolves.toBeUndefined();
-      // No bundled provider is present in this suite (getProviderPluginPath is
-      // mocked to ""), so the pip provider is installed as the fallback.
-      expect(vi.mocked(spawn).mock.calls[1][1]).toEqual([
-        "install",
-        "--user",
-        "yt-dlp[default,curl-cffi]",
-        "bgutil-ytdlp-pot-provider",
-      ]);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalled();
+      expect(
+        vi.mocked(spawn).mock.calls.some(
+          ([, args]) => Array.isArray(args) && args.includes("--user")
+        )
+      ).toBe(false);
     });
 
     it("should serialize concurrent pip runs so two installs never overlap", async () => {
-      // ensureYtDlpAvailable() and the operator-triggered update hold separate
-      // locks, so without a shared mutex both can put pip on the same
-      // user-site directory at once.
-      const pipProcs: MockProcess[] = [];
-      vi.mocked(spawn).mockImplementation(() => {
-        const proc = createMockProcess();
-        pipProcs.push(proc);
-        return proc as any;
+      let releaseInstall: () => void = () => {};
+      const firstGate = new Promise<ReturnType<typeof publishOutcome>>((resolve) => {
+        releaseInstall = () =>
+          resolve(publishOutcome("rel-test", 1));
       });
+      vi.mocked(installManagedRelease)
+        .mockImplementationOnce(() => firstGate)
+        .mockResolvedValue(publishOutcome("rel-test-2", 2, "rel-test"));
 
       const first = installYtDlp();
       const second = installYtDlp({ upgrade: true });
       await flushAsyncSpawns();
 
-      // The second caller is queued: only one pip process exists so far.
-      expect(pipProcs).toHaveLength(1);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalledTimes(2);
 
-      pipProcs[0].emit("close", 0);
-      await flushAsyncSpawns();
-
-      expect(pipProcs).toHaveLength(2);
-      expect(vi.mocked(spawn).mock.calls[1][1]).toContain("-U");
-
-      pipProcs[1].emit("close", 0);
+      releaseInstall();
       await expect(Promise.all([first, second])).resolves.toBeDefined();
     });
 
     it("should keep serializing after a failed pip run", async () => {
-      // Fail every plain install candidate, succeed the upgrade, so the two
-      // queued calls are told apart by their args rather than by call count.
-      vi.mocked(spawn).mockImplementation((_cmd: any, args: any) => {
-        const isUpgrade = Array.isArray(args) && args.includes("-U");
-        const proc = createMockProcess();
-        queueMicrotask(() => proc.emit("close", isUpgrade ? 0 : 1));
-        return proc as any;
-      });
+      vi.mocked(installManagedRelease)
+        .mockRejectedValueOnce(new Error("yt-dlp could not be automatically installed"))
+        .mockResolvedValueOnce(publishOutcome("rel-test", 1));
 
       const failing = installYtDlp();
       const queued = installYtDlp({ upgrade: true });
 
       await expect(failing).rejects.toThrow(/could not be automatically/);
-      // A rejected run must not poison the queue for the caller behind it.
-      await expect(queued).resolves.toBeUndefined();
+      await expect(queued).resolves.toEqual({ published: true });
     });
 
     it("should skip the pip bgutil provider when a bundled provider is present", async () => {
-      // The bundled plugin is injected at the front of PYTHONPATH, so a pip copy
-      // would never be loaded and installing it would report a phantom upgrade.
       vi.mocked(getProviderPluginPath).mockReturnValue("/app/bgutil-ytdlp-pot-provider");
       const versionProc = createMockProcess();
-      const installProc = createMockProcess();
       vi.mocked(spawn)
         .mockImplementationOnce(() => versionProc as any)
-        .mockImplementationOnce(() => installProc as any)
         .mockImplementationOnce(() => createVersionCheckProcess() as any);
 
       const promise = ensureYtDlpAvailable();
       await flushAsyncSpawns();
       versionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
-      await flushAsyncSpawns();
-      installProc.emit("close", 0);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(vi.mocked(spawn).mock.calls[1][1]).toEqual([
-        "install",
-        "--user",
-        "yt-dlp[default,curl-cffi]",
-      ]);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalled();
     });
 
     it("should continue with the current stale yt-dlp when auto-upgrade fails", async () => {
+      vi.mocked(installManagedRelease).mockRejectedValueOnce(
+        new Error("No usable Python interpreter with pip was found.")
+      );
       const staleVersionProc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => staleVersionProc as any)
-        .mockImplementation(() => {
-          const proc = createMockProcess();
-          queueMicrotask(() => {
-            proc.stderr?.emit("data", Buffer.from("install failed\n"));
-            proc.emit("close", 1);
-          });
-          return proc as any;
-        });
+      vi.mocked(spawn).mockImplementationOnce(() => staleVersionProc as any);
 
       const promise = ensureYtDlpAvailable();
       await flushAsyncSpawns();
@@ -659,30 +718,20 @@ describe("ytDlpUtils", () => {
       staleVersionProc.emit("close", 0);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(
-        vi.mocked(spawn).mock.calls.some(
-          ([cmd, args]) => cmd === "pip3" && Array.isArray(args) && args.includes("-U")
-        )
-      ).toBe(true);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalled();
     });
 
-    it("should move an existing user install directory to the front of PATH after auto-upgrade", async () => {
+    it("should not rewrite PATH after a managed auto-upgrade", async () => {
       process.env.YT_DLP_PATH = "yt-dlp";
       process.env.HOME = "/tmp/test-home";
       const userBinDir = path.join(process.env.HOME, ".local", "bin");
-      process.env.PATH = ["/old/bin", userBinDir, "/usr/bin"].join(path.delimiter);
-      const userInstalledYtDlpPath = path.join(userBinDir, "yt-dlp");
-
-      vi.mocked(fs.existsSync).mockImplementation((target: any) => {
-        return String(target) === userInstalledYtDlpPath;
-      });
+      const originalPath = ["/old/bin", userBinDir, "/usr/bin"].join(path.delimiter);
+      process.env.PATH = originalPath;
 
       const staleVersionProc = createMockProcess();
-      const installProc = createMockProcess();
       const freshVersionProc = createMockProcess();
       vi.mocked(spawn)
         .mockImplementationOnce(() => staleVersionProc as any)
-        .mockImplementationOnce(() => installProc as any)
         .mockImplementationOnce(() => freshVersionProc as any);
 
       const promise = ensureYtDlpAvailable();
@@ -690,66 +739,45 @@ describe("ytDlpUtils", () => {
       staleVersionProc.stdout?.emit("data", Buffer.from("2020.01.01\n"));
       staleVersionProc.emit("close", 0);
       await flushAsyncSpawns();
-      installProc.emit("close", 0);
-      await flushAsyncSpawns();
       freshVersionProc.stdout?.emit("data", Buffer.from(`${FRESH_YT_DLP_VERSION}\n`));
       freshVersionProc.emit("close", 0);
 
       await expect(promise).resolves.toBeUndefined();
-
-      const retriedVersionProbe = vi.mocked(spawn).mock.calls[2];
-      expect(retriedVersionProbe?.[0]).toBe("yt-dlp");
-      expect(
-        (
-          retriedVersionProbe?.[2] as { env?: NodeJS.ProcessEnv } | undefined
-        )?.env?.PATH
-      ).toBe(
-        [userBinDir, "/old/bin", "/usr/bin"].join(path.delimiter)
-      );
-      expect(process.env.PATH).toBe(
-        [userBinDir, "/old/bin", "/usr/bin"].join(path.delimiter)
-      );
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalled();
+      expect(process.env.PATH).toBe(originalPath);
     });
 
-    it("should resolve a user-installed yt-dlp outside PATH after auto-install", async () => {
+    it("should not scan ~/.local/bin after a managed auto-install", async () => {
       delete process.env.YT_DLP_PATH;
       process.env.PATH = "/usr/bin";
       process.env.HOME = "/tmp/test-home";
-      const installedYtDlpPath = path.join(
+      const userSiteYtDlp = path.join(
         process.env.HOME,
         ".local",
         "bin",
         "yt-dlp"
       );
 
-      vi.mocked(fs.existsSync).mockImplementation((target: any) => {
-        return String(target) === installedYtDlpPath;
-      });
-
-      const versionProc = createMockProcess();
-      const installProc = createMockProcess();
+      const firstVersionProc = createMockProcess();
+      const secondVersionProc = createMockProcess();
       vi.mocked(spawn)
-        .mockImplementationOnce(() => versionProc as any)
-        .mockImplementationOnce(() => installProc as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("plural") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any);
+        .mockImplementationOnce(() => firstVersionProc as any)
+        .mockImplementationOnce(() => secondVersionProc as any);
 
       const promise = ensureYtDlpAvailable();
       await flushAsyncSpawns();
-      versionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
+      firstVersionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
       await flushAsyncSpawns();
-      installProc.emit("close", 0);
+      secondVersionProc.emit("error", Object.assign(new Error("still missing"), { code: "ENOENT" }));
 
-      await expect(promise).resolves.toBeUndefined();
+      await expect(promise).rejects.toThrow(/still not usable/);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalledTimes(1);
       expect(
-        vi.mocked(fs.existsSync).mock.calls.some(
-          ([target]) => String(target) === installedYtDlpPath
-        )
-      ).toBe(true);
+        vi.mocked(spawn).mock.calls.some(([cmd]) => String(cmd) === userSiteYtDlp)
+      ).toBe(false);
     });
 
-    it("should resolve a Windows user-installed yt-dlp from Python Scripts after auto-install", async () => {
+    it("should not scan Windows Python Scripts after a managed auto-install", async () => {
       const originalPlatform = process.platform;
       Object.defineProperty(process, "platform", {
         value: "win32",
@@ -764,43 +792,31 @@ describe("ytDlpUtils", () => {
         process.env.APPDATA = "/tmp/test-user/AppData/Roaming";
         delete process.env.LOCALAPPDATA;
 
-        const scriptsRoot = path.join(process.env.APPDATA, "Python");
-        const installedYtDlpPath = path.join(
-          scriptsRoot,
+        const scriptsYtDlp = path.join(
+          process.env.APPDATA,
+          "Python",
           "Python313",
           "Scripts",
           "yt-dlp.exe"
         );
 
-        vi.mocked(fs.readdirSync).mockImplementation((target: any) => {
-          if (String(target) === scriptsRoot) {
-            return ["Python313"] as any;
-          }
-          throw createMissingFileError();
-        });
-        vi.mocked(fs.existsSync).mockImplementation((target: any) => {
-          return String(target) === installedYtDlpPath;
-        });
-
-        const versionProc = createMockProcess();
-        const installProc = createMockProcess();
+        const firstVersionProc = createMockProcess();
+        const secondVersionProc = createMockProcess();
         vi.mocked(spawn)
-          .mockImplementationOnce(() => versionProc as any)
-          .mockImplementationOnce(() => installProc as any)
-          .mockImplementationOnce(() => createVersionCheckProcess() as any)
-          .mockImplementationOnce(() => createHelpCheckProcess("plural") as any)
-          .mockImplementationOnce(() => createVersionCheckProcess() as any);
+          .mockImplementationOnce(() => firstVersionProc as any)
+          .mockImplementationOnce(() => secondVersionProc as any);
 
         const promise = ensureYtDlpAvailable();
         await flushAsyncSpawns();
-        versionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
+        firstVersionProc.emit("error", Object.assign(new Error("not found"), { code: "ENOENT" }));
         await flushAsyncSpawns();
-        installProc.emit("close", 0);
+        secondVersionProc.emit("error", Object.assign(new Error("still missing"), { code: "ENOENT" }));
 
-        await expect(promise).resolves.toBeUndefined();
+        await expect(promise).rejects.toThrow(/still not usable/);
+        expect(vi.mocked(installManagedRelease)).toHaveBeenCalledTimes(1);
         expect(
-          vi.mocked(spawn).mock.calls.some(([cmd]) => cmd === installedYtDlpPath)
-        ).toBe(true);
+          vi.mocked(spawn).mock.calls.some(([cmd]) => String(cmd) === scriptsYtDlp)
+        ).toBe(false);
       } finally {
         Object.defineProperty(process, "platform", {
           value: originalPlatform,
@@ -810,34 +826,29 @@ describe("ytDlpUtils", () => {
     });
 
     it("should stop retrying auto-install when yt-dlp is still missing after install", async () => {
-      const initialVersionProc = createMockProcess();
-      const installProc = createMockProcess();
+      const firstVersionProc = createMockProcess();
       const secondVersionProc = createMockProcess();
       vi.mocked(spawn)
-        .mockImplementationOnce(() => initialVersionProc as any)
-        .mockImplementationOnce(() => installProc as any)
+        .mockImplementationOnce(() => firstVersionProc as any)
         .mockImplementationOnce(() => secondVersionProc as any);
 
       const promise = ensureYtDlpAvailable();
       await flushAsyncSpawns();
-      initialVersionProc.emit(
+      firstVersionProc.emit(
         "error",
         Object.assign(new Error("not found"), { code: "ENOENT" })
       );
-      await flushAsyncSpawns();
-      installProc.emit("close", 0);
       await flushAsyncSpawns();
       secondVersionProc.emit(
         "error",
         Object.assign(new Error("still not found"), { code: "ENOENT" })
       );
 
-      await expect(promise).rejects.toThrow(
-        "yt-dlp was installed automatically but is still not available on PATH"
-      );
+      await expect(promise).rejects.toThrow(/still not usable/);
+      expect(vi.mocked(installManagedRelease)).toHaveBeenCalledTimes(1);
       expect(
         vi.mocked(spawn).mock.calls.filter(([cmd]) => cmd === "pip3")
-      ).toHaveLength(1);
+      ).toHaveLength(0);
     });
 
     it("should throw when yt-dlp exists but is not executable", async () => {
@@ -901,15 +912,21 @@ describe("ytDlpUtils", () => {
       });
 
       const proc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess(OLDER_FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess(FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("plural") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("plural") as any)
-        .mockImplementationOnce(() => createDenoCheckProcess() as any)
-        .mockImplementationOnce(() => proc as any);
+      mockPathCandidateSpawn(
+        [
+          {
+            binDir: "/old/bin",
+            version: OLDER_FRESH_YT_DLP_VERSION,
+            helpStyle: "none",
+          },
+          {
+            binDir: "/new/bin",
+            version: FRESH_YT_DLP_VERSION,
+            helpStyle: "plural",
+          },
+        ],
+        proc
+      );
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -943,13 +960,20 @@ describe("ytDlpUtils", () => {
 
       const brokenProc = createMockProcess();
       const proc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => brokenProc as any)
-        .mockImplementationOnce(() => createVersionCheckProcess(FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => proc as any);
+      mockPathCandidateSpawn(
+        [
+          {
+            binDir: "/broken/bin",
+            versionProc: brokenProc,
+          },
+          {
+            binDir: "/working/bin",
+            version: FRESH_YT_DLP_VERSION,
+            helpStyle: "none",
+          },
+        ],
+        proc
+      );
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -985,14 +1009,21 @@ describe("ytDlpUtils", () => {
 
       const brokenProc = createMockProcess();
       const proc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess(OLDER_FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => brokenProc as any)
-        .mockImplementationOnce(() => createVersionCheckProcess(FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => proc as any);
+      mockPathCandidateSpawn(
+        [
+          {
+            binDir: "/broken/bin",
+            version: OLDER_FRESH_YT_DLP_VERSION,
+            helpProc: brokenProc,
+          },
+          {
+            binDir: "/working/bin",
+            version: FRESH_YT_DLP_VERSION,
+            helpStyle: "none",
+          },
+        ],
+        proc
+      );
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -1029,13 +1060,20 @@ describe("ytDlpUtils", () => {
 
       const hangingProc = createMockProcess();
       const proc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => hangingProc as any)
-        .mockImplementationOnce(() => createVersionCheckProcess(FRESH_YT_DLP_VERSION) as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => proc as any);
+      mockPathCandidateSpawn(
+        [
+          {
+            binDir: "/hanging/bin",
+            versionProc: hangingProc,
+          },
+          {
+            binDir: "/working/bin",
+            version: FRESH_YT_DLP_VERSION,
+            helpStyle: "none",
+          },
+        ],
+        proc
+      );
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await vi.advanceTimersByTimeAsync(5000);
@@ -1473,18 +1511,16 @@ describe("ytDlpUtils", () => {
       process.env.YT_DLP_JS_RUNTIME = "node";
       const firstProc = createMockProcess();
       const secondProc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("none") as any)
-        .mockImplementationOnce(() => firstProc as any)
-        .mockImplementationOnce(() => createHelpCheckProcess("plural") as any)
-        .mockImplementationOnce(() => secondProc as any);
+      mockRoutedYtDlpSpawn({ helpStyle: "none" }, firstProc);
 
       const firstPromise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
       firstProc.stdout?.emit("data", Buffer.from('{"attempt":1}'));
       firstProc.emit("close", 0);
       await expect(firstPromise).resolves.toEqual({ attempt: 1 });
+
+      resetYtDlpAvailabilityCacheForTests();
+      mockRoutedYtDlpSpawn({ helpStyle: "plural" }, secondProc);
 
       const secondPromise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -1502,11 +1538,7 @@ describe("ytDlpUtils", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const denoCheckProc = createMockProcess();
       const ytProc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess() as any)
-        .mockImplementationOnce(() => denoCheckProc as any)
-        .mockImplementationOnce(() => ytProc as any);
+      mockRoutedYtDlpSpawn({ helpStyle: "plural", denoProc: denoCheckProc }, ytProc);
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -1554,11 +1586,7 @@ describe("ytDlpUtils", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const denoCheckProc = createMockProcess();
       const ytProc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess() as any)
-        .mockImplementationOnce(() => denoCheckProc as any)
-        .mockImplementationOnce(() => ytProc as any);
+      mockRoutedYtDlpSpawn({ helpStyle: "plural", denoProc: denoCheckProc }, ytProc);
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();
@@ -1587,11 +1615,7 @@ describe("ytDlpUtils", () => {
       const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
       const denoCheckProc = createMockProcess();
       const ytProc = createMockProcess();
-      vi.mocked(spawn)
-        .mockImplementationOnce(() => createVersionCheckProcess() as any)
-        .mockImplementationOnce(() => createHelpCheckProcess() as any)
-        .mockImplementationOnce(() => denoCheckProc as any)
-        .mockImplementationOnce(() => ytProc as any);
+      mockRoutedYtDlpSpawn({ helpStyle: "plural", denoProc: denoCheckProc }, ytProc);
 
       const promise = executeYtDlpJson("https://www.youtube.com/watch?v=abc");
       await flushAsyncSpawns();

--- a/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
+++ b/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
@@ -1,0 +1,1511 @@
+import { spawn } from "child_process";
+import fs from "fs";
+import fsExtra from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
+import {
+  acquireLease,
+  atomicReplaceFile,
+  collectGarbage,
+  decidePublication,
+  hasLeases,
+  releaseLease,
+  recoverUsableManagedRelease,
+  resetManagedReleaseStateForTests,
+  setManagedStoreRootForTests,
+} from "../../utils/ytdlp/release";
+import { createManagedRelease } from "../../utils/ytdlp/release/acquire";
+import { buildExternalSpawnEnv, buildManagedSpawnEnv } from "../../utils/ytdlp/release/env";
+import { spawnYtDlp } from "../../utils/ytdlp/release/launcher";
+import { createReleaseId } from "../../utils/ytdlp/release/ids";
+import {
+  parseCurrentManifest,
+  parseReleaseManifest,
+  writeCurrentManifest,
+  writePublishedManifest,
+  writeReleaseManifest,
+} from "../../utils/ytdlp/release/manifests";
+import {
+  ensureManagedStoreLayout,
+  getManagedStoreLayout,
+  removeGenerationClaim,
+  writeJsonExclusive,
+  getReleaseDir,
+  getSitePackagesPath,
+} from "../../utils/ytdlp/release/paths";
+import { attachCapabilities } from "../../utils/ytdlp/release/capabilities";
+import {
+  abortGcMarker,
+  beginGcMarker,
+  getInstanceId,
+} from "../../utils/ytdlp/release/leases";
+import {
+  acquirePublishLock,
+  assertLockOwnership,
+  releasePublishLock,
+} from "../../utils/ytdlp/release/lock";
+import * as manifests from "../../utils/ytdlp/release/manifests";
+import { publishValidatedRelease } from "../../utils/ytdlp/release/publish";
+import { runProcess } from "../../utils/ytdlp/release/process";
+import { logger } from "../../utils/logger";
+import {
+  CURRENT_JSON_FILENAME,
+  SITE_PACKAGES_DIRNAME,
+  type CurrentManifest,
+  type ReleaseManifest,
+} from "../../utils/ytdlp/release/types";
+
+vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderPluginPath: vi.fn(() => "/app/bgutil-ytdlp-pot-provider"),
+}));
+
+/** Windows only permits directory symlinks with developer mode or elevation. */
+function canCreateDirSymlink(): boolean {
+  const probe = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-symlink-probe-"));
+  try {
+    fs.symlinkSync(os.tmpdir(), path.join(probe, "link"), "dir");
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probe, { recursive: true, force: true });
+  }
+}
+
+function makeTempStore(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-store-"));
+}
+
+function seedRelease(
+  root: string,
+  input: { releaseId?: string; version: string; installedAt?: string }
+): ReleaseManifest {
+  const layout = ensureManagedStoreLayout(getManagedStoreLayout(root));
+  const releaseId = input.releaseId ?? createReleaseId(input.version);
+  const releaseDir = getReleaseDir(layout, releaseId);
+  const sitePackagesPath = getSitePackagesPath(layout, releaseId);
+  fs.mkdirSync(sitePackagesPath, { recursive: true });
+  const manifest: ReleaseManifest = {
+    schemaVersion: 1,
+    releaseId,
+    version: input.version,
+    installedAt: input.installedAt ?? new Date().toISOString(),
+    pythonExecutable: process.execPath,
+    pythonPrefixArgs: [],
+    sitePackages: SITE_PACKAGES_DIRNAME,
+  };
+  writeReleaseManifest(root, manifest);
+  expect(fs.existsSync(path.join(releaseDir, "release.json"))).toBe(true);
+  return manifest;
+}
+
+describe("managed yt-dlp release store", () => {
+  let storeRoot: string;
+
+  beforeEach(() => {
+    storeRoot = makeTempStore();
+    setManagedStoreRootForTests(storeRoot);
+    vi.mocked(getProviderPluginPath).mockReturnValue("/app/bgutil-ytdlp-pot-provider");
+  });
+
+  afterEach(() => {
+    resetManagedReleaseStateForTests();
+    fs.rmSync(storeRoot, { recursive: true, force: true });
+  });
+
+  describe("manifest validation", () => {
+    it("accepts a well-formed release.json and current.json", () => {
+      const release = parseReleaseManifest({
+        schemaVersion: 1,
+        releaseId: "ytdlp-aaaabbbb",
+        version: "2026.08.19",
+        installedAt: "2026-08-23T20:00:00.000Z",
+        pythonExecutable: "/usr/bin/python3",
+        pythonPrefixArgs: [],
+        sitePackages: "site-packages",
+      });
+      expect(release.releaseId).toBe("ytdlp-aaaabbbb");
+
+      const current = parseCurrentManifest({
+        schemaVersion: 1,
+        generation: 3,
+        releaseId: "ytdlp-aaaabbbb",
+        previousReleaseId: null,
+        publishedAt: "2026-08-23T20:00:05.000Z",
+      });
+      expect(current.generation).toBe(3);
+    });
+
+    it("rejects traversal, wrong relative site-packages, and bad ids", () => {
+      expect(() =>
+        parseReleaseManifest({
+          schemaVersion: 1,
+          releaseId: "../escape",
+          version: "2026.08.19",
+          installedAt: "2026-08-23T20:00:00.000Z",
+          pythonExecutable: "/usr/bin/python3",
+          pythonPrefixArgs: [],
+          sitePackages: "site-packages",
+        })
+      ).toThrow(/releaseId/);
+
+      expect(() =>
+        parseReleaseManifest({
+          schemaVersion: 1,
+          releaseId: "ytdlp-aaaabbbb",
+          version: "2026.08.19",
+          installedAt: "2026-08-23T20:00:00.000Z",
+          pythonExecutable: "/usr/bin/python3",
+          pythonPrefixArgs: [],
+          sitePackages: "../other",
+        })
+      ).toThrow(/sitePackages/);
+    });
+  });
+
+  describe("publication policy", () => {
+    it("publishes the first release and rejects same-version or older candidates", () => {
+      expect(
+        decidePublication({
+          current: null,
+          currentVersion: null,
+          candidateVersion: "2026.08.19",
+          candidateReleaseId: "ytdlp-newwwwww",
+          generationAtInstallStart: null,
+        })
+      ).toMatchObject({ action: "publish", generation: 1, previousReleaseId: null });
+
+      const current: CurrentManifest = {
+        schemaVersion: 1,
+        generation: 4,
+        releaseId: "ytdlp-current1",
+        previousReleaseId: "ytdlp-prev0001",
+        publishedAt: "2026-08-01T00:00:00.000Z",
+      };
+
+      expect(
+        decidePublication({
+          current,
+          currentVersion: "2026.08.19",
+          candidateVersion: "2026.08.19",
+          candidateReleaseId: "ytdlp-same0001",
+          generationAtInstallStart: 4,
+        })
+      ).toMatchObject({ action: "reject" });
+
+      expect(
+        decidePublication({
+          current,
+          currentVersion: "2026.08.19",
+          candidateVersion: "2026.07.01",
+          candidateReleaseId: "ytdlp-older001",
+          generationAtInstallStart: 4,
+        })
+      ).toMatchObject({ action: "reject" });
+    });
+
+    it("rejects an unorderable candidate when generation changed concurrently", () => {
+      const current: CurrentManifest = {
+        schemaVersion: 1,
+        generation: 8,
+        releaseId: "ytdlp-current1",
+        previousReleaseId: null,
+        publishedAt: "2026-08-01T00:00:00.000Z",
+      };
+      expect(
+        decidePublication({
+          current,
+          currentVersion: "nightly",
+          candidateVersion: "master",
+          candidateReleaseId: "ytdlp-other001",
+          generationAtInstallStart: 7,
+        })
+      ).toMatchObject({ action: "reject" });
+    });
+  });
+
+  describe("atomic current.json replacement", () => {
+    const manifestJson = (generation: number) =>
+      `${JSON.stringify({
+        schemaVersion: 1,
+        generation,
+        releaseId: "ytdlp-aaaabbbb",
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      })}\n`;
+
+    const strayTempFiles = (root: string) =>
+      fs.readdirSync(root).filter((name) => name.endsWith(".tmp"));
+
+    it("replaces current.json by rename and never unlinks it first", () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const unlinkSpy = vi.spyOn(fs, "unlinkSync");
+      atomicReplaceFile(layout.currentPath, layout.root, manifestJson(1));
+
+      expect(fs.existsSync(layout.currentPath)).toBe(true);
+      expect(path.basename(layout.currentPath)).toBe(CURRENT_JSON_FILENAME);
+      expect(
+        unlinkSpy.mock.calls.some(([target]) => String(target) === layout.currentPath)
+      ).toBe(false);
+      unlinkSpy.mockRestore();
+    });
+
+    // Windows refuses to replace a file another handle never releases. The
+    // contract is that the update fails and the previous manifest survives
+    // whole - never an unlink-then-rename that would expose an empty current.
+    it("keeps the previous manifest intact when replacement cannot complete", () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      atomicReplaceFile(layout.currentPath, layout.root, manifestJson(1));
+
+      const readerFd = fs.openSync(layout.currentPath, "r");
+      let replaced = true;
+      try {
+        atomicReplaceFile(layout.currentPath, layout.root, manifestJson(2));
+      } catch {
+        replaced = false;
+      } finally {
+        fs.closeSync(readerFd);
+      }
+
+      // Either outcome is acceptable; a partial or missing manifest is not.
+      const observed = JSON.parse(fs.readFileSync(layout.currentPath, "utf8"));
+      expect(observed.generation).toBe(replaced ? 2 : 1);
+      expect(observed.releaseId).toBe("ytdlp-aaaabbbb");
+      // A failed replacement must not leave its temporary file behind.
+      expect(strayTempFiles(layout.root)).toEqual([]);
+    });
+
+    // The bounded retry exists for exactly this case: a reader that holds the
+    // manifest open only briefly. A separate process is used because the
+    // publication path is synchronous and blocks its own event loop.
+    it("retries the replacement until a transient reader lets go", async () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      atomicReplaceFile(layout.currentPath, layout.root, manifestJson(1));
+
+      const holderScript = [
+        'const fs = require("fs");',
+        "const fd = fs.openSync(process.argv[1], 'r');",
+        'process.stdout.write("open\\n");',
+        "setTimeout(() => { try { fs.closeSync(fd); } catch {} }, 300);",
+      ].join("\n");
+      const holder = spawn(
+        process.execPath,
+        ["-e", holderScript, "--", layout.currentPath],
+        { stdio: ["ignore", "pipe", "pipe"] }
+      );
+
+      try {
+        await new Promise<void>((resolve, reject) => {
+          holder.stdout?.on("data", (chunk: Buffer) => {
+            if (chunk.toString().includes("open")) {
+              resolve();
+            }
+          });
+          holder.once("error", reject);
+        });
+        atomicReplaceFile(layout.currentPath, layout.root, manifestJson(2));
+      } finally {
+        holder.kill();
+      }
+
+      expect(
+        JSON.parse(fs.readFileSync(layout.currentPath, "utf8")).generation
+      ).toBe(2);
+      expect(strayTempFiles(layout.root)).toEqual([]);
+    });
+  });
+
+  describe("command construction", () => {
+    const managedRelease = () =>
+      createManagedRelease({
+        current: null,
+        release: {
+          schemaVersion: 1,
+          releaseId: "ytdlp-command-shape",
+          version: "2026.08.19",
+          installedAt: new Date().toISOString(),
+          pythonExecutable: "/usr/bin/python3",
+          pythonPrefixArgs: [],
+          sitePackages: SITE_PACKAGES_DIRNAME,
+        },
+        releaseDir: "/store/releases/ytdlp-command-shape",
+        sitePackagesPath: "/store/releases/ytdlp-command-shape/site-packages",
+      });
+
+    // Acceptance criterion #9: the command a managed release runs must be
+    // identical on every platform.
+    it("runs a managed release as <python> -m yt_dlp", () => {
+      const release = managedRelease();
+      expect(release.command).toBe("/usr/bin/python3");
+      expect(release.prefixArgs).toEqual(["-m", "yt_dlp"]);
+      expect(release.spawnEnv.PYTHONPATH).toBe(
+        [
+          "/app/bgutil-ytdlp-pot-provider",
+          "/store/releases/ytdlp-command-shape/site-packages",
+        ].join(path.delimiter)
+      );
+    });
+
+    // Runs a real child on each CI platform: argument arrays must survive
+    // without shell quoting, and the snapshot environment must win over
+    // anything the caller passes.
+    it("delivers unquoted arguments and the snapshot env to the child", async () => {
+      const reporter = [
+        "const out = {",
+        "  argv: process.argv.slice(1),",
+        "  pythonPath: process.env.PYTHONPATH,",
+        "  noUserSite: process.env.PYTHONNOUSERSITE,",
+        "  hijacked: process.env.HIJACKED ?? null,",
+        "};",
+        "console.log(JSON.stringify(out));",
+      ].join("\n");
+
+      const release = attachCapabilities({
+        kind: "managed",
+        releaseId: "ytdlp-command-shape",
+        version: "2026.08.19",
+        command: process.execPath,
+        prefixArgs: ["-e", reporter, "--"],
+        spawnEnv: managedRelease().spawnEnv,
+      });
+
+      const child = spawnYtDlp(
+        release,
+        ["--impersonate", "chrome:windows-10", "a b"],
+        { env: { HIJACKED: "1" } } as never
+      );
+      const stdout = await new Promise<string>((resolve) => {
+        let buffer = "";
+        child.stdout?.on("data", (chunk: Buffer) => {
+          buffer += chunk.toString();
+        });
+        child.on("close", () => resolve(buffer));
+      });
+
+      const observed = JSON.parse(stdout);
+      expect(observed.argv).toEqual([
+        "--impersonate",
+        "chrome:windows-10",
+        "a b",
+      ]);
+      // A caller-supplied env cannot replace the release snapshot.
+      expect(observed.hijacked).toBeNull();
+      expect(observed.noUserSite).toBe("1");
+      expect(observed.pythonPath).toContain(
+        "/store/releases/ytdlp-command-shape/site-packages"
+      );
+    });
+  });
+
+  describe("spawn environment", () => {
+    it("replaces PYTHONPATH for managed releases and sets PYTHONNOUSERSITE", () => {
+      const env = buildManagedSpawnEnv("/store/releases/a/site-packages", {
+        PATH: "/usr/bin",
+        PYTHONPATH: "/ambient/site",
+        HOME: "/app/data/.home",
+      });
+      expect(env.PYTHONPATH).toBe(
+        ["/app/bgutil-ytdlp-pot-provider", "/store/releases/a/site-packages"].join(
+          path.delimiter
+        )
+      );
+      expect(env.PYTHONPATH).not.toContain("/ambient/site");
+      expect(env.PYTHONNOUSERSITE).toBe("1");
+      expect(env.PATH).toBe("/usr/bin");
+    });
+
+    it("prepends the bundled provider for external releases and keeps ambient PYTHONPATH", () => {
+      const env = buildExternalSpawnEnv({
+        PYTHONPATH: "/ambient/site",
+      });
+      expect(env.PYTHONPATH?.split(path.delimiter)[0]).toBe(
+        "/app/bgutil-ytdlp-pot-provider"
+      );
+      expect(env.PYTHONPATH).toContain("/ambient/site");
+      expect(env.PYTHONNOUSERSITE).toBeUndefined();
+    });
+  });
+
+  describe("leases and GC", () => {
+    // Retention keeps the newest current-plus-two, so seeds need distinct ages.
+    const daysAgo = (days: number): string =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+    /** Backdate a release directory past the minimum retention age. */
+    function ageReleaseDir(
+      layout: ReturnType<typeof getManagedStoreLayout>,
+      releaseId: string
+    ): void {
+      const old = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      fs.utimesSync(getReleaseDir(layout, releaseId), old, old);
+    }
+
+    it("keeps current, previous, and leased releases", async () => {
+      const currentRel = seedRelease(storeRoot, {
+        version: "2026.08.19",
+        installedAt: daysAgo(1),
+      });
+      const previousRel = seedRelease(storeRoot, {
+        version: "2026.07.01",
+        installedAt: daysAgo(2),
+      });
+      const leasedRel = seedRelease(storeRoot, {
+        version: "2026.05.01",
+        installedAt: daysAgo(3),
+      });
+      const unusedRel = seedRelease(storeRoot, {
+        version: "2026.06.01",
+        installedAt: daysAgo(4),
+      });
+
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 4,
+        releaseId: currentRel.releaseId,
+        previousReleaseId: previousRel.releaseId,
+        publishedAt: new Date().toISOString(),
+      });
+
+      const layout = getManagedStoreLayout(storeRoot);
+      for (const release of [currentRel, previousRel, leasedRel, unusedRel]) {
+        ageReleaseDir(layout, release.releaseId);
+      }
+
+      const lease = acquireLease(leasedRel.releaseId, "op-0123456789abcdef");
+      expect(hasLeases(leasedRel.releaseId)).toBe(true);
+
+      await collectGarbage();
+
+      expect(fs.existsSync(getReleaseDir(layout, currentRel.releaseId))).toBe(true);
+      expect(fs.existsSync(getReleaseDir(layout, previousRel.releaseId))).toBe(true);
+      expect(fs.existsSync(getReleaseDir(layout, leasedRel.releaseId))).toBe(true);
+      expect(fs.existsSync(getReleaseDir(layout, unusedRel.releaseId))).toBe(false);
+
+      releaseLease(lease.releaseId, lease.leaseFilename);
+      expect(hasLeases(leasedRel.releaseId)).toBe(false);
+    });
+
+    it("never collects a release younger than the retention age", async () => {
+      // An installer finalizes a release directory before it publishes the new
+      // current pointer. Collecting in that window would delete the release a
+      // publisher is about to point at — and the manifest date says nothing
+      // about when the directory appeared.
+      const currentRel = seedRelease(storeRoot, {
+        version: "2026.08.19",
+        installedAt: daysAgo(1),
+      });
+      seedRelease(storeRoot, { version: "2026.08.18", installedAt: daysAgo(2) });
+      seedRelease(storeRoot, { version: "2026.08.17", installedAt: daysAgo(3) });
+      const justFinalized = seedRelease(storeRoot, {
+        version: "2026.08.16",
+        installedAt: daysAgo(4),
+      });
+
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: currentRel.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      await collectGarbage();
+
+      const layout = getManagedStoreLayout(storeRoot);
+      expect(fs.existsSync(getReleaseDir(layout, justFinalized.releaseId))).toBe(
+        true
+      );
+    });
+
+    it("keeps a rollback window when current.json is unreadable", async () => {
+      const releases = [
+        seedRelease(storeRoot, { version: "2026.08.19", installedAt: daysAgo(1) }),
+        seedRelease(storeRoot, { version: "2026.07.01", installedAt: daysAgo(2) }),
+        seedRelease(storeRoot, { version: "2026.06.01", installedAt: daysAgo(3) }),
+        seedRelease(storeRoot, { version: "2026.05.01", installedAt: daysAgo(4) }),
+      ];
+      const layout = getManagedStoreLayout(storeRoot);
+      for (const release of releases) {
+        ageReleaseDir(layout, release.releaseId);
+      }
+      fs.writeFileSync(path.join(layout.root, CURRENT_JSON_FILENAME), "{ broken");
+
+      await collectGarbage();
+
+      // Newest three (current plus two rollbacks) survive; the oldest goes.
+      const survivors = releases.filter((release) =>
+        fs.existsSync(getReleaseDir(layout, release.releaseId))
+      );
+      expect(survivors).toHaveLength(3);
+      expect(fs.existsSync(getReleaseDir(layout, releases[3].releaseId))).toBe(
+        false
+      );
+    });
+  });
+
+  describe("publication fencing", () => {
+    it("refuses to move the pointer once its lock has been reclaimed", async () => {
+      const first = seedRelease(storeRoot, { version: "2026.07.01" });
+      const candidate = seedRelease(storeRoot, { version: "2026.08.19" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: first.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+      const layout = getManagedStoreLayout(storeRoot);
+
+      // Simulate another backend reclaiming the lock while this publisher is
+      // recording its publication: the owner file changes between the two
+      // ownership checks that bracket the record write.
+      const realWrite = manifests.writePublishedManifest;
+      const spy = vi
+        .spyOn(manifests, "writePublishedManifest")
+        .mockImplementation((root, manifest) => {
+          realWrite(root, manifest);
+          fs.writeFileSync(
+            path.join(layout.publishLockDir, "owner.json"),
+            JSON.stringify({
+              operationId: "op-0123456789abcdef",
+              nonce: "f".repeat(32),
+              pid: 4242,
+              instanceId: "4242-aabbccddeeff",
+              createdAt: new Date().toISOString(),
+            })
+          );
+        });
+
+      try {
+        await expect(
+          publishValidatedRelease({
+            releaseId: candidate.releaseId,
+            version: "2026.08.19",
+            generationAtInstallStart: 1,
+          })
+        ).rejects.toThrow(/stolen/);
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The pointer never moved...
+      expect(manifests.readCurrentManifest(storeRoot)?.releaseId).toBe(first.releaseId);
+      // ...and the publication record was withdrawn, so recovery cannot later
+      // promote a transition that never committed.
+      expect(
+        fs.existsSync(
+          path.join(getReleaseDir(layout, candidate.releaseId), "published.json")
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("generation claims", () => {
+    it("lets only one publisher own a generation", async () => {
+      const base = seedRelease(storeRoot, { version: "2026.07.01" });
+      const first = seedRelease(storeRoot, { version: "2026.08.19" });
+      const second = seedRelease(storeRoot, { version: "2026.08.20" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: base.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      const winner = await publishValidatedRelease({
+        releaseId: first.releaseId,
+        version: "2026.08.19",
+        generationAtInstallStart: 1,
+      });
+      expect(winner.published).toBe(true);
+      expect(winner.current?.generation).toBe(2);
+
+      // A publisher that decided from the same current.json computes the same
+      // generation. Exclusive creation is what makes the swap a real
+      // compare-and-swap rather than a check followed by a write, so this one
+      // must lose even though it never noticed the winner.
+      fs.writeFileSync(
+        path.join(getManagedStoreLayout(storeRoot).root, "current.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          generation: 1,
+          releaseId: base.releaseId,
+          previousReleaseId: null,
+          publishedAt: new Date().toISOString(),
+        })
+      );
+
+      await expect(
+        publishValidatedRelease({
+          releaseId: second.releaseId,
+          version: "2026.08.20",
+          generationAtInstallStart: 1,
+        })
+      ).rejects.toThrow(/generation 2 was claimed/);
+
+      // The loser left nothing behind that recovery could promote.
+      expect(
+        fs.existsSync(
+          path.join(getReleaseDir(getManagedStoreLayout(storeRoot), second.releaseId), "published.json")
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("per-release coordination directories", () => {
+    it.skipIf(!canCreateDirSymlink())(
+      "refuses a symlinked lease or marker directory",
+      () => {
+        // Created on demand per release, so they are not covered by the store
+        // layout checks. Following a link would write a lease outside the store.
+        const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+        const release = seedRelease(storeRoot, { version: "2026.08.19" });
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-coord-"));
+        try {
+          fs.mkdirSync(layout.leasesDir, { recursive: true });
+          fs.symlinkSync(
+            outside,
+            path.join(layout.leasesDir, release.releaseId),
+            "dir"
+          );
+          expect(() =>
+            acquireLease(release.releaseId, "op-0123456789abcdef")
+          ).toThrow(/symlink/i);
+
+          fs.mkdirSync(layout.gcMarkersDir, { recursive: true });
+          fs.symlinkSync(
+            outside,
+            path.join(layout.gcMarkersDir, `${release.releaseId}.deleting`),
+            "dir"
+          );
+          expect(beginGcMarker(release.releaseId)).toBeNull();
+          expect(fs.readdirSync(outside)).toEqual([]);
+        } finally {
+          fs.rmSync(outside, { recursive: true, force: true });
+        }
+      }
+    );
+  });
+
+  describe("retiring a release", () => {
+    it("makes a release unreachable before deleting it, and sweeps leftovers", async () => {
+      // The marker only has to cover the rename, not the deletion - so a slow
+      // or suspended delete cannot outlive it and let a reader lease a
+      // half-removed release.
+      const daysAgo = (days: number) =>
+        new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+      const current = seedRelease(storeRoot, { version: "2026.08.19" });
+      const keep = [
+        seedRelease(storeRoot, { version: "2026.07.01", installedAt: daysAgo(10) }),
+        seedRelease(storeRoot, { version: "2026.06.01", installedAt: daysAgo(20) }),
+      ];
+      const doomed = seedRelease(storeRoot, {
+        version: "2026.05.01",
+        installedAt: daysAgo(30),
+      });
+      const layout = getManagedStoreLayout(storeRoot);
+      const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      for (const release of [...keep, doomed]) {
+        fs.utimesSync(getReleaseDir(layout, release.releaseId), old, old);
+      }
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: current.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      await collectGarbage();
+
+      expect(fs.existsSync(getReleaseDir(layout, doomed.releaseId))).toBe(false);
+      // Nothing is stranded: the trash is emptied as part of the same pass.
+      expect(fs.readdirSync(layout.trashDir)).toEqual([]);
+      // And no marker is left holding the release hostage.
+      expect(
+        fs.existsSync(path.join(layout.gcMarkersDir, `${doomed.releaseId}.deleting`))
+          ? fs.readdirSync(
+              path.join(layout.gcMarkersDir, `${doomed.releaseId}.deleting`)
+            )
+          : []
+      ).toEqual([]);
+    });
+
+    it("sweeps a retired release a previous collector failed to delete", async () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const stranded = path.join(layout.trashDir, "ytdlp-old-1111aaaa.abcdef0123456789");
+      fs.mkdirSync(path.join(stranded, "site-packages"), { recursive: true });
+
+      await collectGarbage();
+
+      // Entries here are unreachable by construction, so they need no reasoning
+      // about age or ownership.
+      expect(fs.existsSync(stranded)).toBe(false);
+    });
+  });
+
+  describe("deletion markers", () => {
+    it("blocks a second collector, ignores an expired one, and only removes its own", () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const release = seedRelease(storeRoot, { version: "2026.08.19" });
+      const markerDir = path.join(
+        layout.gcMarkersDir,
+        `${release.releaseId}.deleting`
+      );
+
+      const first = beginGcMarker(release.releaseId);
+      expect(first).not.toBeNull();
+      // A live marker still blocks another collector and any reader.
+      expect(beginGcMarker(release.releaseId)).toBeNull();
+      expect(() => acquireLease(release.releaseId, "op-0123456789abcdef")).toThrow(
+        /being deleted/
+      );
+
+      // A collector killed mid-collection leaves its marker behind. It is
+      // ignored once expired rather than reclaimed, so nothing ever deletes a
+      // marker it does not own.
+      const markerPath = path.join(markerDir, `${first}.json`);
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(markerPath, longAgo, longAgo);
+
+      const second = beginGcMarker(release.releaseId);
+      expect(second).not.toBeNull();
+      expect(second).not.toBe(first);
+
+      // The original collector resuming removes only its own file, leaving the
+      // replacement's marker - and the release - protected.
+      abortGcMarker(release.releaseId, first as string);
+      expect(fs.existsSync(path.join(markerDir, `${second}.json`))).toBe(true);
+      expect(() => acquireLease(release.releaseId, "op-0123456789abcdef")).toThrow(
+        /being deleted/
+      );
+
+      abortGcMarker(release.releaseId, second as string);
+      expect(fs.readdirSync(markerDir)).toEqual([]);
+    });
+  });
+
+  describe("generation claim cleanup", () => {
+    it("frees the claim when publication fails so later updates still work", async () => {
+      const base = seedRelease(storeRoot, { version: "2026.07.01" });
+      const failing = seedRelease(storeRoot, { version: "2026.08.19" });
+      const later = seedRelease(storeRoot, { version: "2026.08.20" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: base.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      // Fail after the generation is claimed but before the pointer moves.
+      const spy = vi
+        .spyOn(manifests, "writeCurrentManifest")
+        .mockImplementationOnce(() => {
+          throw new Error("read-only file system");
+        });
+      try {
+        await expect(
+          publishValidatedRelease({
+            releaseId: failing.releaseId,
+            version: "2026.08.19",
+            generationAtInstallStart: 1,
+          })
+        ).rejects.toThrow(/read-only/);
+      } finally {
+        spy.mockRestore();
+      }
+
+      // The claim must not survive: every later publisher computes the same
+      // generation from the unchanged pointer and would be rejected forever.
+      const layout = getManagedStoreLayout(storeRoot);
+      expect(fs.existsSync(path.join(layout.generationsDir, "2.json"))).toBe(
+        false
+      );
+
+      const retry = await publishValidatedRelease({
+        releaseId: later.releaseId,
+        version: "2026.08.20",
+        generationAtInstallStart: 1,
+      });
+      expect(retry.published).toBe(true);
+      expect(retry.current?.generation).toBe(2);
+    });
+  });
+
+  describe("generation claim ownership", () => {
+    it("does not let a resumed publisher drop a replacement's claim", () => {
+      // Claims are reclaimable by age, so a suspended publisher can have its
+      // claim taken over. If it then removed the replacement's claim, a third
+      // publisher could commit the same generation and defeat the fence.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const claimPath = path.join(layout.generationsDir, "7.json");
+      writeJsonExclusive(claimPath, {
+        releaseId: "ytdlp-replacement-3333cccc",
+        claimedAt: new Date().toISOString(),
+        token: "b".repeat(32),
+      });
+
+      // The original publisher's token no longer matches.
+      removeGenerationClaim(layout, 7, "a".repeat(32));
+      expect(fs.existsSync(claimPath)).toBe(true);
+
+      removeGenerationClaim(layout, 7, "b".repeat(32));
+      expect(fs.existsSync(claimPath)).toBe(false);
+    });
+  });
+
+  describe("reclaiming an abandoned generation", () => {
+    it("drops the publication record the dead publisher left behind", async () => {
+      // A backend can die between recording its publication and moving the
+      // pointer. Freeing the generation without dropping that record leaves two
+      // releases claiming it, and both recovery and the rollback window order
+      // by generation.
+      const base = seedRelease(storeRoot, { version: "2026.07.01" });
+      const abandoned = seedRelease(storeRoot, { version: "2026.08.19" });
+      const next = seedRelease(storeRoot, { version: "2026.08.20" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: base.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+
+      // Exactly what a crash between the two writes leaves behind.
+      writePublishedManifest(storeRoot, {
+        schemaVersion: 1,
+        releaseId: abandoned.releaseId,
+        generation: 2,
+        previousReleaseId: base.releaseId,
+        publishedAt: new Date().toISOString(),
+      });
+      const claimPath = path.join(layout.generationsDir, "2.json");
+      writeJsonExclusive(claimPath, {
+        releaseId: abandoned.releaseId,
+        claimedAt: new Date().toISOString(),
+        token: "c".repeat(32),
+      });
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(claimPath, longAgo, longAgo);
+
+      const outcome = await publishValidatedRelease({
+        releaseId: next.releaseId,
+        version: "2026.08.20",
+        generationAtInstallStart: 1,
+      });
+
+      expect(outcome.published).toBe(true);
+      expect(outcome.current?.generation).toBe(2);
+      // Only one release records generation 2.
+      expect(
+        fs.existsSync(
+          path.join(getReleaseDir(layout, abandoned.releaseId), "published.json")
+        )
+      ).toBe(false);
+      expect(
+        fs.existsSync(
+          path.join(getReleaseDir(layout, next.releaseId), "published.json")
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("failed publication cleanup", () => {
+    it("keeps the generation claimed while its record cannot be removed", async () => {
+      // Freeing the generation while the record survives would let the next
+      // update reuse it, leaving two releases recording the same generation.
+      const base = seedRelease(storeRoot, { version: "2026.07.01" });
+      const failing = seedRelease(storeRoot, { version: "2026.08.19" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: base.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+
+      const pointerSpy = vi
+        .spyOn(manifests, "writeCurrentManifest")
+        .mockImplementationOnce(() => {
+          throw new Error("read-only file system");
+        });
+      const unlinkSpy = vi
+        .spyOn(fsExtra, "unlinkSync")
+        .mockImplementation((target: fsExtra.PathLike) => {
+          if (String(target).endsWith("published.json")) {
+            throw Object.assign(new Error("sharing violation"), {
+              code: "EPERM",
+            });
+          }
+          return undefined as never;
+        });
+      try {
+        await expect(
+          publishValidatedRelease({
+            releaseId: failing.releaseId,
+            version: "2026.08.19",
+            generationAtInstallStart: 1,
+          })
+        ).rejects.toThrow(/read-only/);
+      } finally {
+        unlinkSpy.mockRestore();
+        pointerSpy.mockRestore();
+      }
+
+      // The record survived, so the generation must still be claimed.
+      expect(
+        fs.existsSync(
+          path.join(getReleaseDir(layout, failing.releaseId), "published.json")
+        )
+      ).toBe(true);
+      expect(fs.existsSync(path.join(layout.generationsDir, "2.json"))).toBe(
+        true
+      );
+    });
+  });
+
+  describe("repairing a broken release", () => {
+    it("publishes a same-version candidate when the current release is unusable", () => {
+      // pip keeps producing the same latest version, so a repair would be
+      // rejected as a no-op and the broken release would stay current forever.
+      const shared = {
+        current: {
+          schemaVersion: 1 as const,
+          generation: 3,
+          releaseId: "ytdlp-broken-1111aaaa",
+          previousReleaseId: null,
+          publishedAt: new Date().toISOString(),
+        },
+        currentVersion: "2026.08.19",
+        candidateVersion: "2026.08.19",
+        candidateReleaseId: "ytdlp-repair-2222bbbb",
+        generationAtInstallStart: 3,
+      };
+
+      expect(decidePublication(shared)).toMatchObject({
+        action: "reject",
+        kind: "already-current",
+      });
+      expect(
+        decidePublication({ ...shared, currentIsUsable: false })
+      ).toMatchObject({ action: "publish", generation: 4 });
+    });
+  });
+
+  describe("rollback window", () => {
+    const daysAgo = (days: number) =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+    function publishRecord(
+      releaseId: string,
+      generation: number,
+      previousReleaseId: string | null = null
+    ): void {
+      writePublishedManifest(storeRoot, {
+        schemaVersion: 1,
+        releaseId,
+        generation,
+        previousReleaseId,
+        publishedAt: new Date().toISOString(),
+      });
+    }
+
+    it("keeps published rollback targets even when a rejected candidate is newer", async () => {
+      // An already-current update finalizes a candidate that is never
+      // published. Counting it toward current-plus-two would displace a real
+      // rollback target and collect it.
+      const oldest = seedRelease(storeRoot, {
+        version: "2026.06.01",
+        installedAt: daysAgo(30),
+      });
+      const previous = seedRelease(storeRoot, {
+        version: "2026.07.01",
+        installedAt: daysAgo(20),
+      });
+      const current = seedRelease(storeRoot, {
+        version: "2026.08.19",
+        installedAt: daysAgo(10),
+      });
+      // Finalized moments after the others, but rejected at publication.
+      const rejected = seedRelease(storeRoot, {
+        version: "2026.08.19",
+        installedAt: daysAgo(1),
+      });
+
+      publishRecord(oldest.releaseId, 1);
+      publishRecord(previous.releaseId, 2, oldest.releaseId);
+      publishRecord(current.releaseId, 3, previous.releaseId);
+
+      const layout = getManagedStoreLayout(storeRoot);
+      const long = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      for (const release of [oldest, previous, current, rejected]) {
+        fs.utimesSync(getReleaseDir(layout, release.releaseId), long, long);
+      }
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 3,
+        releaseId: current.releaseId,
+        previousReleaseId: previous.releaseId,
+        publishedAt: new Date().toISOString(),
+      });
+
+      await collectGarbage();
+
+      // current + the two published rollback targets survive...
+      for (const release of [current, previous, oldest]) {
+        expect(
+          fs.existsSync(getReleaseDir(layout, release.releaseId))
+        ).toBe(true);
+      }
+      // ...and the never-published candidate is what gets collected.
+      expect(fs.existsSync(getReleaseDir(layout, rejected.releaseId))).toBe(
+        false
+      );
+    });
+  });
+
+  describe("store recovery", () => {
+    it("falls back to the previous release when current is unusable", () => {
+      const previousRel = seedRelease(storeRoot, { version: "2026.07.01" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 2,
+        releaseId: "ytdlp-missingrelease",
+        previousReleaseId: previousRel.releaseId,
+        publishedAt: new Date().toISOString(),
+      });
+
+      expect(recoverUsableManagedRelease(storeRoot)?.release.releaseId).toBe(
+        previousRel.releaseId
+      );
+    });
+
+    it("degrades to external discovery instead of throwing on a broken store", () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      // Unexpected content where the store expects a directory. The backend
+      // must still serve rather than fail every yt-dlp operation.
+      fs.rmSync(layout.releasesDir, { recursive: true, force: true });
+      fs.writeFileSync(layout.releasesDir, "not a directory");
+
+      expect(recoverUsableManagedRelease(storeRoot)).toBeNull();
+    });
+
+    it("does not recover a conflict-rejected finalized candidate", () => {
+      const twoDaysAgo = new Date(
+        Date.now() - 2 * 24 * 60 * 60 * 1000
+      ).toISOString();
+      const oneDayAgo = new Date(
+        Date.now() - 24 * 60 * 60 * 1000
+      ).toISOString();
+      const published = seedRelease(storeRoot, {
+        version: "2026.08.20",
+        installedAt: twoDaysAgo,
+      });
+      const rejected = seedRelease(storeRoot, {
+        version: "2026.08.19",
+        installedAt: oneDayAgo,
+      });
+      writePublishedManifest(storeRoot, {
+        schemaVersion: 1,
+        releaseId: published.releaseId,
+        generation: 2,
+        previousReleaseId: null,
+        publishedAt: twoDaysAgo,
+      });
+      fs.writeFileSync(getManagedStoreLayout(storeRoot).currentPath, "{ broken");
+
+      const recovered = recoverUsableManagedRelease(storeRoot);
+      expect(recovered?.release.releaseId).toBe(published.releaseId);
+      expect(recovered?.release.releaseId).not.toBe(rejected.releaseId);
+    });
+
+    it.skipIf(!canCreateDirSymlink())(
+      "refuses to prepare a store whose staging directory is a symlink",
+      () => {
+        // Otherwise `pip --target` would write outside the managed store and
+        // staging cleanup would delete through the link.
+        const layout = getManagedStoreLayout(storeRoot);
+        fs.mkdirSync(layout.root, { recursive: true });
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-outside-"));
+        try {
+          fs.symlinkSync(outside, layout.stagingDir, "dir");
+          expect(() => ensureManagedStoreLayout(layout)).toThrow(/symlink/i);
+        } finally {
+          fs.rmSync(outside, { recursive: true, force: true });
+        }
+      }
+    );
+
+    // Directory symlinks need elevation on Windows, so this one is skipped
+    // where the runner cannot create them.
+    it.skipIf(!canCreateDirSymlink())(
+      "refuses a symlinked releases directory",
+      () => {
+        const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+        fs.rmSync(layout.releasesDir, { recursive: true, force: true });
+        fs.symlinkSync(os.tmpdir(), layout.releasesDir, "dir");
+
+        expect(recoverUsableManagedRelease(storeRoot)).toBeNull();
+      }
+    );
+  });
+
+  describe("release-scoped capabilities", () => {
+    it("caches a definitive absence but retries an incomplete probe", async () => {
+      const release = attachCapabilities({
+        kind: "managed",
+        releaseId: "ytdlp-capability-probe",
+        version: "2026.08.19",
+        command: process.execPath,
+        prefixArgs: [],
+        spawnEnv: process.env,
+      });
+
+      // An old yt-dlp exits non-zero on --list-impersonate-targets. That is the
+      // release telling us the feature is missing, so the other capabilities
+      // parsed from --help must survive and the answer must be cached.
+      const first = await release.capabilities;
+      expect(first.impersonateAvailable).toBe(false);
+      expect(await release.capabilities).toBe(first);
+    });
+
+    it("reprobes a mutable external install on a new acquisition", async () => {
+      const markerPath = path.join(storeRoot, "curl-cffi-installed");
+      const probePath = path.join(storeRoot, "mutable-ytdlp.cjs");
+      fs.writeFileSync(
+        probePath,
+        [
+          'const fs = require("fs");',
+          `const marker = ${JSON.stringify(markerPath)};`,
+          'if (process.argv.includes("--help")) {',
+          '  console.log("--js-runtimes --remote-components");',
+          '} else if (process.argv.includes("--list-impersonate-targets")) {',
+          "  const target = fs.existsSync(marker)",
+          '    ? "chrome curl_cffi"',
+          '    : "chrome curl_cffi unavailable";',
+          "  console.log(target);",
+          "}",
+        ].join("\n")
+      );
+      const acquireExternal = () =>
+        attachCapabilities({
+          kind: "external",
+          releaseId: `external:${probePath}:2026.08.20`,
+          version: "2026.08.20",
+          command: process.execPath,
+          prefixArgs: [probePath],
+          spawnEnv: process.env,
+        });
+
+      const before = acquireExternal();
+      expect((await before.capabilities).impersonateAvailable).toBe(false);
+
+      fs.writeFileSync(markerPath, "installed");
+      const after = acquireExternal();
+      expect((await after.capabilities).impersonateAvailable).toBe(true);
+    });
+  });
+
+  describe("pip timeout", () => {
+    it("kills a hung child and reports timedOut", async () => {
+      const result = await runProcess(
+        process.execPath,
+        ["-e", "setTimeout(() => {}, 60_000)"],
+        { timeoutMs: 50 }
+      );
+      expect(result.timedOut).toBe(true);
+    });
+
+    // `child.killed` is true the moment SIGTERM is *sent*, so gating the
+    // escalation on it would leave a SIGTERM-ignoring pip running forever with
+    // runProcess never resolving - wedging the process-wide pip queue.
+    it("terminates a child that ignores SIGTERM instead of waiting forever", async () => {
+      const stubborn = [
+        'process.on("SIGTERM", () => {});',
+        'process.stdout.write("ready\\n");',
+        "setTimeout(() => {}, 60_000);",
+      ].join("\n");
+
+      // Generous enough that the child has certainly booted and installed its
+      // handler before the timeout fires; a shorter window races process
+      // startup under load and the default SIGTERM action wins instead.
+      const result = await runProcess(process.execPath, ["-e", stubborn], {
+        timeoutMs: 1_500,
+      });
+
+      expect(result.timedOut).toBe(true);
+      // A reported signal can only come from an observed exit: the last-resort
+      // timer reports none. So this is a deterministic check that the child was
+      // really terminated, with no reliance on elapsed time.
+      if (process.platform === "win32") {
+        // Windows has no signal delivery: the timeout path shells out to
+        // taskkill /F, so the child reports an exit code and no signal. A
+        // non-null code still proves it was terminated rather than abandoned,
+        // since the last-resort timer reports neither.
+        expect(result.code).not.toBeNull();
+        return;
+      }
+      expect(result.signal).toBe("SIGKILL");
+    }, 20_000);
+  });
+
+  describe("process tree termination", () => {
+    it("terminates a grandchild the timed-out process launched", async () => {
+      // pip spawns build and download helpers. Signalling only the interpreter
+      // leaves those running against the staging directory the failure path is
+      // about to delete, and lets the next install start alongside them.
+      const marker = path.join(storeRoot, "grandchild-heartbeat");
+      // Paths travel as argv rather than being interpolated into source: it
+      // keeps the scripts constant and avoids building code from values.
+      const grandchild = [
+        "const fs = require('fs');",
+        "const target = process.argv[1];",
+        "setInterval(() => fs.writeFileSync(target, String(Date.now())), 50);",
+        "setTimeout(() => process.exit(0), 60000);",
+      ].join("\n");
+      const parent = [
+        "const { spawn } = require('child_process');",
+        "const script = process.argv[1];",
+        "const target = process.argv[2];",
+        "spawn(process.execPath, ['-e', script, '--', target], { stdio: 'ignore' });",
+        "setTimeout(() => {}, 60000);",
+      ].join("\n");
+
+      const result = await runProcess(
+        process.execPath,
+        ["-e", parent, "--", grandchild, marker],
+        { timeoutMs: 1_500 }
+      );
+      expect(result.timedOut).toBe(true);
+      // The grandchild must actually have run, or this test would pass
+      // vacuously by observing nothing on both sides.
+      expect(fs.existsSync(marker)).toBe(true);
+
+      // Give any survivor room to write again, then confirm it stopped when
+      // its parent was killed.
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const settled = fs.readFileSync(marker, "utf8");
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(fs.readFileSync(marker, "utf8")).toBe(settled);
+    }, 20_000);
+  });
+
+  describe("publish lock recovery", () => {
+    function writeLockOwner(owner: Record<string, unknown>): string {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(layout.publishLockDir, { recursive: true });
+      const ownerPath = path.join(layout.publishLockDir, "owner.json");
+      fs.writeFileSync(ownerPath, JSON.stringify(owner));
+      return ownerPath;
+    }
+
+    const expiredOwner = (overrides: Record<string, unknown> = {}) => ({
+      operationId: "op-0123456789abcdef",
+      nonce: "0123456789abcdef0123456789abcdef",
+      // A restarted container routinely hands the replacement backend the same
+      // PID, so this one is alive and belongs to somebody else entirely.
+      pid: process.pid,
+      instanceId: "1-deadbeefdead",
+      createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+      ...overrides,
+    });
+
+    it("recovers an expired lock whose recorded pid has been reused", async () => {
+      writeLockOwner(expiredOwner());
+
+      const lock = await acquirePublishLock(
+        getManagedStoreLayout(storeRoot),
+        2000
+      );
+
+      expect(lock.owner.nonce).not.toBe(
+        "0123456789abcdef0123456789abcdef"
+      );
+      releasePublishLock(lock);
+    });
+
+    it("leaves a lock held by this very instance alone", async () => {
+      // Our own process is wedged; stealing from ourselves helps nobody.
+      writeLockOwner(expiredOwner({ instanceId: getInstanceId() }));
+
+      await expect(
+        acquirePublishLock(getManagedStoreLayout(storeRoot), 300)
+      ).rejects.toThrow(/Timed out waiting/);
+    });
+
+    it("never deletes a young lock directory that has no owner file yet", async () => {
+      // A contender can arrive between another process's mkdir and its owner
+      // write. Reclaiming then would destroy a lock that is about to be valid,
+      // and let both processes believe they hold it.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(layout.publishLockDir, { recursive: true });
+
+      await expect(
+        acquirePublishLock(layout, 300)
+      ).rejects.toThrow(/Timed out waiting/);
+      expect(fs.existsSync(layout.publishLockDir)).toBe(true);
+    });
+
+    it("reclaims a lock directory left without an owner file", async () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(layout.publishLockDir, { recursive: true });
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(layout.publishLockDir, longAgo, longAgo);
+
+      const lock = await acquirePublishLock(layout, 2000);
+
+      expect(lock.owner.instanceId).toBe(getInstanceId());
+      releasePublishLock(lock);
+    });
+
+    it("reclaims a lock whose owner file is malformed rather than wedging", async () => {
+      // writeJsonExclusive can still be interrupted by a crash, leaving partial
+      // JSON. Refusing to act on an unparseable owner would fail every future
+      // update for the life of the store.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(layout.publishLockDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(layout.publishLockDir, "owner.json"),
+        '{"operationId":"op-0123456789abcdef","non'
+      );
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(layout.publishLockDir, longAgo, longAgo);
+
+      const lock = await acquirePublishLock(layout, 2000);
+
+      expect(lock.owner.instanceId).toBe(getInstanceId());
+      releasePublishLock(lock);
+    });
+
+    it("refuses to overwrite an owner file a contender already wrote", () => {
+      // The directory creation alone is not the whole claim; the owner write
+      // must fail rather than clobber a contender that recreated the directory.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(layout.publishLockDir, { recursive: true });
+      const ownerPath = path.join(layout.publishLockDir, "owner.json");
+      fs.writeFileSync(ownerPath, JSON.stringify(expiredOwner()));
+
+      expect(() => writeJsonExclusive(ownerPath, expiredOwner({ nonce: "f".repeat(32) })))
+        .toThrow();
+      expect(JSON.parse(fs.readFileSync(ownerPath, "utf8")).nonce).toBe(
+        "0123456789abcdef0123456789abcdef"
+      );
+    });
+
+    it("does not delete a replacement lock while recovering a stale one", async () => {
+      // Two processes can decide the same lock is stale. The second must not
+      // remove the fresh lock the first already replaced it with, or the new
+      // publisher fails its own ownership assertion.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      writeLockOwner(expiredOwner());
+
+      // First recovery wins and takes the lock.
+      const replacement = await acquirePublishLock(layout, 2000);
+
+      // A second process now acts on the stale owner it observed earlier.
+      await expect(acquirePublishLock(layout, 300)).rejects.toThrow(
+        /Timed out waiting/
+      );
+
+      // The replacement still owns the lock and can still publish.
+      expect(() => assertLockOwnership(replacement)).not.toThrow();
+      releasePublishLock(replacement);
+    });
+
+    it.skipIf(!canCreateDirSymlink())(
+      "refuses a symlinked publish lock directory",
+      async () => {
+        // The lock directory is created on demand, so it is not covered by the
+        // store's layout checks. Following a symlink here would let stale-lock
+        // recovery unlink an owner file outside the managed store.
+        const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+        const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-lock-"));
+        try {
+          fs.symlinkSync(outside, layout.publishLockDir, "dir");
+          await expect(acquirePublishLock(layout, 300)).rejects.toThrow(
+            /symlink/i
+          );
+        } finally {
+          fs.rmSync(outside, { recursive: true, force: true });
+        }
+      }
+    );
+
+    it("aborts a publication whose lock was recovered underneath it", async () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const lock = await acquirePublishLock(layout, 2000);
+      // Somebody else recovered and re-took the lock.
+      writeLockOwner(expiredOwner({ createdAt: new Date().toISOString() }));
+
+      expect(() => assertLockOwnership(lock)).toThrow(/stolen/);
+    });
+  });
+
+  describe("stale lease reporting", () => {
+    it("warns about an old lease from another instance but never removes it", async () => {
+      const daysAgo = (days: number) =>
+        new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+      const current = seedRelease(storeRoot, { version: "2026.08.19" });
+      // Enough newer releases that the orphaned one falls outside the rollback
+      // window, so only its lease can be keeping it alive.
+      const fillers = [
+        seedRelease(storeRoot, { version: "2026.07.01", installedAt: daysAgo(10) }),
+        seedRelease(storeRoot, { version: "2026.06.01", installedAt: daysAgo(20) }),
+      ];
+      const orphaned = seedRelease(storeRoot, {
+        version: "2026.05.01",
+        installedAt: daysAgo(30),
+      });
+      const layout = getManagedStoreLayout(storeRoot);
+      const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+      for (const release of [...fillers, orphaned]) {
+        fs.utimesSync(getReleaseDir(layout, release.releaseId), old, old);
+      }
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: current.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      // A lease left behind by a backend that crashed two days ago.
+      const leaseDir = path.join(layout.leasesDir, orphaned.releaseId);
+      fs.mkdirSync(leaseDir, { recursive: true });
+      const leaseFile = path.join(leaseDir, "4242-aabbccddeeff-0123456789abcdef.json");
+      fs.writeFileSync(
+        leaseFile,
+        JSON.stringify({
+          schemaVersion: 1,
+          releaseId: orphaned.releaseId,
+          instanceId: "4242-aabbccddeeff",
+          pid: 4242,
+          operationId: "op-0123456789abcdef",
+          createdAt: daysAgo(2),
+        })
+      );
+
+      const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+      await collectGarbage();
+      const warnings = warnSpy.mock.calls.map((call) => String(call[0]));
+      warnSpy.mockRestore();
+
+      // Reported for an operator to act on...
+      expect(
+        warnings.some(
+          (message) =>
+            message.includes(orphaned.releaseId) && message.includes("still pinned")
+        )
+      ).toBe(true);
+      // ...but never reclaimed: an orphaned child may still be reading from it.
+      expect(fs.existsSync(leaseFile)).toBe(true);
+      expect(fs.existsSync(getReleaseDir(layout, orphaned.releaseId))).toBe(true);
+    });
+  });
+});

--- a/backend/src/__tests__/utils/ytdlpReleaseConcurrency.test.ts
+++ b/backend/src/__tests__/utils/ytdlpReleaseConcurrency.test.ts
@@ -1,0 +1,567 @@
+import fs from "fs";
+import fsExtra from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
+import { YT_DLP_GC_MIN_INTERVAL_MS } from "../../utils/ytdlp/constants";
+import { acquireYtDlpRelease } from "../../utils/ytdlp/release/acquire";
+import {
+  collectGarbage,
+  resetCollectionThrottleForTests,
+} from "../../utils/ytdlp/release/gc";
+import {
+  acquireLease,
+  beginGcMarker,
+  hasLeases,
+  listLeaseFilenames,
+} from "../../utils/ytdlp/release/leases";
+import { withYtDlpRelease } from "../../utils/ytdlp/release/launcher";
+import {
+  readCurrentManifest,
+  writeCurrentManifest,
+  writeReleaseManifest,
+} from "../../utils/ytdlp/release/manifests";
+import {
+  ensureManagedStoreLayout,
+  getManagedStoreLayout,
+  getReleaseDir,
+  getSitePackagesPath,
+  setManagedStoreRootForTests,
+} from "../../utils/ytdlp/release/paths";
+import { publishValidatedRelease } from "../../utils/ytdlp/release/publish";
+import { resetCapabilityCacheForTests } from "../../utils/ytdlp/release/capabilities";
+import { SITE_PACKAGES_DIRNAME } from "../../utils/ytdlp/release/types";
+import { resetYtDlpAvailablePromise } from "../../utils/ytdlp/install";
+import { appendYouTubeJsRuntimeArg, resetRuntimeCaches } from "../../utils/ytdlp/runtime";
+
+// Stable ids so the hoisted runProcess mock can tell the two releases apart by
+// the site-packages path in the spawn environment alone.
+const LEGACY_ID = "ytdlp-legacy-aaaa1111";
+const MODERN_ID = "ytdlp-modern-bbbb2222";
+
+vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderPluginPath: vi.fn(() => "/app/bgutil-ytdlp-pot-provider"),
+  getProviderScript: vi.fn(() => ""),
+}));
+
+// Capability probes answer according to whichever release's environment they
+// are handed, which is what makes "A's capabilities with B's executable"
+// detectable at all.
+vi.mock("../../utils/ytdlp/release/process", () => ({
+  runProcess: vi.fn(
+    async (
+      _command: string,
+      args: readonly string[],
+      options: { env?: NodeJS.ProcessEnv }
+    ) => {
+      const pythonPath = String(options?.env?.PYTHONPATH ?? "");
+      const isLegacy = pythonPath.includes("ytdlp-legacy");
+      const ok = (stdout: string) => ({
+        code: 0,
+        signal: null,
+        stdout,
+        stderr: "",
+        timedOut: false,
+      });
+      if (args.includes("--help")) {
+        return ok(
+          isLegacy
+            ? "    --js-runtime RUNTIME[:PATH]\n"
+            : "    --js-runtimes RUNTIME[:PATH]\n    --remote-components COMPONENT\n"
+        );
+      }
+      if (args.includes("--list-impersonate-targets")) {
+        return ok(isLegacy ? "chrome  (unavailable)\n" : "chrome  curl_cffi\n");
+      }
+      return ok("");
+    }
+  ),
+}));
+
+type Seeded = { releaseId: string; version: string; sitePackagesPath: string };
+
+function seed(
+  root: string,
+  releaseId: string,
+  version: string,
+  installedAt = new Date().toISOString()
+): Seeded {
+  const layout = ensureManagedStoreLayout(getManagedStoreLayout(root));
+  const sitePackagesPath = getSitePackagesPath(layout, releaseId);
+  fs.mkdirSync(sitePackagesPath, { recursive: true });
+  writeReleaseManifest(root, {
+    schemaVersion: 1,
+    releaseId,
+    version,
+    installedAt,
+    // Never actually spawned: runProcess is mocked and the tests assert on the
+    // snapshot rather than on child output.
+    pythonExecutable: process.execPath,
+    pythonPrefixArgs: [],
+    sitePackages: SITE_PACKAGES_DIRNAME,
+  });
+  return { releaseId, version, sitePackagesPath };
+}
+
+function publish(
+  root: string,
+  releaseId: string,
+  generation: number,
+  previousReleaseId: string | null = null
+): void {
+  writeCurrentManifest(root, {
+    schemaVersion: 1,
+    generation,
+    releaseId,
+    previousReleaseId,
+    publishedAt: new Date().toISOString(),
+  });
+}
+
+/** A promise the test opens and closes by hand, to pause a task mid-flight. */
+function gate(): { wait: Promise<void>; open: () => void } {
+  let open: () => void = () => {};
+  const wait = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { wait, open };
+}
+
+function backdate(root: string, releaseId: string): void {
+  const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  fs.utimesSync(getReleaseDir(getManagedStoreLayout(root), releaseId), old, old);
+}
+
+describe("yt-dlp release concurrency", () => {
+  let storeRoot: string;
+  const originalYtDlpPath = process.env.YT_DLP_PATH;
+  const originalJsRuntime = process.env.YT_DLP_JS_RUNTIME;
+
+  beforeEach(() => {
+    storeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-concurrency-"));
+    setManagedStoreRootForTests(storeRoot);
+    delete process.env.YT_DLP_PATH;
+    // Pins the JS runtime so no probe spawns a real `deno`.
+    process.env.YT_DLP_JS_RUNTIME = "node";
+    vi.mocked(getProviderPluginPath).mockReturnValue(
+      "/app/bgutil-ytdlp-pot-provider"
+    );
+    resetYtDlpAvailablePromise();
+    resetCapabilityCacheForTests();
+    resetRuntimeCaches();
+    resetCollectionThrottleForTests();
+  });
+
+  afterEach(() => {
+    resetYtDlpAvailablePromise();
+    resetCapabilityCacheForTests();
+    resetRuntimeCaches();
+    setManagedStoreRootForTests(null);
+    fs.rmSync(storeRoot, { recursive: true, force: true });
+    if (originalYtDlpPath === undefined) {
+      delete process.env.YT_DLP_PATH;
+    } else {
+      process.env.YT_DLP_PATH = originalYtDlpPath;
+    }
+    if (originalJsRuntime === undefined) {
+      delete process.env.YT_DLP_JS_RUNTIME;
+    } else {
+      process.env.YT_DLP_JS_RUNTIME = originalJsRuntime;
+    }
+  });
+
+  it("keeps a paused task on its snapshot when a newer release is published", async () => {
+    // Acceptance criteria #2 and #3: a task suspended between capability
+    // resolution and spawn cannot end up combining A's capabilities with B's
+    // executable, nor the other way round.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    publish(storeRoot, legacy.releaseId, 1);
+
+    const acquired = gate();
+    const paused = gate();
+    const observed: {
+      before?: string;
+      after?: string;
+      pythonPath?: string;
+      args?: string[];
+    } = {};
+
+    const task = withYtDlpRelease(async (release) => {
+      observed.before = release.releaseId;
+      acquired.open();
+      await paused.wait;
+      observed.after = release.releaseId;
+      observed.pythonPath = release.spawnEnv.PYTHONPATH;
+      const args: string[] = [];
+      await appendYouTubeJsRuntimeArg(
+        args,
+        "https://www.youtube.com/watch?v=abc",
+        release
+      );
+      observed.args = args;
+    });
+
+    // Publish B only once the task is provably parked on A.
+    await acquired.wait;
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    publish(storeRoot, modern.releaseId, 2, legacy.releaseId);
+
+    // A fresh acquisition must already see B — otherwise this test would prove
+    // nothing about the paused task.
+    const fresh = await acquireYtDlpRelease();
+    expect(fresh.releaseId).toBe(MODERN_ID);
+
+    paused.open();
+    await task;
+
+    expect(observed.before).toBe(LEGACY_ID);
+    expect(observed.after).toBe(LEGACY_ID);
+    expect(observed.pythonPath).toContain(legacy.sitePackagesPath);
+    expect(observed.pythonPath).not.toContain(modern.sitePackagesPath);
+    // A's help text only offers the singular flag; B's offers the plural one.
+    expect(observed.args).toEqual(["--js-runtime", "node"]);
+  });
+
+  it("protects a leased release from collection across a publication", async () => {
+    // Acceptance criterion #7: a running child's release cannot be collected.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    // Enough newer releases that A falls outside the rollback window, so only
+    // the lease can save it.
+    seed(storeRoot, "ytdlp-filler-1111cccc", "2099.04.01");
+    seed(storeRoot, "ytdlp-filler-2222dddd", "2099.05.01");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    for (const id of [
+      LEGACY_ID,
+      "ytdlp-filler-1111cccc",
+      "ytdlp-filler-2222dddd",
+      MODERN_ID,
+    ]) {
+      backdate(storeRoot, id);
+    }
+    publish(storeRoot, legacy.releaseId, 1);
+
+    const acquired = gate();
+    const paused = gate();
+    let leasedDuringTask = false;
+    let observedReleaseId = "";
+
+    const task = withYtDlpRelease(async (release) => {
+      observedReleaseId = release.releaseId;
+      leasedDuringTask = hasLeases(LEGACY_ID);
+      acquired.open();
+      await paused.wait;
+      // The release directory must still be intact after GC ran underneath.
+      expect(
+        fs.existsSync(getReleaseDir(getManagedStoreLayout(storeRoot), LEGACY_ID))
+      ).toBe(true);
+    });
+
+    // Publish B with an unrelated previous pointer, then collect.
+    await acquired.wait;
+    publish(storeRoot, modern.releaseId, 2, "ytdlp-filler-2222dddd");
+    await collectGarbage();
+
+    paused.open();
+    await task;
+
+    expect(observedReleaseId).toBe(LEGACY_ID);
+    expect(leasedDuringTask).toBe(true);
+    // Once the operation finishes the lease is gone and the release becomes
+    // collectable.
+    expect(hasLeases(LEGACY_ID)).toBe(false);
+    await collectGarbage();
+    expect(
+      fs.existsSync(getReleaseDir(getManagedStoreLayout(storeRoot), LEGACY_ID))
+    ).toBe(false);
+  });
+
+  it("collects a release once the lease pinning it is released", async () => {
+    // Collection is skipped while a download holds the release. Nothing else
+    // would revisit it until the next install, which may be months away, so
+    // releasing the lease offers a (throttled) collection.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    seed(storeRoot, "ytdlp-filler-1111cccc", "2099.04.01");
+    seed(storeRoot, "ytdlp-filler-2222dddd", "2099.05.01");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    for (const id of [
+      LEGACY_ID,
+      "ytdlp-filler-1111cccc",
+      "ytdlp-filler-2222dddd",
+      MODERN_ID,
+    ]) {
+      backdate(storeRoot, id);
+    }
+    publish(storeRoot, legacy.releaseId, 1);
+
+    const layout = getManagedStoreLayout(storeRoot);
+    await withYtDlpRelease(async (release) => {
+      expect(release.releaseId).toBe(LEGACY_ID);
+      publish(storeRoot, modern.releaseId, 2, "ytdlp-filler-2222dddd");
+      // No explicit collection here: running one would arm the throttle and
+      // mask whether releasing the lease offers its own.
+      expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(true);
+    });
+
+    // The scope has exited: the lease is gone and collection was offered.
+    await vi.waitFor(() => {
+      expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(false);
+    });
+  });
+
+  it("defers, rather than drops, a collection suppressed by the throttle", async () => {
+    // Publication runs its own collection, which arms the throttle. The
+    // follow-up that actually matters - the one after the last lease goes away
+    // - would then be the one discarded.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    seed(storeRoot, "ytdlp-filler-1111cccc", "2099.04.01");
+    seed(storeRoot, "ytdlp-filler-2222dddd", "2099.05.01");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    for (const id of [
+      LEGACY_ID,
+      "ytdlp-filler-1111cccc",
+      "ytdlp-filler-2222dddd",
+      MODERN_ID,
+    ]) {
+      backdate(storeRoot, id);
+    }
+    publish(storeRoot, legacy.releaseId, 1);
+    const layout = getManagedStoreLayout(storeRoot);
+    // Only the deferral timer is faked; the filesystem work stays real.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+    await withYtDlpRelease(async () => {
+      publish(storeRoot, modern.releaseId, 2, "ytdlp-filler-2222dddd");
+      // Arms the throttle while the release is still leased and skipped.
+      await collectGarbage();
+      expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(true);
+    });
+
+    // Suppressed, so nothing happened yet...
+    expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(true);
+    // ...but the request was kept and fires once the interval elapses.
+    await vi.advanceTimersByTimeAsync(YT_DLP_GC_MIN_INTERVAL_MS + 1_000);
+    await vi.waitFor(() => {
+      expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(false);
+    });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("restores a release if a reader leases it mid-retirement", async () => {
+    // A reader writes its lease before validating the release directory, so a
+    // lease can appear while the collector is renaming. Re-checking after the
+    // rename - and putting the release back - is what makes the protocol safe
+    // without depending on how long a marker stays live.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    seed(storeRoot, "ytdlp-filler-1111cccc", "2099.04.01");
+    seed(storeRoot, "ytdlp-filler-2222dddd", "2099.05.01");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    for (const id of [
+      LEGACY_ID,
+      "ytdlp-filler-1111cccc",
+      "ytdlp-filler-2222dddd",
+      MODERN_ID,
+    ]) {
+      backdate(storeRoot, id);
+    }
+    publish(storeRoot, modern.releaseId, 2, "ytdlp-filler-2222dddd");
+    const layout = getManagedStoreLayout(storeRoot);
+
+    // A lease that lands after the collector's first check: written directly so
+    // it bypasses the marker the collector is about to hold.
+    const leaseDir = path.join(layout.leasesDir, legacy.releaseId);
+    fs.mkdirSync(leaseDir, { recursive: true });
+    // security.ts renames through fs-extra, so that is what has to be observed.
+    const realRename = fsExtra.renameSync;
+    const renameSpy = vi
+      .spyOn(fsExtra, "renameSync")
+      .mockImplementationOnce((from: fsExtra.PathLike, to: fsExtra.PathLike) => {
+        realRename(from, to);
+        fs.writeFileSync(
+          path.join(leaseDir, "4242-aabbccddeeff-0123456789abcdef.json"),
+          JSON.stringify({
+            schemaVersion: 1,
+            releaseId: legacy.releaseId,
+            instanceId: "4242-aabbccddeeff",
+            pid: 4242,
+            operationId: "op-0123456789abcdef",
+            createdAt: new Date().toISOString(),
+          })
+        );
+      });
+
+    try {
+      await collectGarbage();
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    // The release is back where a reader can resolve it, and nothing is left in
+    // the trash.
+    expect(fs.existsSync(getReleaseDir(layout, LEGACY_ID))).toBe(true);
+    expect(fs.readdirSync(layout.trashDir)).toEqual([]);
+  });
+
+  it("leaves no lease behind when acquisition fails", async () => {
+    // The lease file is written before the marker and directory checks, and
+    // those checks can throw on a malformed store. A lease left behind would
+    // pin the release permanently, even after the store is repaired.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    publish(storeRoot, legacy.releaseId, 1);
+    const layout = getManagedStoreLayout(storeRoot);
+    fs.mkdirSync(layout.gcMarkersDir, { recursive: true });
+    // A file where the marker directory belongs makes the check throw.
+    fs.writeFileSync(
+      path.join(layout.gcMarkersDir, `${LEGACY_ID}.deleting`),
+      "not a directory"
+    );
+
+    expect(() => acquireLease(LEGACY_ID, "op-0123456789abcdef")).toThrow();
+    expect(listLeaseFilenames(LEGACY_ID)).toEqual([]);
+  });
+
+  it("reports success even when the lease cannot be cleaned up", async () => {
+    // Cleanup runs in a finally, so anything thrown there would replace the
+    // task's result and report a completed download as failed.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    publish(storeRoot, legacy.releaseId, 1);
+
+    const unlinkSpy = vi
+      .spyOn(fsExtra, "unlinkSync")
+      .mockImplementation(() => {
+        throw Object.assign(new Error("read-only file system"), {
+          code: "EROFS",
+        });
+      });
+    try {
+      await expect(withYtDlpRelease(async () => "done")).resolves.toBe("done");
+    } finally {
+      unlinkSpy.mockRestore();
+    }
+  });
+
+  it("keeps serving when the store cannot hand out leases", async () => {
+    // A store problem must degrade rather than fail every operation: a lease
+    // directory that cannot be written is not a reason to stop downloading.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    publish(storeRoot, legacy.releaseId, 1);
+    const layout = getManagedStoreLayout(storeRoot);
+    fs.mkdirSync(layout.leasesDir, { recursive: true });
+    // A file where the per-release lease directory needs to be.
+    fs.writeFileSync(path.join(layout.leasesDir, LEGACY_ID), "not a directory");
+
+    const release = await withYtDlpRelease(async (r) => r);
+
+    expect(release.kind).toBe("external");
+  });
+
+  it("gives every concurrent reader exactly one complete release", async () => {
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    publish(storeRoot, legacy.releaseId, 1);
+
+    const readers = Array.from({ length: 24 }, () =>
+      withYtDlpRelease(async (release) => ({
+        releaseId: release.releaseId,
+        pythonPath: String(release.spawnEnv.PYTHONPATH),
+      }))
+    );
+    // Flip current underneath the in-flight acquisitions.
+    publish(storeRoot, modern.releaseId, 2, legacy.releaseId);
+
+    const results = await Promise.all(readers);
+    for (const result of results) {
+      expect([LEGACY_ID, MODERN_ID]).toContain(result.releaseId);
+      // Never a mix: the environment must belong to the very release reported.
+      const own =
+        result.releaseId === LEGACY_ID
+          ? legacy.sitePackagesPath
+          : modern.sitePackagesPath;
+      const other =
+        result.releaseId === LEGACY_ID
+          ? modern.sitePackagesPath
+          : legacy.sitePackagesPath;
+      expect(result.pythonPath).toContain(own);
+      expect(result.pythonPath).not.toContain(other);
+    }
+  });
+
+  it("serializes two publishers without regressing current", async () => {
+    // Acceptance criterion #8.
+    const first = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    const second = seed(storeRoot, MODERN_ID, "2099.06.01");
+    publish(storeRoot, "ytdlp-origin-9999eeee", 1);
+    seed(storeRoot, "ytdlp-origin-9999eeee", "2099.01.01");
+
+    const results = await Promise.allSettled([
+      publishValidatedRelease({
+        releaseId: second.releaseId,
+        version: second.version,
+        generationAtInstallStart: 1,
+      }),
+      publishValidatedRelease({
+        releaseId: first.releaseId,
+        version: first.version,
+        generationAtInstallStart: 1,
+      }),
+    ]);
+
+    const current = readCurrentManifest(storeRoot);
+    expect(current).not.toBeNull();
+    expect(current?.generation).toBeGreaterThan(1);
+    // Whatever interleaving occurred, current must name a release that exists
+    // and must never point back at the older candidate.
+    expect(
+      fs.existsSync(
+        getReleaseDir(getManagedStoreLayout(storeRoot), current!.releaseId)
+      )
+    ).toBe(true);
+    expect(current?.releaseId).toBe(MODERN_ID);
+    expect(results.some((r) => r.status === "fulfilled")).toBe(true);
+  });
+
+  it("refuses to lease a release that collection already claimed", async () => {
+    // The two-phase marker protocol: a reader arriving after the marker exists
+    // must abandon the release and leave no orphan lease behind.
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    publish(storeRoot, legacy.releaseId, 1);
+
+    expect(beginGcMarker(LEGACY_ID)).not.toBeNull();
+    // A second collector must not be able to claim the same marker.
+    expect(beginGcMarker(LEGACY_ID)).toBeNull();
+
+    expect(() => acquireLease(LEGACY_ID, "op-0123456789abcdef")).toThrow(
+      /being deleted/
+    );
+    expect(listLeaseFilenames(LEGACY_ID)).toEqual([]);
+  });
+
+  it("skips collecting a release an existing lease still refers to", async () => {
+    const legacy = seed(storeRoot, LEGACY_ID, "2099.03.17");
+    seed(storeRoot, "ytdlp-filler-1111cccc", "2099.04.01");
+    seed(storeRoot, "ytdlp-filler-2222dddd", "2099.05.01");
+    const modern = seed(storeRoot, MODERN_ID, "2099.06.01");
+    for (const id of [
+      LEGACY_ID,
+      "ytdlp-filler-1111cccc",
+      "ytdlp-filler-2222dddd",
+      MODERN_ID,
+    ]) {
+      backdate(storeRoot, id);
+    }
+    publish(storeRoot, modern.releaseId, 2, "ytdlp-filler-2222dddd");
+
+    // A lease written by another backend instance: nothing in this process
+    // knows about it, only the file on disk.
+    acquireLease(legacy.releaseId, "op-0123456789abcdef");
+
+    await collectGarbage();
+
+    expect(
+      fs.existsSync(getReleaseDir(getManagedStoreLayout(storeRoot), LEGACY_ID))
+    ).toBe(true);
+  });
+});

--- a/backend/src/__tests__/utils/ytdlpReleaseFailureInjection.test.ts
+++ b/backend/src/__tests__/utils/ytdlpReleaseFailureInjection.test.ts
@@ -1,0 +1,296 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  pipInstallToTarget,
+  validateStagedRelease,
+} from "../../utils/ytdlp/release/candidate";
+import { collectGarbage } from "../../utils/ytdlp/release/gc";
+import { installManagedRelease } from "../../utils/ytdlp/release/install";
+import { discoverPythonInterpreter } from "../../utils/ytdlp/release/interpreter";
+import {
+  readCurrentManifest,
+  resetObservedGenerationForTests,
+  writeCurrentManifest,
+  writeReleaseManifest,
+} from "../../utils/ytdlp/release/manifests";
+import {
+  ensureManagedStoreLayout,
+  getManagedStoreLayout,
+  getReleaseDir,
+  getSitePackagesPath,
+  renameInRoot,
+  setManagedStoreRootForTests,
+} from "../../utils/ytdlp/release/paths";
+import { recoverUsableManagedRelease } from "../../utils/ytdlp/release/recover";
+import {
+  RELEASE_JSON_FILENAME,
+  SITE_PACKAGES_DIRNAME,
+  type CurrentManifest,
+  type ReleaseManifest,
+} from "../../utils/ytdlp/release/types";
+
+const BASE_ID = "ytdlp-base-1111aaaa";
+const BASE_VERSION = "2026.07.01";
+const CANDIDATE_VERSION = "2026.08.19";
+
+vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderPluginPath: vi.fn(() => ""),
+  getProviderScript: vi.fn(() => ""),
+}));
+
+vi.mock("../../utils/ytdlp/release/interpreter", () => ({
+  discoverPythonInterpreter: vi.fn(),
+}));
+
+vi.mock("../../utils/ytdlp/release/candidate", () => ({
+  pipInstallToTarget: vi.fn(),
+  validateStagedRelease: vi.fn(),
+}));
+
+// Partial mocks so a single step can be made to fail while the rest of the
+// publication path runs for real.
+vi.mock("../../utils/ytdlp/release/paths", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../utils/ytdlp/release/paths")>();
+  return { ...actual, renameInRoot: vi.fn(actual.renameInRoot) };
+});
+
+vi.mock("../../utils/ytdlp/release/manifests", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../utils/ytdlp/release/manifests")>();
+  return { ...actual, writeCurrentManifest: vi.fn(actual.writeCurrentManifest) };
+});
+
+describe("managed release failure injection", () => {
+  let storeRoot: string;
+  let baseline: CurrentManifest;
+
+  beforeEach(() => {
+    storeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-inject-"));
+    setManagedStoreRootForTests(storeRoot);
+    resetObservedGenerationForTests();
+
+    seedRelease(BASE_ID, BASE_VERSION);
+    baseline = {
+      schemaVersion: 1,
+      generation: 4,
+      releaseId: BASE_ID,
+      previousReleaseId: null,
+      publishedAt: new Date().toISOString(),
+    };
+    writeCurrentManifest(storeRoot, baseline);
+
+    vi.mocked(discoverPythonInterpreter).mockResolvedValue({
+      command: process.execPath,
+      prefixArgs: [],
+      executable: process.execPath,
+    });
+    // A successful pip run leaves a populated target behind.
+    vi.mocked(pipInstallToTarget).mockImplementation(
+      async (_interpreter, targetDir) => {
+        fs.mkdirSync(path.join(targetDir, "yt_dlp"), { recursive: true });
+        fs.writeFileSync(path.join(targetDir, "yt_dlp", "__init__.py"), "");
+      }
+    );
+    vi.mocked(validateStagedRelease).mockImplementation(async (input) => {
+      const manifest: ReleaseManifest = {
+        schemaVersion: 1,
+        releaseId: input.createReleaseId(CANDIDATE_VERSION),
+        version: CANDIDATE_VERSION,
+        installedAt: input.installedAt,
+        pythonExecutable: process.execPath,
+        pythonPrefixArgs: [],
+        sitePackages: SITE_PACKAGES_DIRNAME,
+      };
+      fs.writeFileSync(
+        path.join(input.stagingRoot, RELEASE_JSON_FILENAME),
+        `${JSON.stringify(manifest, null, 2)}\n`
+      );
+      return manifest;
+    });
+  });
+
+  afterEach(() => {
+    vi.mocked(renameInRoot).mockReset();
+    vi.mocked(writeCurrentManifest).mockReset();
+    setManagedStoreRootForTests(null);
+    fs.rmSync(storeRoot, { recursive: true, force: true });
+  });
+
+  function seedRelease(releaseId: string, version: string): ReleaseManifest {
+    const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+    fs.mkdirSync(getSitePackagesPath(layout, releaseId), { recursive: true });
+    const manifest: ReleaseManifest = {
+      schemaVersion: 1,
+      releaseId,
+      version,
+      installedAt: new Date().toISOString(),
+      pythonExecutable: process.execPath,
+      pythonPrefixArgs: [],
+      sitePackages: SITE_PACKAGES_DIRNAME,
+    };
+    writeReleaseManifest(storeRoot, manifest);
+    return manifest;
+  }
+
+  function listReleaseDirs(): string[] {
+    return fs
+      .readdirSync(getManagedStoreLayout(storeRoot).releasesDir)
+      .sort();
+  }
+
+  function listStagingDirs(): string[] {
+    return fs.readdirSync(getManagedStoreLayout(storeRoot).stagingDir).sort();
+  }
+
+  /**
+   * The invariant every pre-publication failure must preserve: a reader still
+   * gets the complete previous release, never a partial candidate.
+   */
+  function expectReaderStillSeesBaseline(): void {
+    expect(readCurrentManifest(storeRoot)).toEqual(baseline);
+    const loaded = recoverUsableManagedRelease(storeRoot);
+    expect(loaded?.release.releaseId).toBe(BASE_ID);
+    expect(loaded?.release.version).toBe(BASE_VERSION);
+    expect(fs.existsSync(loaded!.sitePackagesPath)).toBe(true);
+    expect(
+      fs.existsSync(path.join(loaded!.releaseDir, RELEASE_JSON_FILENAME))
+    ).toBe(true);
+  }
+
+  it("keeps current usable when interpreter discovery fails", async () => {
+    vi.mocked(discoverPythonInterpreter).mockRejectedValueOnce(
+      new Error("No usable Python interpreter with pip was found.")
+    );
+
+    await expect(installManagedRelease()).rejects.toThrow(/Python interpreter/);
+
+    expectReaderStillSeesBaseline();
+    expect(listReleaseDirs()).toEqual([BASE_ID]);
+  });
+
+  it("keeps current usable and cleans staging when pip fails", async () => {
+    vi.mocked(pipInstallToTarget).mockRejectedValueOnce(
+      new Error("pip install failed: no matching distribution")
+    );
+
+    await expect(installManagedRelease()).rejects.toThrow(/pip install failed/);
+
+    expectReaderStillSeesBaseline();
+    expect(listReleaseDirs()).toEqual([BASE_ID]);
+    expect(listStagingDirs()).toEqual([]);
+  });
+
+  it("keeps current usable when validation rejects the candidate", async () => {
+    vi.mocked(validateStagedRelease).mockRejectedValueOnce(
+      new Error("Candidate yt-dlp --version probe failed")
+    );
+
+    await expect(installManagedRelease()).rejects.toThrow(/--version probe/);
+
+    expectReaderStillSeesBaseline();
+    // A candidate that failed validation never reaches releases/.
+    expect(listReleaseDirs()).toEqual([BASE_ID]);
+    expect(listStagingDirs()).toEqual([]);
+  });
+
+  it("keeps current usable when finalization fails", async () => {
+    vi.mocked(renameInRoot).mockImplementationOnce(() => {
+      throw Object.assign(new Error("no space left on device"), {
+        code: "ENOSPC",
+      });
+    });
+
+    await expect(installManagedRelease()).rejects.toThrow(/no space left/);
+
+    expectReaderStillSeesBaseline();
+    expect(listReleaseDirs()).toEqual([BASE_ID]);
+  });
+
+  it("keeps current usable when publication fails after finalization", async () => {
+    vi.mocked(writeCurrentManifest).mockImplementationOnce(() => {
+      throw Object.assign(new Error("read-only file system"), { code: "EROFS" });
+    });
+
+    await expect(installManagedRelease()).rejects.toThrow(/read-only/);
+
+    // The candidate directory exists but nothing points at it, so the reader
+    // still gets the old release; ordinary GC reclaims the orphan later.
+    expectReaderStillSeesBaseline();
+    expect(listReleaseDirs()).toHaveLength(2);
+  });
+
+  it("hands the reader the complete new release immediately after publication", async () => {
+    const outcome = await installManagedRelease();
+
+    expect(outcome.published).toBe(true);
+    const current = readCurrentManifest(storeRoot);
+    expect(current?.generation).toBe(baseline.generation + 1);
+    expect(current?.previousReleaseId).toBe(BASE_ID);
+
+    const loaded = recoverUsableManagedRelease(storeRoot);
+    expect(loaded?.release.releaseId).toBe(current?.releaseId);
+    expect(loaded?.release.version).toBe(CANDIDATE_VERSION);
+    // Publishing B never touches A.
+    expect(
+      fs.existsSync(
+        path.join(
+          getReleaseDir(getManagedStoreLayout(storeRoot), BASE_ID),
+          RELEASE_JSON_FILENAME
+        )
+      )
+    ).toBe(true);
+    expect(listStagingDirs()).toEqual([]);
+  });
+
+  it("recovers from a corrupt current.json by revalidating and starting a new lineage", async () => {
+    const layout = getManagedStoreLayout(storeRoot);
+    fs.writeFileSync(layout.currentPath, "{ not json");
+
+    // Recovery falls back to the finalized release without publishing it.
+    expect(recoverUsableManagedRelease(storeRoot)?.release.releaseId).toBe(
+      BASE_ID
+    );
+    expect(readCurrentManifest(storeRoot)).toBeNull();
+
+    const outcome = await installManagedRelease();
+
+    expect(outcome.published).toBe(true);
+    const current = readCurrentManifest(storeRoot);
+    expect(current).not.toBeNull();
+    // A new lineage continues past the highest generation this process saw,
+    // so a stale reader cannot mistake it for going backwards.
+    expect(current!.generation).toBeGreaterThan(baseline.generation);
+    expect(recoverUsableManagedRelease(storeRoot)?.release.version).toBe(
+      CANDIDATE_VERSION
+    );
+  });
+
+  it("recovers an unreferenced finalized release when current.json is missing", async () => {
+    const layout = getManagedStoreLayout(storeRoot);
+    fs.rmSync(layout.currentPath, { force: true });
+
+    const loaded = recoverUsableManagedRelease(storeRoot);
+    expect(loaded?.release.releaseId).toBe(BASE_ID);
+    expect(fs.existsSync(loaded!.sitePackagesPath)).toBe(true);
+  });
+
+  it("cleans stale staging directories but leaves a younger install alone", async () => {
+    const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+    const stale = path.join(layout.stagingDir, "op-00000000000000000000");
+    const fresh = path.join(layout.stagingDir, "op-11111111111111111111");
+    fs.mkdirSync(stale, { recursive: true });
+    fs.mkdirSync(fresh, { recursive: true });
+    const longAgo = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(stale, longAgo, longAgo);
+
+    await collectGarbage();
+
+    // The age threshold is what protects another backend process that is
+    // legitimately mid-install in a shared data directory.
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+});

--- a/backend/src/__tests__/utils/ytdlpReleaseIntegration.test.ts
+++ b/backend/src/__tests__/utils/ytdlpReleaseIntegration.test.ts
@@ -1,0 +1,888 @@
+import { spawn } from "child_process";
+import { EventEmitter } from "events";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { PassThrough } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
+import { executeYtDlpJson } from "../../utils/ytdlp/execute";
+import { ensureYtDlpAvailable, installYtDlp } from "../../utils/ytdlp/install";
+import { getYtDlpStatus, updateYtDlp } from "../../utils/ytdlp/maintenance";
+import {
+  pipInstallToTarget,
+  validateStagedRelease,
+} from "../../utils/ytdlp/release/candidate";
+import { discoverPythonInterpreter } from "../../utils/ytdlp/release/interpreter";
+import { withYtDlpRelease } from "../../utils/ytdlp/release/launcher";
+import {
+  readCurrentManifest,
+  writeCurrentManifest,
+  writeReleaseManifest,
+} from "../../utils/ytdlp/release/manifests";
+import {
+  ensureManagedStoreLayout,
+  getManagedStoreLayout,
+  getSitePackagesPath,
+  setManagedStoreRootForTests,
+} from "../../utils/ytdlp/release/paths";
+import { runProcess } from "../../utils/ytdlp/release/process";
+import { isYtDlpImpersonateAvailable } from "../../utils/ytdlp/runtime";
+import { resetYtDlpAvailabilityCacheForTests } from "../../utils/ytDlpUtils";
+import {
+  RELEASE_JSON_FILENAME,
+  SITE_PACKAGES_DIRNAME,
+  type ReleaseManifest,
+} from "../../utils/ytdlp/release/types";
+
+const CANDIDATE_VERSION = "2099.08.19";
+const VIDEO_URL = "https://example.com/watch?v=abc";
+const MISSAV_URL = "https://missav.example/video";
+const NEWER_VERSION = "2099.09.01";
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderPluginPath: vi.fn(() => ""),
+  getProviderScript: vi.fn(() => ""),
+}));
+
+vi.mock("../../utils/ytdlp/release/interpreter", () => ({
+  discoverPythonInterpreter: vi.fn(),
+}));
+
+vi.mock("../../utils/ytdlp/release/candidate", () => ({
+  pipInstallToTarget: vi.fn(),
+  validateStagedRelease: vi.fn(),
+}));
+
+// Capability probes go through the shared low-level runner, which is stubbed
+// so no test needs a real yt-dlp on the machine.
+vi.mock("../../utils/ytdlp/release/process", () => ({ runProcess: vi.fn() }));
+
+type MockProcess = EventEmitter & {
+  stdout: PassThrough | null;
+  stderr: PassThrough | null;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function createMockProcess(): MockProcess {
+  const proc = new EventEmitter() as MockProcess;
+  proc.stdout = new PassThrough();
+  proc.stderr = new PassThrough();
+  proc.killed = false;
+  proc.kill = vi.fn(() => {
+    proc.killed = true;
+    return true;
+  });
+  return proc;
+}
+
+/**
+ * Each published release records its own interpreter file, so a spawn can be
+ * attributed to one specific release. The file must exist on disk: loading a
+ * release validates that its interpreter is still there.
+ */
+let interpreterFor: (version: string) => string = () => "";
+let managedInterpreterPrefix = "";
+
+/** Every `spawn` this suite sees is either a discovery probe or a real run. */
+function routeSpawn(onCommandRun: (proc: MockProcess) => void) {
+  const commandRuns: Array<{ command: string; args: string[] }> = [];
+  vi.mocked(spawn).mockImplementation(
+    (command: string, args?: readonly string[]) => {
+      const list = Array.isArray(args) ? [...args] : [];
+      // Nothing usable on PATH: discovery probes always fail with ENOENT.
+      if (!command.startsWith(managedInterpreterPrefix)) {
+        const proc = createMockProcess();
+        queueMicrotask(() =>
+          proc.emit(
+            "error",
+            Object.assign(new Error("not found"), { code: "ENOENT" })
+          )
+        );
+        return proc as never;
+      }
+      commandRuns.push({ command, args: list });
+      const proc = createMockProcess();
+      queueMicrotask(() => onCommandRun(proc));
+      return proc as never;
+    }
+  );
+  return commandRuns;
+}
+
+/**
+ * The health probe runs the module-origin script, not `--version`: it has to
+ * prove the release runs *and* that it is this release rather than the
+ * image-wide install.
+ */
+const isHealthProbe = (args: readonly string[]) => args[0] === "-c";
+
+function stubCapabilityProbes() {
+  vi.mocked(runProcess).mockImplementation(
+    async (_command: string, args: readonly string[]) => ({
+      code: 0,
+      signal: null,
+      stdout: isHealthProbe(args)
+        ? '{"yt_dlp": "inside"}\n'
+        : args.includes("--list-impersonate-targets")
+          ? "chrome  curl_cffi\n"
+          : "  --js-runtimes RUNTIME\n  --remote-components COMPONENT\n",
+      stderr: "",
+      timedOut: false,
+    })
+  );
+}
+
+describe("managed release integration", () => {
+  let dataRoot: string;
+  let storeRoot: string;
+  let legacyUserSite: string;
+  let publishedVersion = CANDIDATE_VERSION;
+  const originalYtDlpPath = process.env.YT_DLP_PATH;
+  const originalJsRuntime = process.env.YT_DLP_JS_RUNTIME;
+  const originalHome = process.env.HOME;
+
+  beforeEach(() => {
+    dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-integration-"));
+    storeRoot = path.join(dataRoot, "ytdlp");
+    // A Docker-style legacy runtime install that predates the managed store.
+    managedInterpreterPrefix = path.join(dataRoot, "managed-python3-");
+    interpreterFor = (version: string) => {
+      const executable = `${managedInterpreterPrefix}${version}`;
+      if (!fs.existsSync(executable)) {
+        fs.writeFileSync(executable, "#!/bin/sh\n", { mode: 0o755 });
+      }
+      return executable;
+    };
+    legacyUserSite = path.join(dataRoot, ".home", ".local", "lib", "yt_dlp");
+    fs.mkdirSync(legacyUserSite, { recursive: true });
+    fs.writeFileSync(path.join(legacyUserSite, "__init__.py"), "legacy\n");
+
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+    delete process.env.YT_DLP_PATH;
+    process.env.YT_DLP_JS_RUNTIME = "node";
+    process.env.HOME = path.join(dataRoot, ".home");
+    publishedVersion = CANDIDATE_VERSION;
+
+    vi.mocked(getProviderPluginPath).mockReturnValue("");
+    stubCapabilityProbes();
+    vi.mocked(discoverPythonInterpreter).mockImplementation(async () => ({
+      command: interpreterFor(publishedVersion),
+      prefixArgs: [],
+      executable: interpreterFor(publishedVersion),
+    }));
+    vi.mocked(pipInstallToTarget).mockImplementation(
+      async (_interpreter, targetDir) => {
+        fs.mkdirSync(path.join(targetDir, "yt_dlp"), { recursive: true });
+        fs.writeFileSync(path.join(targetDir, "yt_dlp", "__init__.py"), "");
+      }
+    );
+    vi.mocked(validateStagedRelease).mockImplementation(async (input) => {
+      const manifest: ReleaseManifest = {
+        schemaVersion: 1,
+        releaseId: input.createReleaseId(publishedVersion),
+        version: publishedVersion,
+        installedAt: input.installedAt,
+        pythonExecutable: interpreterFor(publishedVersion),
+        pythonPrefixArgs: [],
+        sitePackages: SITE_PACKAGES_DIRNAME,
+      };
+      fs.writeFileSync(
+        path.join(input.stagingRoot, RELEASE_JSON_FILENAME),
+        `${JSON.stringify(manifest, null, 2)}\n`
+      );
+      return manifest;
+    });
+  });
+
+  afterEach(() => {
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(null);
+    fs.rmSync(dataRoot, { recursive: true, force: true });
+    restoreEnv("YT_DLP_PATH", originalYtDlpPath);
+    restoreEnv("YT_DLP_JS_RUNTIME", originalJsRuntime);
+    restoreEnv("HOME", originalHome);
+  });
+
+  function restoreEnv(name: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
+
+  function snapshotTree(root: string): Record<string, string> {
+    const files: Record<string, string> = {};
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.isFile()) {
+          files[path.relative(root, full)] = fs.readFileSync(full, "utf8");
+        }
+      }
+    };
+    walk(root);
+    return files;
+  }
+
+  it("installs the first managed release when yt-dlp is missing, then executes it", async () => {
+    const runs = routeSpawn((proc) => {
+      proc.stdout?.emit("data", Buffer.from('{"title":"ok"}'));
+      proc.emit("close", 0);
+    });
+
+    await expect(
+      executeYtDlpJson(VIDEO_URL)
+    ).resolves.toEqual({ title: "ok" });
+
+    // A managed release now exists and is what actually ran.
+    const current = readCurrentManifest(storeRoot);
+    expect(current?.releaseId).toBeTruthy();
+    expect(runs).toHaveLength(1);
+    expect(runs[0].command).toBe(interpreterFor(CANDIDATE_VERSION));
+    expect(runs[0].args.slice(0, 2)).toEqual(["-m", "yt_dlp"]);
+    expect(runs[0].args).toContain(VIDEO_URL);
+  });
+
+  it("does not accept a release that resolves yt_dlp from the image install", async () => {
+    // PYTHONNOUSERSITE only disables the *user* site and the image installs
+    // yt-dlp globally, so a `--version` probe would succeed against the
+    // image-wide copy while status reported the manifest's version. The health
+    // probe therefore checks module origin, not just that something ran.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const shadowed = readCurrentManifest(storeRoot)!.releaseId;
+
+    const probes: string[][] = [];
+    vi.mocked(runProcess).mockImplementation(async (_command, args) => {
+      if (isHealthProbe(args)) {
+        probes.push([...args]);
+        // The script exits 2 when yt_dlp resolved outside the target.
+        return {
+          code: 2,
+          signal: null,
+          stdout: '{"yt_dlp": "outside"}\n',
+          stderr: "",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    const status = await getYtDlpStatus();
+
+    // The probe is handed the release's own site-packages as the allowed root.
+    expect(probes.length).toBeGreaterThan(0);
+    expect(probes[0].some((arg) => arg.includes(shadowed))).toBe(true);
+    // And a release importing from elsewhere is not reported as available.
+    expect(status.version).not.toBe(CANDIDATE_VERSION);
+  });
+
+  it("reinstalls when a persisted release no longer runs", async () => {
+    // A store that outlives an image upgrade can keep a valid interpreter path
+    // and a populated site-packages whose dependencies no longer match the new
+    // Python. Existence checks alone would keep selecting a release on which
+    // every invocation fails.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const broken = readCurrentManifest(storeRoot)!.releaseId;
+
+    // The recorded interpreter still exists but now fails to run yt_dlp.
+    const brokenInterpreter = interpreterFor(CANDIDATE_VERSION);
+    vi.mocked(runProcess).mockImplementation(
+      async (command: string, args: readonly string[]) => {
+        // Only the release installed against the old interpreter is broken.
+        if (isHealthProbe(args) && command === brokenInterpreter) {
+          return {
+            code: 1,
+            signal: null,
+            stdout: "",
+            stderr: "No module named yt_dlp",
+            timedOut: false,
+          };
+        }
+        return {
+          code: 0,
+          signal: null,
+          stdout: "  --js-runtimes RUNTIME\n",
+          stderr: "",
+          timedOut: false,
+        };
+      }
+    );
+    publishedVersion = NEWER_VERSION;
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    await ensureYtDlpAvailable();
+
+    // A new release was installed rather than the broken one kept.
+    const repaired = readCurrentManifest(storeRoot)!.releaseId;
+    expect(repaired).not.toBe(broken);
+
+    // And acquisition must not re-select the broken one: an existence check
+    // cannot tell it apart from a healthy release.
+    const release = await withYtDlpRelease(async (r) => r);
+    expect(release.releaseId).toBe(repaired);
+  });
+
+  it("does not report a release that cannot run as available", async () => {
+    // An operator checking status or pressing Update before any download would
+    // otherwise see a broken release reported as healthy, and the update would
+    // treat a same-version repair as a redundant no-op.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const broken = readCurrentManifest(storeRoot)!.releaseId;
+
+    const brokenInterpreter = interpreterFor(CANDIDATE_VERSION);
+    vi.mocked(runProcess).mockImplementation(async (command, args) => {
+      if (isHealthProbe(args) && command === brokenInterpreter) {
+        return {
+          code: 1,
+          signal: null,
+          stdout: "",
+          stderr: "No module named yt_dlp",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    const status = await getYtDlpStatus();
+    expect(status.path).not.toBe(brokenInterpreter);
+
+    // And the operator update repairs it even though pip yields the same
+    // version it is replacing.
+    const result = await updateYtDlp();
+    expect(result.changed).toBe(false);
+    expect(readCurrentManifest(storeRoot)!.releaseId).not.toBe(broken);
+  });
+
+  it("repairs a current release whose site-packages went missing", async () => {
+    // release.json still parses, so the version is known and a same-version
+    // candidate would be rejected as already current - leaving the structurally
+    // broken pointer in place forever.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const broken = readCurrentManifest(storeRoot)!.releaseId;
+    fs.rmSync(
+      path.join(
+        getManagedStoreLayout(storeRoot).releasesDir,
+        broken,
+        SITE_PACKAGES_DIRNAME
+      ),
+      { recursive: true, force: true }
+    );
+
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+    stubCapabilityProbes();
+
+    // pip yields the same version it is replacing, which would be rejected as
+    // already current if the broken pointer were treated as usable.
+    const result = await updateYtDlp();
+
+    expect(result.status.version).toBe(CANDIDATE_VERSION);
+    expect(readCurrentManifest(storeRoot)!.releaseId).not.toBe(broken);
+    // The replacement is complete, not another pointer at nothing.
+    expect(
+      fs.existsSync(
+        path.join(
+          getManagedStoreLayout(storeRoot).releasesDir,
+          readCurrentManifest(storeRoot)!.releaseId,
+          SITE_PACKAGES_DIRNAME
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("validates a release published after availability was already resolved", async () => {
+    // Availability is resolved once per process. A second backend sharing the
+    // store can publish afterwards, and if it runs a different image or Python
+    // ABI its release may be structurally valid here yet unrunnable.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const healthy = readCurrentManifest(storeRoot)!.releaseId;
+    await ensureYtDlpAvailable();
+
+    // Another backend publishes; this process never re-resolves availability.
+    publishedVersion = NEWER_VERSION;
+    await installYtDlp();
+    const foreign = readCurrentManifest(storeRoot)!.releaseId;
+    expect(foreign).not.toBe(healthy);
+
+    const foreignInterpreter = interpreterFor(NEWER_VERSION);
+    vi.mocked(runProcess).mockImplementation(async (command, args) => {
+      if (isHealthProbe(args) && command === foreignInterpreter) {
+        return {
+          code: 1,
+          signal: null,
+          stdout: "",
+          stderr: "No module named yt_dlp",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+
+    const release = await withYtDlpRelease(async (r) => r);
+
+    // The newly observed release cannot run here, so the operation must not use
+    // it just because current.json points at it.
+    expect(release.releaseId).toBe(healthy);
+  });
+
+  it("retries a probe that timed out instead of condemning the release", async () => {
+    // A timeout or a spawn failure under load says nothing about an immutable
+    // release. Caching it as a verdict would strand a healthy current release
+    // for the life of the process and force a needless reinstall.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const healthy = readCurrentManifest(storeRoot)!.releaseId;
+
+    let probes = 0;
+    vi.mocked(runProcess).mockImplementation(async (_command, args) => {
+      if (isHealthProbe(args)) {
+        probes += 1;
+        if (probes === 1) {
+          return {
+            code: null,
+            signal: null,
+            stdout: "",
+            stderr: "",
+            timedOut: true,
+          };
+        }
+        return {
+          code: 0,
+          signal: null,
+          stdout: `${CANDIDATE_VERSION}\n`,
+          stderr: "",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    const first = await withYtDlpRelease(async (r) => r);
+    expect(first.releaseId).toBe(healthy);
+
+    // The transient result was not remembered, so the release is probed again
+    // rather than skipped.
+    const second = await withYtDlpRelease(async (r) => r);
+    expect(second.releaseId).toBe(healthy);
+    expect(probes).toBeGreaterThan(1);
+  });
+
+  it("does not fall back onto a rollback release that also cannot run", async () => {
+    // An ABI change breaks every persisted release, not just the current one.
+    // Validating only the current one would leave acquisition free to return
+    // the rollback on structural checks alone.
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const first = readCurrentManifest(storeRoot)!.releaseId;
+    publishedVersion = NEWER_VERSION;
+    await installYtDlp();
+    const second = readCurrentManifest(storeRoot)!.releaseId;
+    expect(readCurrentManifest(storeRoot)!.previousReleaseId).toBe(first);
+
+    // Every managed interpreter now fails, and the repair cannot run either.
+    vi.mocked(runProcess).mockImplementation(async (command, args) => {
+      if (isHealthProbe(args) && command.startsWith(managedInterpreterPrefix)) {
+        return {
+          code: 1,
+          signal: null,
+          stdout: "",
+          stderr: "No module named yt_dlp",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+    vi.mocked(pipInstallToTarget).mockRejectedValue(new Error("pip is gone"));
+
+    const emptyBin = path.join(dataRoot, "empty-bin");
+    fs.mkdirSync(emptyBin, { recursive: true });
+    const previousPath = process.env.PATH;
+    process.env.PATH = emptyBin;
+    vi.mocked(spawn).mockImplementation(
+      (_command: string, args?: readonly string[]) => {
+        const proc = createMockProcess();
+        const list = Array.isArray(args) ? args : [];
+        queueMicrotask(() => {
+          if (list.includes("--version")) {
+            proc.stdout?.emit("data", Buffer.from("2099.05.05\n"));
+          }
+          proc.emit("close", 0);
+        });
+        return proc as never;
+      }
+    );
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    try {
+      const release = await withYtDlpRelease(async (r) => r);
+      expect(release.kind).toBe("external");
+      expect(release.releaseId).not.toContain(first);
+      expect(release.releaseId).not.toContain(second);
+    } finally {
+      restoreEnv("PATH", previousPath);
+    }
+  });
+
+  it("falls back to discovery when a broken release cannot be reinstalled", async () => {
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const broken = readCurrentManifest(storeRoot)!.releaseId;
+
+    vi.mocked(runProcess).mockImplementation(async (_c, args) => {
+      if (isHealthProbe(args)) {
+        return {
+          code: 1,
+          signal: null,
+          stdout: "",
+          stderr: "No module named yt_dlp",
+          timedOut: false,
+        };
+      }
+      return {
+        code: 0,
+        signal: null,
+        stdout: "  --js-runtimes RUNTIME\n",
+        stderr: "",
+        timedOut: false,
+      };
+    });
+    // The repair cannot succeed either.
+    vi.mocked(pipInstallToTarget).mockRejectedValue(new Error("pip is gone"));
+    // A working binary is reachable through discovery.
+    const previousPath = process.env.PATH;
+    process.env.PATH = path.join(dataRoot, "empty-bin");
+    fs.mkdirSync(process.env.PATH, { recursive: true });
+    vi.mocked(spawn).mockImplementation(
+      (_command: string, args?: readonly string[]) => {
+        const proc = createMockProcess();
+        const list = Array.isArray(args) ? args : [];
+        queueMicrotask(() => {
+          if (list.includes("--version")) {
+            proc.stdout?.emit("data", Buffer.from("2099.05.05\n"));
+          }
+          proc.emit("close", 0);
+        });
+        return proc as never;
+      }
+    );
+
+    resetYtDlpAvailabilityCacheForTests();
+    setManagedStoreRootForTests(storeRoot);
+
+    try {
+      const release = await withYtDlpRelease(async (r) => r);
+      // The known-broken managed release must not come back.
+      expect(release.releaseId).not.toContain(broken);
+      expect(release.kind).toBe("external");
+    } finally {
+      restoreEnv("PATH", previousPath);
+    }
+  });
+
+  it("leaves a legacy user install untouched and out of the managed environment", async () => {
+    const legacyBefore = snapshotTree(path.join(dataRoot, ".home"));
+    routeSpawn((proc) => {
+      proc.stdout?.emit("data", Buffer.from("{}"));
+      proc.emit("close", 0);
+    });
+
+    let observedEnv: NodeJS.ProcessEnv = {};
+    await withYtDlpRelease(async (release) => {
+      observedEnv = release.spawnEnv;
+    });
+
+    expect(snapshotTree(path.join(dataRoot, ".home"))).toEqual(legacyBefore);
+    // PYTHONNOUSERSITE keeps a persistent --user install from contaminating the
+    // release, and PYTHONPATH is replaced rather than extended.
+    expect(observedEnv.PYTHONNOUSERSITE).toBe("1");
+    expect(observedEnv.PYTHONPATH).not.toContain(".local");
+    expect(observedEnv.PYTHONPATH).toContain(storeRoot);
+  });
+
+  it("publishes an operator update by adding a release and rewriting only current.json", async () => {
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+
+    const layout = getManagedStoreLayout(storeRoot);
+    const before = snapshotTree(layout.releasesDir);
+    const firstCurrent = readCurrentManifest(storeRoot);
+
+    publishedVersion = NEWER_VERSION;
+    const result = await updateYtDlp();
+
+    expect(result.changed).toBe(true);
+    expect(result.previousVersion).toBe(CANDIDATE_VERSION);
+    expect(result.status.version).toBe(NEWER_VERSION);
+    // For a managed release the reported path is the interpreter MyTube runs.
+    expect(result.status.path).toBe(interpreterFor(NEWER_VERSION));
+    expect(result.status.updateSupported).toBe(true);
+
+    const after = snapshotTree(layout.releasesDir);
+    // Every previously published file is byte-identical; only new files appear.
+    for (const [relativePath, contents] of Object.entries(before)) {
+      expect(after[relativePath]).toBe(contents);
+    }
+    expect(Object.keys(after).length).toBeGreaterThan(Object.keys(before).length);
+
+    const secondCurrent = readCurrentManifest(storeRoot);
+    expect(secondCurrent?.generation).toBe(firstCurrent!.generation + 1);
+    expect(secondCurrent?.previousReleaseId).toBe(firstCurrent!.releaseId);
+  });
+
+  it("reports no change when the operator updates an already-current release", async () => {
+    routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const firstCurrent = readCurrentManifest(storeRoot);
+
+    // Same version comes back: this is a successful no-op, not a failure.
+    const result = await updateYtDlp();
+
+    expect(result.changed).toBe(false);
+    expect(result.status.version).toBe(CANDIDATE_VERSION);
+    expect(readCurrentManifest(storeRoot)?.generation).toBe(
+      firstCurrent!.generation
+    );
+  });
+
+  it("probes and spawns MissAV-style work against one release", async () => {
+    const runs = routeSpawn((proc) => proc.emit("close", 0));
+    await installYtDlp();
+    const firstRelease = readCurrentManifest(storeRoot)!.releaseId;
+
+    const observed: { probeRelease?: string; spawnRelease?: string } = {};
+    await withYtDlpRelease(async (release) => {
+      observed.probeRelease = release.releaseId;
+      await isYtDlpImpersonateAvailable(release);
+
+      // A newer release is published between the probe and the spawn.
+      publishedVersion = NEWER_VERSION;
+      await installYtDlp();
+
+      observed.spawnRelease = release.releaseId;
+      const { spawnYtDlp } = await import("../../utils/ytdlp/release/launcher");
+      const child = spawnYtDlp(release, [MISSAV_URL]);
+      await new Promise<void>((resolve) => child.on("close", () => resolve()));
+    });
+
+    expect(observed.probeRelease).toBe(firstRelease);
+    expect(observed.spawnRelease).toBe(firstRelease);
+    // The published release did move on, so this really was a race.
+    expect(readCurrentManifest(storeRoot)?.releaseId).not.toBe(firstRelease);
+    const missavRun = runs.find((run) =>
+      run.args.some((arg) => arg === MISSAV_URL)
+    );
+    // The probe answered for the first release, so the spawn must use its
+    // interpreter, not the one the newer release records.
+    expect(missavRun?.command).toBe(interpreterFor(CANDIDATE_VERSION));
+  });
+
+  it("keeps a same-operation retry on its snapshot and gives a new call the newer release", async () => {
+    await installYtDlp();
+    const firstRelease = readCurrentManifest(storeRoot)!.releaseId;
+
+    let attempt = 0;
+    const runs = routeSpawn((proc) => {
+      attempt += 1;
+      if (attempt === 1) {
+        // Publish a newer release *between* the two attempts of the same
+        // logical operation, then drive the format-restriction retry.
+        void (async () => {
+          publishedVersion = NEWER_VERSION;
+          await installYtDlp();
+          proc.stderr?.emit(
+            "data",
+            Buffer.from("ERROR: Requested format is not available")
+          );
+          proc.emit("close", 1);
+        })();
+        return;
+      }
+      proc.stdout?.emit("data", Buffer.from(`{"attempt":"${attempt}"}`));
+      proc.emit("close", 0);
+    });
+
+    await expect(
+      executeYtDlpJson(VIDEO_URL, { format: "bestvideo" })
+    ).resolves.toEqual({ attempt: "2" });
+
+    const jsonRuns = runs.filter((run) =>
+      run.args.some((arg) => arg === VIDEO_URL)
+    );
+    expect(jsonRuns).toHaveLength(2);
+    // Both attempts belong to one logical operation, so both must run the
+    // release acquired at the start — never the one published in between.
+    for (const run of jsonRuns) {
+      expect(run.command).toBe(interpreterFor(CANDIDATE_VERSION));
+    }
+
+    // The newer release really is current, and the next logical operation and
+    // the status endpoint both see it.
+    const secondRelease = readCurrentManifest(storeRoot)!.releaseId;
+    expect(secondRelease).not.toBe(firstRelease);
+    const status = await getYtDlpStatus();
+    expect(status.version).toBe(NEWER_VERSION);
+    expect(status.path).toBe(interpreterFor(NEWER_VERSION));
+  });
+  // Design section 10.5 / acceptance criterion 13: upgrading an existing
+  // installation must behave exactly like the previous version until a managed
+  // release is deliberately published, and a broken store must never stop the
+  // backend from serving.
+  describe("upgrade compatibility", () => {
+    const originalPath = process.env.PATH;
+
+    beforeEach(() => {
+      // An empty PATH makes discovery deterministic: it falls through to the
+      // default `yt-dlp` name instead of finding whatever this machine has.
+      const emptyBin = path.join(dataRoot, "empty-bin");
+      fs.mkdirSync(emptyBin, { recursive: true });
+      process.env.PATH = emptyBin;
+      // A working fallback binary answers the discovery probe.
+      vi.mocked(spawn).mockImplementation(
+        (command: string, args?: readonly string[]) => {
+          const proc = createMockProcess();
+          const list = Array.isArray(args) ? args : [];
+          queueMicrotask(() => {
+            if (list.includes("--version")) {
+              proc.stdout?.emit("data", Buffer.from("2099.05.05\n"));
+            }
+            proc.emit("close", 0);
+          });
+          return proc as never;
+        }
+      );
+    });
+
+    afterEach(() => {
+      restoreEnv("PATH", originalPath);
+    });
+
+    it("serves from fallback discovery when no managed store exists", async () => {
+      expect(fs.existsSync(storeRoot)).toBe(false);
+
+      const status = await getYtDlpStatus();
+
+      expect(status.available).toBe(true);
+      expect(status.version).toBe("2099.05.05");
+      expect(status.path).toBe("yt-dlp");
+      expect(status.customPathConfigured).toBe(false);
+      // The store is created lazily by an install, never eagerly at startup.
+      expect(fs.existsSync(storeRoot)).toBe(false);
+
+      const release = await withYtDlpRelease(async (r) => r);
+      expect(release.kind).toBe("external");
+      // External releases keep the previous version's environment semantics.
+      expect(release.spawnEnv.PYTHONNOUSERSITE).toBeUndefined();
+    });
+
+    it("serves with a legacy user install present and leaves it untouched", async () => {
+      const legacyBefore = snapshotTree(path.join(dataRoot, ".home"));
+
+      const status = await getYtDlpStatus();
+      await withYtDlpRelease(async () => undefined);
+
+      expect(status.available).toBe(true);
+      expect(snapshotTree(path.join(dataRoot, ".home"))).toEqual(legacyBefore);
+      expect(fs.existsSync(storeRoot)).toBe(false);
+    });
+
+    it("adopts a managed store left behind by a newer run", async () => {
+      // No installer runs here: the store is exactly what a newer version of
+      // MyTube would have written.
+      const releaseId = "ytdlp-preexisting-7777ffff";
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.mkdirSync(getSitePackagesPath(layout, releaseId), { recursive: true });
+      writeReleaseManifest(storeRoot, {
+        schemaVersion: 1,
+        releaseId,
+        version: NEWER_VERSION,
+        installedAt: new Date().toISOString(),
+        pythonExecutable: interpreterFor(NEWER_VERSION),
+        pythonPrefixArgs: [],
+        sitePackages: SITE_PACKAGES_DIRNAME,
+      });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 9,
+        releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+
+      const status = await getYtDlpStatus();
+      expect(status.version).toBe(NEWER_VERSION);
+      expect(status.path).toBe(interpreterFor(NEWER_VERSION));
+      expect(status.updateSupported).toBe(true);
+
+      const release = await withYtDlpRelease(async (r) => r);
+      expect(release.kind).toBe("managed");
+      expect(release.releaseId).toBe(releaseId);
+    });
+
+    it("degrades to fallback discovery when the managed store is unusable", async () => {
+      // Unexpected content in data/ytdlp/. A store problem may disable the
+      // update feature; it must not prevent serving.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      fs.rmSync(layout.releasesDir, { recursive: true, force: true });
+      fs.writeFileSync(layout.releasesDir, "not a directory");
+
+      const status = await getYtDlpStatus();
+
+      expect(status.available).toBe(true);
+      expect(status.path).toBe("yt-dlp");
+      await expect(
+        withYtDlpRelease(async (r) => r.kind)
+      ).resolves.toBe("external");
+    });
+  });
+});

--- a/backend/src/__tests__/utils/ytdlpReleaseValidation.test.ts
+++ b/backend/src/__tests__/utils/ytdlpReleaseValidation.test.ts
@@ -1,0 +1,252 @@
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
+import { validateStagedRelease } from "../../utils/ytdlp/release/candidate";
+import { MODULE_ORIGIN_SCRIPT } from "../../utils/ytdlp/release/moduleOrigin";
+import { runProcess } from "../../utils/ytdlp/release/process";
+import { RELEASE_JSON_FILENAME } from "../../utils/ytdlp/release/types";
+
+vi.mock("../../services/downloaders/ytdlp/ytdlpHelpers", () => ({
+  getProviderPluginPath: vi.fn(() => ""),
+  getProviderScript: vi.fn(() => ""),
+}));
+
+vi.mock("../../utils/ytdlp/release/process", () => ({
+  runProcess: vi.fn(),
+}));
+
+const PYTHON = findPython();
+
+function findPython(): string | null {
+  for (const candidate of ["python3", "python"]) {
+    const probe = spawnSync(candidate, ["-c", "print(1)"], {
+      stdio: "ignore",
+      shell: false,
+    });
+    if (probe.status === 0) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+type ProbeResult = {
+  code: number | null;
+  signal: null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+const ok = (stdout = ""): ProbeResult => ({
+  code: 0,
+  signal: null,
+  stdout,
+  stderr: "",
+  timedOut: false,
+});
+
+describe("candidate validation", () => {
+  let stagingRoot: string;
+  let sitePackagesPath: string;
+
+  beforeEach(() => {
+    stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-staging-"));
+    sitePackagesPath = path.join(stagingRoot, "site-packages");
+    fs.mkdirSync(sitePackagesPath, { recursive: true });
+    vi.mocked(getProviderPluginPath).mockReturnValue("");
+  });
+
+  afterEach(() => {
+    vi.mocked(runProcess).mockReset();
+    fs.rmSync(stagingRoot, { recursive: true, force: true });
+  });
+
+  function validate() {
+    return validateStagedRelease({
+      interpreter: {
+        command: "/usr/bin/python3",
+        prefixArgs: [],
+        executable: "/usr/bin/python3",
+      },
+      stagingRoot,
+      sitePackagesPath,
+      createReleaseId: (version) => `ytdlp-${version.replace(/\./g, "")}-abcd1234`,
+      installedAt: new Date().toISOString(),
+    });
+  }
+
+  /** Route each probe by the flag it carries, so order is not assumed. */
+  function stubProbes(overrides: Record<string, ProbeResult> = {}) {
+    vi.mocked(runProcess).mockImplementation(
+      async (_command: string, args: readonly string[]) => {
+        if (args.includes("--version")) {
+          return overrides.version ?? ok("2026.08.19\n");
+        }
+        if (args.includes("--help")) {
+          return overrides.help ?? ok("  --js-runtimes RUNTIME\n");
+        }
+        if (args.includes("--list-impersonate-targets")) {
+          return overrides.impersonate ?? ok("chrome  curl_cffi\n");
+        }
+        // Anything else is the `python -c` module-origin probe.
+        return overrides.origin ?? ok('{"yt_dlp": true}\n');
+      }
+    );
+  }
+
+  it("writes release.json only after every probe passes", async () => {
+    stubProbes();
+    const manifest = await validate();
+
+    expect(manifest.version).toBe("2026.08.19");
+    expect(manifest.releaseId).toBe("ytdlp-20260819-abcd1234");
+    const written = JSON.parse(
+      fs.readFileSync(path.join(stagingRoot, RELEASE_JSON_FILENAME), "utf8")
+    );
+    expect(written.releaseId).toBe(manifest.releaseId);
+  });
+
+  it("rejects a candidate whose modules resolve outside the managed site-packages", async () => {
+    // The origin probe exits 2 when `yt_dlp.__file__` is not inside the target.
+    stubProbes({
+      origin: {
+        code: 2,
+        signal: null,
+        stdout: '{"yt_dlp": false}\n',
+        stderr: "",
+        timedOut: false,
+      },
+    });
+
+    await expect(validate()).rejects.toThrow(/outside the managed site-packages/);
+    // Nothing may be published from a rejected candidate.
+    expect(fs.existsSync(path.join(stagingRoot, RELEASE_JSON_FILENAME))).toBe(
+      false
+    );
+  });
+
+  it("rejects a candidate that cannot report a version or complete --help", async () => {
+    stubProbes({
+      version: { code: 1, signal: null, stdout: "", stderr: "boom", timedOut: false },
+    });
+    await expect(validate()).rejects.toThrow(/--version probe failed/);
+
+    stubProbes({
+      help: { code: null, signal: null, stdout: "", stderr: "", timedOut: true },
+    });
+    await expect(validate()).rejects.toThrow(/--help probe failed/);
+  });
+
+  it("treats an unavailable impersonation target as a capability, not a failure", async () => {
+    // Design section 8.3: absence of an available target is recorded as a
+    // capability. Only a probe that never completes fails the candidate.
+    stubProbes({
+      impersonate: {
+        code: 0,
+        signal: null,
+        stdout: "chrome  (unavailable)\n",
+        stderr: "",
+        timedOut: false,
+      },
+    });
+    await expect(validate()).resolves.toMatchObject({ version: "2026.08.19" });
+
+    stubProbes({
+      impersonate: {
+        code: null,
+        signal: null,
+        stdout: "",
+        stderr: "",
+        timedOut: true,
+      },
+    });
+    await expect(validate()).rejects.toThrow(/impersonation probe timed out/);
+  });
+
+  // The probe above asserts the wiring. This one runs the actual script the
+  // installer ships, so a change to it that stops detecting an ambient install
+  // is caught too.
+  describe.skipIf(!PYTHON)("module-origin script against a real interpreter", () => {
+    function runOriginScript(pythonPath: string[], target: string) {
+      return spawnSync(PYTHON as string, ["-c", MODULE_ORIGIN_SCRIPT, target], {
+        env: {
+          ...process.env,
+          PYTHONPATH: pythonPath.join(path.delimiter),
+          PYTHONNOUSERSITE: "1",
+        },
+        encoding: "utf8",
+        shell: false,
+      });
+    }
+
+    function writeFakeModule(dir: string): void {
+      const moduleDir = path.join(dir, "yt_dlp");
+      fs.mkdirSync(moduleDir, { recursive: true });
+      fs.writeFileSync(path.join(moduleDir, "__init__.py"), "__version__ = '0'\n");
+    }
+
+    it("accepts an import that resolves inside the target", () => {
+      writeFakeModule(sitePackagesPath);
+      const result = runOriginScript([sitePackagesPath], sitePackagesPath);
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout).yt_dlp).toBe("inside");
+    });
+
+    it("rejects an optional module that resolves outside the target", () => {
+      // curl_cffi missing entirely is fine — impersonation is simply
+      // unavailable. curl_cffi resolving from a system install is not: the
+      // release would run against a mutable ambient dependency.
+      const ambient = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-ambient-"));
+      try {
+        writeFakeModule(sitePackagesPath);
+        const moduleDir = path.join(ambient, "curl_cffi");
+        fs.mkdirSync(moduleDir, { recursive: true });
+        fs.writeFileSync(path.join(moduleDir, "__init__.py"), "");
+
+        const result = runOriginScript(
+          [sitePackagesPath, ambient],
+          sitePackagesPath
+        );
+
+        expect(JSON.parse(result.stdout)).toMatchObject({
+          yt_dlp: "inside",
+          curl_cffi: "outside",
+        });
+        expect(result.status).toBe(2);
+      } finally {
+        fs.rmSync(ambient, { recursive: true, force: true });
+      }
+    });
+
+    it("accepts a candidate whose optional modules are simply absent", () => {
+      writeFakeModule(sitePackagesPath);
+      const result = runOriginScript([sitePackagesPath], sitePackagesPath);
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        yt_dlp: "inside",
+        curl_cffi: "absent",
+      });
+    });
+
+    it("rejects an import shadowed by an ambient install", () => {
+      // The target is empty; yt_dlp resolves from an unrelated directory, which
+      // is exactly the silent version-mixing this check exists to prevent.
+      const ambient = fs.mkdtempSync(path.join(os.tmpdir(), "ytdlp-ambient-"));
+      try {
+        writeFakeModule(ambient);
+        const result = runOriginScript(
+          [sitePackagesPath, ambient],
+          sitePackagesPath
+        );
+        expect(result.status).toBe(2);
+        expect(JSON.parse(result.stdout).yt_dlp).toBe("outside");
+      } finally {
+        fs.rmSync(ambient, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/backend/src/__tests__/utils/ytdlpSpawnBoundary.test.ts
+++ b/backend/src/__tests__/utils/ytdlpSpawnBoundary.test.ts
@@ -1,0 +1,174 @@
+import fs from "fs";
+import path from "path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const SRC_ROOT = path.resolve(__dirname, "../../");
+
+/**
+ * Only these modules may create a yt-dlp child process. `launcher.ts` owns
+ * execution (`spawnYtDlp`), `process.ts` owns bounded probe runs, and
+ * `versionProbe.ts` owns the bootstrap `--version`/`--help` probes that run
+ * before any release exists. `runtime.ts` spawns Deno, which is not yt-dlp and
+ * is never updated at runtime.
+ */
+const SPAWN_OWNERS: Record<string, number> = {
+  "utils/ytdlp/release/launcher.ts": 1,
+  // spawn for the probe itself, plus a spawnSync("taskkill") used only on the
+  // Windows timeout path to terminate the process tree.
+  "utils/ytdlp/release/process.ts": 2,
+  "utils/ytdlp/versionProbe.ts": 2,
+  "utils/ytdlp/runtime.ts": 1,
+};
+
+/** Every module that builds yt-dlp arguments or runs yt-dlp work. */
+const YT_DLP_MODULES = [
+  ...listTsFiles("utils/ytdlp"),
+  "services/downloaders/MissAVDownloader.ts",
+];
+
+function listTsFiles(relativeDir: string): string[] {
+  const absoluteDir = path.join(SRC_ROOT, relativeDir);
+  return fs
+    .readdirSync(absoluteDir, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) =>
+      // Keys in SPAWN_OWNERS are POSIX-style, so normalize Windows separators.
+      path
+        .relative(SRC_ROOT, path.join(entry.parentPath ?? absoluteDir, entry.name))
+        .split(path.sep)
+        .join("/")
+    );
+}
+
+function parse(relativePath: string): ts.SourceFile {
+  const absolutePath = path.join(SRC_ROOT, relativePath);
+  return ts.createSourceFile(
+    absolutePath,
+    fs.readFileSync(absolutePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    true
+  );
+}
+
+/**
+ * Count call expressions that create a process directly, whatever name the
+ * import was bound to. Counting (rather than listing files) is the point: a
+ * second direct spawn added to an already-allowed module changes the count and
+ * fails the test.
+ */
+function countDirectProcessCreations(source: ts.SourceFile): number {
+  const childProcessBindings = new Set<string>();
+  const creators = new Set(["spawn", "spawnSync", "exec", "execFile", "fork"]);
+
+  const collectImports = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      node.moduleSpecifier.text === "child_process"
+    ) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = (element.propertyName ?? element.name).text;
+          if (creators.has(imported)) {
+            childProcessBindings.add(element.name.text);
+          }
+        }
+      }
+      if (bindings && ts.isNamespaceImport(bindings)) {
+        childProcessBindings.add(bindings.name.text);
+      }
+    }
+    ts.forEachChild(node, collectImports);
+  };
+  collectImports(source);
+
+  let count = 0;
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      if (ts.isIdentifier(callee) && childProcessBindings.has(callee.text)) {
+        count += 1;
+      }
+      // `cp.spawn(...)`, `(await import("child_process")).spawn(...)`
+      if (
+        ts.isPropertyAccessExpression(callee) &&
+        creators.has(callee.name.text) &&
+        ts.isIdentifier(callee.expression) &&
+        childProcessBindings.has(callee.expression.text)
+      ) {
+        count += 1;
+      }
+    }
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      node.arguments[0].text === "child_process"
+    ) {
+      count += 1;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return count;
+}
+
+describe("yt-dlp spawn boundary", () => {
+  it("creates yt-dlp processes only in the release launcher and bootstrap probes", () => {
+    const offenders = YT_DLP_MODULES.filter(
+      (relativePath) =>
+        countDirectProcessCreations(parse(relativePath)) >
+        (SPAWN_OWNERS[relativePath] ?? 0)
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("fails when a second direct spawn is added to an already-allowed module", () => {
+    // The guarantee the design asks for: the rule counts calls, so growing an
+    // existing caller is caught, not just adding a new file.
+    const launcher = parse("utils/ytdlp/release/launcher.ts");
+    expect(countDirectProcessCreations(launcher)).toBe(
+      SPAWN_OWNERS["utils/ytdlp/release/launcher.ts"]
+    );
+
+    const withExtraSpawn = ts.createSourceFile(
+      "launcher.ts",
+      `${launcher.getFullText()}\nfunction sneaky() { return spawn("yt-dlp", []); }\n`,
+      ts.ScriptTarget.Latest,
+      true
+    );
+    expect(countDirectProcessCreations(withExtraSpawn)).toBeGreaterThan(
+      SPAWN_OWNERS["utils/ytdlp/release/launcher.ts"]
+    );
+  });
+
+  it("routes application callers through the release API", () => {
+    for (const relativePath of [
+      "utils/ytdlp/execute.ts",
+      "services/downloaders/MissAVDownloader.ts",
+    ]) {
+      const source = fs.readFileSync(path.join(SRC_ROOT, relativePath), "utf8");
+      expect(source).toMatch(/spawnYtDlp/);
+      expect(source).toMatch(/withYtDlpRelease/);
+    }
+  });
+
+  it("keeps release-scoped probes on an explicit release argument", () => {
+    const runtime = fs.readFileSync(
+      path.join(SRC_ROOT, "utils/ytdlp/runtime.ts"),
+      "utf8"
+    );
+    for (const probe of [
+      "isYtDlpImpersonateAvailable",
+      "getYouTubeJsRuntimeFlag",
+      "ytDlpSupportsRemoteComponents",
+    ]) {
+      expect(runtime).toMatch(
+        new RegExp(`export async function ${probe}\\(\\s*release: YtDlpRelease`)
+      );
+    }
+  });
+});

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -1,5 +1,4 @@
 import * as cheerio from "cheerio";
-import { spawn } from "child_process";
 import fs from "fs-extra";
 import path from "path";
 import puppeteer from "puppeteer";
@@ -38,6 +37,7 @@ import {
   InvalidProxyError,
   isYtDlpImpersonateAvailable,
 } from "../../utils/ytDlpUtils";
+import { spawnYtDlp, withYtDlpRelease } from "../../utils/ytdlp/release";
 import {
   removeMediaServerArtifactsForVideo,
   syncMediaServerArtifactsForRecord,
@@ -46,7 +46,7 @@ import { regenerateSmallThumbnailForThumbnailPath } from "../thumbnailMirrorServ
 import * as storageService from "../storageService";
 import { Video } from "../storageService";
 import { BaseDownloader, DownloadOptions, VideoInfo } from "./BaseDownloader";
-import { MISSAV_PROGRESS_LOG_INTERVAL_MS, YT_DLP_PATH } from "./missav/constants";
+import { MISSAV_PROGRESS_LOG_INTERVAL_MS } from "./missav/constants";
 import {
   buildSafeMissAvNavigationTarget,
   isCloudflareChallengeHtml,
@@ -541,155 +541,159 @@ export class MissAVDownloader extends BaseDownloader {
       // when curl_cffi is missing, which can happen on non-Docker installs. When
       // unavailable, omit it and warn — the download proceeds unimpersonated
       // (works for non-blocked hosts) instead of erroring outright.
-      const canImpersonate = await isYtDlpImpersonateAvailable();
-      if (!canImpersonate) {
-        logger.warn(
-          "[MissAV] yt-dlp browser impersonation is unavailable (curl_cffi not installed); " +
-            "proceeding without --impersonate. Cloudflare-protected hosts may return 403. " +
-            "Install it with: pip install curl-cffi",
+      await withYtDlpRelease(async (release) => {
+        const canImpersonate = await isYtDlpImpersonateAvailable(release);
+        if (!canImpersonate) {
+          logger.warn(
+            "[MissAV] yt-dlp browser impersonation is unavailable (curl_cffi not installed); " +
+              "proceeding without --impersonate. Cloudflare-protected hosts may return 403. " +
+              "Install it with: pip install curl-cffi",
+          );
+        }
+
+        // Prepare flags object - merge user config with required settings
+        const flags: any = {
+          ...networkConfig, // Apply network settings (proxy, etc.)
+          output: videoDownloadPath,
+          format: downloadFormat,
+          mergeOutputFormat: mergeOutputFormat,
+          noOverwrites: true,
+          ...(canImpersonate ? { impersonate: "chrome" } : {}),
+          addHeader: [`Referer:${referer}`],
+        };
+
+        // Apply format sort if user specified it
+        if (formatSortValue) {
+          flags.formatSort = formatSortValue;
+          logger.info("Using format sort for MissAV:", formatSortValue);
+        }
+
+        logger.info("Final MissAV yt-dlp flags:", flags);
+
+        // Use ProgressTracker for centralized progress parsing
+        const progressTracker = new ProgressTracker(downloadId);
+        // Capped ring-buffer for stderr: retain only the last 4 KB so that
+        // long downloads with chatty ffmpeg/yt-dlp output don't grow memory unboundedly.
+        const STDERR_MAX_BYTES = 4 * 1024;
+        let stderrBuffer = "";
+        let lastProgressLogAt = 0;
+        let cleanedTemporaryFiles = false;
+        const cleanupTemporaryFilesOnce = async (): Promise<void> => {
+          if (cleanedTemporaryFiles) return;
+          cleanedTemporaryFiles = true;
+          await cleanupTemporaryFiles(videoDownloadPath);
+        };
+        const shouldLogDownloadProgress = (line: string): boolean => {
+          const now = Date.now();
+          const percentMatch = line.match(/\[download\]\s+(\d+(?:\.\d+)?)%/);
+          const percent = percentMatch ? Number(percentMatch[1]) : null;
+          const isComplete = percent !== null && percent >= 100;
+
+          if (
+            lastProgressLogAt === 0 ||
+            now - lastProgressLogAt >= MISSAV_PROGRESS_LOG_INTERVAL_MS ||
+            isComplete
+          ) {
+            lastProgressLogAt = now;
+            return true;
+          }
+
+          return false;
+        };
+        const parseProgress = (output: string, source: "stdout" | "stderr") => {
+          const lines = output
+            .split(/[\r\n]+/)
+            .filter((line) => line.trim());
+          for (const line of lines) {
+            if (line.includes("[download]")) {
+              if (shouldLogDownloadProgress(line)) {
+                logger.info(`[MissAV Progress ${source}]:`, line.substring(0, 120));
+              }
+            } else if (source === "stderr" && line.trim()) {
+              // Only log actual errors/warnings, not generic informational lines.
+              // yt-dlp/ffmpeg stderr is very chatty during HLS segment downloads.
+              if (line.startsWith("ERROR") || line.startsWith("WARNING")) {
+                logger.warn(`[MissAV stderr]:`, line);
+              }
+              // Append to ring-buffer, trimming the oldest content when over the cap.
+              stderrBuffer += line + "\n";
+              if (stderrBuffer.length > STDERR_MAX_BYTES) {
+                stderrBuffer = stderrBuffer.slice(stderrBuffer.length - STDERR_MAX_BYTES);
+              }
+            }
+          }
+          progressTracker.parseAndUpdate(output);
+        };
+
+        logger.info("Starting yt-dlp process with spawn...");
+
+        // Convert flags object to array of args using the utility function
+        const args = [m3u8Url, ...flagsToArgs(flags)];
+
+        // Log the full command for debugging
+        logger.info(
+          `[yt-dlp] executing release=${release.releaseId} version=${release.version ?? "unknown"}`
         );
-      }
 
-      // Prepare flags object - merge user config with required settings
-      const flags: any = {
-        ...networkConfig, // Apply network settings (proxy, etc.)
-        output: videoDownloadPath,
-        format: downloadFormat,
-        mergeOutputFormat: mergeOutputFormat,
-        noOverwrites: true,
-        ...(canImpersonate ? { impersonate: "chrome" } : {}),
-        addHeader: [`Referer:${referer}`],
-      };
+        try {
+          await new Promise<void>((resolve, reject) => {
+            const child = spawnYtDlp(release, args);
+            let cancellationRequested = false;
 
-      // Apply format sort if user specified it
-      if (formatSortValue) {
-        flags.formatSort = formatSortValue;
-        logger.info("Using format sort for MissAV:", formatSortValue);
-      }
-
-      logger.info("Final MissAV yt-dlp flags:", flags);
-
-      // Use ProgressTracker for centralized progress parsing
-      const progressTracker = new ProgressTracker(downloadId);
-      // Capped ring-buffer for stderr: retain only the last 4 KB so that
-      // long downloads with chatty ffmpeg/yt-dlp output don't grow memory unboundedly.
-      const STDERR_MAX_BYTES = 4 * 1024;
-      let stderrBuffer = "";
-      let lastProgressLogAt = 0;
-      let cleanedTemporaryFiles = false;
-      const cleanupTemporaryFilesOnce = async (): Promise<void> => {
-        if (cleanedTemporaryFiles) return;
-        cleanedTemporaryFiles = true;
-        await cleanupTemporaryFiles(videoDownloadPath);
-      };
-      const shouldLogDownloadProgress = (line: string): boolean => {
-        const now = Date.now();
-        const percentMatch = line.match(/\[download\]\s+(\d+(?:\.\d+)?)%/);
-        const percent = percentMatch ? Number(percentMatch[1]) : null;
-        const isComplete = percent !== null && percent >= 100;
-
-        if (
-          lastProgressLogAt === 0 ||
-          now - lastProgressLogAt >= MISSAV_PROGRESS_LOG_INTERVAL_MS ||
-          isComplete
-        ) {
-          lastProgressLogAt = now;
-          return true;
-        }
-
-        return false;
-      };
-      const parseProgress = (output: string, source: "stdout" | "stderr") => {
-        const lines = output
-          .split(/[\r\n]+/)
-          .filter((line) => line.trim());
-        for (const line of lines) {
-          if (line.includes("[download]")) {
-            if (shouldLogDownloadProgress(line)) {
-              logger.info(`[MissAV Progress ${source}]:`, line.substring(0, 120));
-            }
-          } else if (source === "stderr" && line.trim()) {
-            // Only log actual errors/warnings, not generic informational lines.
-            // yt-dlp/ffmpeg stderr is very chatty during HLS segment downloads.
-            if (line.startsWith("ERROR") || line.startsWith("WARNING")) {
-              logger.warn(`[MissAV stderr]:`, line);
-            }
-            // Append to ring-buffer, trimming the oldest content when over the cap.
-            stderrBuffer += line + "\n";
-            if (stderrBuffer.length > STDERR_MAX_BYTES) {
-              stderrBuffer = stderrBuffer.slice(stderrBuffer.length - STDERR_MAX_BYTES);
-            }
-          }
-        }
-        progressTracker.parseAndUpdate(output);
-      };
-
-      logger.info("Starting yt-dlp process with spawn...");
-
-      // Convert flags object to array of args using the utility function
-      const args = [m3u8Url, ...flagsToArgs(flags)];
-
-      // Log the full command for debugging
-      logger.info("Executing yt-dlp command:", YT_DLP_PATH, args.join(" "));
-
-      try {
-        await new Promise<void>((resolve, reject) => {
-          const child = spawn(YT_DLP_PATH, args);
-          let cancellationRequested = false;
-
-          child.stdout.on("data", (data) => {
-            parseProgress(data.toString(), "stdout");
-          });
-
-          child.stderr.on("data", (data) => {
-            parseProgress(data.toString(), "stderr");
-          });
-
-          child.on("close", (code, signal) => {
-            // Flush any throttled progress and clear the tracker's timer.
-            progressTracker.dispose();
-            if (code === 0) {
-              resolve();
-            } else if (
-              cancellationRequested ||
-              signal === "SIGTERM" ||
-              signal === "SIGINT"
-            ) {
-              reject(DownloadCancelledError.create());
-            } else {
-              const err = new Error(`yt-dlp process exited with code ${code}`);
-              (err as any).stderr = stderrBuffer;
-              reject(err);
-            }
-          });
-
-          child.on("error", (err) => {
-            reject(err);
-          });
-
-          if (onStart) {
-            onStart(async () => {
-              cancellationRequested = true;
-              logger.info("Killing subprocess for download:", downloadId);
-              child.kill();
-
-              // Clean up temporary files created by yt-dlp (*.part, *.ytdl, etc.)
-              logger.info("Cleaning up temporary files...");
-              await cleanupTemporaryFilesOnce();
+            child.stdout?.on("data", (data) => {
+              parseProgress(data.toString(), "stdout");
             });
-          }
-        });
 
-        logger.info("Video downloaded successfully");
-      } catch (err: unknown) {
-        // Use base class helper for cancellation handling
-        const downloader = new MissAVDownloader();
-        await downloader.handleCancellationError(err, async () => {
-          await cleanupTemporaryFilesOnce();
-        });
-        logger.error("yt-dlp execution failed:", err);
-        throw err;
-      }
+            child.stderr?.on("data", (data) => {
+              parseProgress(data.toString(), "stderr");
+            });
+
+            child.on("close", (code, signal) => {
+              // Flush any throttled progress and clear the tracker's timer.
+              progressTracker.dispose();
+              if (code === 0) {
+                resolve();
+              } else if (
+                cancellationRequested ||
+                signal === "SIGTERM" ||
+                signal === "SIGINT"
+              ) {
+                reject(DownloadCancelledError.create());
+              } else {
+                const err = new Error(`yt-dlp process exited with code ${code}`);
+                (err as any).stderr = stderrBuffer;
+                reject(err);
+              }
+            });
+
+            child.on("error", (err) => {
+              reject(err);
+            });
+
+            if (onStart) {
+              onStart(async () => {
+                cancellationRequested = true;
+                logger.info("Killing subprocess for download:", downloadId);
+                child.kill();
+
+                // Clean up temporary files created by yt-dlp (*.part, *.ytdl, etc.)
+                logger.info("Cleaning up temporary files...");
+                await cleanupTemporaryFilesOnce();
+              });
+            }
+          });
+
+          logger.info("Video downloaded successfully");
+        } catch (err: unknown) {
+          // Use base class helper for cancellation handling
+          const downloader = new MissAVDownloader();
+          await downloader.handleCancellationError(err, async () => {
+            await cleanupTemporaryFilesOnce();
+          });
+          logger.error("yt-dlp execution failed:", err);
+          throw err;
+        }
+      });
 
       // Check if download was cancelled (it might have been removed from active downloads)
       const downloader = new MissAVDownloader();

--- a/backend/src/services/downloaders/missav/constants.ts
+++ b/backend/src/services/downloaders/missav/constants.ts
@@ -1,4 +1,3 @@
-export const YT_DLP_PATH = process.env.YT_DLP_PATH || "yt-dlp";
 export const MISSAV_PROGRESS_LOG_INTERVAL_MS = 10_000;
 
 export const MISSAV_NAVIGATION_ORIGINS: Record<string, string> = {

--- a/backend/src/utils/ytDlpUtils.ts
+++ b/backend/src/utils/ytDlpUtils.ts
@@ -6,6 +6,7 @@ import { resetProviderPluginCache } from "./ytdlp/spawnEnv";
 import { resetResolvedYtDlpPath } from "./ytdlp/pathResolver";
 import { resetRuntimeCaches } from "./ytdlp/runtime";
 import { resetCookiesFileCache } from "./ytdlp/cookies";
+import { resetManagedReleaseStateForTests } from "./ytdlp/release";
 
 export { ensureYtDlpAvailable } from "./ytdlp/install";
 export { isYtDlpImpersonateAvailable } from "./ytdlp/runtime";
@@ -41,4 +42,5 @@ export function resetYtDlpAvailabilityCacheForTests(): void {
   resetResolvedYtDlpPath();
   resetRuntimeCaches();
   resetCookiesFileCache();
+  resetManagedReleaseStateForTests();
 }

--- a/backend/src/utils/ytdlp/constants.ts
+++ b/backend/src/utils/ytdlp/constants.ts
@@ -2,6 +2,35 @@ export const DEFAULT_YT_DLP_PATH = "yt-dlp";
 export const YT_DLP_JS_RUNTIME_ENV = "YT_DLP_JS_RUNTIME";
 export const YT_DLP_HELP_PROBE_TIMEOUT_MS = 5000;
 export const YT_DLP_STALE_AFTER_DAYS = 90;
+export const YT_DLP_PIP_PACKAGE = "yt-dlp[default,curl-cffi]";
+export const YT_DLP_PIP_PROVIDER_PACKAGE = "bgutil-ytdlp-pot-provider";
+export const YT_DLP_PIP_TIMEOUT_MS = 10 * 60 * 1000;
+export const YT_DLP_PYTHON_PROBE_TIMEOUT_MS = 15_000;
+export const YT_DLP_PUBLISH_LOCK_STALE_MS = 2 * 60 * 1000;
+export const YT_DLP_PUBLISH_LOCK_WAIT_MS = 15_000;
+export const YT_DLP_STAGING_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+export const YT_DLP_GC_KEEP_PREVIOUS_COUNT = 2;
+/**
+ * A release is finalized before it is published, and an installer can crash in
+ * between. Never collect a release younger than this, so a concurrent
+ * collection can't delete a candidate a publisher is about to point at.
+ */
+export const YT_DLP_RELEASE_MIN_RETENTION_MS = 60 * 60 * 1000;
+/**
+ * How long a lease must sit before collection reports it. Leases are never
+ * reclaimed automatically — PID reuse, container namespaces and orphaned
+ * subprocesses make that unsafe — so this only controls the warning.
+ */
+export const YT_DLP_STALE_LEASE_WARN_MS = 24 * 60 * 60 * 1000;
+/**
+ * Minimum spacing between opportunistic collections. Collection scans the
+ * store, so it must not run once per finished download; this bounds it while
+ * still reclaiming a release soon after the lease pinning it goes away.
+ */
+export const YT_DLP_GC_MIN_INTERVAL_MS = 60 * 60 * 1000;
+export const YT_DLP_WINDOWS_RENAME_ATTEMPTS = 8;
+export const YT_DLP_MANAGED_STORE_DIRNAME = "ytdlp";
+export const YT_DLP_MANIFEST_SCHEMA_VERSION = 1;
 export const DEFAULT_YOUTUBE_PLAYER_CLIENT_EXTRACTOR_ARG =
   "youtube:player_client=default,mweb";
 export const DEFAULT_YOUTUBE_REMOTE_COMPONENTS = "ejs:github";

--- a/backend/src/utils/ytdlp/execute.ts
+++ b/backend/src/utils/ytdlp/execute.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { type ChildProcess } from "child_process";
 import path from "path";
 import { PassThrough } from "stream";
 import { isBilibiliUrl } from "../helpers";
@@ -7,18 +7,17 @@ import {
   pathExistsSafeSync,
   resolveSafeChildPath,
 } from "../security";
-import { ensureYtDlpAvailable } from "./install";
-import { getConfiguredYtDlpPath } from "./pathResolver";
-import { getYtDlpSpawnEnv } from "./spawnEnv";
+import { logger } from "../logger";
 import { ensureCookiesFileIsNormalized } from "./cookies";
-import { appendYouTubeJsRuntimeArg } from "./runtime";
+import { isMembersOnlyError } from "./errorClassification";
 import {
   resolveYouTubeRemoteComponents,
   withDefaultYouTubeExtractorArgs,
 } from "./extractorArgs";
 import { flagsToArgs } from "./flags";
-import { isMembersOnlyError } from "./errorClassification";
-import { logger } from "../logger";
+import { spawnYtDlp, withYtDlpRelease } from "./release";
+import type { YtDlpRelease } from "./release/types";
+import { appendYouTubeJsRuntimeArg } from "./runtime";
 
 /**
  * Error thrown when a yt-dlp invocation fails. Carries the captured `stderr` and
@@ -67,10 +66,29 @@ export async function executeYtDlpJson(
   flags: Record<string, any> = {},
   retryWithoutFormatRestrictions: boolean = true
 ): Promise<any> {
-  await ensureYtDlpAvailable();
+  return withYtDlpRelease((release) =>
+    executeYtDlpJsonWithRelease(
+      release,
+      rawUrl,
+      flags,
+      retryWithoutFormatRestrictions
+    )
+  );
+}
+
+async function executeYtDlpJsonWithRelease(
+  release: YtDlpRelease,
+  rawUrl: string,
+  flags: Record<string, any>,
+  retryWithoutFormatRestrictions: boolean
+): Promise<any> {
   const url = preprocessUrl(rawUrl);
   const partialFlags = withDefaultYouTubeExtractorArgs(url, flags);
-  const effectiveFlags = await resolveYouTubeRemoteComponents(url, partialFlags);
+  const effectiveFlags = await resolveYouTubeRemoteComponents(
+    url,
+    partialFlags,
+    release
+  );
   const { noWarnings: _noWarnings, ...jsonFlags } = effectiveFlags;
   const args = [
     "--dump-single-json",
@@ -78,24 +96,20 @@ export async function executeYtDlpJson(
     ...flagsToArgs(jsonFlags),
   ];
 
-  // Add cookies after ensuring the file is in a yt-dlp-compatible format.
   const cookiesPath = ensureCookiesFileIsNormalized();
   if (cookiesPath) {
     args.push("--cookies", cookiesPath);
   }
 
-  await appendYouTubeJsRuntimeArg(args, url);
-
+  await appendYouTubeJsRuntimeArg(args, url, release);
   args.push(url);
 
-  const ytDlpPath = getConfiguredYtDlpPath();
-  logger.info(`Executing: ${ytDlpPath} ${args.join(" ")}`);
+  logger.info(
+    `[yt-dlp] executing release=${release.releaseId} version=${release.version ?? "unknown"}`
+  );
 
   return new Promise<any>((resolve, reject) => {
-    const subprocess = spawn(ytDlpPath, args, {
-      env: getYtDlpSpawnEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const subprocess = spawnYtDlp(release, args);
 
     let stdout = "";
     let stderr = "";
@@ -110,13 +124,11 @@ export async function executeYtDlpJson(
 
     subprocess.on("close", async (code) => {
       if (code !== 0) {
-        // Check if this is a format availability error
         const isFormatError =
           stderr.includes("Requested format is not available") ||
           stderr.includes("format is not available") ||
           stderr.includes("No video formats found");
 
-        // If it's a format error and we should retry, try again without format restrictions
         if (isFormatError && retryWithoutFormatRestrictions) {
           const hasFormatRestrictions =
             (effectiveFlags.formatSort !== undefined &&
@@ -131,7 +143,6 @@ export async function executeYtDlpJson(
               "Format not available, retrying without format restrictions and with --ignore-config..."
             );
             try {
-              // Remove format-related flags
               const retryFlags: Record<string, any> = {
                 ...effectiveFlags,
                 ignoreConfig: true,
@@ -140,12 +151,15 @@ export async function executeYtDlpJson(
               delete retryFlags.format;
               delete retryFlags.S;
               delete retryFlags.f;
-              // Retry without format restrictions (don't retry again to avoid infinite loop)
-              const result = await executeYtDlpJson(url, retryFlags, false);
+              const result = await executeYtDlpJsonWithRelease(
+                release,
+                url,
+                retryFlags,
+                false
+              );
               resolve(result);
               return;
-            } catch (retryError) {
-              // If retry also fails, reject with original error
+            } catch {
               reject(
                 new YtDlpExecutionError(
                   `yt-dlp process exited with code ${code}`,
@@ -163,12 +177,15 @@ export async function executeYtDlpJson(
                 ...effectiveFlags,
                 ignoreConfig: true,
               };
-              // Retry without format restrictions (don't retry again to avoid infinite loop)
-              const result = await executeYtDlpJson(url, retryFlags, false);
+              const result = await executeYtDlpJsonWithRelease(
+                release,
+                url,
+                retryFlags,
+                false
+              );
               resolve(result);
               return;
-            } catch (retryError) {
-              // If retry also fails, reject with original error
+            } catch {
               reject(
                 new YtDlpExecutionError(
                   `yt-dlp process exited with code ${code}`,
@@ -221,67 +238,53 @@ export async function getChannelUrlFromVideo(
   networkConfig: Record<string, any> = {}
 ): Promise<string | null> {
   try {
-    await ensureYtDlpAvailable();
+    return await withYtDlpRelease(async (release) => {
+      const videoUrl = preprocessUrl(videoUrlRaw);
+      const args = [
+        "--print",
+        "channel_url",
+        "--skip-download",
+        "--no-warnings",
+        ...flagsToArgs(networkConfig),
+      ];
+
+      const cookiesPath = ensureCookiesFileIsNormalized();
+      if (cookiesPath) {
+        args.push("--cookies", cookiesPath);
+      }
+
+      await appendYouTubeJsRuntimeArg(args, videoUrl, release);
+      args.push(videoUrl);
+
+      return await new Promise<string | null>((resolve) => {
+        const subprocess = spawnYtDlp(release, args);
+        let stdout = "";
+        let stderr = "";
+
+        subprocess.stdout?.on("data", (data: Buffer) => {
+          stdout += data.toString();
+        });
+        subprocess.stderr?.on("data", (data: Buffer) => {
+          stderr += data.toString();
+        });
+        subprocess.on("close", (code) => {
+          if (code !== 0) {
+            logger.warn(`Failed to get channel URL: ${stderr}`);
+            resolve(null);
+            return;
+          }
+          resolve(stdout.trim() || null);
+        });
+        subprocess.on("error", (error) => {
+          logger.warn(`Error getting channel URL:`, error);
+          resolve(null);
+        });
+      });
+    });
   } catch (error) {
-    // Swallow availability errors: channel URL is supplementary metadata, not critical.
-    // Callers treat null as "not found", which is the correct fallback behavior here.
     logger.warn("yt-dlp unavailable when fetching channel URL:", error);
     return null;
   }
-
-  const videoUrl = preprocessUrl(videoUrlRaw);
-  const args = [
-    "--print",
-    "channel_url",
-    "--skip-download",
-    "--no-warnings",
-    ...flagsToArgs(networkConfig),
-  ];
-
-  // Add cookies after ensuring the file is in a yt-dlp-compatible format.
-  const cookiesPath = ensureCookiesFileIsNormalized();
-  if (cookiesPath) {
-    args.push("--cookies", cookiesPath);
-  }
-
-  await appendYouTubeJsRuntimeArg(args, videoUrl);
-
-  args.push(videoUrl);
-  const ytDlpPath = getConfiguredYtDlpPath();
-
-  return new Promise<string | null>((resolve, reject) => {
-    const subprocess = spawn(ytDlpPath, args, {
-      env: getYtDlpSpawnEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stdout = "";
-    let stderr = "";
-
-    subprocess.stdout?.on("data", (data: Buffer) => {
-      stdout += data.toString();
-    });
-
-    subprocess.stderr?.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    subprocess.on("close", (code) => {
-      if (code !== 0) {
-        logger.warn(`Failed to get channel URL: ${stderr}`);
-        resolve(null);
-        return;
-      }
-
-      const channelUrl = stdout.trim();
-      resolve(channelUrl || null);
-    });
-
-    subprocess.on("error", (error) => {
-      logger.warn(`Error getting channel URL:`, error);
-      resolve(null);
-    });
-  });
 }
 
 /**
@@ -294,116 +297,108 @@ export async function downloadChannelAvatar(
   networkConfig: Record<string, any> = {}
 ): Promise<boolean> {
   try {
-    await ensureYtDlpAvailable();
-  } catch (error) {
-    // Swallow availability errors: avatar download failures are non-fatal.
-    // Callers treat false as "avatar unavailable" and continue without it.
-    logger.warn("yt-dlp unavailable when downloading channel avatar:", error);
-    return false;
-  }
+    return await withYtDlpRelease(async (release) => {
+      const channelUrl = preprocessUrl(channelUrlRaw);
+      const outputDir = path.dirname(outputPath);
+      const outputFilename = path.basename(outputPath, path.extname(outputPath));
+      const outputTemplate = resolveSafeChildPath(
+        outputDir,
+        `${outputFilename}.%(ext)s`
+      );
 
-  const channelUrl = preprocessUrl(channelUrlRaw);
-  const outputDir = path.dirname(outputPath);
-  const outputFilename = path.basename(outputPath, path.extname(outputPath));
-  const outputTemplate = resolveSafeChildPath(
-    outputDir,
-    `${outputFilename}.%(ext)s`
-  );
+      const args = [
+        "--write-thumbnail",
+        "--playlist-items",
+        "0",
+        "--skip-download",
+        "--no-warnings",
+        "--output",
+        outputTemplate,
+        ...flagsToArgs(networkConfig),
+      ];
 
-  const args = [
-    "--write-thumbnail",
-    "--playlist-items",
-    "0",
-    "--skip-download",
-    "--no-warnings",
-    "--output",
-    outputTemplate,
-    ...flagsToArgs(networkConfig),
-  ];
-
-  // Add cookies after ensuring the file is in a yt-dlp-compatible format.
-  const cookiesPath = ensureCookiesFileIsNormalized();
-  if (cookiesPath) {
-    args.push("--cookies", cookiesPath);
-  }
-
-  await appendYouTubeJsRuntimeArg(args, channelUrl);
-
-  args.push(channelUrl);
-  const ytDlpPath = getConfiguredYtDlpPath();
-
-  return new Promise<boolean>((resolve, reject) => {
-    const subprocess = spawn(ytDlpPath, args, {
-      env: getYtDlpSpawnEnv(),
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    let stderr = "";
-
-    subprocess.stderr?.on("data", (data: Buffer) => {
-      stderr += data.toString();
-    });
-
-    subprocess.on("close", (code) => {
-      if (code !== 0) {
-        logger.warn(`Failed to download channel avatar: ${stderr}`);
-        // For Bilibili, this might be expected - log but don't fail completely
-        if (isBilibiliUrl(channelUrl)) {
-          logger.warn(`Bilibili channel avatar download may not be supported by yt-dlp`);
-        }
-        resolve(false);
-        return;
+      const cookiesPath = ensureCookiesFileIsNormalized();
+      if (cookiesPath) {
+        args.push("--cookies", cookiesPath);
       }
 
-      // Check if the file was created (yt-dlp might save with different extension)
-      const possibleExtensions = ["jpg", "jpeg", "png", "webp"];
-      let foundFile = false;
-      for (const ext of possibleExtensions) {
-        const possiblePath = resolveSafeChildPath(
-          outputDir,
-          `${outputFilename}.${ext}`
-        );
-        if (pathExistsSafeSync(possiblePath, outputDir)) {
-          // If it's not a jpg, rename it to jpg
-          if (ext !== "jpg" && outputPath.endsWith(".jpg")) {
-            try {
-              moveSafeSync(possiblePath, outputDir, outputPath, outputDir, {
-                overwrite: true,
-              });
-            } catch (error) {
-              logger.warn(`Failed to rename avatar to .jpg:`, error);
-              // If rename fails, just use the original file
-              resolve(true);
-              return;
+      await appendYouTubeJsRuntimeArg(args, channelUrl, release);
+      args.push(channelUrl);
+
+      return await new Promise<boolean>((resolve) => {
+        const subprocess = spawnYtDlp(release, args);
+
+        let stderr = "";
+
+        subprocess.stderr?.on("data", (data: Buffer) => {
+          stderr += data.toString();
+        });
+
+        subprocess.on("close", (code) => {
+          if (code !== 0) {
+            logger.warn(`Failed to download channel avatar: ${stderr}`);
+            // For Bilibili, this might be expected - log but don't fail completely
+            if (isBilibiliUrl(channelUrl)) {
+              logger.warn(`Bilibili channel avatar download may not be supported by yt-dlp`);
             }
-          } else if (ext !== "jpg") {
-            // File exists but with different extension - that's okay, we'll handle it
+            resolve(false);
+            return;
+          }
+
+          // Check if the file was created (yt-dlp might save with different extension)
+          const possibleExtensions = ["jpg", "jpeg", "png", "webp"];
+          let foundFile = false;
+          for (const ext of possibleExtensions) {
+            const possiblePath = resolveSafeChildPath(
+              outputDir,
+              `${outputFilename}.${ext}`
+            );
+            if (pathExistsSafeSync(possiblePath, outputDir)) {
+              // If it's not a jpg, rename it to jpg
+              if (ext !== "jpg" && outputPath.endsWith(".jpg")) {
+                try {
+                  moveSafeSync(possiblePath, outputDir, outputPath, outputDir, {
+                    overwrite: true,
+                  });
+                } catch (error) {
+                  logger.warn(`Failed to rename avatar to .jpg:`, error);
+                  // If rename fails, just use the original file
+                  resolve(true);
+                  return;
+                }
+              } else if (ext !== "jpg") {
+                // File exists but with different extension - that's okay, we'll handle it
+                resolve(true);
+                return;
+              }
+              foundFile = true;
+              break;
+            }
+          }
+
+          // If no file found, check if outputPath exists (might have been created directly)
+          if (pathExistsSafeSync(outputPath, outputDir)) {
             resolve(true);
             return;
           }
-          foundFile = true;
-          break;
-        }
-      }
 
-      // If no file found, check if outputPath exists (might have been created directly)
-      if (pathExistsSafeSync(outputPath, outputDir)) {
-        resolve(true);
-        return;
-      }
+          if (!foundFile) {
+            logger.warn(`Channel avatar file not found after download. Checked extensions: ${possibleExtensions.join(", ")}`);
+            logger.warn(`Output directory: ${outputDir}, Output filename: ${outputFilename}`);
+          }
+          resolve(foundFile);
+        });
 
-      if (!foundFile) {
-        logger.warn(`Channel avatar file not found after download. Checked extensions: ${possibleExtensions.join(", ")}`);
-        logger.warn(`Output directory: ${outputDir}, Output filename: ${outputFilename}`);
-      }
-      resolve(foundFile);
+        subprocess.on("error", (error) => {
+          logger.warn(`Error downloading channel avatar:`, error);
+          resolve(false);
+        });
+      });
     });
-
-    subprocess.on("error", (error) => {
-      logger.warn(`Error downloading channel avatar:`, error);
-      resolve(false);
-    });
-  });
+  } catch (error) {
+    logger.warn("yt-dlp unavailable when downloading channel avatar:", error);
+    return false;
+  }
 }
 
 /**
@@ -432,7 +427,7 @@ export function executeYtDlpSpawn(
   const stdoutPass = new PassThrough();
   const stderrPass = new PassThrough();
 
-  let activeSubprocess: ReturnType<typeof spawn> | null = null;
+  let activeSubprocess: ChildProcess | null = null;
   let killRequested = false;
   let killSignal: NodeJS.Signals | undefined;
   let resolved = false;
@@ -472,27 +467,26 @@ export function executeYtDlpSpawn(
     stderr += data.toString();
   });
 
-  const promise = ensureYtDlpAvailable()
-    .then(
-      async () => {
+  const promise = withYtDlpRelease(async (release) => {
         const effectiveFlags = await resolveYouTubeRemoteComponents(
           url,
-          partialFlags
+          partialFlags,
+          release
         );
         const baseArgs = [...flagsToArgs(effectiveFlags)];
 
-        // Add cookies after ensuring the file is in a yt-dlp-compatible format.
         const cookiesPath = ensureCookiesFileIsNormalized();
         if (cookiesPath) {
           baseArgs.push("--cookies", cookiesPath);
         }
 
-        const ytDlpPath = getConfiguredYtDlpPath();
         const args = [...baseArgs];
-        await appendYouTubeJsRuntimeArg(args, url);
+        await appendYouTubeJsRuntimeArg(args, url, release);
         args.push(url);
 
-        logger.info(`Spawning: ${ytDlpPath} ${args.join(" ")}`);
+        logger.info(
+          `[yt-dlp] spawning release=${release.releaseId} version=${release.version ?? "unknown"}`
+        );
 
         return await new Promise<void>((resolve, reject) => {
           if (killRequested) {
@@ -506,10 +500,7 @@ export function executeYtDlpSpawn(
             return;
           }
 
-          activeSubprocess = spawn(ytDlpPath, args, {
-            env: getYtDlpSpawnEnv(),
-            stdio: ["ignore", "pipe", "pipe"],
-          });
+          activeSubprocess = spawnYtDlp(release, args);
 
           pipeOrForward(activeSubprocess.stdout, stdoutPass);
           pipeOrForward(activeSubprocess.stderr, stderrPass);
@@ -563,8 +554,7 @@ export function executeYtDlpSpawn(
             }
           });
         });
-      }
-    )
+      })
     .catch((err) => {
       // End streams without emitting stream "error" events that callers don't subscribe to.
       endPassThroughStreams();

--- a/backend/src/utils/ytdlp/extractorArgs.ts
+++ b/backend/src/utils/ytdlp/extractorArgs.ts
@@ -6,6 +6,7 @@ import {
 } from "./constants";
 import { getProviderScript } from "../../services/downloaders/ytdlp/ytdlpHelpers";
 import { isYouTubeUrl } from "../helpers";
+import type { YtDlpRelease } from "./release/types";
 import { ytDlpSupportsRemoteComponents } from "./runtime";
 
 function parseExtractorArgParts(value: unknown): string[] {
@@ -65,7 +66,8 @@ export function withDefaultYouTubeExtractorArgs(
 
 export async function resolveYouTubeRemoteComponents(
   url: string,
-  flags: Record<string, any>
+  flags: Record<string, any>,
+  release: YtDlpRelease
 ): Promise<Record<string, any>> {
   if (!isYouTubeUrl(url) || !getProviderScript()) {
     return flags;
@@ -83,7 +85,7 @@ export async function resolveYouTubeRemoteComponents(
     return flags;
   }
 
-  if (!(await ytDlpSupportsRemoteComponents())) {
+  if (!(await ytDlpSupportsRemoteComponents(release))) {
     const {
       remoteComponents: _remoteComponents,
       remote_components: _remote_components,

--- a/backend/src/utils/ytdlp/install.ts
+++ b/backend/src/utils/ytdlp/install.ts
@@ -1,159 +1,50 @@
-import { spawn } from "child_process";
-import { getProviderPluginPath } from "../../services/downloaders/ytdlp/ytdlpHelpers";
 import { getErrorMessage } from "../errors";
+import { logger } from "../logger";
 import { YT_DLP_STALE_AFTER_DAYS } from "./constants";
 import {
   hasCustomConfiguredYtDlpPath,
   resetResolvedYtDlpPath,
   resolveYtDlpPath,
-  updatePathAfterAutoInstall,
 } from "./pathResolver";
-import { getYtDlpVersionInfo } from "./versionProbe";
+import { resetPipQueue } from "./pipLock";
+import { collectGarbage, installManagedRelease } from "./release";
+import { isReleaseStale } from "./release/acquire";
+import {
+  managedReleaseRunsCached,
+  recoverUsableManagedRelease,
+} from "./release/recover";
 import {
   resetJsRuntimeFlag,
   resetRemoteComponentsSupport,
 } from "./runtime";
-import { logger } from "../logger";
+import {
+  getYtDlpVersionInfo,
+  resetYtDlpVersionInfoCache,
+} from "./versionProbe";
 
-// Cached promise so we only check/install once per process
 let ytDlpAvailablePromise: Promise<void> | null = null;
 
-// Request yt-dlp through its extras rather than naming its companions here.
-// A yt-dlp release pins the dependencies that are coupled to it — "default"
-// carries the yt-dlp-ejs pin for the YouTube JS challenge solver, "curl-cffi"
-// the browser-impersonation range that --impersonate (and with it the MissAV
-// downloader) depends on. Letting pip read those pins off the release being
-// installed keeps them in lockstep automatically; a hand-written list here
-// would silently keep an old solver next to a freshly upgraded yt-dlp.
-const YT_DLP_PIP_PACKAGE = "yt-dlp[default,curl-cffi]";
-
 /**
- * Decide which packages pip should install.
- *
- * The bgutil POT provider is only added when no bundled copy is present.
- * getYtDlpSpawnEnv() puts the bundled plugin at the front of PYTHONPATH, ahead
- * of site-packages, and its Node counterpart (generate_once.js) ships with the
- * image and is not on PyPI at all — so where a bundle exists, a pip copy of the
- * plugin is loaded by nothing and "upgrading" it would report progress that
- * never reaches the yt-dlp process. Bumping the bundled provider is a rebuild,
- * not a runtime install.
- */
-function getPipPackages(): string[] {
-  if (getProviderPluginPath()) {
-    return [YT_DLP_PIP_PACKAGE];
-  }
-
-  return [YT_DLP_PIP_PACKAGE, "bgutil-ytdlp-pot-provider"];
-}
-
-// Every pip run in this process queues here. Two callers reach this module
-// under independent locks — ensureYtDlpAvailable() through its cached
-// availability promise, updateYtDlp() through its own in-flight promise — so
-// an operator pressing "Update yt-dlp" while the first download of the process
-// triggers the missing-binary or stale-version install would otherwise put two
-// pip processes on the same user-site directory at once. pip is not safe to run
-// concurrently against one environment: the two runs rewrite the same package
-// files and either can fail or leave the install half-written. Serializing here
-// rather than in the callers keeps future call sites covered by default.
-let pipQueue: Promise<unknown> = Promise.resolve();
-
-function withPipLock<T>(task: () => Promise<T>): Promise<T> {
-  // Run the task whether or not the previous one settled cleanly, and keep a
-  // swallowed copy as the tail so one failure cannot poison the queue.
-  const run = pipQueue.then(task, task);
-  pipQueue = run.catch(() => undefined);
-  return run;
-}
-
-/**
- * Try to install yt-dlp via pip, trying multiple pip variants.
- *
- * Serialized process-wide: concurrent callers queue instead of overlapping.
+ * Install a new managed release and, when it beats the current one, publish it.
+ * A candidate that turns out to match what is already current is not an error:
+ * the operator asked for the newest yt-dlp and that is what they have.
  */
 export async function installYtDlp(
-  options: { upgrade?: boolean } = {}
-): Promise<void> {
-  return withPipLock(() => runPipInstall(options));
+  options: { upgrade?: boolean; currentIsUsable?: boolean } = {}
+): Promise<{ published: boolean }> {
+  const outcome = await installManagedRelease({
+    currentIsUsable: options.currentIsUsable,
+  });
+  resetResolvedYtDlpPath();
+  resetYtDlpVersionInfoCache();
+  resetJsRuntimeFlag();
+  resetRemoteComponentsSupport();
+  // Collection never blocks the update path; a failure to collect is logged
+  // and retried by the next maintenance run.
+  void collectGarbage().catch(() => undefined);
+  return { published: outcome.published };
 }
 
-async function runPipInstall(options: { upgrade?: boolean } = {}): Promise<void> {
-  const { upgrade = false } = options;
-  const packages = getPipPackages();
-  const installArgs = ["install"];
-  if (upgrade) {
-    installArgs.push("-U");
-  }
-
-  // pip candidates to try in order
-  const candidates =
-    process.platform === "win32"
-      ? [
-          ["py", "-m", "pip", ...installArgs, ...packages],
-          ["python", "-m", "pip", ...installArgs, ...packages],
-          ["python3", "-m", "pip", ...installArgs, ...packages],
-          ["pip", ...installArgs, ...packages],
-          ["pip3", ...installArgs, ...packages],
-        ]
-      : [
-          ["pip3", ...installArgs, "--user", ...packages],
-          ["pip3", ...installArgs, ...packages],
-          ["pip3", ...installArgs, "--break-system-packages", ...packages],
-          ["pip", ...installArgs, "--user", ...packages],
-          ["pip", ...installArgs, ...packages],
-          ["pip", ...installArgs, "--break-system-packages", ...packages],
-          ["python3", "-m", "pip", ...installArgs, "--user", ...packages],
-          ["python3", "-m", "pip", ...installArgs, ...packages],
-        ];
-
-  for (const [cmd, ...args] of candidates) {
-    try {
-      logger.info(`[yt-dlp] Attempting: ${cmd} ${args.join(" ")}`);
-      await new Promise<void>((resolve, reject) => {
-        let stderr = "";
-        const proc = spawn(cmd, args, {
-          stdio: ["ignore", "ignore", "pipe"],
-        });
-        proc.stderr?.on("data", (data: Buffer) => {
-          stderr += data.toString();
-        });
-        proc.on("close", (code) =>
-          code === 0
-            ? resolve()
-            : reject(
-                Object.assign(new Error(`${cmd} exited with code ${code}`), {
-                  code,
-                  stderr,
-                })
-              )
-        );
-        proc.on("error", reject);
-      });
-      logger.info(
-        `[yt-dlp] Successfully ${upgrade ? "updated" : "installed"} ${packages.join(", ")}.`
-      );
-      updatePathAfterAutoInstall();
-      return;
-    } catch (error: unknown) {
-      const stderr = String(
-        (error as { stderr?: unknown })?.stderr || ""
-      ).trim();
-      if (stderr) {
-        logger.warn(`[yt-dlp] ${cmd} failed: ${stderr.split("\n").pop()}`);
-      }
-      // Try next candidate
-    }
-  }
-
-  throw new Error(
-    `yt-dlp could not be automatically ${upgrade ? "updated" : "installed"}. ` +
-      "Please install it manually: https://github.com/yt-dlp/yt-dlp#installation"
-  );
-}
-
-/**
- * Ensure yt-dlp is available, auto-installing via pip if not found.
- * Result is cached so the check only runs once per process.
- */
 export async function ensureYtDlpAvailable(): Promise<void> {
   if (ytDlpAvailablePromise) return ytDlpAvailablePromise;
 
@@ -162,6 +53,57 @@ export async function ensureYtDlpAvailable(): Promise<void> {
     let attemptedAutoInstall = false;
 
     while (true) {
+      if (hasCustomConfiguredYtDlpPath()) {
+        await ensureCustomPathAvailable();
+        return;
+      }
+
+      const managed = recoverUsableManagedRelease();
+      if (managed && !(await managedReleaseRunsCached(managed))) {
+        logger.warn(
+          `[yt-dlp] Managed release ${managed.release.releaseId} no longer runs ` +
+            "(the interpreter or its dependencies may have changed). Installing a new managed release."
+        );
+        if (!attemptedAutoInstall) {
+          attemptedAutoInstall = true;
+          try {
+            // pip usually produces the same latest version, so the repair has
+            // to be allowed to replace a same-version current release.
+            await installYtDlp({ upgrade: true, currentIsUsable: false });
+          } catch (installError: unknown) {
+            logger.warn(
+              `[yt-dlp] Reinstall failed (${getErrorMessage(installError, "unknown error")}). Trying the next release.`
+            );
+          }
+        }
+        // Re-evaluate. The probe marked this release unusable, so the next
+        // candidate - the rollback release, or another finalized one - is
+        // picked up and validated in turn rather than trusted structurally.
+        // The marked set only grows, so this terminates at external discovery.
+        continue;
+      }
+      if (managed) {
+        if (
+          !attemptedAutoUpgrade &&
+          isReleaseStale(managed.release.version)
+        ) {
+          attemptedAutoUpgrade = true;
+          logger.warn(
+            `[yt-dlp] Managed release ${managed.release.version} is older than ${YT_DLP_STALE_AFTER_DAYS} days. Installing a new managed release.`
+          );
+          try {
+            await installYtDlp({ upgrade: true });
+            continue;
+          } catch (upgradeError: unknown) {
+            logger.warn(
+              `[yt-dlp] Automatic update failed (${getErrorMessage(upgradeError, "unknown error")}). Continuing with the existing managed release.`
+            );
+            return;
+          }
+        }
+        return;
+      }
+
       const ytDlpPath = await resolveYtDlpPath();
       try {
         const versionInfo = await getYtDlpVersionInfo(ytDlpPath);
@@ -175,20 +117,13 @@ export async function ensureYtDlpAvailable(): Promise<void> {
           );
         }
 
-        if (
-          !hasCustomConfiguredYtDlpPath() &&
-          !attemptedAutoUpgrade &&
-          versionInfo.isStale
-        ) {
+        if (!attemptedAutoUpgrade && versionInfo.isStale) {
           attemptedAutoUpgrade = true;
           logger.warn(
-            `[yt-dlp] ${versionInfo.version || ytDlpPath} is older than ${YT_DLP_STALE_AFTER_DAYS} days. Updating yt-dlp to avoid known YouTube 360p regressions.`
+            `[yt-dlp] ${versionInfo.version || ytDlpPath} is older than ${YT_DLP_STALE_AFTER_DAYS} days. Installing a managed yt-dlp release.`
           );
           try {
             await installYtDlp({ upgrade: true });
-            resetResolvedYtDlpPath();
-            resetJsRuntimeFlag();
-            resetRemoteComponentsSupport();
             continue;
           } catch (upgradeError: unknown) {
             logger.warn(
@@ -201,7 +136,6 @@ export async function ensureYtDlpAvailable(): Promise<void> {
         return;
       } catch (err: unknown) {
         const e = err as NodeJS.ErrnoException & { kind?: string };
-        // Non-zero exit from --version means binary executed; continue.
         if (e.kind === "close") {
           return;
         }
@@ -214,45 +148,27 @@ export async function ensureYtDlpAvailable(): Promise<void> {
         }
 
         if (e.code === "ENOENT") {
-          // Only auto-install when using the default path (not a user-configured path).
-          if (hasCustomConfiguredYtDlpPath()) {
-            throw new Error(
-              `yt-dlp not found at configured path: ${ytDlpPath}. ` +
-                "Please check your YT_DLP_PATH environment variable."
-            );
-          }
-
           if (attemptedAutoInstall) {
             throw new Error(
-              "yt-dlp was installed automatically but is still not available on PATH. " +
-                "Please add it to PATH or set YT_DLP_PATH to the installed binary."
+              "yt-dlp was installed automatically but is still not usable. " +
+                "Please install Python 3 and pip, or set YT_DLP_PATH to a working binary."
             );
           }
 
           logger.warn(
-            "[yt-dlp] yt-dlp not found in PATH. Attempting automatic installation..."
+            "[yt-dlp] yt-dlp not found in PATH. Attempting managed installation..."
           );
           attemptedAutoInstall = true;
           await installYtDlp();
-          resetResolvedYtDlpPath();
-          resetJsRuntimeFlag();
-          resetRemoteComponentsSupport();
           continue;
         }
 
-        if (hasCustomConfiguredYtDlpPath()) {
-          throw new Error(
-            `Failed to execute configured yt-dlp at ${ytDlpPath} ` +
-              `(${e.code || "unknown"}): ${e.message}`
-          );
-        }
         throw new Error(
           `Failed to execute yt-dlp (${e.code || "unknown"}): ${e.message}`
         );
       }
     }
   })().catch((err) => {
-    // Reset cache so the next call retries instead of getting the same error.
     ytDlpAvailablePromise = null;
     throw err;
   });
@@ -260,13 +176,32 @@ export async function ensureYtDlpAvailable(): Promise<void> {
   return ytDlpAvailablePromise;
 }
 
+async function ensureCustomPathAvailable(): Promise<void> {
+  const ytDlpPath = await resolveYtDlpPath();
+  const versionInfo = await getYtDlpVersionInfo(ytDlpPath);
+  if (versionInfo.canRun || versionInfo.errorKind === "close") {
+    return;
+  }
+  if (versionInfo.errorCode === "EACCES" || versionInfo.errorCode === "EPERM") {
+    throw new Error(
+      `yt-dlp exists but is not executable at: ${ytDlpPath}. ` +
+        "Please fix file permissions or install yt-dlp manually."
+    );
+  }
+  if (versionInfo.errorCode === "ENOENT") {
+    throw new Error(
+      `yt-dlp not found at configured path: ${ytDlpPath}. ` +
+        "Please check your YT_DLP_PATH environment variable."
+    );
+  }
+  throw new Error(
+    `Failed to execute configured yt-dlp at ${ytDlpPath} ` +
+      `(${versionInfo.errorCode || "unknown"}): ${versionInfo.errorMessage || "unknown error"}`
+  );
+}
+
 export function resetYtDlpAvailablePromise(): void {
   ytDlpAvailablePromise = null;
 }
 
-/**
- * @internal Test helper: drop a queue tail left pending by a mocked pip run.
- */
-export function resetPipQueue(): void {
-  pipQueue = Promise.resolve();
-}
+export { resetPipQueue };

--- a/backend/src/utils/ytdlp/maintenance.ts
+++ b/backend/src/utils/ytdlp/maintenance.ts
@@ -10,12 +10,28 @@ import {
   resetJsRuntimeFlag,
   resetRemoteComponentsSupport,
 } from "./runtime";
+import {
+  parseYtDlpReleaseTimestamp,
+  isYtDlpUpdateAvailable,
+} from "./versionStamp";
+import { recoverUsableManagedRelease } from "./release";
+import {
+  isManagedReleaseUnusable,
+  managedReleaseRunsCached,
+} from "./release/recover";
+import {
+  loadManagedRelease,
+  readCurrentManifest,
+} from "./release/manifests";
+import { isReleaseStale } from "./release/acquire";
 import { getYtDlpVersionInfo } from "./versionProbe";
 import { getErrorMessage } from "../errors";
 import { logger } from "../logger";
 
 const PYPI_YT_DLP_URL = "https://pypi.org/pypi/yt-dlp/json";
 const PYPI_TIMEOUT_MS = 5000;
+
+export { parseYtDlpReleaseTimestamp, isYtDlpUpdateAvailable };
 
 export type YtDlpStatus = {
   /** Version string reported by `yt-dlp --version`, or null when it cannot run. */
@@ -44,48 +60,6 @@ export type YtDlpUpdateResult = {
   /** True when the reported version actually changed. */
   changed: boolean;
 };
-
-/**
- * Parse a yt-dlp release date out of a version string. Accepts both the
- * zero-padded form the binary prints ("2026.08.19") and the PyPI form
- * ("2026.8.19"). Returns null for nightly/unknown formats.
- */
-export function parseYtDlpReleaseTimestamp(
-  version: string | null | undefined
-): number | null {
-  if (!version) {
-    return null;
-  }
-
-  const match = version.trim().match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})/);
-  if (!match) {
-    return null;
-  }
-
-  const timestamp = Date.UTC(
-    Number(match[1]),
-    Number(match[2]) - 1,
-    Number(match[3])
-  );
-  return Number.isFinite(timestamp) ? timestamp : null;
-}
-
-/**
- * Compare an installed version against the latest published one. Unknown or
- * unparsable versions never claim an update is available, so the UI stays quiet
- * instead of nagging about a version it cannot reason about.
- */
-export function isYtDlpUpdateAvailable(
-  installedVersion: string | null,
-  latestVersion: string | null
-): boolean {
-  const installed = parseYtDlpReleaseTimestamp(installedVersion);
-  const latest = parseYtDlpReleaseTimestamp(latestVersion);
-  if (installed === null || latest === null) {
-    return false;
-  }
-  return latest > installed;
-}
 
 /**
  * Look up the newest yt-dlp release on PyPI. Network failures are not fatal:
@@ -119,13 +93,34 @@ export async function getYtDlpStatus(
   options: { checkLatest?: boolean } = {}
 ): Promise<YtDlpStatus> {
   const { checkLatest = false } = options;
-  const ytDlpPath = await resolveYtDlpPath();
-  const [versionInfo, latestVersion] = await Promise.all([
-    getYtDlpVersionInfo(ytDlpPath),
-    checkLatest ? getLatestYtDlpVersion() : Promise.resolve(null),
-  ]);
-
   const customPathConfigured = hasCustomConfiguredYtDlpPath();
+  const latestVersion = checkLatest
+    ? await getLatestYtDlpVersion()
+    : null;
+
+  if (!customPathConfigured) {
+    const managed = recoverUsableManagedRelease();
+    // Existence is not usability. Without this the endpoint would report a
+    // release that cannot run as available, and an operator update would then
+    // treat a same-version repair as a redundant no-op.
+    if (managed && (await managedReleaseRunsCached(managed))) {
+      const version = managed.release.version;
+      return {
+        version,
+        path: managed.release.pythonExecutable,
+        available: true,
+        isStale: isReleaseStale(version),
+        staleAfterDays: YT_DLP_STALE_AFTER_DAYS,
+        latestVersion,
+        updateAvailable: isYtDlpUpdateAvailable(version, latestVersion),
+        updateSupported: true,
+        customPathConfigured,
+      };
+    }
+  }
+
+  const ytDlpPath = await resolveYtDlpPath();
+  const versionInfo = await getYtDlpVersionInfo(ytDlpPath);
 
   return {
     version: versionInfo.version,
@@ -139,6 +134,34 @@ export async function getYtDlpStatus(
     customPathConfigured,
     ...(versionInfo.canRun ? {} : { errorMessage: versionInfo.errorMessage }),
   };
+}
+
+/**
+ * Whether the release current.json names cannot run.
+ *
+ * Deliberately reads the pointer rather than going through
+ * recoverUsableManagedRelease: that helper hides releases already known to be
+ * unusable, which is exactly the case this needs to detect.
+ */
+async function currentManagedReleaseIsBroken(): Promise<boolean> {
+  if (hasCustomConfiguredYtDlpPath()) {
+    return false;
+  }
+  const current = readCurrentManifest();
+  if (!current) {
+    return false;
+  }
+  if (isManagedReleaseUnusable(current.releaseId)) {
+    return true;
+  }
+  const loaded = loadManagedRelease(current.releaseId, current);
+  if (!loaded) {
+    // The pointer names a release whose directory or site-packages is gone.
+    // That is as broken as one that fails to run, and a same-version repair
+    // must be allowed to replace it.
+    return true;
+  }
+  return !(await managedReleaseRunsCached(loaded));
 }
 
 // Shared across concurrent callers so a double-click cannot start two pip runs.
@@ -155,7 +178,16 @@ async function runYtDlpUpdate(): Promise<YtDlpUpdateResult> {
   logger.info(
     `[yt-dlp] Updating yt-dlp (currently ${previousVersion || "unknown"}) on operator request.`
   );
-  await installYtDlp({ upgrade: true });
+  // A current release that failed validation must be replaceable even by the
+  // same version, which is what pip usually produces.
+  const brokenCurrent = await currentManagedReleaseIsBroken();
+  const { published } = await installYtDlp({
+    upgrade: true,
+    currentIsUsable: !brokenCurrent,
+  });
+  if (!published) {
+    logger.info("[yt-dlp] Already on the newest available release.");
+  }
 
   // The upgrade may have landed a different binary on PATH, so drop every
   // cached capability probe before re-reading the version.

--- a/backend/src/utils/ytdlp/pipLock.ts
+++ b/backend/src/utils/ytdlp/pipLock.ts
@@ -1,0 +1,21 @@
+/**
+ * Process-wide pip serialization.
+ *
+ * Staging isolation makes concurrent pip runs safe, but they still compete for
+ * the package index and download bandwidth. Serializing in one place covers
+ * both the managed installer and any remaining fallback callers.
+ */
+let pipQueue: Promise<unknown> = Promise.resolve();
+
+export function withPipLock<T>(task: () => Promise<T>): Promise<T> {
+  const run = pipQueue.then(task, task);
+  pipQueue = run.catch(() => undefined);
+  return run;
+}
+
+/**
+ * @internal Test helper: drop a queue tail left pending by a mocked pip run.
+ */
+export function resetPipQueue(): void {
+  pipQueue = Promise.resolve();
+}

--- a/backend/src/utils/ytdlp/release/acquire.ts
+++ b/backend/src/utils/ytdlp/release/acquire.ts
@@ -1,0 +1,113 @@
+import { DEFAULT_YT_DLP_PATH, YT_DLP_STALE_AFTER_DAYS } from "../constants";
+import { hasCustomConfiguredYtDlpPath, resolveYtDlpPath } from "../pathResolver";
+import { parseYtDlpReleaseTimestamp } from "../versionStamp";
+import {
+  getCachedYtDlpVersionInfo,
+  type YtDlpVersionInfo,
+} from "../versionProbe";
+import { attachCapabilities } from "./capabilities";
+import {
+  captureProcessEnv,
+  buildExternalSpawnEnv,
+  buildManagedSpawnEnv,
+} from "./env";
+import {
+  managedReleaseRunsCached,
+  recoverUsableManagedRelease,
+} from "./recover";
+import { logger } from "../../logger";
+import type { LoadedManagedRelease, YtDlpRelease } from "./types";
+
+/**
+ * Select the release this operation will run against.
+ *
+ * `ensureAvailable` delegates to `ensureYtDlpAvailable()` — the one place that
+ * owns auto-install of a missing binary and the stale auto-upgrade — so those
+ * behaviours stay on the execution path instead of being reimplemented here.
+ * It is imported lazily because `install.ts` reaches back into this module for
+ * the staleness helper.
+ */
+/** Bounded so a pathological store cannot spin; recovery narrows each pass. */
+const MANAGED_SELECTION_ATTEMPTS = 4;
+
+export async function acquireYtDlpRelease(
+  options: { ensureAvailable?: boolean } = {}
+): Promise<YtDlpRelease> {
+  if (options.ensureAvailable) {
+    const { ensureYtDlpAvailable } = await import("../install");
+    await ensureYtDlpAvailable();
+  }
+
+  if (hasCustomConfiguredYtDlpPath()) {
+    return createExternalRelease(await resolveYtDlpPath());
+  }
+
+  // Re-read current.json on every acquisition: a second backend process may
+  // have published a release this process has never observed. Availability was
+  // resolved once for this process, so a release that appeared afterwards has
+  // never been validated here - and a publisher running a different image or
+  // Python ABI can leave one that is structurally valid but cannot run.
+  // managedReleaseRunsCached probes once per release id and records a failure,
+  // so the next pass through recovery skips it.
+  for (let attempt = 0; attempt < MANAGED_SELECTION_ATTEMPTS; attempt += 1) {
+    const managed = recoverUsableManagedRelease();
+    if (!managed) {
+      break;
+    }
+    if (await managedReleaseRunsCached(managed)) {
+      return createManagedRelease(managed);
+    }
+    logger.warn(
+      `[yt-dlp] Managed release ${managed.release.releaseId} cannot run; trying the next candidate.`
+    );
+  }
+
+  const resolvedPath = await resolveYtDlpPath();
+  return createExternalRelease(resolvedPath || DEFAULT_YT_DLP_PATH);
+}
+
+export function createManagedRelease(
+  loaded: LoadedManagedRelease
+): YtDlpRelease {
+  const env = captureProcessEnv();
+  return attachCapabilities({
+    kind: "managed",
+    releaseId: loaded.release.releaseId,
+    version: loaded.release.version,
+    command: loaded.release.pythonExecutable,
+    prefixArgs: ["-m", "yt_dlp", ...loaded.release.pythonPrefixArgs],
+    spawnEnv: buildManagedSpawnEnv(loaded.sitePackagesPath, env),
+    pythonExecutable: loaded.release.pythonExecutable,
+    sitePackagesPath: loaded.sitePackagesPath,
+    generation: loaded.current?.generation,
+  });
+}
+
+export async function createExternalRelease(
+  resolvedPath: string,
+  versionInfo?: YtDlpVersionInfo
+): Promise<YtDlpRelease> {
+  const resolvedVersionInfo =
+    versionInfo ?? (await getCachedYtDlpVersionInfo(resolvedPath));
+  const version = resolvedVersionInfo.version;
+  const env = captureProcessEnv();
+  return attachCapabilities({
+    kind: "external",
+    // MyTube does not own an external binary, so the fingerprint is the most
+    // it can offer: a different path or version means a different release.
+    releaseId: `external:${resolvedPath}:${version ?? "unknown"}`,
+    version,
+    command: resolvedPath,
+    prefixArgs: [],
+    spawnEnv: buildExternalSpawnEnv(env),
+  });
+}
+
+export function isReleaseStale(version: string | null): boolean {
+  const timestamp = parseYtDlpReleaseTimestamp(version);
+  if (timestamp === null) {
+    return false;
+  }
+  const staleAfterMs = YT_DLP_STALE_AFTER_DAYS * 24 * 60 * 60 * 1000;
+  return Date.now() - timestamp > staleAfterMs;
+}

--- a/backend/src/utils/ytdlp/release/candidate.ts
+++ b/backend/src/utils/ytdlp/release/candidate.ts
@@ -1,0 +1,135 @@
+import path from "path";
+import { getProviderPluginPath } from "../../../services/downloaders/ytdlp/ytdlpHelpers";
+import { logger } from "../../logger";
+import {
+  YT_DLP_HELP_PROBE_TIMEOUT_MS,
+  YT_DLP_PIP_PACKAGE,
+  YT_DLP_PIP_PROVIDER_PACKAGE,
+} from "../constants";
+import { captureProcessEnv, buildManagedSpawnEnv } from "./env";
+import type { PythonInterpreter } from "./interpreter";
+import { assertNotSymlink, chmodQuiet, writeJsonAtomic } from "./paths";
+import { MODULE_ORIGIN_SCRIPT } from "./moduleOrigin";
+import { runProcess } from "./process";
+import {
+  RELEASE_JSON_FILENAME,
+  SITE_PACKAGES_DIRNAME,
+  type ReleaseManifest,
+} from "./types";
+
+
+export async function pipInstallToTarget(
+  interpreter: PythonInterpreter,
+  targetDir: string,
+  timeoutMs: number
+): Promise<void> {
+  const packages = [YT_DLP_PIP_PACKAGE];
+  if (!getProviderPluginPath()) {
+    packages.push(YT_DLP_PIP_PROVIDER_PACKAGE);
+  }
+  logger.info(`[yt-dlp] Installing ${packages.join(", ")} into ${targetDir}`);
+  const result = await runProcess(
+    interpreter.executable,
+    [
+      "-m",
+      "pip",
+      "install",
+      "--disable-pip-version-check",
+      "--no-cache-dir",
+      "--no-input",
+      "--target",
+      targetDir,
+      ...packages,
+    ],
+    { timeoutMs }
+  );
+  if (result.timedOut) {
+    throw new Error("pip install timed out while assembling a yt-dlp release");
+  }
+  if (result.code !== 0) {
+    const detail = (result.stderr || result.stdout).trim().split("\n").pop();
+    throw new Error(`pip install failed${detail ? `: ${detail}` : ""}`);
+  }
+}
+
+/**
+ * Run every check that must pass before a candidate can become current: the
+ * version and help probes, the impersonation probe (an absent target is a
+ * capability, not a failure) and the module-origin check that proves the
+ * candidate imports from its own site-packages rather than an ambient install.
+ * Only then is release.json written and flushed.
+ */
+export async function validateStagedRelease(input: {
+  interpreter: PythonInterpreter;
+  stagingRoot: string;
+  sitePackagesPath: string;
+  createReleaseId: (version: string) => string;
+  installedAt: string;
+}): Promise<ReleaseManifest> {
+  const { interpreter, stagingRoot, sitePackagesPath, installedAt } = input;
+  assertNotSymlink(sitePackagesPath, stagingRoot);
+  const env = buildManagedSpawnEnv(sitePackagesPath, captureProcessEnv());
+  const prefix = ["-m", "yt_dlp"];
+
+  const versionResult = await runProcess(
+    interpreter.executable,
+    [...prefix, "--version"],
+    { env, timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS }
+  );
+  if (versionResult.timedOut || versionResult.code !== 0) {
+    throw new Error("Candidate yt-dlp --version probe failed");
+  }
+  const version = (versionResult.stdout || versionResult.stderr).trim();
+  if (!version) {
+    throw new Error("Candidate yt-dlp did not print a version");
+  }
+
+  const helpResult = await runProcess(
+    interpreter.executable,
+    [...prefix, "--help"],
+    { env, timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS }
+  );
+  if (helpResult.timedOut || helpResult.code !== 0) {
+    throw new Error("Candidate yt-dlp --help probe failed");
+  }
+
+  const impersonateResult = await runProcess(
+    interpreter.executable,
+    [...prefix, "--list-impersonate-targets"],
+    { env, timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS }
+  );
+  if (impersonateResult.timedOut) {
+    throw new Error("Candidate yt-dlp impersonation probe timed out");
+  }
+
+  const allowedOrigins = [sitePackagesPath, getProviderPluginPath()].filter(
+    Boolean
+  );
+  const originResult = await runProcess(
+    interpreter.executable,
+    ["-c", MODULE_ORIGIN_SCRIPT, ...allowedOrigins],
+    { env, timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS }
+  );
+  if (originResult.timedOut || originResult.code !== 0) {
+    throw new Error(
+      "Candidate yt-dlp imported modules from outside the managed site-packages"
+    );
+  }
+
+  const manifest: ReleaseManifest = {
+    schemaVersion: 1,
+    releaseId: input.createReleaseId(version),
+    version,
+    installedAt,
+    pythonExecutable: interpreter.executable,
+    pythonPrefixArgs: [],
+    sitePackages: SITE_PACKAGES_DIRNAME,
+  };
+  writeJsonAtomic(
+    path.join(stagingRoot, RELEASE_JSON_FILENAME),
+    stagingRoot,
+    manifest
+  );
+  chmodQuiet(path.join(stagingRoot, RELEASE_JSON_FILENAME), 0o600);
+  return manifest;
+}

--- a/backend/src/utils/ytdlp/release/capabilities.ts
+++ b/backend/src/utils/ytdlp/release/capabilities.ts
@@ -1,0 +1,132 @@
+import { logger } from "../../logger";
+import {
+  YT_DLP_HELP_PROBE_TIMEOUT_MS,
+  type YouTubeJsRuntimeFlag,
+} from "../constants";
+import { runProcess } from "./process";
+import type { YtDlpCapabilities, YtDlpRelease } from "./types";
+
+const capabilityCache = new Map<string, Promise<YtDlpCapabilities>>();
+
+export function resetCapabilityCacheForTests(): void {
+  capabilityCache.clear();
+}
+
+export function getReleaseCapabilities(
+  release: YtDlpRelease
+): Promise<YtDlpCapabilities> {
+  if (release.kind === "external") {
+    return probeCapabilitiesWithLogging(release);
+  }
+  const cached = capabilityCache.get(release.releaseId);
+  if (cached) {
+    return cached;
+  }
+  const pending = probeCapabilitiesWithLogging(release).catch(
+    (error: unknown) => {
+      // Probe-infrastructure failure: drop the entry so a later acquisition can
+      // retry this release instead of inheriting one transient timeout forever.
+      capabilityCache.delete(release.releaseId);
+      throw error;
+    }
+  );
+  capabilityCache.set(release.releaseId, pending);
+  return pending;
+}
+
+async function probeCapabilitiesWithLogging(
+  release: YtDlpRelease
+): Promise<YtDlpCapabilities> {
+  try {
+    return await probeCapabilities(release);
+  } catch (error: unknown) {
+    logger.warn(
+      `[yt-dlp] Capability probe failed for ${release.releaseId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    throw error;
+  }
+}
+
+async function probeCapabilities(
+  release: YtDlpRelease
+): Promise<YtDlpCapabilities> {
+  // Two failure kinds must not be confused. A probe that ran to completion and
+  // reported "no" describes the immutable release and is cached for its
+  // lifetime. A probe that never produced an answer (timeout, spawn failure)
+  // says nothing about the release, so it rejects and evicts the cache entry so
+  // a later acquisition retries instead of disabling the feature forever.
+  const help = await runYtDlp(release, ["--help"]);
+  const helpText = `${help.stdout}\n${help.stderr}`.trim();
+  if (help.timedOut || help.code === null || !helpText) {
+    throw new Error(
+      `yt-dlp --help probe did not complete for ${release.releaseId}`
+    );
+  }
+
+  const impersonate = await runYtDlp(release, ["--list-impersonate-targets"]);
+  if (impersonate.timedOut || impersonate.code === null) {
+    throw new Error(
+      `yt-dlp impersonation probe did not complete for ${release.releaseId}`
+    );
+  }
+
+  return {
+    jsRuntimeFlag: parseJsRuntimeFlag(helpText),
+    supportsRemoteComponents: helpText.includes("--remote-components"),
+    // A non-zero exit means this yt-dlp has no --list-impersonate-targets at
+    // all: definitive absence, not a probe failure.
+    impersonateAvailable:
+      impersonate.code === 0 &&
+      parseImpersonateAvailable(`${impersonate.stdout}\n${impersonate.stderr}`),
+  };
+}
+
+async function runYtDlp(release: YtDlpRelease, args: string[]) {
+  return runProcess(release.command, [...release.prefixArgs, ...args], {
+    env: release.spawnEnv,
+    timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS,
+  });
+}
+
+function parseJsRuntimeFlag(helpText: string): YouTubeJsRuntimeFlag | null {
+  if (helpText.includes("--js-runtimes")) {
+    return "--js-runtimes";
+  }
+  if (helpText.includes("--js-runtime")) {
+    return "--js-runtime";
+  }
+  return null;
+}
+
+function parseImpersonateAvailable(output: string): boolean {
+  return output.split("\n").some(
+    (line) =>
+      /chrome/i.test(line) &&
+      /curl_cffi/.test(line) &&
+      !/unavailable/i.test(line)
+  );
+}
+
+export function attachCapabilities(
+  release: Omit<YtDlpRelease, "capabilities">
+): YtDlpRelease {
+  const wrapped = { ...release } as YtDlpRelease;
+  let snapshotCapabilities: Promise<YtDlpCapabilities> | null = null;
+  Object.defineProperty(wrapped, "capabilities", {
+    configurable: true,
+    // Non-enumerable on purpose: reading this property probes the release with
+    // real child processes. An incidental spread, JSON.stringify, or object
+    // logging of a release must never launch one.
+    enumerable: false,
+    get() {
+      // External installations are mutable without their path or version
+      // changing (for example, curl_cffi may be added later). Cache only for
+      // this acquired snapshot; a later acquisition gets a fresh probe.
+      snapshotCapabilities ??= getReleaseCapabilities(wrapped);
+      return snapshotCapabilities;
+    },
+  });
+  return wrapped;
+}

--- a/backend/src/utils/ytdlp/release/env.ts
+++ b/backend/src/utils/ytdlp/release/env.ts
@@ -1,0 +1,40 @@
+import path from "path";
+import { getProviderPluginPath } from "../../../services/downloaders/ytdlp/ytdlpHelpers";
+
+export function captureProcessEnv(
+  source: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  return { ...source };
+}
+
+export function buildManagedSpawnEnv(
+  sitePackagesPath: string,
+  capturedEnv: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  const bundled = getProviderPluginPath();
+  const pythonPath = [bundled, sitePackagesPath].filter(Boolean).join(path.delimiter);
+  return {
+    ...capturedEnv,
+    PYTHONPATH: pythonPath,
+    PYTHONNOUSERSITE: "1",
+  };
+}
+
+export function buildExternalSpawnEnv(
+  capturedEnv: NodeJS.ProcessEnv
+): NodeJS.ProcessEnv {
+  const bundled = getProviderPluginPath();
+  if (!bundled) {
+    return { ...capturedEnv };
+  }
+  const entries = (capturedEnv.PYTHONPATH ?? "")
+    .split(path.delimiter)
+    .filter(Boolean);
+  if (!entries.includes(bundled)) {
+    entries.unshift(bundled);
+  }
+  return {
+    ...capturedEnv,
+    PYTHONPATH: entries.join(path.delimiter),
+  };
+}

--- a/backend/src/utils/ytdlp/release/gc.ts
+++ b/backend/src/utils/ytdlp/release/gc.ts
@@ -1,0 +1,310 @@
+import fs from "fs";
+import path from "path";
+import { removeSafe } from "../../security";
+import { logger } from "../../logger";
+import {
+  YT_DLP_GC_KEEP_PREVIOUS_COUNT,
+  YT_DLP_GC_MIN_INTERVAL_MS,
+  YT_DLP_RELEASE_MIN_RETENTION_MS,
+  YT_DLP_STAGING_MAX_AGE_MS,
+  YT_DLP_STALE_LEASE_WARN_MS,
+} from "../constants";
+import { isValidOperationId, isValidReleaseId } from "./ids";
+import {
+  abortGcMarker,
+  beginGcMarker,
+  getInstanceId,
+  hasLeases,
+  readLeaseRecords,
+} from "./leases";
+import {
+  readCurrentManifest,
+  readPublishedManifest,
+  readReleaseManifest,
+} from "./manifests";
+import {
+  getManagedStoreLayout,
+  getReleaseDir,
+  getTrashPath,
+  listSafeDirNames,
+  pathExistsInRoot,
+  renameInRoot,
+} from "./paths";
+import type { CurrentManifest, ManagedStoreLayout } from "./types";
+
+type FinalizedRelease = {
+  releaseId: string;
+  installedAt: number;
+  /** Directory mtime: how long this release has actually existed on disk. */
+  finalizedAt: number;
+  /**
+   * Publication generation, or null for a finalized candidate that was never
+   * published (a conflict- or no-op-rejected install). Only published releases
+   * form the rollback window.
+   */
+  generation: number | null;
+};
+
+/**
+ * Conservative, lease-aware collection. It runs after a successful publication
+ * or during maintenance, never before publication and never while the
+ * publication lock is held. Every ambiguity favours retention.
+ */
+let lastCollectionAt = 0;
+let deferredCollection: NodeJS.Timeout | null = null;
+
+export function resetCollectionThrottleForTests(): void {
+  lastCollectionAt = 0;
+  if (deferredCollection) {
+    clearTimeout(deferredCollection);
+    deferredCollection = null;
+  }
+}
+
+/**
+ * Collection also has to happen outside the update path. A release pinned by a
+ * long download is skipped while its lease exists, and nothing else would look
+ * at it again until the next install - which may be months away. Releasing a
+ * lease therefore offers a collection.
+ *
+ * A request that arrives inside the throttle window is deferred rather than
+ * dropped: publication runs a collection of its own, so the follow-up that
+ * matters (the one after the last lease goes away) would otherwise be the one
+ * discarded.
+ */
+export function collectGarbageIfDue(): void {
+  const waitMs = lastCollectionAt + YT_DLP_GC_MIN_INTERVAL_MS - Date.now();
+  if (waitMs <= 0) {
+    void collectGarbage().catch(() => undefined);
+    return;
+  }
+  if (deferredCollection) {
+    return;
+  }
+  deferredCollection = setTimeout(() => {
+    deferredCollection = null;
+    void collectGarbage().catch(() => undefined);
+  }, waitMs);
+  // Never hold the process open for maintenance.
+  deferredCollection.unref?.();
+}
+
+export async function collectGarbage(): Promise<void> {
+  lastCollectionAt = Date.now();
+  const layout = getManagedStoreLayout();
+  await collectStaleStaging(layout);
+  await emptyTrash(layout);
+  const current = readCurrentManifest(layout.root);
+  const finalized = listFinalizedReleases(layout);
+  const protectedIds = listProtectedReleaseIds(current, finalized);
+  const now = Date.now();
+
+  for (const release of finalized) {
+    if (protectedIds.has(release.releaseId)) {
+      continue;
+    }
+    // A finalized-but-unpublished release belongs to an installer that may
+    // still be between finalize and publish. The directory's own age answers
+    // that, whatever date the manifest carries.
+    if (now - release.finalizedAt < YT_DLP_RELEASE_MIN_RETENTION_MS) {
+      continue;
+    }
+    await collectReleaseIfUnused(layout, release.releaseId);
+  }
+}
+
+function listFinalizedReleases(layout: ManagedStoreLayout): FinalizedRelease[] {
+  const releases: FinalizedRelease[] = [];
+  for (const name of listSafeDirNames(layout.releasesDir, layout.root)) {
+    if (!isValidReleaseId(name)) {
+      continue;
+    }
+    const manifest = readReleaseManifest(name, layout.root);
+    if (!manifest) {
+      // An unreadable manifest may be a half-written directory rather than a
+      // collectable release, so leave it alone.
+      continue;
+    }
+    let finalizedAt = Date.now();
+    try {
+      finalizedAt = fs.statSync(getReleaseDir(layout, name)).mtimeMs;
+    } catch {
+      // Unstattable: treat it as brand new and keep it.
+    }
+    releases.push({
+      releaseId: name,
+      installedAt: Date.parse(manifest.installedAt) || 0,
+      finalizedAt,
+      generation: readPublishedManifest(name, layout.root)?.generation ?? null,
+    });
+  }
+  return releases.sort((a, b) => b.installedAt - a.installedAt);
+}
+
+function listProtectedReleaseIds(
+  current: CurrentManifest | null,
+  finalized: FinalizedRelease[]
+): Set<string> {
+  const ids = new Set<string>();
+  if (current) {
+    ids.add(current.releaseId);
+    if (current.previousReleaseId) {
+      ids.add(current.previousReleaseId);
+    }
+  }
+  // The rollback window is publication lineage, not install order. A candidate
+  // that was finalized but rejected (an already-current update, or a loser in a
+  // concurrent install) carries the newest install time yet was never current,
+  // so counting it here would displace a real rollback target.
+  const published = finalized
+    .filter((release) => release.generation !== null)
+    .sort((a, b) => (b.generation as number) - (a.generation as number));
+  const window = published.length ? published : finalized;
+  for (const release of window.slice(0, 1 + YT_DLP_GC_KEEP_PREVIOUS_COUNT)) {
+    ids.add(release.releaseId);
+  }
+  return ids;
+}
+
+async function collectReleaseIfUnused(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): Promise<void> {
+  if (hasLeases(releaseId)) {
+    reportStaleLeases(releaseId);
+    return;
+  }
+  // Claim the deleting marker exclusively first, then re-check leases: a reader
+  // that arrives after the marker exists abandons this release and retries.
+  const token = beginGcMarker(releaseId);
+  if (!token) {
+    return;
+  }
+  if (hasLeases(releaseId)) {
+    abortGcMarker(releaseId, token);
+    return;
+  }
+  // Move the release out of reach before deleting it. The rename is atomic and
+  // takes microseconds, so the marker only has to stay visible across it rather
+  // than across the whole deletion - which means a slow or suspended delete can
+  // no longer outlive the marker and let a reader lease a half-removed release.
+  // Once renamed, nothing can resolve it: recovery simply picks another.
+  const releaseDir = getReleaseDir(layout, releaseId);
+  const trashPath = getTrashPath(layout, releaseId, token);
+  try {
+    renameInRoot(releaseDir, trashPath, layout.root);
+  } catch (error: unknown) {
+    abortGcMarker(releaseId, token);
+    logger.warn(
+      `[yt-dlp] Failed to retire release ${releaseId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return;
+  }
+
+  // Re-check after the rename, not just before it. A reader writes its lease
+  // before it validates the release directory, so a lease that appeared while
+  // we were renaming is visible now - and putting the release back is what lets
+  // that reader's own directory check succeed. This is what makes the protocol
+  // safe without relying on how long the marker stays live.
+  if (hasLeases(releaseId)) {
+    try {
+      renameInRoot(trashPath, releaseDir, layout.root);
+      logger.info(
+        `[yt-dlp] Restored release ${releaseId}: a reader leased it mid-retirement`
+      );
+    } catch (error: unknown) {
+      logger.warn(
+        `[yt-dlp] Could not restore release ${releaseId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+    abortGcMarker(releaseId, token);
+    return;
+  }
+  abortGcMarker(releaseId, token);
+
+  try {
+    await removeSafe(trashPath, layout.root);
+    logger.info(`[yt-dlp] Garbage-collected unused release ${releaseId}`);
+  } catch (error: unknown) {
+    // Harmless: the release is already unreachable, and the next collection
+    // sweeps whatever is left behind.
+    logger.warn(
+      `[yt-dlp] Retired release ${releaseId} but could not delete it yet: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+  }
+}
+
+/**
+ * Report, never reclaim. A lease whose owner looks dead may still have an
+ * orphaned yt-dlp child reading from the release, and PIDs are reused across
+ * container restarts, so removing one is an explicit operator decision.
+ */
+function reportStaleLeases(releaseId: string): void {
+  const now = Date.now();
+  for (const lease of readLeaseRecords(releaseId)) {
+    const createdAt = Date.parse(lease.createdAt);
+    if (!Number.isFinite(createdAt)) {
+      continue;
+    }
+    const ageMs = now - createdAt;
+    if (
+      ageMs < YT_DLP_STALE_LEASE_WARN_MS ||
+      lease.instanceId === getInstanceId()
+    ) {
+      continue;
+    }
+    logger.warn(
+      `[yt-dlp] Release ${releaseId} is still pinned by a lease from instance ` +
+        `${lease.instanceId} (pid ${lease.pid}, operation ${lease.operationId}) created ` +
+        `${lease.createdAt}, ${Math.round(ageMs / 3_600_000)}h ago. If that backend is gone, ` +
+        "delete the lease file to let this release be reclaimed."
+    );
+  }
+}
+
+/**
+ * Delete anything left in the trash. Entries here are unreachable by
+ * construction - they were renamed out of releases/ - so a collector that died
+ * mid-deletion leaves nothing that needs to be reasoned about.
+ */
+async function emptyTrash(layout: ManagedStoreLayout): Promise<void> {
+  if (!pathExistsInRoot(layout.trashDir, layout.root)) {
+    return;
+  }
+  for (const name of listSafeDirNames(layout.trashDir, layout.root)) {
+    try {
+      await removeSafe(path.join(layout.trashDir, name), layout.root);
+    } catch {
+      // Retried by the next collection.
+    }
+  }
+}
+
+async function collectStaleStaging(layout: ManagedStoreLayout): Promise<void> {
+  if (!pathExistsInRoot(layout.stagingDir, layout.root)) {
+    return;
+  }
+  const now = Date.now();
+  for (const name of listSafeDirNames(layout.stagingDir, layout.root)) {
+    if (!isValidOperationId(name)) {
+      continue;
+    }
+    const dir = path.join(layout.stagingDir, name);
+    try {
+      // The age threshold is what protects a second backend process that is
+      // legitimately mid-install in a shared data directory.
+      if (now - fs.statSync(dir).mtimeMs < YT_DLP_STAGING_MAX_AGE_MS) {
+        continue;
+      }
+      await removeSafe(dir, layout.root);
+    } catch {
+      // Leave staging dirs we cannot stat or delete.
+    }
+  }
+}

--- a/backend/src/utils/ytdlp/release/ids.ts
+++ b/backend/src/utils/ytdlp/release/ids.ts
@@ -1,0 +1,73 @@
+import crypto from "crypto";
+
+const RELEASE_ID_PATTERN = /^[A-Za-z0-9._-]{8,96}$/;
+const OPERATION_ID_PATTERN = /^op-[a-f0-9]{16,32}$/;
+const INSTANCE_ID_PATTERN = /^[0-9]+-[a-f0-9]{8,16}$/;
+const LEASE_FILENAME_PATTERN = /^[0-9]+-[a-f0-9]{8,16}-[a-f0-9]{16}\.json$/;
+const HEX_ID_PATTERN = /^[a-f0-9]{16,32}$/;
+
+export function isValidReleaseId(value: string): boolean {
+  return RELEASE_ID_PATTERN.test(value);
+}
+
+export function isValidOperationId(value: string): boolean {
+  return OPERATION_ID_PATTERN.test(value);
+}
+
+export function isValidInstanceId(value: string): boolean {
+  return INSTANCE_ID_PATTERN.test(value);
+}
+
+export function isValidLeaseFilename(value: string): boolean {
+  return LEASE_FILENAME_PATTERN.test(value);
+}
+
+export function isValidHexNonce(value: string): boolean {
+  return HEX_ID_PATTERN.test(value);
+}
+
+export function createOperationId(): string {
+  return `op-${crypto.randomBytes(10).toString("hex")}`;
+}
+
+export function createNonce(): string {
+  return crypto.randomBytes(16).toString("hex");
+}
+
+export function createInstanceId(pid: number = process.pid): string {
+  return `${pid}-${crypto.randomBytes(6).toString("hex")}`;
+}
+
+export function createLeaseFilename(
+  instanceId: string,
+  leaseId: string
+): string {
+  return `${instanceId}-${leaseId}.json`;
+}
+
+export function isValidLeaseId(value: string): boolean {
+  return /^[a-f0-9]{16}$/.test(value);
+}
+
+export function createLeaseId(): string {
+  return crypto.randomBytes(8).toString("hex");
+}
+
+export function createReleaseId(version: string): string {
+  const safeVersion = version
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, ".")
+    .replace(/^\.+|\.+$/g, "")
+    .slice(0, 40);
+  const suffix = crypto.randomBytes(8).toString("hex");
+  const releaseId = `${safeVersion || "ytdlp"}-${suffix}`;
+  if (!isValidReleaseId(releaseId)) {
+    return `ytdlp-${suffix}`;
+  }
+  return releaseId;
+}
+
+export function createTempBasename(prefix: string): string {
+  const safePrefix = prefix.replace(/[^A-Za-z0-9._-]+/g, "");
+  return `.${safePrefix || "tmp"}.${crypto.randomBytes(8).toString("hex")}.tmp`;
+}

--- a/backend/src/utils/ytdlp/release/index.ts
+++ b/backend/src/utils/ytdlp/release/index.ts
@@ -1,0 +1,36 @@
+export { acquireYtDlpRelease } from "./acquire";
+export { getReleaseCapabilities, resetCapabilityCacheForTests } from "./capabilities";
+export { decidePublication } from "./manifests";
+export { withYtDlpRelease, spawnYtDlp } from "./launcher";
+export { installManagedRelease, setPipTimeoutMsForTests } from "./install";
+export { collectGarbage, collectGarbageIfDue } from "./gc";
+export {
+  managedReleaseRuns,
+  markManagedReleaseUnusable,
+  recoverUsableManagedRelease,
+} from "./recover";
+export {
+  setManagedStoreRootForTests,
+  getManagedStoreRoot,
+  getManagedStoreLayout,
+  atomicReplaceFile,
+} from "./paths";
+export { resetObservedGenerationForTests } from "./manifests";
+export { acquireLease, releaseLease, hasLeases } from "./leases";
+export type { YtDlpRelease, YtDlpCapabilities, CurrentManifest, ReleaseManifest } from "./types";
+
+import { resetObservedGenerationForTests } from "./manifests";
+import { resetCapabilityCacheForTests } from "./capabilities";
+import { setManagedStoreRootForTests } from "./paths";
+import { setPipTimeoutMsForTests } from "./install";
+import { resetCollectionThrottleForTests } from "./gc";
+import { resetUnusableManagedReleasesForTests } from "./recover";
+
+export function resetManagedReleaseStateForTests(): void {
+  setManagedStoreRootForTests(null);
+  resetObservedGenerationForTests();
+  resetCapabilityCacheForTests();
+  setPipTimeoutMsForTests(null);
+  resetCollectionThrottleForTests();
+  resetUnusableManagedReleasesForTests();
+}

--- a/backend/src/utils/ytdlp/release/install.ts
+++ b/backend/src/utils/ytdlp/release/install.ts
@@ -1,0 +1,98 @@
+import path from "path";
+import { ensureDirSafeSync, removeSafe } from "../../security";
+import { logger } from "../../logger";
+import { YT_DLP_PIP_TIMEOUT_MS } from "../constants";
+import { withPipLock } from "../pipLock";
+import { pipInstallToTarget, validateStagedRelease } from "./candidate";
+import { createOperationId, createReleaseId } from "./ids";
+import { discoverPythonInterpreter } from "./interpreter";
+import { readCurrentManifest } from "./manifests";
+import {
+  ensureManagedStoreLayout,
+  fsyncDirectory,
+  getReleaseDir,
+  getStagingDir,
+  pathExistsInRoot,
+  renameInRoot,
+} from "./paths";
+import { publishValidatedRelease } from "./publish";
+import { SITE_PACKAGES_DIRNAME, type PublishOutcome } from "./types";
+
+let pipTimeoutMs = YT_DLP_PIP_TIMEOUT_MS;
+
+export function setPipTimeoutMsForTests(timeoutMs: number | null): void {
+  pipTimeoutMs = timeoutMs ?? YT_DLP_PIP_TIMEOUT_MS;
+}
+
+export type InstallManagedReleaseOptions = {
+  /** Set when the current release was found not to run and must be replaced. */
+  currentIsUsable?: boolean;
+};
+
+export async function installManagedRelease(
+  options: InstallManagedReleaseOptions = {}
+): Promise<PublishOutcome> {
+  return withPipLock(() => installManagedReleaseLocked(options));
+}
+
+async function installManagedReleaseLocked(
+  options: InstallManagedReleaseOptions
+): Promise<PublishOutcome> {
+  const layout = ensureManagedStoreLayout();
+  const generationAtInstallStart =
+    readCurrentManifest(layout.root)?.generation ?? null;
+  const interpreter = await discoverPythonInterpreter();
+  const operationId = createOperationId();
+  const stagingRoot = getStagingDir(layout, operationId);
+  const sitePackagesPath = path.join(stagingRoot, SITE_PACKAGES_DIRNAME);
+  ensureDirSafeSync(sitePackagesPath, layout.root);
+  logger.info(
+    `[yt-dlp] ${operationId}: staging a candidate release in ${stagingRoot}`
+  );
+
+  try {
+    await pipInstallToTarget(interpreter, sitePackagesPath, pipTimeoutMs);
+    const validated = await validateStagedRelease({
+      interpreter,
+      stagingRoot,
+      sitePackagesPath,
+      // The id is derived from the version the candidate actually reports, so
+      // a release directory names the release it holds.
+      createReleaseId,
+      installedAt: new Date().toISOString(),
+    });
+    logger.info(
+      `[yt-dlp] ${operationId}: candidate ${validated.version} validated as ${validated.releaseId}`
+    );
+    const releaseDir = getReleaseDir(layout, validated.releaseId);
+    if (pathExistsInRoot(releaseDir, layout.root)) {
+      throw new Error(
+        `Managed yt-dlp release id collided: ${validated.releaseId}`
+      );
+    }
+    // After this rename the directory is immutable; nothing writes into it.
+    renameInRoot(stagingRoot, releaseDir, layout.root);
+    // A rename is not durable until its parent directory is. current.json's
+    // parent is flushed when the pointer is replaced, so without this a crash
+    // could leave a surviving pointer naming a release whose directory entry
+    // was lost - turning a completed update into a silent rollback.
+    fsyncDirectory(layout.releasesDir);
+    logger.info(
+      `[yt-dlp] ${operationId}: finalized release ${validated.releaseId}`
+    );
+    return await publishValidatedRelease({
+      releaseId: validated.releaseId,
+      version: validated.version,
+      generationAtInstallStart,
+      currentIsUsable: options.currentIsUsable,
+    });
+  } catch (error: unknown) {
+    await removeSafe(stagingRoot, layout.root).catch(() => undefined);
+    logger.warn(
+      `[yt-dlp] ${operationId}: managed release install failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    throw error;
+  }
+}

--- a/backend/src/utils/ytdlp/release/interpreter.ts
+++ b/backend/src/utils/ytdlp/release/interpreter.ts
@@ -1,0 +1,78 @@
+import { YT_DLP_PYTHON_PROBE_TIMEOUT_MS } from "../constants";
+import { logger } from "../../logger";
+import { runProcess } from "./process";
+
+export type PythonInterpreter = {
+  command: string;
+  prefixArgs: string[];
+  executable: string;
+};
+
+function pythonCandidates(): Array<{ command: string; prefixArgs: string[] }> {
+  if (process.platform === "win32") {
+    return [
+      { command: "py", prefixArgs: ["-3"] },
+      { command: "python", prefixArgs: [] },
+      { command: "python3", prefixArgs: [] },
+    ];
+  }
+  return [
+    { command: "python3", prefixArgs: [] },
+    { command: "python", prefixArgs: [] },
+  ];
+}
+
+export async function discoverPythonInterpreter(): Promise<PythonInterpreter> {
+  for (const candidate of pythonCandidates()) {
+    const discovered = await probePythonCandidate(candidate);
+    if (discovered) {
+      logger.info(
+        `[yt-dlp] Using Python interpreter ${discovered.executable}`
+      );
+      return discovered;
+    }
+  }
+  throw new Error(
+    "No usable Python interpreter with pip was found. Install Python 3 and pip to manage yt-dlp."
+  );
+}
+
+async function probePythonCandidate(candidate: {
+  command: string;
+  prefixArgs: string[];
+}): Promise<PythonInterpreter | null> {
+  const executableProbe = await runProcess(
+    candidate.command,
+    [
+      ...candidate.prefixArgs,
+      "-c",
+      "import json,sys; print(json.dumps(sys.executable))",
+    ],
+    { timeoutMs: YT_DLP_PYTHON_PROBE_TIMEOUT_MS }
+  );
+  if (executableProbe.timedOut || executableProbe.code !== 0) {
+    return null;
+  }
+  let executable = executableProbe.stdout.trim().replace(/^"|"$/g, "");
+  try {
+    executable = JSON.parse(executableProbe.stdout.trim());
+  } catch {
+    return null;
+  }
+  if (typeof executable !== "string" || !executable) {
+    return null;
+  }
+
+  const pipProbe = await runProcess(executable, ["-m", "pip", "--version"], {
+    timeoutMs: YT_DLP_PYTHON_PROBE_TIMEOUT_MS,
+  });
+  if (pipProbe.timedOut || pipProbe.code !== 0) {
+    return null;
+  }
+
+  return {
+    command: executable,
+    prefixArgs: [],
+    executable,
+  };
+}

--- a/backend/src/utils/ytdlp/release/launcher.ts
+++ b/backend/src/utils/ytdlp/release/launcher.ts
@@ -1,0 +1,206 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
+import { AsyncLocalStorage } from "async_hooks";
+import { logger } from "../../logger";
+import { createOperationId } from "./ids";
+import { acquireLease, releaseLease } from "./leases";
+import { acquireYtDlpRelease, createExternalRelease } from "./acquire";
+import { resolveYtDlpPath } from "../pathResolver";
+import { DEFAULT_YT_DLP_PATH } from "../constants";
+import { collectGarbageIfDue } from "./gc";
+import type { YtDlpRelease } from "./types";
+
+type TrackedChild = {
+  child: ChildProcess;
+  /** True once the OS reported a running process for this child. */
+  spawned: boolean;
+};
+
+type ReleaseScope = {
+  release: YtDlpRelease;
+  operationId: string;
+  leaseFilename: string | null;
+  children: Map<ChildProcess, TrackedChild>;
+};
+
+const scopeStorage = new AsyncLocalStorage<ReleaseScope>();
+
+/**
+ * A release may be garbage-collected between reading current.json and writing
+ * the lease. The reader retries with a freshly acquired release rather than
+ * failing the operation.
+ */
+const LEASE_ACQUISITION_ATTEMPTS = 3;
+
+export type SpawnYtDlpOptions = Omit<SpawnOptions, "env" | "shell"> & {
+  timeoutMs?: number;
+};
+
+export async function withYtDlpRelease<T>(
+  task: (release: YtDlpRelease) => Promise<T>
+): Promise<T> {
+  // A nested call belongs to the same logical operation, so it reuses the
+  // snapshot (and its lease) instead of acquiring a possibly newer release.
+  const existing = scopeStorage.getStore();
+  if (existing) {
+    return task(existing.release);
+  }
+
+  const { release, lease } = await acquireReleaseWithLease();
+  const scope: ReleaseScope = {
+    release,
+    operationId: lease?.operationId ?? createOperationId(),
+    leaseFilename: lease?.leaseFilename ?? null,
+    children: new Map(),
+  };
+
+  try {
+    return await scopeStorage.run(scope, () => task(release));
+  } finally {
+    await waitForChildren(scope);
+    if (lease) {
+      // Cleanup runs in a finally, so anything thrown here would replace the
+      // task's result: a download that succeeded would be reported as failed
+      // purely because its lease could not be deleted. A leaked lease costs
+      // disk, which is the lesser problem by far.
+      try {
+        releaseLease(lease.releaseId, lease.leaseFilename);
+      } catch (error: unknown) {
+        logger.warn(
+          `[yt-dlp] Could not release the lease on ${lease.releaseId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        );
+      }
+      // Never awaited: collection is best-effort maintenance, not part of the
+      // operation's result.
+      try {
+        collectGarbageIfDue();
+      } catch {
+        // Same reasoning: maintenance never changes an operation's outcome.
+      }
+    }
+  }
+}
+
+async function acquireReleaseWithLease(): Promise<{
+  release: YtDlpRelease;
+  lease: {
+    releaseId: string;
+    leaseFilename: string;
+    operationId: string;
+  } | null;
+}> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= LEASE_ACQUISITION_ATTEMPTS; attempt += 1) {
+    const release = await acquireYtDlpRelease({ ensureAvailable: true });
+    // MyTube neither collects nor guarantees immutability for files it does
+    // not own, so external releases are never leased.
+    if (release.kind !== "managed") {
+      return { release, lease: null };
+    }
+    const operationId = createOperationId();
+    try {
+      const lease = acquireLease(release.releaseId, operationId);
+      return { release, lease: { ...lease, operationId } };
+    } catch (error: unknown) {
+      lastError = error;
+      logger.warn(
+        `[yt-dlp] Could not lease release ${release.releaseId} (attempt ${attempt}/${LEASE_ACQUISITION_ATTEMPTS}): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+  // The store cannot hand out leases at all - unwritable, symlinked, or being
+  // collected out from under every attempt. That is a store problem, and a
+  // store problem must degrade rather than fail every operation, so fall back
+  // to discovery exactly as an unusable store does elsewhere.
+  logger.warn(
+    `[yt-dlp] Could not lease a managed release (${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }); falling back to external discovery.`
+  );
+  const resolvedPath = await resolveYtDlpPath();
+  return {
+    release: await createExternalRelease(resolvedPath || DEFAULT_YT_DLP_PATH),
+    lease: null,
+  };
+}
+
+export function spawnYtDlp(
+  release: YtDlpRelease,
+  args: readonly string[],
+  options: SpawnYtDlpOptions = {}
+): ChildProcess {
+  const { timeoutMs: _ignoredTimeoutMs, stdio, ...spawnOptions } = options;
+  const child = spawn(release.command, [...release.prefixArgs, ...args], {
+    ...spawnOptions,
+    // The snapshot environment is not overridable: a caller-supplied env would
+    // break the guarantee that every child of this operation runs the same
+    // release with the same module path.
+    env: release.spawnEnv,
+    shell: false,
+    windowsHide: true,
+    stdio: stdio ?? ["ignore", "pipe", "pipe"],
+  });
+  trackChild(child);
+  return child;
+}
+
+function trackChild(child: ChildProcess): void {
+  if (!child || typeof child.once !== "function") {
+    return;
+  }
+  const scope = scopeStorage.getStore();
+  if (!scope) {
+    return;
+  }
+  const tracked: TrackedChild = { child, spawned: false };
+  scope.children.set(child, tracked);
+  child.once("spawn", () => {
+    tracked.spawned = true;
+  });
+  child.once("error", () => {
+    // An error before "spawn" means startup failed and there is no process to
+    // protect. After "spawn" the process may well still be running, so the
+    // lease must survive until "close".
+    if (!tracked.spawned) {
+      scope.children.delete(child);
+    }
+  });
+  child.once("close", () => {
+    scope.children.delete(child);
+  });
+}
+
+function waitForChildren(scope: ReleaseScope): Promise<void> {
+  const tracked = [...scope.children.values()].filter(
+    (entry) => typeof entry.child.once === "function"
+  );
+  if (tracked.length === 0) {
+    return Promise.resolve();
+  }
+  return Promise.all(
+    tracked.map(
+      (entry) =>
+        new Promise<void>((resolve) => {
+          // `killed` only records that a signal was delivered — the process can
+          // still be reading from its release — so only a real exit counts.
+          if (entry.child.exitCode != null || entry.child.signalCode != null) {
+            resolve();
+            return;
+          }
+          entry.child.once("close", () => resolve());
+          entry.child.once("error", () => {
+            if (!entry.spawned) {
+              resolve();
+            }
+          });
+        })
+    )
+  ).then(() => undefined);
+}
+
+export function getScopedYtDlpRelease(): YtDlpRelease | undefined {
+  return scopeStorage.getStore()?.release;
+}

--- a/backend/src/utils/ytdlp/release/leases.ts
+++ b/backend/src/utils/ytdlp/release/leases.ts
@@ -1,0 +1,263 @@
+import fs from "fs";
+import path from "path";
+import { logger } from "../../logger";
+import { YT_DLP_PUBLISH_LOCK_STALE_MS } from "../constants";
+import { ensureDirSafeSync } from "../../security";
+import {
+  createInstanceId,
+  createLeaseFilename,
+  createLeaseId,
+  isValidLeaseFilename,
+  isValidLeaseId,
+  isValidReleaseId,
+} from "./ids";
+import {
+  assertNotSymlink,
+  chmodQuiet,
+  getGcMarkerPath,
+  getLeaseDir,
+  getManagedStoreLayout,
+  getReleaseDir,
+  listSafeDirNames,
+  mkdirExclusive,
+  pathExistsInRoot,
+  readTextFile,
+  statMtimeMs,
+  unlinkInRoot,
+  writeJsonInPlace,
+} from "./paths";
+import type { LeaseRecord } from "./types";
+
+const MARKER_OWNER_FILENAME = "owner.json";
+
+const instanceId = createInstanceId();
+
+export function getInstanceId(): string {
+  return instanceId;
+}
+
+export function acquireLease(
+  releaseId: string,
+  operationId: string
+): { releaseId: string; leaseFilename: string } {
+  if (!isValidReleaseId(releaseId)) {
+    throw new Error(`Invalid release id: ${releaseId}`);
+  }
+  const layout = getManagedStoreLayout();
+  const leaseDir = getLeaseDir(layout, releaseId);
+  // Created on demand per release, so it needs its own check: following a
+  // symlink here would write the lease outside the managed store.
+  assertNotSymlink(leaseDir, layout.root);
+  ensureDirSafeSync(leaseDir, layout.root);
+  const leaseFilename = createLeaseFilename(instanceId, createLeaseId());
+  const leasePath = path.join(leaseDir, leaseFilename);
+  const record: LeaseRecord = {
+    schemaVersion: 1,
+    releaseId,
+    instanceId,
+    pid: process.pid,
+    operationId,
+    createdAt: new Date().toISOString(),
+  };
+  writeJsonInPlace(leasePath, record);
+  chmodQuiet(leasePath, 0o600);
+
+  // Two-phase marker protocol: the lease exists before these checks, so a
+  // collector that claims the marker afterwards still sees the lease and skips
+  // the release. A marker already present means this reader lost the race and
+  // must retry acquisition without using this release.
+  //
+  // Every exit from here has to take the lease with it. These checks can throw
+  // as well as fail - a malformed store makes the symlink guard throw - and a
+  // lease left behind would pin the release permanently.
+  try {
+    if (hasLiveGcMarker(releaseId)) {
+      throw new Error("Release is being deleted");
+    }
+    if (!pathExistsInRoot(getReleaseDir(layout, releaseId), layout.root)) {
+      throw new Error("Release directory is missing");
+    }
+  } catch (error: unknown) {
+    unlinkInRoot(leasePath, layout.root);
+    throw error;
+  }
+  return { releaseId, leaseFilename };
+}
+
+export function releaseLease(
+  releaseId: string,
+  leaseFilename: string
+): void {
+  if (!isValidReleaseId(releaseId) || !isValidLeaseFilename(leaseFilename)) {
+    return;
+  }
+  const layout = getManagedStoreLayout();
+  const leasePath = path.join(getLeaseDir(layout, releaseId), leaseFilename);
+  if (pathExistsInRoot(leasePath, layout.root)) {
+    unlinkInRoot(leasePath, layout.root);
+  }
+}
+
+export function listLeaseFilenames(releaseId: string): string[] {
+  const layout = getManagedStoreLayout();
+  const leaseDir = getLeaseDir(layout, releaseId);
+  if (!pathExistsInRoot(leaseDir, layout.root)) {
+    return [];
+  }
+  return listSafeDirNames(leaseDir, layout.root).filter(isValidLeaseFilename);
+}
+
+export function hasLeases(releaseId: string): boolean {
+  return listLeaseFilenames(releaseId).length > 0;
+}
+
+/**
+ * Read the lease records pinning a release. Used for reporting only: a lease is
+ * never removed on the strength of what it says about its owner.
+ */
+export function readLeaseRecords(releaseId: string): LeaseRecord[] {
+  const layout = getManagedStoreLayout();
+  const leaseDir = getLeaseDir(layout, releaseId);
+  const records: LeaseRecord[] = [];
+  for (const filename of listLeaseFilenames(releaseId)) {
+    try {
+      const parsed: unknown = JSON.parse(
+        readTextFile(path.join(leaseDir, filename), layout.root)
+      );
+      if (isLeaseRecord(parsed)) {
+        records.push(parsed);
+      }
+    } catch {
+      // An unreadable lease still counts as a lease; it just cannot be named.
+    }
+  }
+  return records;
+}
+
+function isLeaseRecord(value: unknown): value is LeaseRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    record.schemaVersion === 1 &&
+    typeof record.releaseId === "string" &&
+    typeof record.instanceId === "string" &&
+    typeof record.pid === "number" &&
+    typeof record.operationId === "string" &&
+    typeof record.createdAt === "string"
+  );
+}
+
+/**
+ * Claim the deleting marker for a release. Exclusive directory creation is the
+ * claim: a marker that already exists belongs to another collector, so this
+ * caller reports failure rather than deleting a release it does not own — and,
+ * critically, never removes the other collector's marker on the way out.
+ */
+/**
+ * Claim the deletion marker for a release, returning an ownership token.
+ *
+ * Each collector writes its own uniquely named marker file rather than
+ * competing for one shared path. That removes the reclamation race entirely:
+ * there is never a moment where one collector removes something another
+ * created, because a collector only ever deletes the file it wrote. Presence of
+ * *any* live marker is what blocks a reader, exactly as before.
+ *
+ * Markers left by a killed collector are ignored once older than the stale
+ * window - a collection never legitimately runs that long - so they can neither
+ * block a release forever nor be stolen from a collector still using them.
+ */
+export function beginGcMarker(releaseId: string): string | null {
+  const layout = getManagedStoreLayout();
+  const markerDir = getGcMarkerPath(layout, releaseId);
+  // Same reasoning as the lease directory above.
+  try {
+    assertNotSymlink(markerDir, layout.root);
+  } catch {
+    return null;
+  }
+  ensureDirSafeSync(markerDir, layout.root);
+  const token = createLeaseId();
+  const markerPath = path.join(markerDir, `${token}.json`);
+
+  try {
+    writeJsonInPlace(markerPath, {
+      releaseId,
+      instanceId,
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+    });
+  } catch {
+    return null;
+  }
+
+  // Two-phase, like leases: our marker exists before we look, so a collector
+  // arriving later cannot miss it.
+  if (liveMarkerTokens(layout, releaseId, token).length > 0) {
+    removeMarkerFile(layout, markerPath);
+    return null;
+  }
+  return token;
+}
+
+/** Release a marker. Only ever removes the file this collector wrote. */
+export function abortGcMarker(releaseId: string, token: string): void {
+  const layout = getManagedStoreLayout();
+  if (!isValidLeaseId(token)) {
+    return;
+  }
+  removeMarkerFile(
+    layout,
+    path.join(getGcMarkerPath(layout, releaseId), `${token}.json`)
+  );
+}
+
+/** True while any collector is actively deleting this release. */
+export function hasLiveGcMarker(releaseId: string): boolean {
+  const layout = getManagedStoreLayout();
+  return liveMarkerTokens(layout, releaseId).length > 0;
+}
+
+function liveMarkerTokens(
+  layout: ReturnType<typeof getManagedStoreLayout>,
+  releaseId: string,
+  excludeToken?: string
+): string[] {
+  const markerDir = getGcMarkerPath(layout, releaseId);
+  if (!pathExistsInRoot(markerDir, layout.root)) {
+    return [];
+  }
+  const now = Date.now();
+  const live: string[] = [];
+  for (const name of listSafeDirNames(markerDir, layout.root)) {
+    const token = name.endsWith(".json") ? name.slice(0, -5) : null;
+    if (!token || !isValidLeaseId(token) || token === excludeToken) {
+      continue;
+    }
+    const markedAt = statMtimeMs(path.join(markerDir, name));
+    if (markedAt === null) {
+      continue;
+    }
+    if (now - markedAt >= YT_DLP_PUBLISH_LOCK_STALE_MS) {
+      // Abandoned by a killed collector: ignore it rather than reclaim it, so
+      // nothing ever deletes a marker it does not own.
+      continue;
+    }
+    live.push(token);
+  }
+  return live;
+}
+
+function removeMarkerFile(
+  layout: ReturnType<typeof getManagedStoreLayout>,
+  markerPath: string
+): void {
+  try {
+    if (pathExistsInRoot(markerPath, layout.root)) {
+      unlinkInRoot(markerPath, layout.root);
+    }
+  } catch {
+    // A leftover marker expires on its own; readers retry meanwhile.
+  }
+}

--- a/backend/src/utils/ytdlp/release/lock.ts
+++ b/backend/src/utils/ytdlp/release/lock.ts
@@ -1,0 +1,364 @@
+import fs from "fs";
+import { getErrorMessage } from "../../errors";
+import { logger } from "../../logger";
+import {
+  YT_DLP_PUBLISH_LOCK_STALE_MS,
+  YT_DLP_PUBLISH_LOCK_WAIT_MS,
+} from "../constants";
+import {
+  createNonce,
+  createOperationId,
+  isValidHexNonce,
+  isValidInstanceId,
+  isValidOperationId,
+} from "./ids";
+import { getInstanceId } from "./leases";
+import {
+  assertNotSymlink,
+  chmodQuiet,
+  fsyncDirectory,
+  getManagedStoreLayout,
+  getPublishLockOwnerPath,
+  mkdirExclusive,
+  pathExistsInRoot,
+  readTextFile,
+  statMtimeMs,
+  unlinkInRoot,
+  writeJsonExclusive,
+} from "./paths";
+import type { ManagedStoreLayout, PublishLockOwner } from "./types";
+
+const LOCK_RETRY_MS = 50;
+
+export type PublishLock = {
+  layout: ManagedStoreLayout;
+  owner: PublishLockOwner;
+};
+
+export async function withPublishLock<T>(
+  task: (lock: PublishLock) => Promise<T>,
+  layout: ManagedStoreLayout = getManagedStoreLayout()
+): Promise<T> {
+  const lock = await acquirePublishLock(layout);
+  try {
+    return await task(lock);
+  } finally {
+    releasePublishLock(lock);
+  }
+}
+
+export async function acquirePublishLock(
+  layout: ManagedStoreLayout = getManagedStoreLayout(),
+  waitMs: number = YT_DLP_PUBLISH_LOCK_WAIT_MS
+): Promise<PublishLock> {
+  // Created on demand rather than by ensureManagedStoreLayout, so it needs its
+  // own check: owner reads and stale-lock recovery would otherwise follow a
+  // symlink and could unlink a file outside the managed store.
+  assertNotSymlink(layout.publishLockDir, layout.root);
+
+  const deadline = Date.now() + waitMs;
+  const owner: PublishLockOwner = {
+    operationId: createOperationId(),
+    nonce: createNonce(),
+    pid: process.pid,
+    instanceId: getInstanceId(),
+    createdAt: new Date().toISOString(),
+  };
+
+  while (true) {
+    if (tryClaimLock(layout, owner)) {
+      return { layout, owner };
+    }
+    maybeRecoverStaleLock(layout);
+    if (Date.now() >= deadline) {
+      throw new Error(
+        "Timed out waiting for yt-dlp publish lock: another publisher holds it"
+      );
+    }
+    await delay(LOCK_RETRY_MS);
+  }
+}
+
+/**
+ * Claim the lock, or report that somebody else holds it.
+ *
+ * The directory creation is the exclusive claim, but it is not the whole claim:
+ * there is a window between it and the owner write in which a contender could
+ * have reclaimed and recreated the directory. Writing the owner file
+ * exclusively closes that window - a late writer fails instead of overwriting
+ * the owner file the contender just wrote, which would otherwise let both
+ * processes pass their ownership checks.
+ */
+function tryClaimLock(
+  layout: ManagedStoreLayout,
+  owner: PublishLockOwner
+): boolean {
+  try {
+    mkdirExclusive(layout.publishLockDir);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+
+  try {
+    writeJsonExclusive(getPublishLockOwnerPath(layout), owner);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    // Our own directory is unusable. Drop it rather than leave a lock nobody
+    // can own and everybody waits on.
+    try {
+      fs.rmdirSync(layout.publishLockDir);
+    } catch {
+      // Best effort; stale-lock recovery reclaims it by age.
+    }
+    throw error;
+  }
+
+  chmodQuiet(layout.publishLockDir, 0o700);
+  fsyncDirectory(layout.publishLockDir);
+  return true;
+}
+
+export function assertLockOwnership(lock: PublishLock): void {
+  const ownerPath = getPublishLockOwnerPath(lock.layout);
+  if (!pathExistsInRoot(ownerPath, lock.layout.root)) {
+    throw new Error("Publish lock owner file is missing; aborting publication");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readTextFile(ownerPath, lock.layout.root));
+  } catch {
+    throw new Error(
+      "Publish lock owner file is unreadable; aborting publication"
+    );
+  }
+  const owner = parseLockOwner(parsed);
+  if (!owner || owner.nonce !== lock.owner.nonce) {
+    throw new Error("Publish lock was stolen; aborting publication");
+  }
+}
+
+export function releasePublishLock(lock: PublishLock): void {
+  try {
+    const ownerPath = getPublishLockOwnerPath(lock.layout);
+    if (pathExistsInRoot(ownerPath, lock.layout.root)) {
+      try {
+        const owner = parseLockOwner(
+          JSON.parse(readTextFile(ownerPath, lock.layout.root))
+        );
+        if (owner && owner.nonce !== lock.owner.nonce) {
+          return;
+        }
+      } catch {
+        return;
+      }
+      unlinkInRoot(ownerPath, lock.layout.root);
+    }
+    fs.rmdirSync(lock.layout.publishLockDir);
+  } catch (error: unknown) {
+    logger.warn(
+      `[yt-dlp] Failed to release publish lock: ${getErrorMessage(error, "unknown error")}`
+    );
+  }
+}
+
+function maybeRecoverStaleLock(layout: ManagedStoreLayout): void {
+  const ownerPath = getPublishLockOwnerPath(layout);
+
+  if (!pathExistsInRoot(ownerPath, layout.root)) {
+    // A lock directory with no owner file is either a backend that died between
+    // the mkdir and the owner write, or a live acquisition microseconds away
+    // from writing one. Only age separates them, so never delete a directory
+    // that is still young - doing so destroys a lock that is about to be valid.
+    reclaimExpiredLockDir(layout, "no owner file");
+    return;
+  }
+
+  let owner: PublishLockOwner | null = null;
+  try {
+    owner = parseLockOwner(JSON.parse(readTextFile(ownerPath, layout.root)));
+  } catch {
+    owner = null;
+  }
+  if (!owner) {
+    // A crash partway through the owner write leaves malformed JSON. Giving up
+    // here would wedge the publish lock permanently and fail every future
+    // update, so fall back to the same age-based reclamation.
+    reclaimExpiredLockDir(layout, "unreadable owner file");
+    return;
+  }
+
+  const createdAt = Date.parse(owner.createdAt);
+  if (!Number.isFinite(createdAt)) {
+    reclaimExpiredLockDir(layout, "invalid owner timestamp");
+    return;
+  }
+  // Expiry is the signal, not PID liveness. The critical section contains no
+  // network or pip work and completes in well under a second, so a lock this
+  // old is broken by construction - while a restarted container often reuses
+  // the crashed backend's PID, which would keep a dead owner looking alive and
+  // wedge every future update. Stealing an expired lock is safe because a
+  // suspended publisher rechecks its nonce (assertLockOwnership) immediately
+  // before replacing current.json and aborts if it lost ownership.
+  if (Date.now() - createdAt < YT_DLP_PUBLISH_LOCK_STALE_MS) {
+    return;
+  }
+  if (isOwnedByThisInstance(owner)) {
+    // Our own process is wedged. Another thread of control here cannot make
+    // that safer, and the owner would abort at its nonce check anyway.
+    return;
+  }
+
+  logger.warn(
+    `[yt-dlp] Recovering publish lock held since ${owner.createdAt} by pid ${owner.pid}` +
+      `${owner.instanceId ? ` instance ${owner.instanceId}` : ""} operation ${owner.operationId}`
+  );
+  removeLock(layout, () => ownerNonceMatches(layout, owner.nonce));
+}
+
+/**
+ * Remove a lock directory that has been unusable for longer than the stale
+ * window. Age is measured on the directory itself, which is what a crashed or
+ * partial acquisition leaves behind.
+ */
+function reclaimExpiredLockDir(
+  layout: ManagedStoreLayout,
+  reason: string
+): void {
+  const mtimeMs = statMtimeMs(layout.publishLockDir);
+  if (mtimeMs === null) {
+    return;
+  }
+  const ageMs = Date.now() - mtimeMs;
+  if (ageMs < YT_DLP_PUBLISH_LOCK_STALE_MS) {
+    return;
+  }
+  logger.warn(
+    `[yt-dlp] Reclaiming publish lock with ${reason} after ${Math.round(ageMs / 1000)}s`
+  );
+  // There is no owner identity to match on here, so use the directory itself
+  // plus the absence of a usable owner: if another process already reclaimed
+  // and re-took the lock, either its mtime moved or it now has a real owner.
+  removeLock(
+    layout,
+    () =>
+      statMtimeMs(layout.publishLockDir) === mtimeMs && ownerStillUnusable(layout)
+  );
+}
+
+/**
+ * Remove the lock that was actually observed.
+ *
+ * Two processes can decide the same lock is stale at once. Deleting whichever
+ * owner happens to occupy the path at removal time would let the second one
+ * destroy a fresh lock the first had already replaced it with, and the new
+ * publisher would then fail its own ownership assertion. So the caller supplies
+ * a check of the identity it observed, evaluated immediately before removal.
+ */
+function removeLock(layout: ManagedStoreLayout, stillTheSame: () => boolean): void {
+  try {
+    if (!stillTheSame()) {
+      return;
+    }
+    const ownerPath = getPublishLockOwnerPath(layout);
+    if (pathExistsInRoot(ownerPath, layout.root)) {
+      unlinkInRoot(ownerPath, layout.root);
+    }
+    fs.rmdirSync(layout.publishLockDir);
+  } catch {
+    // Conservative: leave the lock if cleanup races another process.
+  }
+}
+
+/** True while the owner file still names the owner we decided was stale. */
+function ownerNonceMatches(
+  layout: ManagedStoreLayout,
+  nonce: string
+): boolean {
+  const ownerPath = getPublishLockOwnerPath(layout);
+  if (!pathExistsInRoot(ownerPath, layout.root)) {
+    return false;
+  }
+  try {
+    const owner = parseLockOwner(
+      JSON.parse(readTextFile(ownerPath, layout.root))
+    );
+    return owner?.nonce === nonce;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * True while the lock still has no usable owner. A replacement publisher writes
+ * a valid owner file, so a lock that now parses belongs to somebody and must be
+ * left alone.
+ */
+function ownerStillUnusable(layout: ManagedStoreLayout): boolean {
+  const ownerPath = getPublishLockOwnerPath(layout);
+  if (!pathExistsInRoot(ownerPath, layout.root)) {
+    return true;
+  }
+  try {
+    return (
+      parseLockOwner(JSON.parse(readTextFile(ownerPath, layout.root))) === null
+    );
+  } catch {
+    return true;
+  }
+}
+
+function parseLockOwner(value: unknown): PublishLockOwner | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.operationId !== "string" ||
+    !isValidOperationId(record.operationId)
+  ) {
+    return null;
+  }
+  if (typeof record.nonce !== "string" || !isValidHexNonce(record.nonce)) {
+    return null;
+  }
+  if (typeof record.pid !== "number" || !Number.isInteger(record.pid)) {
+    return null;
+  }
+  if (typeof record.createdAt !== "string") {
+    return null;
+  }
+  if (
+    record.instanceId !== undefined &&
+    (typeof record.instanceId !== "string" ||
+      !isValidInstanceId(record.instanceId))
+  ) {
+    return null;
+  }
+  return {
+    operationId: record.operationId,
+    nonce: record.nonce,
+    pid: record.pid,
+    ...(record.instanceId ? { instanceId: record.instanceId } : {}),
+    createdAt: record.createdAt,
+  };
+}
+
+/**
+ * True only when this exact process wrote the lock. A lock without an
+ * instanceId came from an older build and cannot be attributed to anyone, so
+ * it is treated as another instance's and becomes recoverable once expired.
+ */
+function isOwnedByThisInstance(owner: PublishLockOwner): boolean {
+  return owner.instanceId !== undefined && owner.instanceId === getInstanceId();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/backend/src/utils/ytdlp/release/manifests.ts
+++ b/backend/src/utils/ytdlp/release/manifests.ts
@@ -1,0 +1,432 @@
+import { pathExistsTrustedSync } from "../../security";
+import { YT_DLP_WINDOWS_RENAME_ATTEMPTS } from "../constants";
+import { parseYtDlpReleaseTimestamp } from "../versionStamp";
+import { isValidReleaseId } from "./ids";
+import {
+  assertNotSymlink,
+  sleepSync,
+  getManagedStoreLayout,
+  getReleaseDir,
+  getReleaseManifestPath,
+  getPublishedManifestPath,
+  getSitePackagesPath,
+  pathExistsInRoot,
+  readTextFile,
+  unlinkInRoot,
+  writeJsonAtomic,
+} from "./paths";
+import {
+  SITE_PACKAGES_DIRNAME,
+  type CurrentManifest,
+  type LoadedManagedRelease,
+  type PublishedManifest,
+  type PublishDecision,
+  type ReleaseManifest,
+} from "./types";
+
+const PYTHON_PREFIX_ARGS_MAX = 8;
+
+let highestGenerationSeen = 0;
+
+export function noteObservedGeneration(generation: number): void {
+  if (Number.isInteger(generation) && generation > highestGenerationSeen) {
+    highestGenerationSeen = generation;
+  }
+}
+
+export function getHighestObservedGeneration(): number {
+  return highestGenerationSeen;
+}
+
+export function resetObservedGenerationForTests(): void {
+  highestGenerationSeen = 0;
+}
+
+export function parseReleaseManifest(value: unknown): ReleaseManifest {
+  if (!isRecord(value)) {
+    throw new Error("release.json is not an object");
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error("Unsupported release.json schemaVersion");
+  }
+  if (
+    typeof value.releaseId !== "string" ||
+    !isValidReleaseId(value.releaseId)
+  ) {
+    throw new Error("Invalid releaseId in release.json");
+  }
+  if (typeof value.version !== "string" || !value.version.trim()) {
+    throw new Error("Invalid version in release.json");
+  }
+  if (
+    typeof value.installedAt !== "string" ||
+    Number.isNaN(Date.parse(value.installedAt))
+  ) {
+    throw new Error("Invalid installedAt in release.json");
+  }
+  if (
+    typeof value.pythonExecutable !== "string" ||
+    !value.pythonExecutable.trim()
+  ) {
+    throw new Error("Invalid pythonExecutable in release.json");
+  }
+  if (!Array.isArray(value.pythonPrefixArgs)) {
+    throw new Error("Invalid pythonPrefixArgs in release.json");
+  }
+  if (value.pythonPrefixArgs.length > PYTHON_PREFIX_ARGS_MAX) {
+    throw new Error("Too many pythonPrefixArgs in release.json");
+  }
+  const pythonPrefixArgs = value.pythonPrefixArgs.map((arg) => {
+    if (typeof arg !== "string") {
+      throw new Error("pythonPrefixArgs must be strings");
+    }
+    return arg;
+  });
+  if (value.sitePackages !== SITE_PACKAGES_DIRNAME) {
+    throw new Error("sitePackages must be the managed relative directory name");
+  }
+  return {
+    schemaVersion: 1,
+    releaseId: value.releaseId,
+    version: value.version.trim(),
+    installedAt: value.installedAt,
+    pythonExecutable: value.pythonExecutable,
+    pythonPrefixArgs,
+    sitePackages: SITE_PACKAGES_DIRNAME,
+  };
+}
+
+export function parseCurrentManifest(value: unknown): CurrentManifest {
+  if (!isRecord(value)) {
+    throw new Error("current.json is not an object");
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error("Unsupported current.json schemaVersion");
+  }
+  if (
+    typeof value.generation !== "number" ||
+    !Number.isInteger(value.generation) ||
+    value.generation < 1
+  ) {
+    throw new Error("Invalid generation in current.json");
+  }
+  if (
+    typeof value.releaseId !== "string" ||
+    !isValidReleaseId(value.releaseId)
+  ) {
+    throw new Error("Invalid releaseId in current.json");
+  }
+  if (
+    value.previousReleaseId !== null &&
+    (typeof value.previousReleaseId !== "string" ||
+      !isValidReleaseId(value.previousReleaseId))
+  ) {
+    throw new Error("Invalid previousReleaseId in current.json");
+  }
+  if (
+    typeof value.publishedAt !== "string" ||
+    Number.isNaN(Date.parse(value.publishedAt))
+  ) {
+    throw new Error("Invalid publishedAt in current.json");
+  }
+  noteObservedGeneration(value.generation);
+  return {
+    schemaVersion: 1,
+    generation: value.generation,
+    releaseId: value.releaseId,
+    previousReleaseId: value.previousReleaseId,
+    publishedAt: value.publishedAt,
+  };
+}
+
+export function parsePublishedManifest(value: unknown): PublishedManifest {
+  if (!isRecord(value)) {
+    throw new Error("published.json is not an object");
+  }
+  if (value.schemaVersion !== 1) {
+    throw new Error("Unsupported published.json schemaVersion");
+  }
+  if (
+    typeof value.releaseId !== "string" ||
+    !isValidReleaseId(value.releaseId)
+  ) {
+    throw new Error("Invalid releaseId in published.json");
+  }
+  if (
+    typeof value.generation !== "number" ||
+    !Number.isInteger(value.generation) ||
+    value.generation < 1
+  ) {
+    throw new Error("Invalid generation in published.json");
+  }
+  if (
+    value.previousReleaseId !== null &&
+    (typeof value.previousReleaseId !== "string" ||
+      !isValidReleaseId(value.previousReleaseId))
+  ) {
+    throw new Error("Invalid previousReleaseId in published.json");
+  }
+  if (
+    typeof value.publishedAt !== "string" ||
+    Number.isNaN(Date.parse(value.publishedAt))
+  ) {
+    throw new Error("Invalid publishedAt in published.json");
+  }
+  noteObservedGeneration(value.generation);
+  return {
+    schemaVersion: 1,
+    releaseId: value.releaseId,
+    generation: value.generation,
+    previousReleaseId: value.previousReleaseId,
+    publishedAt: value.publishedAt,
+  };
+}
+
+export function readCurrentManifest(
+  root = getManagedStoreLayout().root
+): CurrentManifest | null {
+  const layout = getManagedStoreLayout(root);
+  for (
+    let attempt = 1;
+    attempt <= YT_DLP_WINDOWS_RENAME_ATTEMPTS;
+    attempt += 1
+  ) {
+    if (!pathExistsInRoot(layout.currentPath, layout.root)) {
+      return null;
+    }
+    try {
+      return parseCurrentManifest(
+        JSON.parse(readTextFile(layout.currentPath, layout.root))
+      );
+    } catch (error: unknown) {
+      // On Windows a read can fail transiently while the publisher renames a
+      // new manifest over this one. Anywhere else — and after the last retry —
+      // an unreadable manifest really is invalid and recovery takes over.
+      if (
+        !isTransientWindowsReadError(error) ||
+        attempt === YT_DLP_WINDOWS_RENAME_ATTEMPTS
+      ) {
+        return null;
+      }
+      sleepSync(20 * attempt);
+    }
+  }
+  return null;
+}
+
+function isTransientWindowsReadError(error: unknown): boolean {
+  if (process.platform !== "win32") {
+    return false;
+  }
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EPERM" || code === "EACCES" || code === "EBUSY";
+}
+
+export function readReleaseManifest(
+  releaseId: string,
+  root = getManagedStoreLayout().root
+): ReleaseManifest | null {
+  const layout = getManagedStoreLayout(root);
+  const manifestPath = getReleaseManifestPath(layout, releaseId);
+  if (!pathExistsInRoot(manifestPath, layout.root)) {
+    return null;
+  }
+  try {
+    const manifest = parseReleaseManifest(
+      JSON.parse(readTextFile(manifestPath, layout.root))
+    );
+    return manifest.releaseId === releaseId ? manifest : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readPublishedManifest(
+  releaseId: string,
+  root = getManagedStoreLayout().root
+): PublishedManifest | null {
+  const layout = getManagedStoreLayout(root);
+  const manifestPath = getPublishedManifestPath(layout, releaseId);
+  if (!pathExistsInRoot(manifestPath, layout.root)) {
+    return null;
+  }
+  try {
+    const manifest = parsePublishedManifest(
+      JSON.parse(readTextFile(manifestPath, layout.root))
+    );
+    return manifest.releaseId === releaseId ? manifest : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadManagedRelease(
+  releaseId: string,
+  current: CurrentManifest | null = null,
+  root = getManagedStoreLayout().root
+): LoadedManagedRelease | null {
+  const layout = getManagedStoreLayout(root);
+  const releaseDir = getReleaseDir(layout, releaseId);
+  const sitePackagesPath = getSitePackagesPath(layout, releaseId);
+  try {
+    assertNotSymlink(releaseDir, layout.root);
+    assertNotSymlink(sitePackagesPath, layout.root);
+  } catch {
+    return null;
+  }
+  const release = readReleaseManifest(releaseId, layout.root);
+  if (!release || !pathExistsInRoot(sitePackagesPath, layout.root)) {
+    return null;
+  }
+  if (!pathExistsTrustedSync(release.pythonExecutable)) {
+    return null;
+  }
+  return {
+    current: current ?? {
+      schemaVersion: 1,
+      generation: 0,
+      releaseId,
+      previousReleaseId: null,
+      publishedAt: release.installedAt,
+    },
+    release,
+    releaseDir,
+    sitePackagesPath,
+  };
+}
+
+export function writeReleaseManifest(
+  root: string,
+  manifest: ReleaseManifest
+): void {
+  const layout = getManagedStoreLayout(root);
+  writeJsonAtomic(
+    getReleaseManifestPath(layout, manifest.releaseId),
+    layout.root,
+    manifest
+  );
+}
+
+export function writeCurrentManifest(
+  root: string,
+  manifest: CurrentManifest
+): void {
+  const layout = getManagedStoreLayout(root);
+  writeJsonAtomic(layout.currentPath, layout.root, manifest);
+  noteObservedGeneration(manifest.generation);
+}
+
+export function writePublishedManifest(
+  root: string,
+  manifest: PublishedManifest
+): void {
+  const layout = getManagedStoreLayout(root);
+  writeJsonAtomic(
+    getPublishedManifestPath(layout, manifest.releaseId),
+    layout.root,
+    manifest
+  );
+  noteObservedGeneration(manifest.generation);
+}
+
+/**
+ * Remove a publication record. Used only to undo a record this process wrote
+ * moments earlier and could not commit; a committed record is never deleted
+ * except with the release directory itself.
+ */
+export function removePublishedManifest(
+  root: string,
+  releaseId: string
+): boolean {
+  const layout = getManagedStoreLayout(root);
+  const manifestPath = getPublishedManifestPath(layout, releaseId);
+  try {
+    if (pathExistsInRoot(manifestPath, layout.root)) {
+      unlinkInRoot(manifestPath, layout.root);
+    }
+    return true;
+  } catch {
+    // Reported rather than swallowed: the caller has to know, because freeing
+    // the generation while its record survives would let two releases claim it.
+    return false;
+  }
+}
+
+export function decidePublication(input: {
+  current: CurrentManifest | null;
+  currentVersion: string | null;
+  candidateVersion: string;
+  candidateReleaseId: string;
+  generationAtInstallStart: number | null;
+  /**
+   * False when the current release was found not to run. A same-version
+   * candidate is then a repair, not a no-op, and must be allowed to replace it
+   * - otherwise a broken release can never be superseded, because pip keeps
+   * producing the same latest version.
+   */
+  currentIsUsable?: boolean;
+}): PublishDecision {
+  const { current, currentVersion, candidateVersion, generationAtInstallStart } =
+    input;
+
+  if (!current) {
+    return {
+      action: "publish",
+      generation: Math.max(getHighestObservedGeneration(), 0) + 1,
+      previousReleaseId: null,
+    };
+  }
+
+  if (current.releaseId === input.candidateReleaseId) {
+    return {
+      action: "reject",
+      kind: "already-current",
+      reason: "candidate is already current",
+    };
+  }
+
+  if (
+    currentVersion &&
+    currentVersion === candidateVersion &&
+    input.currentIsUsable !== false
+  ) {
+    return {
+      action: "reject",
+      kind: "already-current",
+      reason: "same version is already current",
+    };
+  }
+
+  const currentTs = parseYtDlpReleaseTimestamp(currentVersion);
+  const candidateTs = parseYtDlpReleaseTimestamp(candidateVersion);
+  if (currentTs !== null && candidateTs !== null && candidateTs < currentTs) {
+    return {
+      action: "reject",
+      kind: "conflict",
+      reason: "candidate is older than the current release",
+    };
+  }
+
+  if (
+    currentTs === null &&
+    candidateTs === null &&
+    generationAtInstallStart !== null &&
+    current.generation !== generationAtInstallStart
+  ) {
+    return {
+      action: "reject",
+      kind: "conflict",
+      reason: "current generation changed while candidate version is unorderable",
+    };
+  }
+
+  return {
+    action: "publish",
+    generation: current.generation + 1,
+    previousReleaseId: current.releaseId,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/backend/src/utils/ytdlp/release/moduleOrigin.ts
+++ b/backend/src/utils/ytdlp/release/moduleOrigin.ts
@@ -1,0 +1,30 @@
+/**
+ * Classify where each module of a candidate release actually resolves from.
+ *
+ * An optional module being absent is fine - the capability is simply
+ * unavailable. An optional module resolving *outside* the candidate is not: the
+ * release would run against a mutable ambient dependency, which is the version
+ * mixing the managed store exists to prevent. The two cases must therefore be
+ * reported separately rather than collapsed into one boolean.
+ */
+export const MODULE_ORIGIN_SCRIPT = [
+  "import json, os, sys",
+  "root = os.path.realpath(sys.argv[1])",
+  "allowed = [root] + [os.path.realpath(p) for p in sys.argv[2:] if p]",
+  "def classify(name):",
+  "    try:",
+  "        module = __import__(name)",
+  "    except Exception:",
+  "        return 'absent'",
+  "    path = getattr(module, '__file__', None)",
+  "    if not path:",
+  "        return 'absent'",
+  "    path = os.path.realpath(path)",
+  "    inside = any(path == item or path.startswith(item + os.sep) for item in allowed)",
+  "    return 'inside' if inside else 'outside'",
+  "optional = ('curl_cffi', 'yt_dlp_ejs')",
+  "result = dict((name, classify(name)) for name in ('yt_dlp',) + optional)",
+  "print(json.dumps(result))",
+  "ok = result['yt_dlp'] == 'inside' and all(result[name] != 'outside' for name in optional)",
+  "raise SystemExit(0 if ok else 2)",
+].join("\n");

--- a/backend/src/utils/ytdlp/release/paths.ts
+++ b/backend/src/utils/ytdlp/release/paths.ts
@@ -1,0 +1,433 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { DATA_DIR } from "../../../config/paths";
+import {
+  YT_DLP_MANAGED_STORE_DIRNAME,
+  YT_DLP_WINDOWS_RENAME_ATTEMPTS,
+} from "../constants";
+import {
+  ensureDirSafeSync,
+  fsyncFileSafeSync,
+  lstatSafeSync,
+  normalizeSafeAbsolutePath,
+  pathExistsSafeSync,
+  readFileSafeSync,
+  readdirSafeSync,
+  renameSafeSync,
+  resolveSafeChildPath,
+  unlinkSafeSync,
+} from "../../security";
+import { createTempBasename, isValidReleaseId } from "./ids";
+import {
+  CURRENT_JSON_FILENAME,
+  GC_MARKERS_DIRNAME,
+  GENERATIONS_DIRNAME,
+  TRASH_DIRNAME,
+  LEASES_DIRNAME,
+  PUBLISH_LOCK_DIRNAME,
+  PUBLISH_LOCK_OWNER_FILENAME,
+  PUBLISHED_JSON_FILENAME,
+  RELEASE_JSON_FILENAME,
+  RELEASES_DIRNAME,
+  SITE_PACKAGES_DIRNAME,
+  STAGING_DIRNAME,
+  type ManagedStoreLayout,
+} from "./types";
+
+let rootOverride: string | null = null;
+
+export function setManagedStoreRootForTests(root: string | null): void {
+  rootOverride = root ? path.resolve(root) : null;
+}
+
+export function getManagedStoreRoot(): string {
+  if (rootOverride) {
+    return rootOverride;
+  }
+  // Unit tests must not consume a developer DATA_DIR/ytdlp store.
+  if (process.env.VITEST) {
+    return path.join(os.tmpdir(), "mytube-vitest-ytdlp-store-absent");
+  }
+  return path.join(DATA_DIR, YT_DLP_MANAGED_STORE_DIRNAME);
+}
+
+export function getManagedStoreLayout(
+  root: string = getManagedStoreRoot()
+): ManagedStoreLayout {
+  const resolvedRoot = normalizeSafeAbsolutePath(root);
+  return {
+    root: resolvedRoot,
+    currentPath: resolveSafeChildPath(resolvedRoot, CURRENT_JSON_FILENAME),
+    releasesDir: resolveSafeChildPath(resolvedRoot, RELEASES_DIRNAME),
+    stagingDir: resolveSafeChildPath(resolvedRoot, STAGING_DIRNAME),
+    leasesDir: resolveSafeChildPath(resolvedRoot, LEASES_DIRNAME),
+    gcMarkersDir: resolveSafeChildPath(resolvedRoot, GC_MARKERS_DIRNAME),
+    generationsDir: resolveSafeChildPath(resolvedRoot, GENERATIONS_DIRNAME),
+    trashDir: resolveSafeChildPath(resolvedRoot, TRASH_DIRNAME),
+    publishLockDir: resolveSafeChildPath(resolvedRoot, PUBLISH_LOCK_DIRNAME),
+  };
+}
+
+export function ensureManagedStoreLayout(
+  layout: ManagedStoreLayout = getManagedStoreLayout()
+): ManagedStoreLayout {
+  ensurePrivateDir(layout.root, layout.root);
+  ensurePrivateDir(layout.releasesDir, layout.root);
+  ensurePrivateDir(layout.stagingDir, layout.root);
+  ensurePrivateDir(layout.leasesDir, layout.root);
+  ensurePrivateDir(layout.gcMarkersDir, layout.root);
+  ensurePrivateDir(layout.generationsDir, layout.root);
+  ensurePrivateDir(layout.trashDir, layout.root);
+  return layout;
+}
+
+function ensurePrivateDir(dirPath: string, root: string): void {
+  // ensureDirSafeSync validates the lexical path but follows an existing
+  // symlink. Without this check a symlinked `staging` or store root would let
+  // `pip --target` write outside the managed store, and staging cleanup would
+  // delete through the link. A malformed store must be unusable, not obeyed.
+  assertNotSymlink(dirPath, root);
+  ensureDirSafeSync(dirPath, root);
+  chmodQuiet(dirPath, 0o700);
+}
+
+export function chmodQuiet(targetPath: string, mode: number): void {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch {
+    // Windows and some network filesystems do not honor POSIX modes.
+  }
+}
+
+export function assertNotSymlink(targetPath: string, root: string): void {
+  if (!pathExistsSafeSync(targetPath, root)) {
+    return;
+  }
+  const stats = lstatSafeSync(targetPath, root);
+  if (stats.isSymbolicLink()) {
+    throw new Error(`Refusing to use symlinked path: ${targetPath}`);
+  }
+}
+
+export function getReleaseDir(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  if (!isValidReleaseId(releaseId)) {
+    throw new Error(`Invalid release id: ${releaseId}`);
+  }
+  return resolveSafeChildPath(layout.releasesDir, releaseId);
+}
+
+export function getReleaseManifestPath(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  return resolveSafeChildPath(
+    getReleaseDir(layout, releaseId),
+    RELEASE_JSON_FILENAME
+  );
+}
+
+export function getPublishedManifestPath(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  return resolveSafeChildPath(
+    getReleaseDir(layout, releaseId),
+    PUBLISHED_JSON_FILENAME
+  );
+}
+
+export function getSitePackagesPath(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  return resolveSafeChildPath(
+    getReleaseDir(layout, releaseId),
+    SITE_PACKAGES_DIRNAME
+  );
+}
+
+export function getStagingDir(
+  layout: ManagedStoreLayout,
+  operationId: string
+): string {
+  return resolveSafeChildPath(layout.stagingDir, operationId);
+}
+
+export function getLeaseDir(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  if (!isValidReleaseId(releaseId)) {
+    throw new Error(`Invalid release id: ${releaseId}`);
+  }
+  return resolveSafeChildPath(layout.leasesDir, releaseId);
+}
+
+export function getGcMarkerPath(
+  layout: ManagedStoreLayout,
+  releaseId: string
+): string {
+  if (!isValidReleaseId(releaseId)) {
+    throw new Error(`Invalid release id: ${releaseId}`);
+  }
+  return resolveSafeChildPath(layout.gcMarkersDir, `${releaseId}.deleting`);
+}
+
+/**
+ * Where a release is moved before it is deleted. Renaming into here is what
+ * makes it unreachable; the deletion itself then has no deadline.
+ */
+export function getTrashPath(
+  layout: ManagedStoreLayout,
+  releaseId: string,
+  token: string
+): string {
+  if (!isValidReleaseId(releaseId)) {
+    throw new Error(`Invalid release id: ${releaseId}`);
+  }
+  return resolveSafeChildPath(layout.trashDir, `${releaseId}.${token}`);
+}
+
+export function getGenerationClaimPath(
+  layout: ManagedStoreLayout,
+  generation: number
+): string {
+  if (!Number.isInteger(generation) || generation < 1) {
+    throw new Error(`Invalid generation: ${generation}`);
+  }
+  return resolveSafeChildPath(layout.generationsDir, `${generation}.json`);
+}
+
+/**
+ * Drop a generation claim, but only while it is still ours.
+ *
+ * Claims are reclaimable by age, so a suspended publisher can have its claim
+ * taken over. Checking the token and then unlinking would let it delete the
+ * replacement's claim in between, and a third publisher could then reserve the
+ * same generation. So the claim is moved aside first - a rename is atomic about
+ * which process takes a path - and the token confirmed on the copy only we can
+ * see. A claim that turns out not to be ours goes straight back.
+ */
+export function removeGenerationClaim(
+  layout: ManagedStoreLayout,
+  generation: number,
+  token: string
+): void {
+  const claimPath = getGenerationClaimPath(layout, generation);
+  const heldPath = `${claimPath}.${token}.releasing`;
+  try {
+    fs.renameSync(claimPath, heldPath);
+  } catch {
+    // Already gone, or another process is mid-reclamation; not ours to delete.
+    return;
+  }
+  if (readClaimToken(heldPath) !== token) {
+    try {
+      fs.renameSync(heldPath, claimPath);
+    } catch {
+      // Best effort; an orphaned claim is reclaimed by age.
+    }
+    return;
+  }
+  try {
+    fs.unlinkSync(heldPath);
+  } catch {
+    // Harmless: it no longer occupies the claim path.
+  }
+}
+
+/** The contents of a generation claim, if it is readable. */
+export function readClaim(
+  claimPath: string
+): { token: string | null; releaseId: string | null } {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(claimPath, "utf8")) as {
+      token?: unknown;
+      releaseId?: unknown;
+    };
+    return {
+      token: typeof parsed?.token === "string" ? parsed.token : null,
+      releaseId:
+        typeof parsed?.releaseId === "string" ? parsed.releaseId : null,
+    };
+  } catch {
+    return { token: null, releaseId: null };
+  }
+}
+
+export function readClaimToken(claimPath: string): string | null {
+  return readClaim(claimPath).token;
+}
+
+export function getPublishLockOwnerPath(layout: ManagedStoreLayout): string {
+  return resolveSafeChildPath(
+    layout.publishLockDir,
+    PUBLISH_LOCK_OWNER_FILENAME
+  );
+}
+
+export function listSafeDirNames(dirPath: string, root: string): string[] {
+  if (!pathExistsSafeSync(dirPath, root)) {
+    return [];
+  }
+  assertNotSymlink(dirPath, root);
+  return readdirSafeSync(dirPath, root);
+}
+
+export function readTextFile(filePath: string, root: string): string {
+  assertNotSymlink(filePath, root);
+  return readFileSafeSync(filePath, root, "utf8");
+}
+
+export function writeTextFileFsync(
+  filePath: string,
+  contents: string,
+  mode = 0o600
+): void {
+  const fd = fs.openSync(filePath, "w", mode);
+  try {
+    fs.writeFileSync(fd, contents, "utf8");
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  chmodQuiet(filePath, mode);
+}
+
+export function atomicReplaceFile(
+  targetPath: string,
+  root: string,
+  contents: string
+): void {
+  const tmpPath = resolveSafeChildPath(root, createTempBasename("current"));
+  writeTextFileFsync(tmpPath, contents, 0o600);
+  try {
+    renameWithRetry(tmpPath, targetPath, root);
+  } catch (error: unknown) {
+    // Windows can refuse to replace a file another handle still holds open.
+    // The previous manifest stays authoritative; drop our temporary file so a
+    // repeatedly failing publisher cannot litter the store.
+    try {
+      unlinkSafeSync(tmpPath, root);
+    } catch {
+      // Best effort: a stray uniquely named temp file is ignored by readers.
+    }
+    throw error;
+  }
+  try {
+    fsyncFileSafeSync(targetPath, root);
+  } catch {
+    // Best-effort post-rename fsync.
+  }
+  fsyncDirectory(root);
+}
+
+/**
+ * Blocking sleep. The publication critical section is synchronous and
+ * sub-second by design, so the few short Windows retries below must not yield
+ * the loop to another publisher mid-replacement.
+ */
+export function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function renameWithRetry(
+  fromPath: string,
+  toPath: string,
+  root: string
+): void {
+  let delayMs = 20;
+  for (let attempt = 1; attempt <= YT_DLP_WINDOWS_RENAME_ATTEMPTS; attempt += 1) {
+    try {
+      renameSafeSync(fromPath, root, toPath, root);
+      return;
+    } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // A concurrent reader holding current.json open makes the replace fail
+      // transiently on Windows. Retry the same atomic rename — never fall back
+      // to unlink-then-rename, which would expose an empty-current window.
+      const transient =
+        process.platform === "win32" &&
+        (code === "EPERM" || code === "EACCES" || code === "EBUSY");
+      if (!transient || attempt === YT_DLP_WINDOWS_RENAME_ATTEMPTS) {
+        throw error;
+      }
+      sleepSync(delayMs);
+      delayMs *= 2;
+    }
+  }
+}
+
+export function fsyncDirectory(dirPath: string): void {
+  try {
+    const fd = fs.openSync(dirPath, "r");
+    try {
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    // Directory fsync is unsupported on some Windows volumes.
+  }
+}
+
+export function mkdirExclusive(dirPath: string): void {
+  fs.mkdirSync(dirPath);
+  chmodQuiet(dirPath, 0o700);
+}
+
+export function pathExistsInRoot(targetPath: string, root: string): boolean {
+  return pathExistsSafeSync(targetPath, root);
+}
+
+export function unlinkInRoot(targetPath: string, root: string): void {
+  unlinkSafeSync(targetPath, root);
+}
+
+export function writeJsonAtomic(
+  targetPath: string,
+  root: string,
+  value: unknown
+): void {
+  atomicReplaceFile(targetPath, root, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function writeJsonInPlace(filePath: string, value: unknown): void {
+  writeTextFileFsync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/**
+ * Create a file only if it does not exist. Used where the write itself is part
+ * of a claim, so a late writer cannot overwrite the file a contender created.
+ */
+export function writeJsonExclusive(filePath: string, value: unknown): void {
+  const contents = `${JSON.stringify(value, null, 2)}\n`;
+  const fd = fs.openSync(filePath, "wx", 0o600);
+  try {
+    fs.writeFileSync(fd, contents, "utf8");
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  chmodQuiet(filePath, 0o600);
+}
+
+export function statMtimeMs(targetPath: string): number | null {
+  try {
+    return fs.statSync(targetPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function renameInRoot(
+  fromPath: string,
+  toPath: string,
+  root: string
+): void {
+  renameWithRetry(fromPath, toPath, root);
+}

--- a/backend/src/utils/ytdlp/release/process.ts
+++ b/backend/src/utils/ytdlp/release/process.ts
@@ -1,0 +1,166 @@
+import { spawn, spawnSync, type ChildProcess } from "child_process";
+
+export type RunProcessResult = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+};
+
+export type RunProcessOptions = {
+  env?: NodeJS.ProcessEnv;
+  timeoutMs: number;
+  cwd?: string;
+  stdin?: "ignore" | "pipe";
+};
+
+const OUTPUT_LIMIT_BYTES = 1024 * 1024;
+/** How long a child gets to exit after SIGTERM before SIGKILL. */
+const SIGKILL_GRACE_MS = 1000;
+/** How long to wait for "close" after SIGKILL before giving up on the child. */
+const ABANDON_GRACE_MS = 5000;
+
+export function runProcess(
+  command: string,
+  args: readonly string[],
+  options: RunProcessOptions
+): Promise<RunProcessResult> {
+  return new Promise((resolve) => {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let killTimer: NodeJS.Timeout | null = null;
+    let abandonTimer: NodeJS.Timeout | null = null;
+
+    const child = spawn(command, [...args], {
+      cwd: options.cwd,
+      env: options.env,
+      shell: false,
+      windowsHide: true,
+      stdio: [options.stdin ?? "ignore", "pipe", "pipe"],
+      // Give the child its own process group so a timeout can terminate what it
+      // launched - pip spawns build and download helpers, and signalling only
+      // the interpreter leaves those running against the staging directory we
+      // are about to delete. Windows has no usable process groups here; the
+      // kill path uses taskkill /T instead.
+      detached: process.platform !== "win32",
+    });
+
+    const finish = (result: RunProcessResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (killTimer) {
+        clearTimeout(killTimer);
+      }
+      if (abandonTimer) {
+        clearTimeout(abandonTimer);
+      }
+      resolve(result);
+    };
+
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      killProcessTree(child);
+      killTimer = setTimeout(() => {
+        killProcessTree(child, "SIGKILL");
+        // Last resort. "close" waits for the stdio streams to close, which a
+        // grandchild that inherited the pipes can hold open long after the
+        // child itself is gone. Every caller runs under a lock or an in-flight
+        // dedup, so a promise that never settles would wedge updates for the
+        // life of the process; report the timeout instead.
+        abandonTimer = setTimeout(() => {
+          // No signal is reported: we stopped waiting rather than observing an
+          // exit, and claiming SIGKILL here would be indistinguishable from a
+          // child that really was killed.
+          finish({ code: null, signal: null, stdout, stderr, timedOut });
+        }, ABANDON_GRACE_MS);
+        abandonTimer.unref?.();
+      }, SIGKILL_GRACE_MS);
+      killTimer.unref?.();
+    }, options.timeoutMs);
+    timeout.unref?.();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = appendLimited(stdout, chunk.toString("utf8"));
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = appendLimited(stderr, chunk.toString("utf8"));
+    });
+    child.on("error", (error: NodeJS.ErrnoException) => {
+      finish({
+        code: null,
+        signal: null,
+        stdout,
+        stderr: stderr || error.message,
+        timedOut,
+      });
+    });
+    child.on("close", (code, signal) => {
+      finish({
+        code,
+        signal,
+        stdout,
+        stderr,
+        timedOut,
+      });
+    });
+  });
+}
+
+function appendLimited(current: string, next: string): string {
+  const combined = current + next;
+  if (combined.length <= OUTPUT_LIMIT_BYTES) {
+    return combined;
+  }
+  return combined.slice(combined.length - OUTPUT_LIMIT_BYTES);
+}
+
+function killProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals = "SIGTERM"
+): void {
+  // `child.killed` only records that a signal was successfully *sent*, so it is
+  // already true after SIGTERM. Gating on it would make the SIGKILL escalation
+  // below a silent no-op against a process that ignores SIGTERM. Only a real
+  // exit means there is nothing left to signal.
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  const pid = child.pid;
+  if (pid === undefined) {
+    return;
+  }
+
+  if (process.platform === "win32") {
+    try {
+      // /T walks the tree, /F forces it. Windows offers no signal semantics,
+      // so this is the only way to reach descendants.
+      spawnSync("taskkill", ["/pid", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      return;
+    } catch {
+      // Fall back to signalling the child alone.
+    }
+  } else {
+    try {
+      // A negative pid targets the whole group created by `detached`.
+      process.kill(-pid, signal);
+      return;
+    } catch {
+      // The group may already be gone; fall back to the child alone.
+    }
+  }
+
+  try {
+    child.kill(signal);
+  } catch {
+    // Already exited, or the pid is gone.
+  }
+}

--- a/backend/src/utils/ytdlp/release/publish.ts
+++ b/backend/src/utils/ytdlp/release/publish.ts
@@ -1,0 +1,227 @@
+import { logger } from "../../logger";
+import { assertLockOwnership, withPublishLock } from "./lock";
+import {
+  decidePublication,
+  readCurrentManifest,
+  readReleaseManifest,
+  removePublishedManifest,
+  writeCurrentManifest,
+  writePublishedManifest,
+} from "./manifests";
+import fs from "fs";
+import {
+  ensureManagedStoreLayout,
+  getGenerationClaimPath,
+  getManagedStoreLayout,
+  readClaim,
+  readClaimToken,
+  removeGenerationClaim,
+  statMtimeMs,
+  writeJsonExclusive,
+} from "./paths";
+import { createNonce } from "./ids";
+import { YT_DLP_PUBLISH_LOCK_STALE_MS } from "../constants";
+import type {
+  CurrentManifest,
+  ManagedStoreLayout,
+  PublishOutcome,
+} from "./types";
+
+/**
+ * Atomically reserve a generation number. Returns false when another publisher
+ * already owns it, which is the signal to abandon this publication.
+ */
+function claimGeneration(
+  layout: ManagedStoreLayout,
+  next: CurrentManifest
+): string | null {
+  const claimPath = getGenerationClaimPath(layout, next.generation);
+  const token = createNonce();
+  const claim = {
+    releaseId: next.releaseId,
+    claimedAt: next.publishedAt,
+    token,
+  };
+  try {
+    writeJsonExclusive(claimPath, claim);
+    return token;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
+
+  // A claim exists. A publisher that merely failed removes its own, so this is
+  // either one still in flight or one whose process died mid-publication.
+  // Leaving it would reject every future update forever, since they all compute
+  // the same next generation. Age separates the two cases: nothing legitimately
+  // sits between claiming and committing for longer than a stale lock.
+  const claimedAt = statMtimeMs(claimPath);
+  if (claimedAt === null || Date.now() - claimedAt < YT_DLP_PUBLISH_LOCK_STALE_MS) {
+    return null;
+  }
+  logger.warn(
+    `[yt-dlp] Reclaiming abandoned generation ${next.generation} claim after ${Math.round(
+      (Date.now() - claimedAt) / 1000
+    )}s`
+  );
+  // Move it aside rather than delete it. A rename is atomic, so exactly one
+  // process can take a given claim out of the way; a concurrent reclaimer's
+  // rename fails and it retries against whatever now exists. Deleting instead
+  // would let a slow reclaimer remove a replacement's fresh claim.
+  const observedToken = readClaimToken(claimPath);
+  if (!retireAbandonedClaim(layout, next.generation, token, observedToken)) {
+    return null;
+  }
+  try {
+    writeJsonExclusive(claimPath, claim);
+    return token;
+  } catch {
+    return null;
+  }
+}
+
+function retireAbandonedClaim(
+  layout: ManagedStoreLayout,
+  generation: number,
+  token: string,
+  observedToken: string | null
+): boolean {
+  const claimPath = getGenerationClaimPath(layout, generation);
+  const retiredPath = `${claimPath}.${token}.abandoned`;
+  try {
+    fs.renameSync(claimPath, retiredPath);
+  } catch {
+    // Somebody else moved it first; they own the reclamation.
+    return false;
+  }
+
+  // The rename is atomic about *who* moves the path, not about *what* was
+  // sitting there: a reclaimer paused after observing the expired claim could
+  // have moved a replacement that appeared meanwhile. Identify what we took by
+  // its token rather than its timestamp - a replacement written within the
+  // filesystem's timestamp resolution would otherwise look like the claim we
+  // judged - and put it back if it is not the one.
+  const retired = readClaim(retiredPath);
+  if (retired.token !== observedToken) {
+    try {
+      fs.renameSync(retiredPath, claimPath);
+    } catch {
+      // Best effort; a lost claim is reclaimed by age on the next attempt.
+    }
+    return false;
+  }
+
+  // A publisher that died between recording its publication and moving the
+  // pointer left a published.json behind. Freeing its generation without
+  // removing that record would leave two releases claiming the same
+  // generation, and both recovery and the rollback window order by generation.
+  // The claim names the release, so this is exactly the record to drop.
+  if (retired.releaseId) {
+    removePublishedManifest(layout.root, retired.releaseId);
+  }
+
+  try {
+    fs.unlinkSync(retiredPath);
+  } catch {
+    // Harmless: it is no longer at the claim path.
+  }
+  return true;
+}
+
+export async function publishValidatedRelease(input: {
+  releaseId: string;
+  version: string;
+  generationAtInstallStart: number | null;
+  currentIsUsable?: boolean;
+}): Promise<PublishOutcome> {
+  const layout = ensureManagedStoreLayout(getManagedStoreLayout());
+  return withPublishLock(async (lock) => {
+    // Re-read under the lock: another publisher may have moved current on
+    // while this candidate was being installed and validated.
+    const current = readCurrentManifest(layout.root);
+    const currentVersion = current
+      ? readReleaseManifest(current.releaseId, layout.root)?.version ?? null
+      : null;
+    const decision = decidePublication({
+      current,
+      currentVersion,
+      candidateVersion: input.version,
+      candidateReleaseId: input.releaseId,
+      generationAtInstallStart: input.generationAtInstallStart,
+      currentIsUsable: input.currentIsUsable,
+    });
+    if (decision.action === "reject") {
+      if (decision.kind === "conflict") {
+        throw new Error(
+          `Refusing to publish yt-dlp release: ${decision.reason}`
+        );
+      }
+      // Already up to date. The candidate directory stays behind for GC; the
+      // operator gets a successful "no change" result rather than an error.
+      logger.info(
+        `[yt-dlp] Keeping the current managed release: ${decision.reason}`
+      );
+      return { current, published: false, reason: decision.reason };
+    }
+    // A suspended publisher whose stale lock was recovered must abort rather
+    // than resume and overwrite a newer generation.
+    assertLockOwnership(lock);
+    const next: CurrentManifest = {
+      schemaVersion: 1,
+      generation: decision.generation,
+      releaseId: input.releaseId,
+      previousReleaseId: decision.previousReleaseId,
+      publishedAt: new Date().toISOString(),
+    };
+    // Record the accepted publication before moving the pointer. If the
+    // pointer write is interrupted, corruption recovery may safely finish the
+    // accepted transition. Conflict-rejected finalized candidates never get
+    // this record and therefore cannot be mistaken for published releases.
+    // Claim the generation before anything else. Exclusive file creation is
+    // the one primitive the filesystem gives us that is genuinely atomic
+    // across processes, so this turns the pointer update from check-then-write
+    // into a compare-and-swap: two publishers racing from the same current.json
+    // compute the same generation, and exactly one of them can create it. A
+    // publisher descheduled past the stale window therefore cannot resume and
+    // overwrite a newer generation - the winner already owns the number.
+    const claimToken = claimGeneration(layout, next);
+    if (!claimToken) {
+      throw new Error(
+        `Refusing to publish yt-dlp release: generation ${next.generation} was claimed by another publisher`
+      );
+    }
+    let committed = false;
+    try {
+      writePublishedManifest(layout.root, next);
+      // Belt and braces: the lock should still be ours, and losing it means
+      // something is badly wrong even though the claim above already fenced us.
+      assertLockOwnership(lock);
+      writeCurrentManifest(layout.root, next);
+      committed = true;
+    } finally {
+      if (!committed) {
+        // Nothing moved the pointer, so undo both marks. Leaving the record
+        // would let recovery promote a transition that never committed, and
+        // leaving the claim would reject every later update at this generation.
+        //
+        // Order matters: only free the generation once its record is actually
+        // gone. A record that could not be deleted - a transient Windows
+        // sharing violation, say - plus a freed generation would let the next
+        // update reuse it and leave two releases recording the same one. The
+        // claim then expires and its age-based reclamation retries the record.
+        if (removePublishedManifest(layout.root, next.releaseId)) {
+          removeGenerationClaim(layout, next.generation, claimToken);
+        } else {
+          logger.warn(
+            `[yt-dlp] Kept the generation ${next.generation} claim: its publication record could not be removed`
+          );
+        }
+      }
+    }
+    logger.info(
+      `[yt-dlp] Published managed release ${input.releaseId} (${input.version}) as generation ${next.generation}`
+    );
+    return { current: next, published: true };
+  });
+}

--- a/backend/src/utils/ytdlp/release/recover.ts
+++ b/backend/src/utils/ytdlp/release/recover.ts
@@ -1,0 +1,226 @@
+import { logger } from "../../logger";
+import { isValidReleaseId } from "./ids";
+import {
+  loadManagedRelease,
+  readCurrentManifest,
+  readPublishedManifest,
+  readReleaseManifest,
+} from "./manifests";
+import { getManagedStoreLayout, listSafeDirNames } from "./paths";
+import { YT_DLP_HELP_PROBE_TIMEOUT_MS } from "../constants";
+import { buildManagedSpawnEnv, captureProcessEnv } from "./env";
+import { runProcess } from "./process";
+import { MODULE_ORIGIN_SCRIPT } from "./moduleOrigin";
+import { getProviderPluginPath } from "../../../services/downloaders/ytdlp/ytdlpHelpers";
+import type { CurrentManifest, LoadedManagedRelease } from "./types";
+
+/**
+ * Pick the release the store says is current, falling back through the
+ * previous pointer and then the newest finalized release.
+ *
+ * A managed store that cannot be read at all (unwritable subtree, symlinked
+ * directories, unexpected content) must never stop the backend from serving:
+ * every failure degrades to external discovery instead of propagating.
+ */
+/**
+ * Releases this process has proven cannot run. Acquisition must skip them, or
+ * it would keep re-selecting a release that availability already rejected and
+ * fell back from - existence checks alone cannot tell the difference.
+ */
+const unusableReleaseIds = new Set<string>();
+
+export function markManagedReleaseUnusable(releaseId: string): void {
+  unusableReleaseIds.add(releaseId);
+}
+
+export function isManagedReleaseUnusable(releaseId: string): boolean {
+  return unusableReleaseIds.has(releaseId);
+}
+
+/** "runs" and "broken" describe the release; "unknown" describes the probe. */
+type ReleaseHealth = "runs" | "broken" | "unknown";
+
+const runnableReleaseIds = new Map<string, Promise<boolean>>();
+
+export function resetUnusableManagedReleasesForTests(): void {
+  unusableReleaseIds.clear();
+  runnableReleaseIds.clear();
+}
+
+/**
+ * Memoized form of {@link managedReleaseRuns}. A release is immutable, so one
+ * definitive answer per release id is enough — which is what makes it
+ * affordable for the status endpoint and the operator update path, not just
+ * execution. Only definitive answers are cached.
+ */
+export function managedReleaseRunsCached(
+  loaded: LoadedManagedRelease
+): Promise<boolean> {
+  const cached = runnableReleaseIds.get(loaded.release.releaseId);
+  if (cached) {
+    return cached;
+  }
+  const pending = managedReleaseRuns(loaded).then((health) => {
+    if (health === "broken") {
+      markManagedReleaseUnusable(loaded.release.releaseId);
+      return false;
+    }
+    if (health === "unknown") {
+      // Nothing was learned, so nothing is remembered: the next caller probes
+      // again rather than inheriting one transient failure for the process
+      // lifetime. Optimistic in the meantime - execution surfaces a genuinely
+      // broken release on its own.
+      runnableReleaseIds.delete(loaded.release.releaseId);
+    }
+    return true;
+  });
+  runnableReleaseIds.set(loaded.release.releaseId, pending);
+  return pending;
+}
+
+export function recoverUsableManagedRelease(
+  root?: string
+): LoadedManagedRelease | null {
+  try {
+    return recoverUsableManagedReleaseUnsafe(root ?? getManagedStoreLayout().root);
+  } catch (error: unknown) {
+    logger.warn(
+      `[yt-dlp] Managed release store is unusable, falling back to discovery: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+}
+
+function recoverUsableManagedReleaseUnsafe(
+  root: string
+): LoadedManagedRelease | null {
+  const current = readCurrentManifest(root);
+  if (current) {
+    const loaded = unusableReleaseIds.has(current.releaseId)
+      ? null
+      : loadManagedRelease(current.releaseId, current, root);
+    if (loaded) {
+      return loaded;
+    }
+    logger.warn(
+      `[yt-dlp] Current managed release ${current.releaseId} failed validation; trying the previous release.`
+    );
+    if (
+      current.previousReleaseId &&
+      !unusableReleaseIds.has(current.previousReleaseId)
+    ) {
+      const previous = loadManagedRelease(
+        current.previousReleaseId,
+        current,
+        root
+      );
+      if (previous) {
+        logger.info(
+          `[yt-dlp] Recovered managed release ${previous.release.releaseId} from previousReleaseId.`
+        );
+        return previous;
+      }
+    }
+  }
+  return loadNewestFinalizedRelease(current, root);
+}
+
+function loadNewestFinalizedRelease(
+  current: CurrentManifest | null,
+  root: string
+): LoadedManagedRelease | null {
+  const layout = getManagedStoreLayout(root);
+  const published: Array<{
+    releaseId: string;
+    generation: number;
+    publishedAt: number;
+  }> = [];
+  const legacy: Array<{ releaseId: string; installedAt: number }> = [];
+  for (const name of listSafeDirNames(layout.releasesDir, layout.root)) {
+    if (!isValidReleaseId(name)) {
+      continue;
+    }
+    const manifest = readReleaseManifest(name, layout.root);
+    if (!manifest || unusableReleaseIds.has(name)) {
+      continue;
+    }
+    const publication = readPublishedManifest(name, layout.root);
+    if (publication) {
+      published.push({
+        releaseId: name,
+        generation: publication.generation,
+        publishedAt: Date.parse(publication.publishedAt),
+      });
+      continue;
+    }
+    legacy.push({
+      releaseId: name,
+      installedAt: Date.parse(manifest.installedAt) || 0,
+    });
+  }
+  // Once this store has publication records, only releases carrying one are
+  // eligible. Falling back to every finalized directory would reintroduce
+  // conflict-rejected candidates. The legacy path exists only for stores that
+  // predate publication records entirely.
+  const candidates = published.length
+    ? published.sort(
+        (a, b) => b.generation - a.generation || b.publishedAt - a.publishedAt
+      )
+    : legacy.sort((a, b) => b.installedAt - a.installedAt);
+  for (const candidate of candidates) {
+    const loaded = loadManagedRelease(candidate.releaseId, current, root);
+    if (loaded) {
+      return loaded;
+    }
+  }
+  return null;
+}
+
+/**
+ * Prove a persisted release can still actually run.
+ *
+ * Existence checks are not enough: a store that outlives an image or host
+ * upgrade can keep a valid interpreter path and a populated site-packages
+ * whose native dependencies no longer match the new Python ABI, and storage
+ * corruption can leave the directory present but unusable. Without this the
+ * backend would keep selecting a release on which every invocation fails,
+ * instead of falling through to another release or reinstalling.
+ *
+ * Deliberately not called per acquisition - it spawns a process. Callers run
+ * it once, where availability is established.
+ */
+export async function managedReleaseRuns(
+  loaded: LoadedManagedRelease
+): Promise<ReleaseHealth> {
+  // Not `-m yt_dlp --version`: PYTHONNOUSERSITE only disables the *user* site,
+  // and the image installs yt-dlp globally, so a release whose site-packages
+  // lost yt_dlp would import the image-wide copy and report success. Status
+  // would then show the manifest's version while executions silently ran a
+  // different one. The origin probe answers "does this release run" and "is it
+  // actually this release" together, and is the same check publication uses.
+  const allowedOrigins = [
+    loaded.sitePackagesPath,
+    getProviderPluginPath(),
+  ].filter(Boolean);
+  const result = await runProcess(
+    loaded.release.pythonExecutable,
+    [...loaded.release.pythonPrefixArgs, "-c", MODULE_ORIGIN_SCRIPT, ...allowedOrigins],
+    {
+      env: buildManagedSpawnEnv(loaded.sitePackagesPath, captureProcessEnv()),
+      timeoutMs: YT_DLP_HELP_PROBE_TIMEOUT_MS,
+    }
+  );
+  if (result.code === 0) {
+    return "runs";
+  }
+  // A probe that never produced an answer - a timeout, or a spawn that failed
+  // under resource pressure - describes the machine, not the release. Treating
+  // it as a verdict would permanently condemn a healthy release and force an
+  // unnecessary reinstall or rollback.
+  if (result.timedOut || result.code === null) {
+    return "unknown";
+  }
+  return "broken";
+}

--- a/backend/src/utils/ytdlp/release/types.ts
+++ b/backend/src/utils/ytdlp/release/types.ts
@@ -1,0 +1,123 @@
+import type { YouTubeJsRuntimeFlag } from "../constants";
+
+export const RELEASE_JSON_FILENAME = "release.json";
+export const PUBLISHED_JSON_FILENAME = "published.json";
+export const CURRENT_JSON_FILENAME = "current.json";
+export const SITE_PACKAGES_DIRNAME = "site-packages";
+export const STAGING_DIRNAME = "staging";
+export const RELEASES_DIRNAME = "releases";
+export const LEASES_DIRNAME = "leases";
+export const GC_MARKERS_DIRNAME = "gc-markers";
+export const GENERATIONS_DIRNAME = "generations";
+export const TRASH_DIRNAME = "trash";
+export const PUBLISH_LOCK_DIRNAME = "publish.lock";
+export const PUBLISH_LOCK_OWNER_FILENAME = "owner.json";
+
+export type ReleaseKind = "managed" | "external";
+
+export type YtDlpCapabilities = {
+  jsRuntimeFlag: YouTubeJsRuntimeFlag | null;
+  supportsRemoteComponents: boolean;
+  impersonateAvailable: boolean;
+};
+
+export type ReleaseManifest = {
+  schemaVersion: 1;
+  releaseId: string;
+  version: string;
+  installedAt: string;
+  pythonExecutable: string;
+  pythonPrefixArgs: string[];
+  sitePackages: typeof SITE_PACKAGES_DIRNAME;
+};
+
+export type PublishedManifest = {
+  schemaVersion: 1;
+  releaseId: string;
+  generation: number;
+  previousReleaseId: string | null;
+  publishedAt: string;
+};
+
+export type CurrentManifest = {
+  schemaVersion: 1;
+  generation: number;
+  releaseId: string;
+  previousReleaseId: string | null;
+  publishedAt: string;
+};
+
+export type PublishLockOwner = {
+  operationId: string;
+  nonce: string;
+  pid: number;
+  /**
+   * Identifies the writing process instance. A PID alone is not an identity: a
+   * restarted container routinely reassigns the same number, which would make
+   * a dead owner's lock look permanently live. Optional so a lock written by
+   * an older build still parses.
+   */
+  instanceId?: string;
+  createdAt: string;
+};
+
+export type LeaseRecord = {
+  schemaVersion: 1;
+  releaseId: string;
+  instanceId: string;
+  pid: number;
+  operationId: string;
+  createdAt: string;
+};
+
+export type YtDlpRelease = {
+  readonly kind: ReleaseKind;
+  readonly releaseId: string;
+  readonly version: string | null;
+  readonly command: string;
+  readonly prefixArgs: readonly string[];
+  readonly spawnEnv: NodeJS.ProcessEnv;
+  readonly pythonExecutable?: string;
+  readonly sitePackagesPath?: string;
+  readonly generation?: number;
+  readonly capabilities: Promise<YtDlpCapabilities>;
+};
+
+export type ManagedStoreLayout = {
+  root: string;
+  generationsDir: string;
+  trashDir: string;
+  currentPath: string;
+  releasesDir: string;
+  stagingDir: string;
+  leasesDir: string;
+  gcMarkersDir: string;
+  publishLockDir: string;
+};
+
+export type LoadedManagedRelease = {
+  current: CurrentManifest | null;
+  release: ReleaseManifest;
+  releaseDir: string;
+  sitePackagesPath: string;
+};
+
+export type PublishDecision =
+  | {
+      action: "publish";
+      generation: number;
+      previousReleaseId: string | null;
+    }
+  /**
+   * `kind` separates a benign no-op ("this release is already current") from a
+   * genuine conflict ("a newer release won the race"). Only the latter is an
+   * error for the operator: re-running an update that is already up to date
+   * must report no change, not a failure.
+   */
+  | { action: "reject"; kind: "already-current" | "conflict"; reason: string };
+
+export type PublishOutcome = {
+  current: CurrentManifest | null;
+  published: boolean;
+  reason?: string;
+};

--- a/backend/src/utils/ytdlp/runtime.ts
+++ b/backend/src/utils/ytdlp/runtime.ts
@@ -1,18 +1,14 @@
 import { spawn } from "child_process";
 import {
-  YT_DLP_HELP_PROBE_TIMEOUT_MS,
   YT_DLP_JS_RUNTIME_ENV,
-  YouTubeJsRuntimeFlag,
+  type YouTubeJsRuntimeFlag,
 } from "./constants";
-import { getYtDlpSpawnEnv } from "./spawnEnv";
-import { resolveYtDlpPath } from "./pathResolver";
 import { isYouTubeUrl } from "../helpers";
 import { logger } from "../logger";
+import { resetCapabilityCacheForTests } from "./release/capabilities";
+import type { YtDlpRelease } from "./release/types";
 
 let denoAvailablePromise: Promise<boolean> | null = null;
-let jsRuntimeFlagPromise: Promise<YouTubeJsRuntimeFlag | null> | null = null;
-let remoteComponentsSupportPromise: Promise<boolean> | null = null;
-let impersonateSupportPromise: Promise<boolean> | null = null;
 const runtimeWarningCache = new Set<string>();
 
 async function isDenoAvailable(): Promise<boolean> {
@@ -38,71 +34,18 @@ async function isDenoAvailable(): Promise<boolean> {
 }
 
 /**
- * Whether the resolved yt-dlp binary can impersonate a Chrome browser via
- * curl_cffi. Probes `--list-impersonate-targets`: when curl_cffi is missing,
- * yt-dlp still lists targets but tags every one "(unavailable)", and passing
- * `--impersonate` would then hard-fail the download. Callers use this to gate
- * the flag and degrade gracefully instead of erroring. Cached per process.
+ * Whether this release can impersonate Chrome via curl_cffi. Callers use this
+ * to gate `--impersonate` and degrade gracefully instead of erroring.
  */
-export async function isYtDlpImpersonateAvailable(): Promise<boolean> {
-  if (impersonateSupportPromise) {
-    return impersonateSupportPromise;
+export async function isYtDlpImpersonateAvailable(
+  release: YtDlpRelease
+): Promise<boolean> {
+  try {
+    const capabilities = await release.capabilities;
+    return capabilities.impersonateAvailable;
+  } catch {
+    return false;
   }
-
-  impersonateSupportPromise = (async () => {
-    try {
-      const ytDlpPath = await resolveYtDlpPath();
-      return await new Promise<boolean>((resolve) => {
-        let output = "";
-        let settled = false;
-        const finish = (value: boolean) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          // A usable target row names a client and ends with the curl_cffi
-          // source without the "(unavailable)" marker.
-          const available = output
-            .split("\n")
-            .some(
-              (line) =>
-                /chrome/i.test(line) &&
-                /curl_cffi/.test(line) &&
-                !/unavailable/i.test(line),
-            );
-          if (!available) {
-            impersonateSupportPromise = null;
-          }
-          resolve(available && value);
-        };
-        const timeout = setTimeout(() => {
-          proc.kill("SIGTERM");
-          finish(true);
-        }, YT_DLP_HELP_PROBE_TIMEOUT_MS);
-        timeout.unref?.();
-
-        // ytDlpPath is either explicitly configured by the operator or selected
-        // from enumerated PATH entries and fixed executable names above.
-        // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-        const proc = spawn(ytDlpPath, ["--list-impersonate-targets"], {
-          env: getYtDlpSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        proc.stdout?.on("data", (data: Buffer) => {
-          output += data.toString();
-        });
-        proc.on("close", () => finish(true));
-        proc.on("error", () => {
-          impersonateSupportPromise = null;
-          finish(false);
-        });
-      });
-    } catch {
-      impersonateSupportPromise = null;
-      return false;
-    }
-  })();
-
-  return impersonateSupportPromise;
 }
 
 function warnRuntimeOnce(key: string, message: string): void {
@@ -113,164 +56,46 @@ function warnRuntimeOnce(key: string, message: string): void {
   logger.warn(message);
 }
 
-export async function getYouTubeJsRuntimeFlag(): Promise<YouTubeJsRuntimeFlag | null> {
-  if (jsRuntimeFlagPromise) {
-    return jsRuntimeFlagPromise;
-  }
-
-  jsRuntimeFlagPromise = (async () => {
-    let helpText = "";
-    const resolveFromHelp = (): YouTubeJsRuntimeFlag | null => {
-      if (helpText.includes("--js-runtimes")) {
-        return "--js-runtimes";
-      }
-
-      if (helpText.includes("--js-runtime")) {
-        return "--js-runtime";
-      }
-
+export async function getYouTubeJsRuntimeFlag(
+  release: YtDlpRelease
+): Promise<YouTubeJsRuntimeFlag | null> {
+  try {
+    const capabilities = await release.capabilities;
+    if (!capabilities.jsRuntimeFlag) {
       warnRuntimeOnce(
         "js-runtime-flag-unsupported",
         "[yt-dlp] Current yt-dlp binary does not support --js-runtimes. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
       );
-      return null;
-    };
-
-    try {
-      const ytDlpPath = await resolveYtDlpPath();
-      const resolvedFlag = await new Promise<YouTubeJsRuntimeFlag | null>((resolve) => {
-        let settled = false;
-        const timeout = setTimeout(() => {
-          if (settled) return;
-          proc.kill("SIGTERM");
-          settled = true;
-          resolve(resolveFromHelp());
-        }, YT_DLP_HELP_PROBE_TIMEOUT_MS);
-        timeout.unref?.();
-        const settle = () => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          resolve(resolveFromHelp());
-        };
-
-        // ytDlpPath is either explicitly configured by the operator or selected
-        // from enumerated PATH entries and fixed executable names above.
-        // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-        const proc = spawn(ytDlpPath, ["--help"], {
-          env: getYtDlpSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-
-        proc.stdout?.on("data", (data: Buffer) => {
-          helpText += data.toString();
-        });
-
-        proc.stderr?.on("data", (data: Buffer) => {
-          helpText += data.toString();
-        });
-
-        proc.on("close", () => {
-          settle();
-        });
-
-        proc.on("error", () => {
-          settle();
-        });
-      });
-      if (!resolvedFlag) {
-        jsRuntimeFlagPromise = null;
-      }
-      return resolvedFlag;
-    } catch {
-      jsRuntimeFlagPromise = null;
-      warnRuntimeOnce(
-        "js-runtime-flag-unsupported",
-        "[yt-dlp] Current yt-dlp binary does not support --js-runtimes. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
-      );
-      return null;
     }
-  })();
-
-  return jsRuntimeFlagPromise;
+    return capabilities.jsRuntimeFlag;
+  } catch {
+    warnRuntimeOnce(
+      "js-runtime-flag-unsupported",
+      "[yt-dlp] Current yt-dlp binary does not support --js-runtimes. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
+    );
+    return null;
+  }
 }
 
-export async function ytDlpSupportsRemoteComponents(): Promise<boolean> {
-  if (remoteComponentsSupportPromise) {
-    return remoteComponentsSupportPromise;
-  }
-
-  remoteComponentsSupportPromise = (async () => {
-    let helpText = "";
-    const resolveFromHelp = (): boolean => {
-      if (helpText.includes("--remote-components")) {
-        return true;
-      }
-
+export async function ytDlpSupportsRemoteComponents(
+  release: YtDlpRelease
+): Promise<boolean> {
+  try {
+    const capabilities = await release.capabilities;
+    if (!capabilities.supportsRemoteComponents) {
       warnRuntimeOnce(
         "remote-components-unsupported",
         "[yt-dlp] Current yt-dlp binary does not support --remote-components. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
       );
-      return false;
-    };
-
-    try {
-      const ytDlpPath = await resolveYtDlpPath();
-      const supported = await new Promise<boolean>((resolve) => {
-        let settled = false;
-        const timeout = setTimeout(() => {
-          if (settled) return;
-          proc.kill("SIGTERM");
-          settled = true;
-          resolve(resolveFromHelp());
-        }, YT_DLP_HELP_PROBE_TIMEOUT_MS);
-        timeout.unref?.();
-        const settle = () => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          resolve(resolveFromHelp());
-        };
-
-        // ytDlpPath is either explicitly configured by the operator or selected
-        // from enumerated PATH entries and fixed executable names above.
-        // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
-        const proc = spawn(ytDlpPath, ["--help"], {
-          env: getYtDlpSpawnEnv(),
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-
-        proc.stdout?.on("data", (data: Buffer) => {
-          helpText += data.toString();
-        });
-
-        proc.stderr?.on("data", (data: Buffer) => {
-          helpText += data.toString();
-        });
-
-        proc.on("close", () => {
-          settle();
-        });
-
-        proc.on("error", () => {
-          settle();
-        });
-      });
-      if (!supported) {
-        remoteComponentsSupportPromise = null;
-      }
-      return supported;
-    } catch {
-      remoteComponentsSupportPromise = null;
-      warnRuntimeOnce(
-        "remote-components-unsupported",
-        "[yt-dlp] Current yt-dlp binary does not support --remote-components. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
-      );
-      return false;
     }
-  })();
-
-  return remoteComponentsSupportPromise;
+    return capabilities.supportsRemoteComponents;
+  } catch {
+    warnRuntimeOnce(
+      "remote-components-unsupported",
+      "[yt-dlp] Current yt-dlp binary does not support --remote-components. Continuing without it. Upgrade yt-dlp or set YT_DLP_PATH to a newer binary if YouTube extraction becomes unreliable."
+    );
+    return false;
+  }
 }
 
 async function getYouTubeJsRuntime(): Promise<"node" | "deno"> {
@@ -323,12 +148,13 @@ async function getYouTubeJsRuntime(): Promise<"node" | "deno"> {
 
 export async function appendYouTubeJsRuntimeArg(
   args: string[],
-  url: string
+  url: string,
+  release: YtDlpRelease
 ): Promise<void> {
   if (!isYouTubeUrl(url)) {
     return;
   }
-  const runtimeFlag = await getYouTubeJsRuntimeFlag();
+  const runtimeFlag = await getYouTubeJsRuntimeFlag(release);
   if (!runtimeFlag) {
     return;
   }
@@ -336,17 +162,15 @@ export async function appendYouTubeJsRuntimeArg(
 }
 
 export function resetJsRuntimeFlag(): void {
-  jsRuntimeFlagPromise = null;
+  resetCapabilityCacheForTests();
 }
 
 export function resetRemoteComponentsSupport(): void {
-  remoteComponentsSupportPromise = null;
+  resetCapabilityCacheForTests();
 }
 
 export function resetRuntimeCaches(): void {
   denoAvailablePromise = null;
-  jsRuntimeFlagPromise = null;
-  remoteComponentsSupportPromise = null;
-  impersonateSupportPromise = null;
   runtimeWarningCache.clear();
+  resetCapabilityCacheForTests();
 }

--- a/backend/src/utils/ytdlp/versionProbe.ts
+++ b/backend/src/utils/ytdlp/versionProbe.ts
@@ -49,6 +49,38 @@ function isYtDlpReleaseStale(releaseTimestamp: number | null): boolean {
   return Date.now() - releaseTimestamp > staleAfterMs;
 }
 
+/**
+ * Release acquisition happens once per logical operation, so an uncached
+ * `--version` probe would add a child process to every download, metadata
+ * lookup and avatar fetch on the external-fallback path. Only successful
+ * probes are memoized, and only for the fallback fingerprint: the status
+ * endpoint keeps probing directly so operators never read a stale version.
+ */
+const externalVersionInfoCache = new Map<string, Promise<YtDlpVersionInfo>>();
+
+export function resetYtDlpVersionInfoCache(): void {
+  externalVersionInfoCache.clear();
+}
+
+export function getCachedYtDlpVersionInfo(
+  ytDlpPath: string
+): Promise<YtDlpVersionInfo> {
+  const cached = externalVersionInfoCache.get(ytDlpPath);
+  if (cached) {
+    return cached;
+  }
+  const pending = getYtDlpVersionInfo(ytDlpPath).then((info) => {
+    // A failed probe describes a transient condition (missing binary, bad
+    // permissions) that an install or a fix should clear immediately.
+    if (!info.canRun) {
+      externalVersionInfoCache.delete(ytDlpPath);
+    }
+    return info;
+  });
+  externalVersionInfoCache.set(ytDlpPath, pending);
+  return pending;
+}
+
 export async function getYtDlpVersionInfo(
   ytDlpPath: string
 ): Promise<YtDlpVersionInfo> {

--- a/backend/src/utils/ytdlp/versionStamp.ts
+++ b/backend/src/utils/ytdlp/versionStamp.ts
@@ -1,0 +1,41 @@
+/**
+ * Parse a yt-dlp release date out of a version string. Accepts both the
+ * zero-padded form the binary prints ("2026.08.19") and the PyPI form
+ * ("2026.8.19"). Returns null for nightly/unknown formats.
+ */
+export function parseYtDlpReleaseTimestamp(
+  version: string | null | undefined
+): number | null {
+  if (!version) {
+    return null;
+  }
+
+  const match = version.trim().match(/^(\d{4})\.(\d{1,2})\.(\d{1,2})/);
+  if (!match) {
+    return null;
+  }
+
+  const timestamp = Date.UTC(
+    Number(match[1]),
+    Number(match[2]) - 1,
+    Number(match[3])
+  );
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+/**
+ * Compare an installed version against the latest published one. Unknown or
+ * unparsable versions never claim an update is available, so the UI stays quiet
+ * instead of nagging about a version it cannot reason about.
+ */
+export function isYtDlpUpdateAvailable(
+  installedVersion: string | null,
+  latestVersion: string | null
+): boolean {
+  const installed = parseYtDlpReleaseTimestamp(installedVersion);
+  const latest = parseYtDlpReleaseTimestamp(latestVersion);
+  if (installed === null || latest === null) {
+    return false;
+  }
+  return latest > installed;
+}

--- a/documents/en/docker-guide.md
+++ b/documents/en/docker-guide.md
@@ -191,61 +191,65 @@ Example backend volume section:
 ### Updating yt-dlp without rebuilding
 
 Settings -> yt-dlp Configuration shows the yt-dlp version the backend actually
-runs and, on `container` admin trust, offers an **Update yt-dlp** button. This
-runs `pip install -U` inside the running container, so a broken extractor can be
-fixed without waiting for a new image.
+runs and, on `container` admin trust, offers an **Update yt-dlp** button.
 
-**The update persists.** It is a `pip --user` install into `$HOME`, which the
-entrypoint points at `/app/data/.home` — part of the `/app/data` volume above.
-The runtime install therefore survives `docker compose down && up`, container
-recreation, and image upgrades, and the backend keeps preferring it over the
-version pinned in the image because it is the newer release.
+Runtime updates no longer run `pip install -U` against the image Python
+environment or a `--user` site. MyTube installs each update into a new
+immutable directory under `/app/data/ytdlp/releases/` and only then atomically
+replaces `/app/data/ytdlp/current.json`. Downloads that already started keep
+using their original release; new jobs pick up the published one.
 
-That also means **recreating from an older image is not a rollback.** To go back
-to the version pinned in the image, delete the complete runtime Python user
-installation, then restart or recreate the service as described below. Removing
-only the `yt-dlp` executable is not enough: the update also installs
-release-coupled packages such as `yt-dlp-ejs` and
-`curl-cffi`, and those user-site packages would continue to shadow the versions
-from the image.
+The managed store lives on the `/app/data` volume, so it survives
+`docker compose down && up`, container recreation, and image upgrades.
 
-For the default two-container stack (`backend` service):
+Each release is a self-contained package directory of roughly 50-100 MB. MyTube
+keeps the current release plus the two before it so a rollback is always
+possible, and deletes older ones automatically once no download is still using
+them. Budget a few hundred MB under `/app/data/ytdlp` on a long-lived install.
 
-```bash
-docker compose exec backend sh -c 'rm -rf /app/data/.home/.local'
-```
+For a managed release, the path shown in Settings is the Python interpreter
+MyTube runs (`<python> -m yt_dlp`), not a `yt-dlp` executable. That is expected:
+the release is a package directory, not a standalone binary. When `YT_DLP_PATH`
+is set, or when no managed release exists yet, Settings shows that executable
+instead.
 
-For the supplied single-container stack (`mytube` service):
+**Recreating from an older image is not a rollback.** `current.json` still
+points at the last published managed release. To return to the image-pinned
+binary:
 
-```bash
-docker compose -f stacks/docker-compose.single-container.yml exec mytube sh -c 'rm -rf /app/data/.home/.local'
-```
-
-The dedicated `.local` tree contains packages and scripts installed by the
-runtime updater; removing it does not remove the database or media under
-`/app/data` and `/app/uploads`. If you deliberately installed other Python user
-packages into this container, they are removed as well. After completing the
-restart or recreation step below, re-check the version in Settings.
-
-If the image-pinned yt-dlp is more than 90 days old, removing `.local` alone is
-only temporary: on the first yt-dlp use after restart, MyTube's stale-version
-check automatically installs a current release into `.local` again. To keep an
-older image version pinned, add the image binary's absolute path to the service
-environment **before running the cleanup command above**:
+1. Pin the image binary **before** deleting the store:
 
 ```yaml
 environment:
   - YT_DLP_PATH=/usr/local/bin/yt-dlp
 ```
 
-Use the image-binary path that Settings showed before the runtime update if it
-differs from the Docker default above. An absolute `YT_DLP_PATH` marks the binary
-as operator-managed: it disables both stale-version auto-upgrades and the
-**Update yt-dlp** button. Setting `YT_DLP_PATH=yt-dlp` is not a hard pin because
-that literal value is treated as the default PATH-based configuration.
+An absolute `YT_DLP_PATH` is treated as operator-managed: MyTube will not
+auto-upgrade it and the **Update yt-dlp** button stays disabled.
+`YT_DLP_PATH=yt-dlp` is not a hard pin.
 
-After adding the variable and deleting `.local` with the appropriate command
-above, recreate the service so Compose applies the changed environment (a plain
+2. Stop the service, then delete the managed store (this does not delete the
+database or media):
+
+Deleting the store from inside a *running* backend removes yt-dlp modules that
+a download in progress may still be using, and a request arriving in the gap can
+recreate the store before the pinned `YT_DLP_PATH` takes effect. Stop first:
+
+For the default two-container stack (`backend` service):
+
+```bash
+docker compose stop backend
+docker compose run --rm --no-deps --entrypoint sh backend -c 'rm -rf /app/data/ytdlp'
+```
+
+For the supplied single-container stack (`mytube` service):
+
+```bash
+docker compose -f stacks/docker-compose.single-container.yml stop mytube
+docker compose -f stacks/docker-compose.single-container.yml run --rm --no-deps --entrypoint sh mytube -c 'rm -rf /app/data/ytdlp'
+```
+
+3. Recreate the service so Compose applies the new environment (a plain
 `restart` does not apply Compose configuration changes):
 
 ```bash
@@ -256,15 +260,18 @@ docker compose up -d --force-recreate backend
 docker compose -f stacks/docker-compose.single-container.yml up -d --force-recreate mytube
 ```
 
-If the image version is recent enough that no hard pin is needed, restart the
-corresponding service after deleting `.local`:
+If you only want to drop a managed update and let MyTube rebuild a store from
+PATH/image discovery (including stale auto-install), omit `YT_DLP_PATH` and
+restart after deleting `/app/data/ytdlp`.
+
+A leftover `/app/data/.home/.local` tree from older MyTube versions is unused
+once a managed release is published (`PYTHONNOUSERSITE=1`). You may delete it
+to reclaim disk, with the service stopped for the same reason as above:
 
 ```bash
-# Default two-container stack
-docker compose restart backend
-
-# Supplied single-container stack
-docker compose -f stacks/docker-compose.single-container.yml restart mytube
+docker compose stop backend
+docker compose run --rm --no-deps --entrypoint sh backend -c 'rm -rf /app/data/.home/.local'
+docker compose up -d backend
 ```
 
 The bundled bgutil POT provider is not part of this update. Its Python plugin is

--- a/documents/zh/docker-guide.md
+++ b/documents/zh/docker-guide.md
@@ -189,51 +189,59 @@ services:
 ### 不重建镜像更新 yt-dlp
 
 设置 -> yt-dlp 配置中会显示后端实际使用的 yt-dlp 版本；在 `container` 管理员信任级别下，
-还会提供 **更新 yt-dlp** 按钮。该操作在运行中的容器内执行 `pip install -U`，因此遇到
-提取器失效时无需等待新镜像即可修复。
+还会提供 **更新 yt-dlp** 按钮。
 
-**该更新会被持久化。** 它是一次 `pip --user` 安装，装到 `$HOME`，而入口脚本把 `$HOME`
-指向 `/app/data/.home` —— 属于上面的 `/app/data` 卷。因此运行时安装的版本会在
-`docker compose down && up`、容器重建、镜像升级之后继续存在；由于它是更新的发行版本，
-后端也会继续优先使用它，而不是镜像中固定的版本。
+运行时更新不再对镜像内的 Python 环境或 `--user` 用户目录执行 `pip install -U`。
+MyTube 会把每一次更新安装到 `/app/data/ytdlp/releases/` 下的新不可变目录，
+校验成功后再原子替换 `/app/data/ytdlp/current.json`。已经开始的下载继续使用
+原来的 release；新任务才会用上刚发布的版本。
 
-这同时意味着**回退到旧镜像并不能回退 yt-dlp**。要恢复为镜像中固定的版本，需要删除完整的
-运行时 Python 用户安装，然后按照下文说明重启或重建服务。只删除 `yt-dlp` 可执行文件并不够：
-更新操作还会安装 `yt-dlp-ejs`、`curl-cffi` 等与发行版耦合的包；如果保留这些用户级包，
-它们仍会覆盖镜像中的固定版本。
+该托管目录位于 `/app/data` 卷上，因此会在 `docker compose down && up`、容器重建
+和镜像升级后继续存在。
 
-对于默认的双容器 stack（服务名为 `backend`）：
+每个 release 都是一个自包含的软件包目录，约占 50-100 MB。MyTube 会保留当前
+release 以及之前的两个版本以便随时回退，并在确认没有下载仍在使用后自动删除更旧
+的版本。长期运行的部署请为 `/app/data/ytdlp` 预留数百 MB 空间。
 
-```bash
-docker compose exec backend sh -c 'rm -rf /app/data/.home/.local'
-```
+对于托管 release，设置页显示的路径是 MyTube 实际调用的 Python 解释器
+（`<python> -m yt_dlp`），而不是 `yt-dlp` 可执行文件——因为 release 是一个软件包
+目录而非独立二进制。当设置了 `YT_DLP_PATH`，或尚未创建任何托管 release 时，
+设置页显示的仍是对应的可执行文件路径。
 
-对于仓库提供的单容器 stack（服务名为 `mytube`）：
+**回退到旧镜像并不能回退 yt-dlp。** `current.json` 仍指向最后一次发布的托管
+release。若要恢复为镜像中固定的二进制：
 
-```bash
-docker compose -f stacks/docker-compose.single-container.yml exec mytube sh -c 'rm -rf /app/data/.home/.local'
-```
-
-专用的 `.local` 目录保存运行时更新器安装的包和脚本；删除它不会删除 `/app/data` 中的数据库，
-也不会删除 `/app/uploads` 中的媒体。如果你曾主动在该容器的 Python 用户环境中安装其他包，
-这些包也会一并删除。完成下文的重启或重建步骤后，请在设置中重新查看版本。
-
-如果镜像固定的 yt-dlp 已超过 90 天，仅删除 `.local` 只能暂时回退：重启后首次使用 yt-dlp
-时，MyTube 的旧版本检查会再次把当前发行版自动安装到 `.local`。若要持续固定旧镜像中的
-版本，请在执行上面的清理命令**之前**，把镜像内可执行文件的绝对路径加入服务环境变量：
+1. 在删除托管目录**之前**固定镜像内路径：
 
 ```yaml
 environment:
   - YT_DLP_PATH=/usr/local/bin/yt-dlp
 ```
 
-如果运行时更新前设置页面显示的镜像路径与上述 Docker 默认值不同，请使用页面原先显示的
-路径。绝对路径形式的 `YT_DLP_PATH` 会把该可执行文件标记为由部署者管理，同时禁用旧版本
-自动升级和 **更新 yt-dlp** 按钮。`YT_DLP_PATH=yt-dlp` 不能实现硬固定，因为代码会把这个
-字面值视为默认的 PATH 查找配置。
+绝对路径形式的 `YT_DLP_PATH` 会把该可执行文件标记为由部署者管理，同时禁用自动
+升级和 **更新 yt-dlp** 按钮。`YT_DLP_PATH=yt-dlp` 不能实现硬固定。
 
-添加环境变量并使用上面的对应命令删除 `.local` 后，需要重新创建服务，让 Compose 应用新的
-环境变量（仅执行 `restart` 不会应用 Compose 配置变更）：
+2. 先停止服务，再删除托管目录（不会删除数据库或媒体）：
+
+在**运行中**的后端里删除托管目录，会把正在进行的下载仍在使用的 yt-dlp 模块直接删掉；
+而且在停机窗口内到达的请求可能会在新的 `YT_DLP_PATH` 生效前重新创建该目录。请先停止服务：
+
+对于默认的双容器 stack（服务名为 `backend`）：
+
+```bash
+docker compose stop backend
+docker compose run --rm --no-deps --entrypoint sh backend -c 'rm -rf /app/data/ytdlp'
+```
+
+对于仓库提供的单容器 stack（服务名为 `mytube`）：
+
+```bash
+docker compose -f stacks/docker-compose.single-container.yml stop mytube
+docker compose -f stacks/docker-compose.single-container.yml run --rm --no-deps --entrypoint sh mytube -c 'rm -rf /app/data/ytdlp'
+```
+
+3. 重新创建服务，让 Compose 应用新的环境变量（仅执行 `restart` 不会应用
+Compose 配置变更）：
 
 ```bash
 # 默认双容器 stack
@@ -243,14 +251,16 @@ docker compose up -d --force-recreate backend
 docker compose -f stacks/docker-compose.single-container.yml up -d --force-recreate mytube
 ```
 
-如果镜像版本足够新，不需要硬固定，请在删除 `.local` 后重启对应服务：
+如果只想丢掉托管更新、让 MyTube 重新从 PATH/镜像发现（含过期自动安装），不要设置
+`YT_DLP_PATH`，删除 `/app/data/ytdlp` 后重启即可。
+
+旧版留下的 `/app/data/.home/.local` 在托管 release 发布后不会再被使用
+（`PYTHONNOUSERSITE=1`）。如需回收磁盘可以删除：
 
 ```bash
-# 默认双容器 stack
-docker compose restart backend
-
-# 仓库提供的单容器 stack
-docker compose -f stacks/docker-compose.single-container.yml restart mytube
+docker compose stop backend
+docker compose run --rm --no-deps --entrypoint sh backend -c 'rm -rf /app/data/.home/.local'
+docker compose up -d backend
 ```
 
 内置的 bgutil POT provider 不在此次更新范围内：它的 Python 插件会优先于任何 pip 副本从


### PR DESCRIPTION
## Why

`master` updates yt-dlp with `pip install -U` in the same Python environment downloads run from. #418 serialized pip writers, which stops pip racing pip — but it does not make *readers* safe. A download can still start while the console script is being replaced, or lazily import a module while pip is rewriting it.

A bounded reader/writer gate was explored in #419 and rejected: waiting indefinitely lets a long download block an operator-requested fix, timing out updates files underneath that download, and killing the download turns a possible failure into a certain one.

Implements [`reports/ytdlp-update-execution-gate-design-2026-08-23.md`](reports/ytdlp-update-execution-gate-design-2026-08-23.md). Closes #416.

## What changes

**Immutable releases, atomic publication.** Each update installs into a fresh `data/ytdlp/staging/<op>` via `pip --target`, is validated there, then renamed into `releases/<id>` and never written to again. Publication swaps a small `current.json` with a single atomic rename under a filesystem lock, with a monotonic `generation` and a nonce ownership recheck so a suspended publisher cannot overwrite a newer release. It never emulates replacement as unlink-then-rename.

**Validation before publication.** Version, `--help`, and impersonation probes, plus a module-origin probe that asserts `yt_dlp` (and `curl_cffi` / `yt_dlp_ejs`) resolve *inside* the candidate rather than from an ambient install. A failed candidate cannot become current.

**One snapshot per operation.** A logical operation acquires one immutable `YtDlpRelease` and keeps it across retries. Its command, spawn environment and capabilities all belong to that release, so a job can never combine one release's capabilities with another's executable. Capabilities are cached per `releaseId`, distinguishing a definitive "no" (cached for the release's lifetime) from a probe that never completed (evicted so a later acquisition retries).

**Leases and conservative GC.** A lease pins a release directory while any child of the operation is running, using a two-phase deleting-marker protocol. GC keeps current plus two rollbacks, skips anything leased, and never touches a release younger than the retention age — so a candidate between finalize and publish cannot be collected out from under its publisher.

**Centralized execution.** All yt-dlp process creation goes through `spawnYtDlp` / `withYtDlpRelease`, enforced by an AST rule that counts process-creation calls per module (so a *second* spawn added to an already-allowed file fails, not just a new file). This includes `MissAVDownloader`, which previously spawned `YT_DLP_PATH` directly — its impersonation probe and its spawn could already disagree on `master`.

**Environment.** Managed releases run `<python> -m yt_dlp` with `PYTHONPATH` **replaced** (not extended) and `PYTHONNOUSERSITE=1`, so an operator `PYTHONPATH` or a legacy `--user` install cannot shadow release modules. External releases keep `master`'s prepend behaviour unchanged.

## Compatibility

Not a breaking change:

- First boot after upgrading is identical to `master` — with no store present, resolution falls through to `YT_DLP_PATH`, the image-pinned binary, then PATH/legacy discovery. The store is created lazily on the first install, never eagerly at startup.
- A store that cannot be read (unwritable, corrupt, unexpected content) logs a warning and degrades to fallback discovery. It never prevents the backend from serving.
- A legacy `/app/data/.home/.local` install is never modified or deleted.
- Downgrading is safe: older versions ignore `data/ytdlp/` entirely.

Visible but non-breaking: `status.path` reports the Python interpreter for a managed release, MissAV resolves through the release API, and the store uses ~50–100 MB per retained release. Both Docker guides are updated for persistence, rollback, legacy cleanup and disk usage.

**Behaviour fix:** re-running the update when already on the newest release now reports `changed: false` instead of returning 500.

`YT_DLP_PATH` remains operator-managed: never overwritten, `updateSupported: false`, update endpoint still 409s with `ytDlpUpdateCustomPath`. The controller contract, the `checkLatest` PyPI lookup and the in-flight update dedup are unchanged.

## Testing

2923 backend tests pass. New coverage, mapped to the design's §16:

| Suite | Covers |
|---|---|
| `ytdlpManagedRelease` | manifest/path-containment validation, publication policy, atomic replacement (incl. replacing while a reader holds `current.json` open), env semantics, command construction, leases/GC retention, store recovery |
| `ytdlpReleaseConcurrency` | a task paused between capability resolution and spawn stays on its release **and its flags**; lease survives a publication + GC; 24 concurrent readers each see exactly one complete release; two publishers cannot regress current; reader-vs-GC marker races |
| `ytdlpReleaseFailureInjection` | failure injected before pip, after pip, after validation, after finalization, before and after the `current.json` rename — each asserting a reader still gets a *complete* release, never a partial candidate; corrupt-manifest lineage recovery; staging age threshold |
| `ytdlpReleaseValidation` | module-origin wiring, and the shipped Python script run against a real interpreter (accepts an in-target import, rejects one shadowed by an ambient install) |
| `ytdlpReleaseIntegration` | first install + execute, legacy install untouched, operator update rewrites only `current.json`, same-version no-op, MissAV probe/spawn agreement, same-operation retry stays on its snapshot while a new call picks up the newer release, plus the three §10.5 data-directory states |
| `ytdlpSpawnBoundary` | AST-based spawn boundary |

Each new invariant was verified by deliberately breaking the implementation and confirming the test goes red.

**CI:** adds a `ytdlp-release-store` job on ubuntu / macOS / windows running the six release suites. Atomic replacement (MoveFileEx sharing violations), lease and GC marker handling, and `PYTHONPATH` delimiters all differ on Windows; the full backend suite stays on Linux.

## Review notes

- `versionProbe.ts` and `runtime.ts` keep direct `spawn` calls by design — the former bootstraps discovery before any release exists, the latter probes Deno, which MyTube does not update at runtime. Both are budgeted explicitly in the boundary rule.
- The `.gitignore` change ignores the Codacy CLI's auto-generated local config snapshots.
