### PR TITLE
chore(deps): upgrade the backend from Express 4 to Express 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Upgrade the backend from Express 4 to Express 5. **Behaviour change for API clients using bracket query syntax:** Express 5 defaults the `query parser` setting to `simple` (Node's `querystring`) instead of `extended` (`qs`), so `?a[b]=1` now arrives as the literal key `a[b]` rather than a nested `{a: {b: "1"}}`, and `?t[]=x&t[]=y` as `t[]` rather than `t`. Flat keys, repeated keys and percent-encoded values are unaffected, as is urlencoded body parsing, which sets `extended: true` explicitly. No endpoint accepts an array or nested query parameter, so nothing in MyTube's own API surface changes; the project follows the Express 5 default rather than restoring the old one. Route patterns also move to path-to-regexp v8 (`/images-small/{*splat}`, `/{*splat}` for the SPA fallback), and a request-body normalizer restores the `req.body = {}` default that body-parser 2 dropped, so a bodyless or mistyped request still gets its route's 400 validation response instead of a 500.
+
 ### Fix
 
 - Answer an unsatisfiable byte range with 416 instead of 500. `send` rejects a Range the file cannot satisfy (`bytes=99999999999-` against a shorter file, typically a client resuming against a stale length) with a 416 error, after already setting the `Content-Range: bytes */<size>` header that tells the client the real length. The error handler recognised only 413 and 404, so the request fell through to the unknown-error branch, was logged as an unhandled failure, and returned 500 — discarding the one status a range-requesting player can actually recover from. Malformed and empty Range headers take the same path on Express 4 and are now answered the same way.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,7 +22,7 @@
         "csrf-csrf": "^4.0.3",
         "dotenv": "^16.6.1",
         "drizzle-orm": "^0.45.2",
-        "express": "^4.22.2",
+        "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
         "file-type": "file:vendor/file-type",
         "fs-extra": "^11.3.3",
@@ -1675,16 +1675,41 @@
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/acorn": {
@@ -1724,29 +1749,6 @@
       "engines": {
         "node": ">= 6.0.0"
       }
-    },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
@@ -1797,12 +1799,6 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
     "node_modules/asap": {
@@ -2004,39 +2000,112 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.6",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
-      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "~3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "~1.2.0",
-        "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
-        "on-finished": "~2.4.1",
-        "qs": "~6.15.1",
-        "raw-body": "~2.5.3",
-        "type-is": "~1.6.18",
-        "unpipe": "~1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/boolbase": {
@@ -2338,15 +2407,16 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -2477,12 +2547,20 @@
       }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -2542,16 +2620,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -3088,45 +3156,42 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
-      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "~1.20.5",
-        "content-disposition": "~0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "~0.7.1",
-        "cookie-signature": "~1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.3.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "~0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "~6.15.1",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "~0.19.0",
-        "serve-static": "~1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "~2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -3149,6 +3214,84 @@
       },
       "peerDependencies": {
         "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express/node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-safe-stringify": {
@@ -3182,21 +3325,24 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
-      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "~2.0.2",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/follow-redirects": {
@@ -3263,12 +3409,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -3399,29 +3545,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/get-uri/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/get-uri/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -3590,29 +3713,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -3625,29 +3725,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -3764,6 +3841,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3849,12 +3932,6 @@
         "node": ">=12",
         "npm": ">=6"
       }
-    },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
@@ -4265,10 +4342,13 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -4277,21 +4357,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -4374,9 +4443,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/multer": {
@@ -4424,12 +4493,32 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/netmask": {
@@ -4491,24 +4580,6 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -4518,13 +4589,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/nodemon/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nodemon/node_modules/supports-color": {
       "version": "5.5.0",
@@ -4642,23 +4706,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
@@ -4672,12 +4719,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/pac-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
       "version": "10.1.0",
@@ -4768,10 +4809,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-      "license": "MIT"
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -4926,23 +4971,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/https-proxy-agent": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
@@ -4956,12 +4984,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/proxy-agent/node_modules/socks-proxy-agent": {
       "version": "10.1.0",
@@ -5103,39 +5125,47 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
-      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
         "http-errors": "~2.0.1",
