### PR TITLE
ci(codeql): move to an advanced setup that can exclude test files

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,11 @@
+name: "MyTube CodeQL config"
+
+# Test files are not deployed and have no network surface, so queries that
+# reason about production request handling do not apply to them. Integration
+# tests in particular build throwaway express apps with supertest, which
+# js/missing-rate-limiting reports as unprotected route handlers -- three such
+# alerts had to be dismissed by hand as "used in tests" before this config
+# existed. Path filters are why this repo uses an advanced setup at all: the
+# default setup does not support them.
+paths-ignore:
+  - "**/__tests__/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: "CodeQL"
+
+# Replaces the repository's CodeQL default setup, which cannot exclude paths.
+# Keeps the same languages, query suite and weekly cadence, and keeps the job
+# named "Analyze" so the checks stay "Analyze (<language>)" as before.
+#
+# The default setup must be turned off for this workflow to publish results:
+# Settings -> Code security -> Code scanning -> CodeQL analysis -> Disable.
+# Until then every run here fails with "CodeQL analyses from advanced
+# configurations cannot be processed when the default setup is enabled".
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Weekly, matching the cadence the default setup ran on.
+    - cron: '25 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ actions, javascript-typescript, python ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Answer an unsatisfiable byte range with 416 instead of 500. `send` rejects a Range the file cannot satisfy (`bytes=99999999999-` against a shorter file, typically a client resuming against a stale length) with a 416 error, after already setting the `Content-Range: bytes */<size>` header that tells the client the real length. The error handler recognised only 413 and 404, so the request fell through to the unknown-error branch, was logged as an unhandled failure, and returned 500 — discarding the one status a range-requesting player can actually recover from. Malformed and empty Range headers take the same path on Express 4 and are now answered the same way.
 
+### Chore
+
+- Move code scanning from CodeQL's default setup to an advanced setup so it can exclude `**/__tests__/**`. The default setup supports no path filters, and the queries that reason about production request handling do not apply to test files: an integration test that builds a throwaway express app with supertest reads to `js/missing-rate-limiting` as an unprotected route handler, and three such alerts had to be dismissed by hand as "used in tests". Same languages, query suite and weekly cadence as before, and the job stays named `Analyze` so the checks remain `Analyze (<language>)`. **Requires turning the default setup off** under Settings -> Code security -> Code scanning; until then every run of the new workflow fails.
+
 ## v1.11.2 (2026-08-31)
 
 ### Security


### PR DESCRIPTION
> **Needs a repository setting changed before merging — see Before this can work.**

## Why

CodeQL's default setup supports no path filters, so every integration test that mounts routes trips `js/missing-rate-limiting` (high): an in-memory express app built with supertest reads as an unprotected route handler. Three such alerts have already been dismissed by hand as *used in tests*:

| Alert | PR | Location | Flagged as |
|---|---|---|---|
| 277 | #429 | `rangeNotSatisfiable.integration.test.ts` | route handler performs file system access |
| 274 | #430 | `imagesSmallVisibility.integration.test.ts:52` | route handler performs authorization |
| 275 | #430 | `imagesSmallVisibility.integration.test.ts:57` | route handler performs authorization |

None of them is a real defect — these fixtures have no network surface — and the same alert will recur with every new integration test. The production handlers they mirror are *not* flagged, because `server.ts` mounts `configureRateLimiting(app)` ahead of the routes; a bare test fixture has no limiter, and adding one purely to satisfy the query would put counters and headers into tests that are asserting something else entirely.

## What

- `.github/workflows/codeql.yml` — an advanced setup replacing the default one.
- `.github/codeql/codeql-config.yml` — `paths-ignore: ["**/__tests__/**"]`.

That single pattern covers **all 410 test files**: every one lives under a `__tests__` directory, and there are no stray `*.test.ts` / `*.spec.ts` outside them.

Continuity with the default setup is deliberate:

| | Default setup | This workflow |
|---|---|---|
| Languages | actions, javascript-typescript, python | same |
| Query suite | default | same (no `queries:` override) |
| Schedule | weekly | weekly |
| Check names | `Analyze (<language>)` | same — job is still named `Analyze` |

`master` has no branch protection today, so no required check depends on those names, but keeping them avoids surprises if protection is added later.

## Before this can work

GitHub will not accept results from an advanced configuration while the default setup is enabled. **Someone with repo admin has to turn it off** — Settings → Code security → Code scanning → CodeQL analysis → Disable — which I have deliberately not done, since it is a repository security setting.

Until that happens, every run of this workflow fails with:

```
CodeQL analyses from advanced configurations cannot be processed
when the default setup is enabled
```

So expect this PR's own CodeQL checks to be red. Either order works and leaves a short gap in scanning: disable the default setup and then merge, or merge and then disable.

## Testing

YAML validated; the matrix produces `Analyze (actions)`, `Analyze (javascript-typescript)`, `Analyze (python)`, and the config parses with `paths-ignore: ["**/__tests__/**"]`, which matches the flagged paths (`backend/src/__tests__/server/...`).

**Not verified by an actual scan.** The CodeQL CLI available locally is 2.23.9 and cannot download query packs built with 2.26.4 (`Unrecognized field "digest"`), so no local run was possible. The path filter's real effect will first be observable in the workflow run after the default setup is disabled — worth a look at that first run before trusting it.

## Note on the other open PR

This touches `CHANGELOG.md` under `## Unreleased`, as does #430. Whichever merges second gets the same trivial keep-both-blocks conflict; no semantic overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
