### PR TITLE
chore(deps): bump multer from 2.2.0 to 2.3.0 in /backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,7 @@
         "file-type": "file:vendor/file-type",
         "fs-extra": "^11.3.3",
         "jsonwebtoken": "^9.0.3",
-        "multer": "^2.2.0",
+        "multer": "^2.3.0",
         "node-cron": "^4.2.1",
         "proxy-agent": "^8.0.2",
         "puppeteer": "^25.1.0",
@@ -4380,9 +4380,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
-      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
     "file-type": "file:vendor/file-type",
     "fs-extra": "^11.3.3",
     "jsonwebtoken": "^9.0.3",
-    "multer": "^2.2.0",
+    "multer": "^2.3.0",
     "node-cron": "^4.2.1",
     "proxy-agent": "^8.0.2",
     "puppeteer": "^25.1.0",


### PR DESCRIPTION
## What

Bumps `multer` in `backend/` from `^2.2.0` to `^2.3.0`, with `backend/package-lock.json` regenerated (`npm install` reports `changed 1 package` — no other dependency is touched).

## Why

Fixes three high-severity advisories reported by Snyk:

| Severity | Issue |
|---|---|
| High | Uncaught Exception — [SNYK-JS-MULTER-19432021](https://snyk.io/vuln/SNYK-JS-MULTER-19432021) |
| High | Race Condition — [SNYK-JS-MULTER-19432134](https://snyk.io/vuln/SNYK-JS-MULTER-19432134) |
| High | Denial of Service — [SNYK-JS-MULTER-19432136](https://snyk.io/vuln/SNYK-JS-MULTER-19432136) |

## Relation to #426

Snyk's automated PR #426 bundles this patch-level multer bump with an `express` 4 → 5 major upgrade. That PR fails CI on five jobs for two reasons:

1. It does not update `package-lock.json`, so every `npm ci` job fails (`lock file's express@4.22.2 does not satisfy express@5.2.1`).
2. Express 5 ships path-to-regexp v8, which rejects bare `*` route patterns. `src/server/staticRoutes.ts` has two (`/images-small/*` at line 189 and the SPA fallback `app.get("*")` at line 263), so `staticRoutes.integration.test.ts` fails with `TypeError: Missing parameter name at index 15`.

This PR takes only the safe half. The express upgrade needs those route changes plus regression testing across `express-rate-limit`, `csrf-csrf` and the upload paths, and should land on its own. The two medium-severity `qs` advisories in #426 are still open and may be addressable with an `overrides` entry instead of the express major — worth checking their fixed version on Snyk first (the lockfile currently pins qs 6.15.2; 6.16.0 is available).

## Compatibility

Patch-level, no API break. The backend uses `multer.memoryStorage()`, `multer.MulterError` and one custom `StorageEngine` (`src/utils/videoUpload.ts`); 2.3.0's race-condition fix relies on storage engines implementing `_removeFile`, which the custom engine already does (`src/utils/videoUpload.ts:412`).

## Testing

`cd backend && npm test` — 220 test files, 2970 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