-        "iconv-lite": "~0.4.24",
+        "iconv-lite": "~0.7.0",
         "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {
@@ -5237,6 +5267,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5285,48 +5331,73 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
-      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
-    "node_modules/serve-static": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
-      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "~0.19.1"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -5519,29 +5590,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5695,24 +5743,6 @@
         "node": ">=14.18.0"
       }
     },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -5725,13 +5755,6 @@
       "engines": {
         "node": ">=4.0.0"
       }
-    },
-    "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/supertest": {
       "version": "7.2.2",
@@ -6152,15 +6175,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/uuid": {
       "version": "14.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,7 +34,7 @@
     "csrf-csrf": "^4.0.3",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.45.2",
-    "express": "^4.22.2",
+    "express": "^5.2.1",
     "express-rate-limit": "^8.5.1",
     "file-type": "file:vendor/file-type",
     "fs-extra": "^11.3.3",

--- a/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
+++ b/backend/src/__tests__/middleware/mediaAuthMiddleware.test.ts
@@ -351,13 +351,33 @@ describe("middleware/requireVisibleMediaForVisitors", () => {
       createReq({
         user: { role: "visitor" } as any,
         path: "/images-small/poster.jpg",
-        params: { 0: "poster.jpg" },
+        params: { splat: ["poster.jpg"] },
       } as any),
       createRes(),
       vi.fn()
     );
     expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
       exactPaths: ["/images/poster.jpg", "/videos/poster.jpg"],
+    });
+  });
+
+  it("joins every wildcard segment for nested images-small paths", () => {
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockReturnValue("public");
+    requireVisibleMediaForVisitors("images-small")(
+      createReq({
+        user: { role: "visitor" } as any,
+        path: "/images-small/nested/dir/poster.jpg",
+        params: { splat: ["nested", "dir", "poster.jpg"] },
+      } as any),
+      createRes(),
+      vi.fn()
+    );
+    expect(classifyMediaVisibilityMock).toHaveBeenCalledWith({
+      exactPaths: [
+        "/images/nested/dir/poster.jpg",
+        "/videos/nested/dir/poster.jpg",
+      ],
     });
   });
 

--- a/backend/src/__tests__/middleware/normalizeRequestBody.test.ts
+++ b/backend/src/__tests__/middleware/normalizeRequestBody.test.ts
@@ -1,0 +1,69 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { normalizeRequestBody } from "../../middleware/normalizeRequestBody";
+
+describe("normalizeRequestBody", () => {
+  const buildApp = () => {
+    const app = express();
+    app.use(express.json());
+    app.use(express.urlencoded({ extended: true }));
+    app.use(normalizeRequestBody);
+
+    // Mirrors how handlers across the API read the body, e.g.
+    // downloadController's `const { url } = req.body;`.
+    app.post("/echo", (req, res) => {
+      const { url } = req.body;
+      res.json({ url: url ?? null });
+    });
+
+    app.use(
+      (
+        err: Error,
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction
+      ) => {
+        res.status(500).json({ error: err.message });
+      }
+    );
+
+    return app;
+  };
+
+  it("should give handlers an empty body when the request carries none", async () => {
+    const response = await request(buildApp()).post("/echo");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: null });
+  });
+
+  it("should give handlers an empty body for a content type no parser claims", async () => {
+    const response = await request(buildApp())
+      .post("/echo")
+      .type("text")
+      .send("not json");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: null });
+  });
+
+  it("should leave a parsed JSON body untouched", async () => {
+    const response = await request(buildApp())
+      .post("/echo")
+      .send({ url: "https://example.com/video" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: "https://example.com/video" });
+  });
+
+  it("should leave a parsed urlencoded body untouched", async () => {
+    const response = await request(buildApp())
+      .post("/echo")
+      .type("form")
+      .send("url=https%3A%2F%2Fexample.com%2Fvideo");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ url: "https://example.com/video" });
+  });
+});

