### PR TITLE
fix(gesture-login): extend the stroke to the pointer release position

### DIFF
--- a/frontend/src/components/Auth/GesturePattern.tsx
+++ b/frontend/src/components/Auth/GesturePattern.tsx
@@ -181,6 +181,19 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
             // Already released, or never captured.
         }
 
+        if (submit) {
+            // Walk the last segment out to where the pointer actually lifted.
+            // pointerup carries its own coordinates and is not guaranteed to be
+            // preceded by a pointermove at the same position - on touch and pen
+            // a fast swipe can lift a dot's width past the final sample. Without
+            // this the closing dot is silently dropped, which at enrolment
+            // stores a gesture the user did not draw, and at login rejects a
+            // correct one and spends one of only three attempts before the
+            // credential locks for good.
+            const releasePoint = pointFromEvent(event.clientX, event.clientY);
+            if (releasePoint) extendTo(releasePoint);
+        }
+
         const drawn = patternRef.current;
         clearStroke();
 

--- a/frontend/src/components/Auth/__tests__/GesturePattern.test.tsx
+++ b/frontend/src/components/Auth/__tests__/GesturePattern.test.tsx
@@ -42,6 +42,15 @@ const selectedDots = (): number[] =>
             screen.getByTestId(`gesture-dot-${index}`).getAttribute('data-selected') === 'true'
     );
 
+/** Press, move through `via`, then lift at `releaseAt` with no move there. */
+const drawReleasingAt = (svg: Element, start: number, via: number[], releaseAt: number) => {
+    fireEvent.pointerDown(svg, { ...PRIMARY, ...at(start) });
+    for (const dot of via) {
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(dot) });
+    }
+    fireEvent.pointerUp(svg, { ...PRIMARY, ...at(releaseAt) });
+};
+
 let onComplete: Mock<(pattern: number[]) => void>;
 
 const renderGrid = (props: Partial<React.ComponentProps<typeof GesturePattern>> = {}) =>
@@ -183,6 +192,81 @@ describe('completing a stroke', () => {
         draw(getSvg(), [0, 2]);
 
         expect(onComplete).toHaveBeenCalledWith([0, 1, 2]);
+    });
+});
+
+describe('the release point', () => {
+    it('includes a dot that only pointerup landed on', () => {
+        renderGrid();
+        // pointerup is not guaranteed to be preceded by a pointermove at the
+        // same spot; on touch and pen a fast swipe can lift past the last
+        // sample.
+        drawReleasingAt(getSvg(), 0, [3], 6);
+
+        expect(onComplete).toHaveBeenCalledWith([0, 3, 6]);
+    });
+
+    it('crosses midpoints on the closing segment', () => {
+        renderGrid();
+        drawReleasingAt(getSvg(), 6, [7], 2);
+
+        // 7 -> 2 is not collinear, so only the release dot is added.
+        expect(onComplete).toHaveBeenCalledWith([6, 7, 2]);
+    });
+
+    it('completes a draw that would otherwise be one dot short', () => {
+        renderGrid();
+        // Two sampled dots plus the release makes three. Dropping the release
+        // would reject a correct login draw and spend one of three attempts.
+        drawReleasingAt(getSvg(), 0, [4], 8);
+
+        expect(onComplete).toHaveBeenCalledWith([0, 4, 8]);
+    });
+
+    it('picks up a dot skipped between the last sample and the release', () => {
+        renderGrid();
+        // 6 -> 0 sweeps the left column through 3, then lifting at 2 sweeps
+        // the top row through 1. Both closing dots come from segments, not
+        // from a sample that landed on them.
+        drawReleasingAt(getSvg(), 6, [0], 2);
+
+        expect(onComplete).toHaveBeenCalledWith([6, 3, 0, 1, 2]);
+    });
+
+    it('adds nothing when the release lands in empty space', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(1) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(2) });
+        // Straight out past the top-right corner, clear of every dot.
+        fireEvent.pointerUp(svg, { ...PRIMARY, clientX: 299, clientY: 50 });
+
+        expect(onComplete).toHaveBeenCalledWith([0, 1, 2]);
+    });
+
+    it('still counts a dot the closing segment sweeps on its way off the grid', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(1) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(2) });
+        fireEvent.pointerUp(svg, { ...PRIMARY, clientX: 299, clientY: 299 });
+
+        // The release itself is outside every dot, but the path from 2 to the
+        // corner passes within 5's hit radius, so the finger did cross it.
+        expect(onComplete).toHaveBeenCalledWith([0, 1, 2, 5]);
+    });
+
+    it('does not apply the release point when the stroke is cancelled', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(3) });
+        fireEvent.pointerCancel(svg, { ...PRIMARY, ...at(6) });
+
+        expect(onComplete).not.toHaveBeenCalled();
+        expect(selectedDots()).toEqual([]);
     });
 });
 


### PR DESCRIPTION
Addresses the unresolved review comment on #434: [*Include the release point before completing the gesture*](https://github.com/franklioxygen/MyTube/pull/434#discussion_r3915879328).

**Based on `feat/gesture-login`, not `master`** — the file it fixes only exists on that branch. Merge #434 first, or merge this into it.

## The bug

`finishStroke` read the pattern accumulated by `pointermove` and never processed the `pointerup` coordinates, so the closing segment was dropped.

`pointerup` carries its own position and is not guaranteed to be preceded by a `pointermove` at the same place. On touch and pen a fast swipe can lift a dot's width past the final sample, and the dot the user finished on is then silently missing.

## Why it matters more than it looks

At enrolment it stores a gesture the user did not draw.

At login it rejects a correct draw and spends one of only **three** attempts before the credential locks permanently. A user whose device consistently drops the endpoint can lock themselves out of gesture login by drawing their gesture correctly three times. Recovery is a password sign-in, so nobody is stranded — but the failure is silent and looks like the feature is broken.

## The fix

The release point now goes through the same segment-extension path as every other sample, so a dot reached only at lift-off is picked up, along with anything the closing segment sweeps. Cancelled strokes are unaffected — they discard the pattern either way.

## Tests

Six cases, **five of which fail without the change**:

- a dot only `pointerup` landed on
- midpoints on the closing segment
- a draw that would otherwise be one dot short of valid — the attempt-burning case
- a release in empty space adding nothing
- a dot swept on the way off the grid
- cancel still discarding the stroke

Two of these caught my own wrong assumptions while writing them: `6 → 0` sweeps the left column through `3`, and a release past the bottom-right corner legitimately crosses `5`. Both expectations were corrected to match the geometry rather than adjusting the code.

## Verification

Frontend: 2031 tests passing under coverage, `tsc` clean, `vite build` clean.
