### PR TITLE
fix(ytdlp): stop trash sweeping in-flight retirements and freeing claimed generations

### DIFF
--- a/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
+++ b/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
@@ -970,6 +970,99 @@ describe("managed yt-dlp release store", () => {
     });
   });
 
+  describe("in-flight retirement", () => {
+    it("does not sweep a retirement that still holds its marker", async () => {
+      // Between the retirement rename and the lease re-check that may put the
+      // release back, it sits in the trash. A concurrent sweep would make that
+      // restoration impossible and leave a leaseholder on removed modules.
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const release = seedRelease(storeRoot, { version: "2026.08.19" });
+      const token = beginGcMarker(release.releaseId);
+      expect(token).not.toBeNull();
+
+      const inFlight = path.join(
+        layout.trashDir,
+        `${release.releaseId}.${token}`
+      );
+      fs.mkdirSync(inFlight, { recursive: true });
+      // A retirement whose collector is gone: no live marker for this token.
+      const abandoned = path.join(
+        layout.trashDir,
+        `${release.releaseId}.0123456789abcdef`
+      );
+      fs.mkdirSync(abandoned, { recursive: true });
+
+      await collectGarbage();
+
+      expect(fs.existsSync(inFlight)).toBe(true);
+      expect(fs.existsSync(abandoned)).toBe(false);
+
+      // Once the collector is done, its entry is swept like any other.
+      abortGcMarker(release.releaseId, token as string);
+      await collectGarbage();
+      expect(fs.existsSync(inFlight)).toBe(false);
+    });
+  });
+
+  describe("reclaiming an abandoned generation", () => {
+    it("keeps the generation claimed when the abandoned record survives", async () => {
+      // Same rule as the immediate-failure path: never free a generation while
+      // a release still records it.
+      const base = seedRelease(storeRoot, { version: "2026.07.01" });
+      const abandoned = seedRelease(storeRoot, { version: "2026.08.19" });
+      const next = seedRelease(storeRoot, { version: "2026.08.20" });
+      writeCurrentManifest(storeRoot, {
+        schemaVersion: 1,
+        generation: 1,
+        releaseId: base.releaseId,
+        previousReleaseId: null,
+        publishedAt: new Date().toISOString(),
+      });
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      writePublishedManifest(storeRoot, {
+        schemaVersion: 1,
+        releaseId: abandoned.releaseId,
+        generation: 2,
+        previousReleaseId: base.releaseId,
+        publishedAt: new Date().toISOString(),
+      });
+      const claimPath = path.join(layout.generationsDir, "2.json");
+      writeJsonExclusive(claimPath, {
+        releaseId: abandoned.releaseId,
+        claimedAt: new Date().toISOString(),
+        token: "d".repeat(32),
+      });
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(claimPath, longAgo, longAgo);
+
+      const unlinkSpy = vi
+        .spyOn(fsExtra, "unlinkSync")
+        .mockImplementation((target: fsExtra.PathLike) => {
+          if (String(target).endsWith("published.json")) {
+            throw Object.assign(new Error("sharing violation"), {
+              code: "EPERM",
+            });
+          }
+          return undefined as never;
+        });
+      try {
+        await expect(
+          publishValidatedRelease({
+            releaseId: next.releaseId,
+            version: "2026.08.20",
+            generationAtInstallStart: 1,
+          })
+        ).rejects.toThrow(/claimed by another publisher/);
+      } finally {
+        unlinkSpy.mockRestore();
+      }
+
+      // The generation is still claimed, so nothing else can reuse it while a
+      // release still records it.
+      expect(fs.existsSync(claimPath)).toBe(true);
+    });
+  });
+
   describe("repairing a broken release", () => {
     it("publishes a same-version candidate when the current release is unusable", () => {
       // pip keeps producing the same latest version, so a repair would be

--- a/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
+++ b/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
@@ -985,6 +985,18 @@ describe("managed yt-dlp release store", () => {
         `${release.releaseId}.${token}`
       );
       fs.mkdirSync(inFlight, { recursive: true });
+      // Reader blocking may expire, but a collector can be suspended beyond
+      // that window and still resume to restore this retirement.
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(
+        path.join(
+          layout.gcMarkersDir,
+          `${release.releaseId}.deleting`,
+          `${token}.json`
+        ),
+        longAgo,
+        longAgo
+      );
       // A retirement whose collector is gone: no live marker for this token.
       const abandoned = path.join(
         layout.trashDir,
@@ -1035,10 +1047,26 @@ describe("managed yt-dlp release store", () => {
       const longAgo = new Date(Date.now() - 10 * 60 * 1000);
       fs.utimesSync(claimPath, longAgo, longAgo);
 
+      let claimOccupiedDuringRemoval = false;
+      let contenderBlockedDuringRemoval = false;
       const unlinkSpy = vi
         .spyOn(fsExtra, "unlinkSync")
         .mockImplementation((target: fsExtra.PathLike) => {
           if (String(target).endsWith("published.json")) {
+            // Rollback must never vacate the canonical claim while it is still
+            // possible for the publication record removal to fail.
+            claimOccupiedDuringRemoval = fs.existsSync(claimPath);
+            try {
+              writeJsonExclusive(claimPath, {
+                releaseId: next.releaseId,
+                claimedAt: new Date().toISOString(),
+                token: "e".repeat(32),
+              });
+              fs.rmSync(claimPath, { force: true });
+            } catch (error: unknown) {
+              contenderBlockedDuringRemoval =
+                (error as NodeJS.ErrnoException).code === "EEXIST";
+            }
             throw Object.assign(new Error("sharing violation"), {
               code: "EPERM",
             });
@@ -1059,6 +1087,8 @@ describe("managed yt-dlp release store", () => {
 
       // The generation is still claimed, so nothing else can reuse it while a
       // release still records it.
+      expect(claimOccupiedDuringRemoval).toBe(true);
+      expect(contenderBlockedDuringRemoval).toBe(true);
       expect(fs.existsSync(claimPath)).toBe(true);
     });
   });

--- a/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
+++ b/backend/src/__tests__/utils/ytdlpManagedRelease.test.ts
@@ -971,7 +971,7 @@ describe("managed yt-dlp release store", () => {
   });
 
   describe("in-flight retirement", () => {
-    it("does not sweep a retirement that still holds its marker", async () => {
+    it("restores a stale retirement for a reader that leased before the rename", async () => {
       // Between the retirement rename and the lease re-check that may put the
       // release back, it sits in the trash. A concurrent sweep would make that
       // restoration impossible and leave a leaseholder on removed modules.
@@ -984,7 +984,20 @@ describe("managed yt-dlp release store", () => {
         layout.trashDir,
         `${release.releaseId}.${token}`
       );
-      fs.mkdirSync(inFlight, { recursive: true });
+      fs.renameSync(getReleaseDir(layout, release.releaseId), inFlight);
+      const leaseDir = path.join(layout.leasesDir, release.releaseId);
+      fs.mkdirSync(leaseDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(leaseDir, "4242-aabbccddeeff-0123456789abcdef.json"),
+        JSON.stringify({
+          schemaVersion: 1,
+          releaseId: release.releaseId,
+          instanceId: "4242-aabbccddeeff",
+          pid: 4242,
+          operationId: "op-0123456789abcdef",
+          createdAt: new Date().toISOString(),
+        })
+      );
       // Reader blocking may expire, but a collector can be suspended beyond
       // that window and still resume to restore this retirement.
       const longAgo = new Date(Date.now() - 10 * 60 * 1000);
@@ -997,22 +1010,45 @@ describe("managed yt-dlp release store", () => {
         longAgo,
         longAgo
       );
-      // A retirement whose collector is gone: no live marker for this token.
-      const abandoned = path.join(
-        layout.trashDir,
-        `${release.releaseId}.0123456789abcdef`
-      );
-      fs.mkdirSync(abandoned, { recursive: true });
 
       await collectGarbage();
 
-      expect(fs.existsSync(inFlight)).toBe(true);
-      expect(fs.existsSync(abandoned)).toBe(false);
-
-      // Once the collector is done, its entry is swept like any other.
-      abortGcMarker(release.releaseId, token as string);
-      await collectGarbage();
       expect(fs.existsSync(inFlight)).toBe(false);
+      expect(fs.existsSync(getReleaseDir(layout, release.releaseId))).toBe(true);
+      expect(
+        fs.existsSync(
+          path.join(
+            layout.gcMarkersDir,
+            `${release.releaseId}.deleting`,
+            `${token}.json`
+          )
+        )
+      ).toBe(false);
+    });
+
+    it("reclaims a stale retirement left by a dead collector", async () => {
+      const layout = ensureManagedStoreLayout(getManagedStoreLayout(storeRoot));
+      const release = seedRelease(storeRoot, { version: "2026.08.19" });
+      const token = beginGcMarker(release.releaseId);
+      expect(token).not.toBeNull();
+
+      const inFlight = path.join(
+        layout.trashDir,
+        `${release.releaseId}.${token}`
+      );
+      fs.renameSync(getReleaseDir(layout, release.releaseId), inFlight);
+      const markerPath = path.join(
+        layout.gcMarkersDir,
+        `${release.releaseId}.deleting`,
+        `${token}.json`
+      );
+      const longAgo = new Date(Date.now() - 10 * 60 * 1000);
+      fs.utimesSync(markerPath, longAgo, longAgo);
+
+      await collectGarbage();
+
+      expect(fs.existsSync(inFlight)).toBe(false);
+      expect(fs.existsSync(markerPath)).toBe(false);
     });
   });
 

--- a/backend/src/utils/ytdlp/release/gc.ts
+++ b/backend/src/utils/ytdlp/release/gc.ts
@@ -13,8 +13,8 @@ import { isValidOperationId, isValidReleaseId } from "./ids";
 import {
   abortGcMarker,
   beginGcMarker,
+  getGcMarkerTokenState,
   getInstanceId,
-  hasGcMarkerToken,
   hasLeases,
   readLeaseRecords,
 } from "./leases";
@@ -269,18 +269,22 @@ function reportStaleLeases(releaseId: string): void {
   }
 }
 
+type RetirementEntry = { releaseId: string; token: string };
+
 /** Trash entries are named `<releaseId>.<collector token>`. */
-function isRetirementInFlight(trashEntryName: string): boolean {
+function parseRetirementEntry(
+  trashEntryName: string
+): RetirementEntry | null {
   const separator = trashEntryName.lastIndexOf(".");
   if (separator <= 0) {
-    return false;
+    return null;
   }
   const releaseId = trashEntryName.slice(0, separator);
   const token = trashEntryName.slice(separator + 1);
   if (!isValidReleaseId(releaseId)) {
-    return false;
+    return null;
   }
-  return hasGcMarkerToken(releaseId, token);
+  return { releaseId, token };
 }
 
 /**
@@ -293,16 +297,53 @@ async function emptyTrash(layout: ManagedStoreLayout): Promise<void> {
     return;
   }
   for (const name of listSafeDirNames(layout.trashDir, layout.root)) {
+    const trashPath = path.join(layout.trashDir, name);
+    const retirement = parseRetirementEntry(name);
     // A retirement in flight has its release sitting here between the rename
     // and the lease re-check that may put it back. Deleting it then would make
     // that restoration impossible and leave a reader that legitimately leased
-    // the release running against removed modules. The owning collector still
-    // holds its marker until the retirement is settled, so that is the signal.
-    if (isRetirementInFlight(name)) {
-      continue;
+    // the release running against removed modules.
+    if (retirement) {
+      const markerState = getGcMarkerTokenState(
+        retirement.releaseId,
+        retirement.token
+      );
+      if (markerState === "live") {
+        continue;
+      }
+      if (markerState === "stale") {
+        // Settle a collector that died or was suspended past the stale window.
+        // A lease could only have been written before the rename, so restore
+        // for that reader; without one the unreachable release is safe to
+        // delete. Keep the marker until either operation succeeds so another
+        // sweep cannot race a failed restoration.
+        if (hasLeases(retirement.releaseId)) {
+          try {
+            renameInRoot(
+              trashPath,
+              getReleaseDir(layout, retirement.releaseId),
+              layout.root
+            );
+            abortGcMarker(retirement.releaseId, retirement.token);
+            logger.info(
+              `[yt-dlp] Restored stale retirement ${retirement.releaseId} for an existing lease`
+            );
+          } catch {
+            // Retried by the next collection while the marker still protects it.
+          }
+          continue;
+        }
+        try {
+          await removeSafe(trashPath, layout.root);
+          abortGcMarker(retirement.releaseId, retirement.token);
+        } catch {
+          // Retried by the next collection while the marker still protects it.
+        }
+        continue;
+      }
     }
     try {
-      await removeSafe(path.join(layout.trashDir, name), layout.root);
+      await removeSafe(trashPath, layout.root);
     } catch {
       // Retried by the next collection.
     }

--- a/backend/src/utils/ytdlp/release/gc.ts
+++ b/backend/src/utils/ytdlp/release/gc.ts
@@ -14,8 +14,8 @@ import {
   abortGcMarker,
   beginGcMarker,
   getInstanceId,
+  hasGcMarkerToken,
   hasLeases,
-  isLiveGcMarkerToken,
   readLeaseRecords,
 } from "./leases";
 import {
@@ -280,7 +280,7 @@ function isRetirementInFlight(trashEntryName: string): boolean {
   if (!isValidReleaseId(releaseId)) {
     return false;
   }
-  return isLiveGcMarkerToken(releaseId, token);
+  return hasGcMarkerToken(releaseId, token);
 }
 
 /**

--- a/backend/src/utils/ytdlp/release/gc.ts
+++ b/backend/src/utils/ytdlp/release/gc.ts
@@ -15,6 +15,7 @@ import {
   beginGcMarker,
   getInstanceId,
   hasLeases,
+  isLiveGcMarkerToken,
   readLeaseRecords,
 } from "./leases";
 import {
@@ -268,6 +269,20 @@ function reportStaleLeases(releaseId: string): void {
   }
 }
 
+/** Trash entries are named `<releaseId>.<collector token>`. */
+function isRetirementInFlight(trashEntryName: string): boolean {
+  const separator = trashEntryName.lastIndexOf(".");
+  if (separator <= 0) {
+    return false;
+  }
+  const releaseId = trashEntryName.slice(0, separator);
+  const token = trashEntryName.slice(separator + 1);
+  if (!isValidReleaseId(releaseId)) {
+    return false;
+  }
+  return isLiveGcMarkerToken(releaseId, token);
+}
+
 /**
  * Delete anything left in the trash. Entries here are unreachable by
  * construction - they were renamed out of releases/ - so a collector that died
@@ -278,6 +293,14 @@ async function emptyTrash(layout: ManagedStoreLayout): Promise<void> {
     return;
   }
   for (const name of listSafeDirNames(layout.trashDir, layout.root)) {
+    // A retirement in flight has its release sitting here between the rename
+    // and the lease re-check that may put it back. Deleting it then would make
+    // that restoration impossible and leave a reader that legitimately leased
+    // the release running against removed modules. The owning collector still
+    // holds its marker until the retirement is settled, so that is the signal.
+    if (isRetirementInFlight(name)) {
+      continue;
+    }
     try {
       await removeSafe(path.join(layout.trashDir, name), layout.root);
     } catch {

--- a/backend/src/utils/ytdlp/release/leases.ts
+++ b/backend/src/utils/ytdlp/release/leases.ts
@@ -220,12 +220,26 @@ export function hasLiveGcMarker(releaseId: string): boolean {
 }
 
 /**
- * True while this specific collector still holds its marker, which is what
- * distinguishes a retirement still in flight from one whose owner is gone.
+ * True while this specific collector's marker physically exists.
+ *
+ * Reader blocking expires so a killed collector cannot make a release
+ * unusable forever. Trash ownership cannot expire the same way: a collector
+ * may be suspended after renaming the release and still need to restore it for
+ * a lease observed when it resumes.
  */
-export function isLiveGcMarkerToken(releaseId: string, token: string): boolean {
+export function hasGcMarkerToken(releaseId: string, token: string): boolean {
+  if (!isValidReleaseId(releaseId) || !isValidLeaseId(token)) {
+    return false;
+  }
   const layout = getManagedStoreLayout();
-  return liveMarkerTokens(layout, releaseId).includes(token);
+  try {
+    return pathExistsInRoot(
+      path.join(getGcMarkerPath(layout, releaseId), `${token}.json`),
+      layout.root
+    );
+  } catch {
+    return false;
+  }
 }
 
 function liveMarkerTokens(

--- a/backend/src/utils/ytdlp/release/leases.ts
+++ b/backend/src/utils/ytdlp/release/leases.ts
@@ -219,27 +219,26 @@ export function hasLiveGcMarker(releaseId: string): boolean {
   return liveMarkerTokens(layout, releaseId).length > 0;
 }
 
-/**
- * True while this specific collector's marker physically exists.
- *
- * Reader blocking expires so a killed collector cannot make a release
- * unusable forever. Trash ownership cannot expire the same way: a collector
- * may be suspended after renaming the release and still need to restore it for
- * a lease observed when it resumes.
- */
-export function hasGcMarkerToken(releaseId: string, token: string): boolean {
+export type GcMarkerTokenState = "missing" | "live" | "stale";
+
+/** Report both physical ownership and reader-blocking freshness. */
+export function getGcMarkerTokenState(
+  releaseId: string,
+  token: string
+): GcMarkerTokenState {
   if (!isValidReleaseId(releaseId) || !isValidLeaseId(token)) {
-    return false;
+    return "missing";
   }
   const layout = getManagedStoreLayout();
-  try {
-    return pathExistsInRoot(
-      path.join(getGcMarkerPath(layout, releaseId), `${token}.json`),
-      layout.root
-    );
-  } catch {
-    return false;
+  const markedAt = statMtimeMs(
+    path.join(getGcMarkerPath(layout, releaseId), `${token}.json`)
+  );
+  if (markedAt === null) {
+    return "missing";
   }
+  return Date.now() - markedAt >= YT_DLP_PUBLISH_LOCK_STALE_MS
+    ? "stale"
+    : "live";
 }
 
 function liveMarkerTokens(

--- a/backend/src/utils/ytdlp/release/leases.ts
+++ b/backend/src/utils/ytdlp/release/leases.ts
@@ -219,6 +219,15 @@ export function hasLiveGcMarker(releaseId: string): boolean {
   return liveMarkerTokens(layout, releaseId).length > 0;
 }
 
+/**
+ * True while this specific collector still holds its marker, which is what
+ * distinguishes a retirement still in flight from one whose owner is gone.
+ */
+export function isLiveGcMarkerToken(releaseId: string, token: string): boolean {
+  const layout = getManagedStoreLayout();
+  return liveMarkerTokens(layout, releaseId).includes(token);
+}
+
 function liveMarkerTokens(
   layout: ReturnType<typeof getManagedStoreLayout>,
   releaseId: string,

--- a/backend/src/utils/ytdlp/release/publish.ts
+++ b/backend/src/utils/ytdlp/release/publish.ts
@@ -89,6 +89,25 @@ function retireAbandonedClaim(
 ): boolean {
   const claimPath = getGenerationClaimPath(layout, generation);
   const retiredPath = `${claimPath}.${token}.abandoned`;
+
+  // Remove a dead publisher's recovery record while its original claim still
+  // occupies the canonical path. If removal fails, no contender can reserve
+  // this generation during a rename-back window and later free its temporary
+  // claim, leaving the surviving record unfenced.
+  const observed = readClaim(claimPath);
+  if (observed.token !== observedToken) {
+    return false;
+  }
+  if (
+    observed.releaseId &&
+    !removePublishedManifest(layout.root, observed.releaseId)
+  ) {
+    logger.warn(
+      `[yt-dlp] Left generation ${generation} claimed: the abandoned publication record for ${observed.releaseId} could not be removed`
+    );
+    return false;
+  }
+
   try {
     fs.renameSync(claimPath, retiredPath);
   } catch {
@@ -108,29 +127,6 @@ function retireAbandonedClaim(
       fs.renameSync(retiredPath, claimPath);
     } catch {
       // Best effort; a lost claim is reclaimed by age on the next attempt.
-    }
-    return false;
-  }
-
-  // A publisher that died between recording its publication and moving the
-  // pointer left a published.json behind. Freeing its generation without
-  // removing that record would leave two releases claiming the same
-  // generation, and both recovery and the rollback window order by generation.
-  // The claim names the release, so this is exactly the record to drop -- and
-  // as on the immediate-failure path, the generation stays claimed until the
-  // record is actually gone. Putting the claim back leaves it expired, so the
-  // next attempt reclaims it and retries the removal.
-  if (
-    retired.releaseId &&
-    !removePublishedManifest(layout.root, retired.releaseId)
-  ) {
-    logger.warn(
-      `[yt-dlp] Left generation ${generation} claimed: the abandoned publication record for ${retired.releaseId} could not be removed`
-    );
-    try {
-      fs.renameSync(retiredPath, claimPath);
-    } catch {
-      // Best effort; an orphaned claim is reclaimed by age.
     }
     return false;
   }

--- a/backend/src/utils/ytdlp/release/publish.ts
+++ b/backend/src/utils/ytdlp/release/publish.ts
@@ -116,9 +116,23 @@ function retireAbandonedClaim(
   // pointer left a published.json behind. Freeing its generation without
   // removing that record would leave two releases claiming the same
   // generation, and both recovery and the rollback window order by generation.
-  // The claim names the release, so this is exactly the record to drop.
-  if (retired.releaseId) {
-    removePublishedManifest(layout.root, retired.releaseId);
+  // The claim names the release, so this is exactly the record to drop -- and
+  // as on the immediate-failure path, the generation stays claimed until the
+  // record is actually gone. Putting the claim back leaves it expired, so the
+  // next attempt reclaims it and retries the removal.
+  if (
+    retired.releaseId &&
+    !removePublishedManifest(layout.root, retired.releaseId)
+  ) {
+    logger.warn(
+      `[yt-dlp] Left generation ${generation} claimed: the abandoned publication record for ${retired.releaseId} could not be removed`
+    );
+    try {
+      fs.renameSync(retiredPath, claimPath);
+    } catch {
+      // Best effort; an orphaned claim is reclaimed by age.
+    }
+    return false;
   }
 
   try {


### PR DESCRIPTION
Follow-up to #420. Two findings were reported on that PR and I merged without reading them — that was a mistake, since a third of the findings in the same batch had turned out to be genuine defects. Both of these are real.

## A concurrent sweep can defeat retirement restoration

Collection retires a release by renaming it into `trash/`, then re-checks for leases and renames it back if a reader got there first. `emptyTrash()` deleted every trash entry unconditionally, so a second collector could delete a retirement that was still waiting on that re-check. The restoration then cannot happen, and a reader holding a legitimate lease is left running against removed modules — precisely the failure the retirement protocol was added to prevent.

A collector holds its marker until its retirement is settled, so that is the signal: trash entries whose token is still a live marker are skipped, and entries left by a collector that is gone are swept exactly as before.

## A freed generation can be reused while a release still records it

Reclaiming an abandoned generation removes the dead publisher's `published.json`, but ignored whether that removal actually succeeded and freed the generation regardless. A record that survives — a persistent Windows sharing violation, for instance — plus a freed generation lets the next update reuse it, leaving two releases recording the same generation. Both corruption recovery and the GC rollback window order by generation, so the abandoned release can outrank the real one.

The immediate-failure path already had this rule; the stale-reclamation path was the sibling branch I missed when adding it. It now keeps the claim (renaming it back, so it stays expired) and a later attempt retries the removal, which makes it self-healing rather than wedging.

## Testing

2,969 backend tests pass. Two new cases, each verified by reverting the fix and confirming the test fails:

- a trash entry whose collector still holds its marker survives a sweep while an abandoned one is removed, and is swept once the collector finishes
- an abandoned record that cannot be deleted leaves its generation claimed, so no other publisher can take it