--- a/backend/src/__tests__/server/imagesSmallVisibility.integration.test.ts
+++ b/backend/src/__tests__/server/imagesSmallVisibility.integration.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import express from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isLoginRequiredMock, getRssTokenMock, classifyMediaVisibilityMock } =
+  vi.hoisted(() => ({
+    isLoginRequiredMock: vi.fn(),
+    getRssTokenMock: vi.fn(),
+    classifyMediaVisibilityMock: vi.fn(),
+  }));
+
+vi.mock("../../services/passwordService", () => ({
+  isLoginRequired: isLoginRequiredMock,
+}));
+vi.mock("../../services/rssService", () => ({ getRssToken: getRssTokenMock }));
+vi.mock("../../services/storageService", () => ({
+  classifyMediaVisibility: classifyMediaVisibilityMock,
+}));
+vi.mock("../../utils/logger", () => ({ logger: { warn: vi.fn() } }));
+
+import { requireVisibleMediaForVisitors } from "../../middleware/mediaAuthMiddleware";
+
+const HIDDEN_ORIGINALS = ["/images/hidden/poster.jpg", "/videos/hidden/poster.jpg"];
+
+describe("images-small visibility guard (Express 5 wildcard)", () => {
+  const seenPaths: string[][] = [];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seenPaths.length = 0;
+    isLoginRequiredMock.mockReturnValue(true);
+    classifyMediaVisibilityMock.mockImplementation((opts: any) => {
+      const paths: string[] = opts.exactPaths ?? [];
+      seenPaths.push(paths);
+      return paths.some((p) => HIDDEN_ORIGINALS.includes(p))
+        ? "hidden"
+        : "unknown";
+    });
+  });
+
+  // Mirrors registerStaticRoutes: an explicit GET that ensures the small
+  // thumbnail exists and falls through, then the use() mount that serves it.
+  const buildApp = () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      (req as any).user = { role: "visitor" };
+      next();
+    });
+    app.get(
+      "/images-small/{*splat}",
+      requireVisibleMediaForVisitors("images-small"),
+      (_req, _res, next) => next()
+    );
+    app.use(
+      "/images-small",
+      requireVisibleMediaForVisitors("images-small"),
+      (_req, res) => res.send("THUMB BYTES")
+    );
+    return app;
+  };
+
+  it("does not serve a visitor the small thumbnail of a hidden video", async () => {
+    const response = await request(buildApp()).get(
+      "/images-small/hidden/poster.jpg"
+    );
+
+    expect(response.text).not.toBe("THUMB BYTES");
+    expect(response.status).toBe(404);
+  });
+
+  it("still serves a visitor a public small thumbnail", async () => {
+    const response = await request(buildApp()).get(
+      "/images-small/public/poster.jpg"
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("THUMB BYTES");
+  });
+
+  it("classifies the wildcard route against the real original paths", async () => {
+    await request(buildApp()).get("/images-small/hidden/poster.jpg");
+
+    // The explicit GET route must resolve /images-small/hidden/poster.jpg to
+    // the originals it mirrors, not to a doubled /images/images-small/... path.
+    expect(seenPaths[0]).toEqual(HIDDEN_ORIGINALS);
+  });
+});

--- a/backend/src/__tests__/server/listenHandler.test.ts
+++ b/backend/src/__tests__/server/listenHandler.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createListenHandler } from "../../server/listenHandler";
+import { logger } from "../../utils/logger";
+
+vi.mock("../../utils/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+describe("server/listenHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should announce the server and start background jobs once listening", () => {
+    const onListening = vi.fn();
+    const exit = vi.fn();
+
+    createListenHandler("0.0.0.0", 5551, onListening, exit)();
+
+    expect(logger.info).toHaveBeenCalledWith("Server running on 0.0.0.0:5551");
+    expect(onListening).toHaveBeenCalledTimes(1);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  // Express 5 hands a bind failure to the listen callback; Express 4 left it as
+  // an unhandled 'error' event that crashed the process. Ignoring the argument
+  // would announce a server that is not listening and start the schedulers
+  // anyway, whose timers then keep the dead process alive.
+  it("should exit without starting background jobs when the port cannot be bound", () => {
+    const onListening = vi.fn();
+    const exit = vi.fn();
+    const error = Object.assign(new Error("listen EADDRINUSE"), {
+      code: "EADDRINUSE",
+    });
+
+    createListenHandler("0.0.0.0", 5551, onListening, exit)(error);
+
+    expect(logger.error).toHaveBeenCalledWith("Failed to bind server:", error);
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(onListening).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should not start background jobs even if exit does not terminate", () => {
+    const onListening = vi.fn();
+
+    createListenHandler("0.0.0.0", 5551, onListening, vi.fn())(
+      new Error("listen EACCES")
+    );
+
+    expect(onListening).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/server/staticRoutes.test.ts
+++ b/backend/src/__tests__/server/staticRoutes.test.ts
@@ -68,10 +68,10 @@ describe("server/staticRoutes", () => {
     registerStaticRoutes(app, "/frontend-dist");
 
     expect(use).toHaveBeenCalledTimes(8);
-    // /images-small/* now carries the media auth stack + visibility guard
-    // before its handler.
+    // /images-small/{*splat} now carries the media auth stack + visibility
+    // guard before its handler.
     expect(get).toHaveBeenCalledWith(
-      "/images-small/*",
+      "/images-small/{*splat}",
       expect.any(Function),
       expect.any(Function),
       expect.any(Function),
@@ -200,7 +200,7 @@ describe("server/staticRoutes", () => {
     const app = { use, get } as any;
     registerStaticRoutes(app, "/frontend-dist");
 
-    // The /images-small/* GET carries [authMiddleware, requireMedia, handler];
+    // The /images-small/{*splat} GET carries [authMiddleware, requireMedia, handler];
     // the handler is the 4th argument (index 3).
     const smallImageHandler = get.mock.calls[0][get.mock.calls[0].length - 1];
     const res = {
@@ -213,7 +213,7 @@ describe("server/staticRoutes", () => {
     smallImageHandler(
       {
         path: "/images-small/folder/poster.jpg",
-        params: { 0: "folder/poster.jpg" },
+        params: { splat: ["folder", "poster.jpg"] },
       } as any,
       res,
       next,
@@ -248,7 +248,7 @@ describe("server/staticRoutes", () => {
     smallImageHandler(
       {
         path: "/images-small/../secret.jpg",
-        params: { 0: "../secret.jpg" },
+        params: { splat: ["..", "secret.jpg"] },
       } as any,
       res,
       next,
@@ -291,7 +291,7 @@ describe("server/staticRoutes", () => {
     smallImageHandler(
       {
         path: "/images-small/folder/poster.jpg",
-        params: { 0: "folder/poster.jpg" },
+        params: { splat: ["folder", "poster.jpg"] },
       } as any,
       res,
       next,
@@ -314,7 +314,7 @@ describe("server/staticRoutes", () => {
     const app = { get } as any;
     registerSpaFallback(app, "/frontend-dist");
 
-    expect(get).toHaveBeenCalledWith("*", expect.any(Function));
+    expect(get).toHaveBeenCalledWith("/{*splat}", expect.any(Function));
     const handler = get.mock.calls[0][1];
 
     const apiRes = {

--- a/backend/src/middleware/mediaAuthMiddleware.ts
+++ b/backend/src/middleware/mediaAuthMiddleware.ts
@@ -2,7 +2,7 @@ import { NextFunction, Request, Response } from "express";
 import { isLoginRequired } from "../services/passwordService";
 import { getRssToken } from "../services/rssService";
 import * as storageService from "../services/storageService";
-import { getStringParam } from "../utils/paramUtils";
+import { getStringParam, getWildcardParam } from "../utils/paramUtils";
 import { logger } from "../utils/logger";
 
 declare global {
@@ -154,7 +154,7 @@ const classifyMediaRequest = (
     case "images-small": {
       // Small thumbnails mirror the original thumbnail, which may live under
       // either /images or /videos. Check both candidate originals.
-      const wildcardPath = getStringParam(req.params["0"]);
+      const wildcardPath = getWildcardParam(req.params);
       const sub = safeDecode(wildcardPath ? `/${wildcardPath}` : req.path);
       return storageService.classifyMediaVisibility({
         exactPaths: [`/images${sub}`, `/videos${sub}`],

--- a/backend/src/middleware/normalizeRequestBody.ts
+++ b/backend/src/middleware/normalizeRequestBody.ts
@@ -1,0 +1,18 @@
+import { NextFunction, Request, Response } from "express";
+
+// body-parser 2 (Express 5) leaves req.body undefined when a request carries no
+// body, or a content type no mounted parser claims; body-parser 1 set it to {}.
+// Handlers across the API destructure req.body directly, so without this a
+// bodyless or mistyped request throws a TypeError and surfaces as a 500 instead
+// of the route's own 400 validation response.
+export function normalizeRequestBody(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  if (req.body === undefined) {
+    req.body = {};
+  }
+
+  next();
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -10,6 +10,7 @@ import path from "path";
 import { DATA_DIR } from "./config/paths";
 import { runMigrations } from "./db/migrate";
 import { errorHandler } from "./middleware/errorHandler";
+import { normalizeRequestBody } from "./middleware/normalizeRequestBody";
 import { rssManagementNoStoreHeaders } from "./middleware/rssManagementNoStoreHeaders";
 import { statisticsEventsJsonParser } from "./controllers/statisticsController";
 import downloadManager from "./services/downloadManager";
@@ -46,6 +47,7 @@ app.use(rssManagementNoStoreHeaders);
 app.use("/api/statistics/events", statisticsEventsJsonParser);
 app.use(express.json({ limit: JSON_BODY_LIMIT }));
 app.use(express.urlencoded({ extended: true, limit: JSON_BODY_LIMIT }));
+app.use(normalizeRequestBody);
 app.use(csrfProtection);
 app.use(csrfTokenProvider);
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -25,6 +25,7 @@ import { configureRateLimiting } from "./server/rateLimit";
 import { registerSpaFallback, registerStaticRoutes } from "./server/staticRoutes";
 import { startBackgroundJobs } from "./server/startupJobs";
 import { registerLiveTranslationSocket } from "./server/liveTranslationSocket";
+import { createListenHandler } from "./server/listenHandler";
 
 VERSION.displayVersion();
 
@@ -92,10 +93,11 @@ const startServer = async (): Promise<void> => {
     app.use(errorHandler);
 
     const HOST = process.env.HOST || "0.0.0.0";
-    const server = app.listen(PORT, HOST, () => {
-      logger.info(`Server running on ${HOST}:${PORT}`);
-      startBackgroundJobs(PORT);
-    });
+    const server = app.listen(
+      PORT,
+      HOST,
+      createListenHandler(HOST, PORT, () => startBackgroundJobs(PORT))
+    );
     // Register the live translation WebSocket on the same HTTP server (noServer
     // mode handles only the live translation upgrade path).
     registerLiveTranslationSocket(server);

--- a/backend/src/server/listenHandler.ts
+++ b/backend/src/server/listenHandler.ts
@@ -1,0 +1,29 @@
+import { logger } from "../utils/logger";
+
+/**
+ * Builds the callback passed to `app.listen`.
+ *
+ * Express 5 forwards a bind failure (EADDRINUSE, EACCES) to this callback,
+ * where Express 4 left it as an unhandled `error` event that crashed the
+ * process. A callback that ignores its argument therefore announces a running
+ * server and starts the background schedulers with no HTTP listener behind
+ * them -- and those timers keep the dead process alive, turning a loud startup
+ * failure into a silent one.
+ */
+export const createListenHandler =
+  (
+    host: string,
+    port: number,
+    onListening: () => void,
+    exit: (code: number) => void = process.exit
+  ) =>
+  (error?: Error): void => {
+    if (error) {
+      logger.error("Failed to bind server:", error);
+      exit(1);
+      return;
+    }
+
+    logger.info(`Server running on ${host}:${port}`);
+    onListening();
+  };

--- a/backend/src/server/staticRoutes.ts
+++ b/backend/src/server/staticRoutes.ts
@@ -18,6 +18,7 @@ import {
   ensureSmallThumbnailForRelativePath,
   getThumbnailRelativePath,
 } from "../services/thumbnailMirrorService";
+import { getWildcardParam } from "../utils/paramUtils";
 import {
   normalizeSafeAbsolutePath,
   resolveSafeChildPath,
@@ -85,7 +86,7 @@ const ensureSmallThumbnail = async (
   res: Response,
   next: express.NextFunction,
 ): Promise<void> => {
-  const wildcardPath = req.params["0"];
+  const wildcardPath = getWildcardParam(req.params);
   const relativePath = getThumbnailRelativePath(
     typeof wildcardPath === "string" ? wildcardPath : req.path,
   );
@@ -186,7 +187,7 @@ export const registerStaticRoutes = (
   );
 
   app.get(
-    "/images-small/*",
+    "/images-small/{*splat}",
     ...mediaAuthStack,
     requireVisibleMediaForVisitors("images-small"),
     (req, res, next) => {
@@ -260,7 +261,7 @@ export const registerSpaFallback = (
 ): void => {
   const safeFrontendDist = normalizeSafeAbsolutePath(frontendDist);
 
-  app.get("*", (req, res) => {
+  app.get("/{*splat}", (req, res) => {
     if (isReservedBackendPath(req.path)) {
       res.status(404).json({ error: "Not Found" });
       return;

--- a/backend/src/utils/paramUtils.ts
+++ b/backend/src/utils/paramUtils.ts
@@ -69,6 +69,26 @@ export function getStringParam(
 }
 
 /**
+ * Extract the value a wildcard route segment matched.
+ *
+ * Express 5 (path-to-regexp v8) names wildcards and hands them back as an array
+ * of path segments, so `req.params["0"]` from the Express 4 syntax is gone and
+ * `getStringParam()` on the array would silently keep only its first segment.
+ * Returns undefined for a use()-mounted route, which carries no params at all
+ * and whose `req.path` is already stripped of the mount path.
+ */
+export function getWildcardParam(
+  params: Record<string, unknown>,
+  name = "splat"
+): string | undefined {
+  const value = params[name];
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value.map(String).join("/") : undefined;
+  }
+  return getStringParam(value as ExpressQueryValue);
+}
+
+/**
  * Safely extract a required string parameter from request query/body/params
  * Throws error if missing or empty
  */


### PR DESCRIPTION
> **Draft.** Docker image build has not been smoke-tested yet — see Remaining below.

## What

`express` `^4.22.2` → `^5.2.1`, with the four source changes the major requires. 62 added / 15 removed lines of source (excluding the lockfile).

| File | Change |
|---|---|
| `backend/package.json`, `package-lock.json` | express 5.2.1 and its dependency tree (body-parser 2, router 2, send 1, serve-static 2) |
| `utils/paramUtils.ts` | new `getWildcardParam()` |
| `server/staticRoutes.ts` | two route patterns + wildcard capture |
| `middleware/mediaAuthMiddleware.ts` | visibility guard's wildcard capture |
| `server.ts`, `middleware/normalizeRequestBody.ts` | request-body normalizer |
| 4 test files | 2 updated, 2 new |
| `CHANGELOG.md` | one `### Changed` entry |

## The four things the major actually required

**1. Route patterns.** path-to-regexp v8 rejects a bare `*`, which is what made CI fail on the Snyk PR (#426) with `TypeError: Missing parameter name at index 15`.

```
/images-small/*        ->  /images-small/{*splat}
app.get("*")           ->  app.get("/{*splat}")     (SPA fallback)
```

**2. Wildcard capture — the part tests would not have caught.** Express 5 names wildcards and returns the match as an **array of path segments**, so Express 4's numeric group `req.params["0"]` is gone. Two readers depended on it, and neither would have crashed:

- `staticRoutes`' `ensureSmallThumbnail` falls back to `req.path`, deriving `/images-small/foo.jpg` instead of `foo.jpg` — on-demand thumbnail generation breaks.
- `mediaAuthMiddleware`'s visibility guard would classify `/images/images-small/...`, judging a hidden video's thumbnail `unknown` instead of `hidden`.

The second one is **not** an exposure: the `use()`-mounted guard that actually serves the bytes reads the mount-stripped `req.path`, classifies correctly, and still returns 404 — verified with a new integration test. But the first guard silently stopped doing its job, and the hidden video's thumbnail would get generated on disk before the second guard blocked it.

Both now go through one `getWildcardParam()` helper. Note that handing the segment array to the existing `getStringParam()` would have silently kept only its **first** segment (`hidden/poster.jpg` → `hidden`); there is a test for the multi-segment case.

**3. Request bodies.** body-parser 2 leaves `req.body` **undefined** where body-parser 1 set `{}`. Seventeen handlers destructure `req.body` directly, so a bodyless or mistyped request throws a `TypeError` and surfaces as a 500 instead of the route's own 400:

```
POST /create   (no body, no content-type)
  500  Cannot destructure property 'url' of 'req.body' as it is undefined.
```

`normalizeRequestBody` restores the old default for all seventeen in one place, mounted after the parsers and before CSRF, rather than editing each call site.

**4. Query parsing — a behaviour change, deliberately kept.** Express 5 defaults `query parser` to `simple` (Node's `querystring`) instead of `extended` (`qs`). Measured difference:

```
?a[b]=1&a[c]=2   v4: {a:{b:"1",c:"2"}}     v5: {"a[b]":"1","a[c]":"2"}
?t[]=x&t[]=y     v4: {t:["x","y"]}         v5: {"t[]":["x","y"]}
?limit=50        same      ?p=1&p=2  same      urlencoded body  same
```

**Not overridden.** No endpoint accepts an array or nested query parameter — all 18 `req.query` reads are flat scalars and `getArrayParam` is never used on `req.query` — and the frontend builds every query with `URLSearchParams`. Restoring the old behaviour is a one-line `app.set("query parser", "extended")` if a third-party client turns out to need it; the CHANGELOG documents the change either way.

## What did *not* need changing

Swept the whole backend: no `app.del`, `req.param()`, `res.sendfile`, `res.json(obj, status)`, `res.redirect('back')`, `app.param()`, array route paths or regex routes. Every other `req.params` read is a named parameter (`:id`, `:token`, `:filename`, `:name`, `:metric`, `:jobId`), identical in both versions. `res.status()` only ever receives literal constants, so Express 5's invalid-status-code throw cannot fire. `@types/express` was already `^5.0.5`, so TypeScript needed nothing.

Middleware compatibility confirmed live: `express-rate-limit@8.5.2` (peer `>= 4.11`), `csrf-csrf@4.0.3`, `cookie-parser`, `cors`, `multer@2.3.0`.

## Testing

`cd backend && npm test` — **222 test files, 2978 tests, all passing.** `npx tsc --noEmit` clean.

Beyond the suite, an HTTP regression against a running server on a real 47 MB video and its thumbnails:

| Area | Result |
|---|---|
| Byte ranges | `bytes=0-1023`, `bytes=1024-2047`, `bytes=-500`, last-byte → 206 with correct `Content-Range`; no range → 200 |
| On-demand thumbnail generation | deleted the small thumbnail, re-requested → 200, regenerated **byte-identical** to the original |
| Nested wildcard path | `/images-small/nested/dir/test.jpg` → 200, 262827 → 32405 bytes |
| SPA fallback | `/home`, `/author/jane.doe`, `/collections/abc/def`, `/` → 200 HTML |
| Reserved paths | `/api/*` → 404 JSON, `/feed/*` → 404, single-segment root file → 404, missing asset → 404 |
| CSRF | no token → 403; with token → accepted |
| `req.body` fallback | no body → 400, `text/plain` body → 400 (neither 500) |
| Rate limiting | general limiter counts down; auth limiter 429s from attempt 6 with `Retry-After: 900`; exempt paths unaffected |
| multer multipart | `req.file` populated, empty multipart correctly detected |

## Relationship to the other open PRs

Depends on nothing. #426 (Snyk's bundled express+multer bump) is fully superseded: its multer half landed in #427, its qs half in #428, and this is its express half done properly with the route changes and a regenerated lockfile — **#426 can be closed.**

#429 (416 instead of 500 for an unsatisfiable range) is independent — the only overlap is a `CHANGELOG.md` insertion point, resolvable by keeping both blocks. That bug is **not** a regression from this upgrade; it reproduces identically on master. Worth knowing when reviewing them together: Express 5's `send` ignores a malformed or empty Range and serves the full body (the RFC 7233 behaviour) where Express 4 raised a 416 error, so after both land only a genuinely unsatisfiable range reaches #429's new branch.

## Remaining before this leaves draft

- [ ] Docker image build smoke test — the one path not yet exercised; `npm ci` has to install the new dependency tree inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
