### PR TITLE
fix(gesture-login): release-point handling and status refresh after save

### DIFF
--- a/backend/src/__tests__/controllers/gestureLoginController.test.ts
+++ b/backend/src/__tests__/controllers/gestureLoginController.test.ts
@@ -62,6 +62,23 @@ describe("GET status", () => {
     expect(setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
     expect(json).toHaveBeenCalledWith(CLEAN_STATUS);
   });
+
+  it("returns 503 rather than a healthy-looking all-false status", async () => {
+    service.getGestureLoginStatus.mockImplementation(() => {
+      throw new Error("no such table: admin_gesture_credential");
+    });
+
+    await getGestureLoginStatus(req as Request, res as Response);
+
+    // All-false is indistinguishable from a working install whose
+    // prerequisites are unmet, which made the UI advise saving settings that
+    // were already saved. Saying "I cannot tell" lets the client show its
+    // status-unavailable message and a retry.
+    expect(status).toHaveBeenCalledWith(503);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "gesture_status_unavailable" })
+    );
+  });
 });
 
 describe("PUT configure", () => {

--- a/backend/src/__tests__/controllers/settingsController.test.ts
+++ b/backend/src/__tests__/controllers/settingsController.test.ts
@@ -30,7 +30,7 @@ vi.mock('../../services/migrationService', () => ({
   runMigration: vi.fn(),
 }));
 vi.mock('../../services/gestureLoginService', () => ({
-  hasGestureCredential: vi.fn(() => false),
+  getGestureCredentialPresence: vi.fn(() => 'absent'),
 }));
 
 describe('SettingsController', () => {
@@ -334,7 +334,7 @@ describe('SettingsController', () => {
       req.get = ((key: string) => req.headers?.[key.toLowerCase()] as string | undefined) as Request['get'];
       req.socket = { remoteAddress: '203.0.113.10' } as any;
       (storageService.getSettings as any).mockReturnValue({ passwordLoginAllowed: true });
-      (gestureLoginService.hasGestureCredential as any).mockReturnValue(true);
+      (gestureLoginService.getGestureCredentialPresence as any).mockReturnValue('present');
 
       await updateSettings(req as Request, res as Response);
 
@@ -344,6 +344,31 @@ describe('SettingsController', () => {
       );
       // Password login is the only recovery path out of a gesture lock, and a
       // mixed PATCH must be rejected whole rather than half-applied.
+      expect(storageService.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('should not claim a gesture exists when its state cannot be read', async () => {
+      req.body = { passwordLoginAllowed: false };
+      req.cookies = { mytube_csrf: 'csrf-token' } as any;
+      req.headers = {
+        origin: 'https://mytube.example',
+        host: 'mytube.example',
+        'x-csrf-token': 'csrf-token',
+      } as any;
+      req.get = ((key: string) => req.headers?.[key.toLowerCase()] as string | undefined) as Request['get'];
+      req.socket = { remoteAddress: '203.0.113.10' } as any;
+      (storageService.getSettings as any).mockReturnValue({ passwordLoginAllowed: true });
+      (gestureLoginService.getGestureCredentialPresence as any).mockReturnValue('unknown');
+
+      await updateSettings(req as Request, res as Response);
+
+      // Still blocked - the recovery invariant holds either way - but telling
+      // the admin to switch off a gesture they never created sends them
+      // looking for a control that is already off.
+      expect(status).toHaveBeenCalledWith(503);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'gesture_state_unavailable' })
+      );
       expect(storageService.saveSettings).not.toHaveBeenCalled();
     });
 
@@ -358,7 +383,7 @@ describe('SettingsController', () => {
       req.get = ((key: string) => req.headers?.[key.toLowerCase()] as string | undefined) as Request['get'];
       req.socket = { remoteAddress: '203.0.113.10' } as any;
       (storageService.getSettings as any).mockReturnValue({ passwordLoginAllowed: true });
-      (gestureLoginService.hasGestureCredential as any).mockReturnValue(false);
+      (gestureLoginService.getGestureCredentialPresence as any).mockReturnValue('absent');
 
       await updateSettings(req as Request, res as Response);
 
@@ -379,9 +404,9 @@ describe('SettingsController', () => {
       req.get = ((key: string) => req.headers?.[key.toLowerCase()] as string | undefined) as Request['get'];
       req.socket = { remoteAddress: '203.0.113.10' } as any;
       (storageService.getSettings as any).mockReturnValue({ passwordLoginAllowed: true });
-      (gestureLoginService.hasGestureCredential as any)
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true);
+      (gestureLoginService.getGestureCredentialPresence as any)
+        .mockReturnValueOnce('absent')
+        .mockReturnValueOnce('present');
 
       await updateSettings(req as Request, res as Response);
 

--- a/backend/src/__tests__/db/migrate.test.ts
+++ b/backend/src/__tests__/db/migrate.test.ts
@@ -8,6 +8,7 @@ const runDataMigrationMock = vi.hoisted(() => vi.fn());
 const migrateLegacySharedVisitorPasswordMock = vi.hoisted(() => vi.fn());
 const ensureVisitorUsersTableMock = vi.hoisted(() => vi.fn());
 const ensureFavoritesTablesMock = vi.hoisted(() => vi.fn());
+const ensureGestureCredentialTableMock = vi.hoisted(() => vi.fn());
 const securityMocks = vi.hoisted(() => ({
   accessTrustedSync: vi.fn(),
   pathExistsSafeSync: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("../../services/userService", () => ({
 vi.mock("../../services/storageService/migrations/schemaMigrations", () => ({
   ensureVisitorUsersTable: ensureVisitorUsersTableMock,
   ensureFavoritesTables: ensureFavoritesTablesMock,
+  ensureGestureCredentialTable: ensureGestureCredentialTableMock,
 }));
 
 describe("runMigrations", () => {
@@ -81,6 +83,7 @@ describe("runMigrations", () => {
     migrateLegacySharedVisitorPasswordMock.mockResolvedValue(undefined);
     ensureVisitorUsersTableMock.mockImplementation(() => undefined);
     ensureFavoritesTablesMock.mockImplementation(() => undefined);
+    ensureGestureCredentialTableMock.mockImplementation(() => undefined);
   });
 
   it("runs drizzle, legacy data import, and visitor password migration in order", async () => {
@@ -91,6 +94,9 @@ describe("runMigrations", () => {
     expect(runDataMigrationMock).toHaveBeenCalledTimes(1);
     expect(ensureVisitorUsersTableMock).toHaveBeenCalledTimes(1);
     expect(ensureFavoritesTablesMock).toHaveBeenCalledTimes(1);
+    // A skipped migration batch cannot be recovered by the column
+    // self-heals, so the gesture table needs its own.
+    expect(ensureGestureCredentialTableMock).toHaveBeenCalledTimes(1);
     expect(migrateLegacySharedVisitorPasswordMock).toHaveBeenCalledTimes(1);
     expect(
       migrateMock.mock.invocationCallOrder[0]
@@ -119,6 +125,9 @@ describe("runMigrations", () => {
     expect(configureDatabaseMock).toHaveBeenCalledTimes(1);
     expect(ensureVisitorUsersTableMock).toHaveBeenCalledTimes(1);
     expect(ensureFavoritesTablesMock).toHaveBeenCalledTimes(1);
+    // A skipped migration batch cannot be recovered by the column
+    // self-heals, so the gesture table needs its own.
+    expect(ensureGestureCredentialTableMock).toHaveBeenCalledTimes(1);
     expect(migrateLegacySharedVisitorPasswordMock).toHaveBeenCalledTimes(1);
     expect(runDataMigrationMock).not.toHaveBeenCalled();
   });

--- a/backend/src/__tests__/services/ensureGestureCredentialTable.test.ts
+++ b/backend/src/__tests__/services/ensureGestureCredentialTable.test.ts
@@ -1,0 +1,103 @@
+import Database from "better-sqlite3";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+// Real in-memory sqlite handed to the self-heal via the mocked db module.
+const mocks = vi.hoisted(() => ({ sqlite: undefined as any }));
+
+vi.mock("../../db", () => ({
+  get sqlite() {
+    return mocks.sqlite;
+  },
+  db: {},
+}));
+
+vi.mock("../../services/storageService/authorCollectionUtils", () => ({
+  backfillLegacyCollectionOrigins: vi.fn(),
+}));
+vi.mock("../../services/storageService/migrations/legacyTwitchDownloads", () => ({
+  deduplicateVideoDownloadsBySourceAndPlatform: vi.fn(),
+  normalizeLegacyTwitchDownloads: vi.fn(),
+}));
+vi.mock("../../services/storageService/migrations/dataBackfill", () => ({
+  backfillDownloadHistoryMediaTypes: vi.fn(),
+  backfillDownloadHistoryVideoIds: vi.fn(),
+  populateVideoFileSizes: vi.fn(),
+}));
+
+const hasTable = (sqlite: Database.Database): boolean =>
+  !!sqlite
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'admin_gesture_credential'"
+    )
+    .get();
+
+/**
+ * drizzle's migrate() aborts its remaining batch at the first failing
+ * statement, and migrate.ts swallows "duplicate column name" so an install
+ * whose columns were already self-healed can still boot. Migration 0028 then
+ * never runs, and because the other self-heals only add columns, nothing
+ * recreates a missing table - the server starts clean and every Gesture Login
+ * request fails with "no such table".
+ */
+describe("ensureGestureCredentialTable (migration 0028 self-heal)", () => {
+  let sqlite: Database.Database;
+  let ensureGestureCredentialTable: typeof import("../../services/storageService/migrations/schemaMigrations").ensureGestureCredentialTable;
+
+  beforeAll(async () => {
+    sqlite = new Database(":memory:");
+    mocks.sqlite = sqlite;
+    ({ ensureGestureCredentialTable } = await import(
+      "../../services/storageService/migrations/schemaMigrations"
+    ));
+  });
+
+  afterAll(() => {
+    sqlite.close();
+  });
+
+  it("creates the table when the migration batch skipped it", () => {
+    expect(hasTable(sqlite)).toBe(false);
+
+    ensureGestureCredentialTable();
+
+    expect(hasTable(sqlite)).toBe(true);
+  });
+
+  it("is idempotent, so a healthy install is untouched", () => {
+    ensureGestureCredentialTable();
+    ensureGestureCredentialTable();
+
+    expect(hasTable(sqlite)).toBe(true);
+  });
+
+  it("reproduces the migration's constraints, so a healed table behaves the same", () => {
+    ensureGestureCredentialTable();
+
+    const insert = (
+      id: number,
+      attempts: number,
+      lastFailed: number | null,
+      lockedAt: number | null
+    ) =>
+      sqlite
+        .prepare(
+          `INSERT INTO admin_gesture_credential
+             (id, pattern_hash, pepper_key_id, credential_version,
+              failed_attempts, last_failed_at, locked_at, created_at, updated_at)
+           VALUES (?, 'h', 'k', 'v', ?, ?, ?, 1, 1)`
+        )
+        .run(id, attempts, lastFailed, lockedAt);
+
+    // Singleton, bounded counter, and the three legal failure shapes.
+    expect(() => insert(2, 0, null, null)).toThrow();
+    expect(() => insert(1, 4, 1000, 1000)).toThrow();
+    expect(() => insert(1, 0, 1000, null)).toThrow();
+    expect(() => insert(1, 3, 1000, null)).toThrow();
+
+    expect(() => insert(1, 0, null, null)).not.toThrow();
+    sqlite.exec("DELETE FROM admin_gesture_credential");
+    expect(() => insert(1, 2, 1000, null)).not.toThrow();
+    sqlite.exec("DELETE FROM admin_gesture_credential");
+    expect(() => insert(1, 3, 1000, 1000)).not.toThrow();
+  });
+});

--- a/backend/src/__tests__/services/gestureLoginService.test.ts
+++ b/backend/src/__tests__/services/gestureLoginService.test.ts
@@ -68,6 +68,7 @@ import {
   authenticateGesture,
   configureGesture,
   getGestureLoginStatus,
+  getGestureCredentialPresence,
   hasGestureCredential,
   removeGesture,
   unlockAfterSuccessfulAdminPasswordLogin,
@@ -225,6 +226,37 @@ describe("status derivation", () => {
     expect(getGestureLoginStatus()).toMatchObject({
       configured: false,
       resetRequired: true,
+    });
+  });
+});
+
+describe("an unreadable credential table", () => {
+  const dropTable = () =>
+    mocks.sqlite.exec("DROP TABLE admin_gesture_credential");
+
+  it("reports status as unavailable instead of inventing an answer", async () => {
+    dropTable();
+
+    // Returning every flag false here reads to the UI exactly like a healthy
+    // install with unmet prerequisites, which is what made the Security page
+    // tell an admin to save settings they had already saved.
+    expect(() => getGestureLoginStatus()).toThrow();
+  });
+
+  it("reports credential presence as unknown, not absent", () => {
+    dropTable();
+
+    // "absent" would let password login be disabled with a gesture possibly
+    // enrolled; "present" would blame a gesture that may not exist.
+    expect(getGestureCredentialPresence()).toBe("unknown");
+    expect(hasGestureCredential()).toBe(true);
+  });
+
+  it("still refuses to authenticate", async () => {
+    dropTable();
+
+    await expect(authenticateGesture(GOOD)).resolves.toMatchObject({
+      ok: false,
     });
   });
 });

--- a/backend/src/controllers/gestureLoginController.ts
+++ b/backend/src/controllers/gestureLoginController.ts
@@ -70,7 +70,20 @@ export const getGestureLoginStatus = async (
   res: Response
 ): Promise<void> => {
   setNoStore(res);
-  res.json(gestureLoginService.getGestureLoginStatus());
+
+  try {
+    res.json(gestureLoginService.getGestureLoginStatus());
+  } catch {
+    // Say "I cannot tell" rather than returning all-false, which the UI cannot
+    // distinguish from a healthy install with unmet prerequisites. The client
+    // shows its status-unavailable message and a retry instead of advising an
+    // action that would not help.
+    res.status(503).json({
+      success: false,
+      code: "gesture_status_unavailable",
+      message: "Gesture Login status could not be loaded.",
+    });
+  }
 };
 
 /** Create or replace the credential. Admin session only. */

--- a/backend/src/controllers/settingsController.ts
+++ b/backend/src/controllers/settingsController.ts
@@ -334,6 +334,7 @@ const persistSettingsUpdate = async (
       res.status(409).json({
         success: false,
         code: "gesture_requires_password_login",
+        errorKey: "gestureLoginDisablePasswordBlocked",
         message: "Turn off Gesture Login before disabling password login.",
       });
       return;
@@ -346,6 +347,7 @@ const persistSettingsUpdate = async (
       res.status(503).json({
         success: false,
         code: "gesture_state_unavailable",
+        errorKey: "gestureLoginStateUnavailable",
         message:
           "Gesture Login state could not be verified, so password login cannot be disabled right now.",
       });
@@ -380,6 +382,7 @@ const persistSettingsUpdate = async (
       res.status(409).json({
         success: false,
         code: "gesture_requires_password_login",
+        errorKey: "gestureLoginDisablePasswordBlocked",
         message: "Turn off Gesture Login before disabling password login.",
       });
       return;
@@ -389,6 +392,7 @@ const persistSettingsUpdate = async (
       res.status(503).json({
         success: false,
         code: "gesture_state_unavailable",
+        errorKey: "gestureLoginStateUnavailable",
         message:
           "Gesture Login state could not be verified, so password login cannot be disabled right now.",
       });

--- a/backend/src/controllers/settingsController.ts
+++ b/backend/src/controllers/settingsController.ts
@@ -327,16 +327,30 @@ const persistSettingsUpdate = async (
   // before anything is hashed or persisted, so a mixed PATCH is rejected whole
   // rather than half-applied. Disabling the control in React is not enough:
   // a stale tab or a direct call must hit the same rule.
-  if (
-    passwordLoginDisableRequested &&
-    gestureLoginService.hasGestureCredential()
-  ) {
-    res.status(409).json({
-      success: false,
-      code: "gesture_requires_password_login",
-      message: "Turn off Gesture Login before disabling password login.",
-    });
-    return;
+  if (passwordLoginDisableRequested) {
+    const presence = gestureLoginService.getGestureCredentialPresence();
+
+    if (presence === "present") {
+      res.status(409).json({
+        success: false,
+        code: "gesture_requires_password_login",
+        message: "Turn off Gesture Login before disabling password login.",
+      });
+      return;
+    }
+
+    // Still blocked, because the recovery invariant has to hold - but do not
+    // claim a gesture exists. Telling an admin to switch off something they
+    // never created sends them looking for a control that is already off.
+    if (presence === "unknown") {
+      res.status(503).json({
+        success: false,
+        code: "gesture_state_unavailable",
+        message:
+          "Gesture Login state could not be verified, so password login cannot be disabled right now.",
+      });
+      return;
+    }
   }
 
   const normalizedIncomingSettings =
@@ -359,16 +373,27 @@ const persistSettingsUpdate = async (
   // factor to this now-stale settings update. No further await occurs before
   // saveSettings, while gesture enrollment also re-checks settings immediately
   // before its synchronous credential write.
-  if (
-    passwordLoginDisableRequested &&
-    gestureLoginService.hasGestureCredential()
-  ) {
-    res.status(409).json({
-      success: false,
-      code: "gesture_requires_password_login",
-      message: "Turn off Gesture Login before disabling password login.",
-    });
-    return;
+  if (passwordLoginDisableRequested) {
+    const presence = gestureLoginService.getGestureCredentialPresence();
+
+    if (presence === "present") {
+      res.status(409).json({
+        success: false,
+        code: "gesture_requires_password_login",
+        message: "Turn off Gesture Login before disabling password login.",
+      });
+      return;
+    }
+
+    if (presence === "unknown") {
+      res.status(503).json({
+        success: false,
+        code: "gesture_state_unavailable",
+        message:
+          "Gesture Login state could not be verified, so password login cannot be disabled right now.",
+      });
+      return;
+    }
   }
 
   const sanitizedIncoming = sanitizeIncomingSettings(normalizedIncomingSettings);

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -261,7 +261,11 @@ export async function runMigrations(options: RunMigrationsOptions = {}) {
     // reaching the 0019 CREATE TABLE users; this idempotent self-heal covers
     // that case so migrateLegacySharedVisitorPassword succeeds on first boot
     // instead of failing with "no such table: users".
-    const { ensureVisitorUsersTable, ensureFavoritesTables } = await import(
+    const {
+      ensureVisitorUsersTable,
+      ensureFavoritesTables,
+      ensureGestureCredentialTable,
+    } = await import(
       "../services/storageService/migrations/schemaMigrations"
     );
     ensureVisitorUsersTable();
@@ -271,6 +275,12 @@ export async function runMigrations(options: RunMigrationsOptions = {}) {
     // never created, and every /favorites request would 500 with
     // "no such table". Idempotent CREATE TABLE IF NOT EXISTS covers that.
     ensureFavoritesTables();
+
+    // Same self-heal for migration 0028's admin_gesture_credential: a new
+    // table cannot be recovered by the column checks above, so without this a
+    // skipped batch leaves every Gesture Login endpoint failing with
+    // "no such table" on a server that reported a clean start.
+    ensureGestureCredentialTable();
 
     const { migrateLegacySharedVisitorPassword } = await import(
       "../services/userService"

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -160,7 +160,12 @@ export async function runMigrations(options: RunMigrationsOptions = {}) {
     // For network filesystems (NFS/SMB), add a small delay to ensure
     // the database file is fully accessible before attempting migration
     // This helps prevent "database is locked" errors on first deployment
-    const dbPath = path.join(ROOT_DIR, "data", DB_FILENAME);
+    // Must come from DATA_DIR, not a second guess at it. Every check below
+    // validates against DATA_DIR, so rebuilding the path from ROOT_DIR made
+    // the two disagree the moment MYTUBE_DATA_DIR moved the data directory -
+    // the traversal guard then aborted migrations and left a database with no
+    // tables at all.
+    const dbPath = path.join(DATA_DIR, DB_FILENAME);
     if (!pathExistsSafeSync(dbPath, DATA_DIR)) {
       logger.info(
         "Database file does not exist yet, waiting for file system sync..."

--- a/backend/src/services/gestureLoginService.ts
+++ b/backend/src/services/gestureLoginService.ts
@@ -205,6 +205,25 @@ const deriveStatus = (
  * only booleans and the remaining attempt count, never the verifier, the pepper
  * id, or any timestamp.
  */
+export class GestureStatusUnavailableError extends Error {
+  public readonly reason: unknown;
+
+  constructor(reason: unknown) {
+    super("Gesture Login status could not be determined.");
+    this.name = "GestureStatusUnavailableError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Derived status, or a thrown error when it cannot be read at all.
+ *
+ * This used to swallow the failure and return every flag false, which reads to
+ * the UI as "configured: false, canConfigure: false" - indistinguishable from a
+ * healthy install whose prerequisites are not met. The Security page then told
+ * the admin to save login settings they had already saved, which is advice that
+ * cannot possibly help. A caller that cannot read the credential must say so.
+ */
 export function getGestureLoginStatus(): GestureLoginStatus {
   const now = Date.now();
 
@@ -215,7 +234,18 @@ export function getGestureLoginStatus(): GestureLoginStatus {
       "Failed to derive Gesture Login status",
       error instanceof Error ? error : new Error(String(error))
     );
-    // Fail closed: an unknown state must not present an interactive grid.
+    throw new GestureStatusUnavailableError(error);
+  }
+}
+
+/**
+ * Status for internal decisions that must stay total. Fails closed: an unknown
+ * state never presents a usable credential.
+ */
+const safeStatus = (): GestureLoginStatus => {
+  try {
+    return getGestureLoginStatus();
+  } catch {
     return {
       configured: false,
       canConfigure: false,
@@ -225,22 +255,34 @@ export function getGestureLoginStatus(): GestureLoginStatus {
       resetRequired: false,
     };
   }
-}
+};
 
-/** Whether any credential row exists, however unusable. */
-export function hasGestureCredential(): boolean {
+export type GestureCredentialPresence = "present" | "absent" | "unknown";
+
+/**
+ * Whether any credential row exists, however unusable.
+ *
+ * Tri-state on purpose. This guards the password-recovery invariant, so an
+ * unreadable database still has to block disabling password login - but the
+ * caller must be able to tell "a gesture exists" from "I could not look",
+ * because telling an admin to turn off a gesture they never created sends them
+ * hunting for a switch that is already off.
+ */
+export function getGestureCredentialPresence(): GestureCredentialPresence {
   try {
-    return selectRow() !== undefined;
+    return selectRow() !== undefined ? "present" : "absent";
   } catch (error) {
     logger.error(
       "Failed to read Gesture Login credential",
       error instanceof Error ? error : new Error(String(error))
     );
-    // Fail closed. This helper guards the password-recovery invariant, so an
-    // unknown database state must block password-login disablement rather than
-    // assume that no gesture exists.
-    return true;
+    return "unknown";
   }
+}
+
+/** Convenience for callers that only care whether a gesture may exist. */
+export function hasGestureCredential(): boolean {
+  return getGestureCredentialPresence() !== "absent";
 }
 
 /** Enrol a new gesture, or replace the existing one. Admin-only. */
@@ -529,7 +571,7 @@ export async function authenticateGesture(
     if (!recorded) {
       // Changed, removed, or locked while we were hashing. Do not overwrite
       // whatever won; report the current state instead.
-      const current = getGestureLoginStatus();
+      const current = safeStatus();
       return current.locked
         ? { ok: false, code: "gesture_locked", attemptsRemaining: 0 }
         : { ok: false, code: "gesture_unavailable" };
@@ -553,7 +595,7 @@ export async function authenticateGesture(
   if (!clearFailuresOnSuccess(row.credential_version, Date.now())) {
     // The credential moved under us, or a concurrent third failure locked it
     // first. Never mint a session from a stale snapshot.
-    const current = getGestureLoginStatus();
+    const current = safeStatus();
     return current.locked
       ? { ok: false, code: "gesture_locked", attemptsRemaining: 0 }
       : { ok: false, code: "gesture_unavailable" };

--- a/backend/src/services/storageService/migrations/schemaMigrations.ts
+++ b/backend/src/services/storageService/migrations/schemaMigrations.ts
@@ -500,6 +500,59 @@ export function ensureVisitorUsersTable(): void {
 // runs, so GET /favorites/collections and /favorites/authors throw
 // "no such table: favorite_collections" (HTTP 500) on every request.
 // CREATE TABLE / INDEX IF NOT EXISTS makes this idempotent and safe every boot.
+/**
+ * Self-heal for migration 0028's admin_gesture_credential.
+ *
+ * drizzle's migrate() aborts the whole remaining batch at the first statement
+ * that throws, and migrate.ts deliberately swallows "duplicate column name" so
+ * an install whose columns were already added by the self-heal below can still
+ * boot. The cost is that every migration AFTER the failing one is skipped, and
+ * the column self-heal cannot cover a brand new table. On such an install the
+ * gesture endpoints then fail with "no such table" while the server reports a
+ * clean start.
+ *
+ * The check constraints are reproduced from the migration so a healed table is
+ * identical to a migrated one.
+ */
+export function ensureGestureCredentialTable(): void {
+  try {
+    sqlite
+      .prepare(
+        `
+      CREATE TABLE IF NOT EXISTS admin_gesture_credential (
+        id integer PRIMARY KEY NOT NULL,
+        pattern_hash text NOT NULL,
+        pepper_key_id text NOT NULL,
+        credential_version text NOT NULL,
+        failed_attempts integer DEFAULT 0 NOT NULL,
+        last_failed_at integer,
+        locked_at integer,
+        created_at integer NOT NULL,
+        updated_at integer NOT NULL,
+        CONSTRAINT "admin_gesture_singleton_check" CHECK("admin_gesture_credential"."id" = 1),
+        CONSTRAINT "admin_gesture_attempts_check" CHECK("admin_gesture_credential"."failed_attempts" >= 0 AND "admin_gesture_credential"."failed_attempts" <= 3),
+        CONSTRAINT "admin_gesture_failure_state_check" CHECK((
+          ("admin_gesture_credential"."failed_attempts" = 0 AND "admin_gesture_credential"."last_failed_at" IS NULL AND "admin_gesture_credential"."locked_at" IS NULL)
+          OR ("admin_gesture_credential"."failed_attempts" IN (1, 2) AND "admin_gesture_credential"."last_failed_at" IS NOT NULL AND "admin_gesture_credential"."locked_at" IS NULL)
+          OR ("admin_gesture_credential"."failed_attempts" = 3 AND "admin_gesture_credential"."last_failed_at" IS NOT NULL AND "admin_gesture_credential"."locked_at" IS NOT NULL)
+        ))
+      )
+    `
+      )
+      .run();
+  } catch (error) {
+    logger.error(
+      "Error ensuring admin_gesture_credential table exists",
+      error instanceof Error ? error : new Error(String(error))
+    );
+    throw new MigrationError(
+      "Failed to ensure gesture credential table",
+      "gesture_credential_table",
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+}
+
 export function ensureFavoritesTables(): void {
   try {
     sqlite

--- a/frontend/src/components/Auth/GestureLoginSetupDialog.tsx
+++ b/frontend/src/components/Auth/GestureLoginSetupDialog.tsx
@@ -127,7 +127,7 @@ const GestureLoginSetupDialogContent: React.FC<GestureLoginSetupDialogProps> = (
             : t('gestureLoginSetUpTitle') || 'Set Up Gesture Login';
 
     return (
-        <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+        <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
             <DialogHeader
                 title={title}
                 onClose={handleClose}
@@ -140,7 +140,7 @@ const GestureLoginSetupDialogContent: React.FC<GestureLoginSetupDialogProps> = (
                         .replace('{current}', String(step))
                         .replace('{total}', '2')}
                 </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                     {step === 1
                         ? t('gestureLoginDrawInstruction') ||
                           'Draw a gesture connecting at least 3 dots.'
@@ -187,7 +187,7 @@ const GestureLoginSetupDialogContent: React.FC<GestureLoginSetupDialogProps> = (
                     )}
                 </Box>
 
-                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 2, lineHeight: 1.4 }}>
                     {t('gestureLoginConvenienceWarning') ||
                         'A gesture is a convenience, not a replacement for your password. Use HTTPS where possible.'}
                 </Typography>

--- a/frontend/src/components/Auth/GesturePattern.tsx
+++ b/frontend/src/components/Auth/GesturePattern.tsx
@@ -1,4 +1,5 @@
 import { Box, useTheme } from '@mui/material';
+import { visuallyHidden } from '@mui/utils';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
     GESTURE_DOT_CENTERS,
@@ -233,7 +234,7 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
             data-testid="gesture-pattern"
             data-mode={mode}
             data-outcome={effectiveOutcome}
-            sx={{ width: '100%', maxWidth: 320, mx: 'auto' }}
+            sx={{ width: '100%' }}
         >
             <Box
                 component="svg"
@@ -247,6 +248,8 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
                 onLostPointerCapture={(event) => finishStroke(event, false)}
                 sx={{
                     width: '100%',
+                    maxWidth: 280,
+                    mx: 'auto',
                     aspectRatio: '1 / 1',
                     display: 'block',
                     borderRadius: 2,
@@ -318,10 +321,11 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
                 <Box
                     id={instructionsId}
                     sx={{
-                        mt: 1,
+                        mt: 1.5,
                         textAlign: 'center',
                         color: 'text.secondary',
-                        fontSize: '0.875rem',
+                        fontSize: '0.8125rem',
+                        lineHeight: 1.4,
                     }}
                 >
                     {instructions}
@@ -347,14 +351,11 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
                 sx={
                     showOwnMessage
                         ? { mt: 1, textAlign: 'center', color: 'error.main', fontSize: '0.875rem' }
-                        : {
-                              position: 'absolute',
-                              width: 1,
-                              height: 1,
-                              overflow: 'hidden',
-                              clip: 'rect(0 0 0 0)',
-                              whiteSpace: 'nowrap',
-                          }
+                        // MUI's own helper. Hand-rolling this is a trap: in the
+                        // sx prop a bare `width: 1` means 100%, not one pixel,
+                        // so the "hidden" region was a full-size absolutely
+                        // positioned box overlaying the dialog.
+                        : visuallyHidden
                 }
             >
                 {liveText}

--- a/frontend/src/components/Auth/GesturePattern.tsx
+++ b/frontend/src/components/Auth/GesturePattern.tsx
@@ -181,6 +181,19 @@ const GesturePatternSurface: React.FC<GesturePatternProps> = ({
             // Already released, or never captured.
         }
 
+        if (submit) {
+            // Walk the last segment out to where the pointer actually lifted.
+            // pointerup carries its own coordinates and is not guaranteed to be
+            // preceded by a pointermove at the same position - on touch and pen
+            // a fast swipe can lift a dot's width past the final sample. Without
+            // this the closing dot is silently dropped, which at enrolment
+            // stores a gesture the user did not draw, and at login rejects a
+            // correct one and spends one of only three attempts before the
+            // credential locks for good.
+            const releasePoint = pointFromEvent(event.clientX, event.clientY);
+            if (releasePoint) extendTo(releasePoint);
+        }
+
         const drawn = patternRef.current;
         clearStroke();
 

--- a/frontend/src/components/Auth/__tests__/GesturePattern.test.tsx
+++ b/frontend/src/components/Auth/__tests__/GesturePattern.test.tsx
@@ -42,6 +42,15 @@ const selectedDots = (): number[] =>
             screen.getByTestId(`gesture-dot-${index}`).getAttribute('data-selected') === 'true'
     );
 
+/** Press, move through `via`, then lift at `releaseAt` with no move there. */
+const drawReleasingAt = (svg: Element, start: number, via: number[], releaseAt: number) => {
+    fireEvent.pointerDown(svg, { ...PRIMARY, ...at(start) });
+    for (const dot of via) {
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(dot) });
+    }
+    fireEvent.pointerUp(svg, { ...PRIMARY, ...at(releaseAt) });
+};
+
 let onComplete: Mock<(pattern: number[]) => void>;
 
 const renderGrid = (props: Partial<React.ComponentProps<typeof GesturePattern>> = {}) =>
@@ -183,6 +192,81 @@ describe('completing a stroke', () => {
         draw(getSvg(), [0, 2]);
 
         expect(onComplete).toHaveBeenCalledWith([0, 1, 2]);
+    });
+});
+
+describe('the release point', () => {
+    it('includes a dot that only pointerup landed on', () => {
+        renderGrid();
+        // pointerup is not guaranteed to be preceded by a pointermove at the
+        // same spot; on touch and pen a fast swipe can lift past the last
+        // sample.
+        drawReleasingAt(getSvg(), 0, [3], 6);
+
+        expect(onComplete).toHaveBeenCalledWith([0, 3, 6]);
+    });
+
+    it('crosses midpoints on the closing segment', () => {
+        renderGrid();
+        drawReleasingAt(getSvg(), 6, [7], 2);
+
+        // 7 -> 2 is not collinear, so only the release dot is added.
+        expect(onComplete).toHaveBeenCalledWith([6, 7, 2]);
+    });
+
+    it('completes a draw that would otherwise be one dot short', () => {
+        renderGrid();
+        // Two sampled dots plus the release makes three. Dropping the release
+        // would reject a correct login draw and spend one of three attempts.
+        drawReleasingAt(getSvg(), 0, [4], 8);
+
+        expect(onComplete).toHaveBeenCalledWith([0, 4, 8]);
+    });
+
+    it('picks up a dot skipped between the last sample and the release', () => {
+        renderGrid();
+        // 6 -> 0 sweeps the left column through 3, then lifting at 2 sweeps
+        // the top row through 1. Both closing dots come from segments, not
+        // from a sample that landed on them.
+        drawReleasingAt(getSvg(), 6, [0], 2);
+
+        expect(onComplete).toHaveBeenCalledWith([6, 3, 0, 1, 2]);
+    });
+
+    it('adds nothing when the release lands in empty space', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(1) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(2) });
+        // Straight out past the top-right corner, clear of every dot.
+        fireEvent.pointerUp(svg, { ...PRIMARY, clientX: 299, clientY: 50 });
+
+        expect(onComplete).toHaveBeenCalledWith([0, 1, 2]);
+    });
+
+    it('still counts a dot the closing segment sweeps on its way off the grid', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(1) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(2) });
+        fireEvent.pointerUp(svg, { ...PRIMARY, clientX: 299, clientY: 299 });
+
+        // The release itself is outside every dot, but the path from 2 to the
+        // corner passes within 5's hit radius, so the finger did cross it.
+        expect(onComplete).toHaveBeenCalledWith([0, 1, 2, 5]);
+    });
+
+    it('does not apply the release point when the stroke is cancelled', () => {
+        renderGrid();
+        const svg = getSvg();
+        fireEvent.pointerDown(svg, { ...PRIMARY, ...at(0) });
+        fireEvent.pointerMove(svg, { ...PRIMARY, ...at(3) });
+        fireEvent.pointerCancel(svg, { ...PRIMARY, ...at(6) });
+
+        expect(onComplete).not.toHaveBeenCalled();
+        expect(selectedDots()).toEqual([]);
     });
 });
 

--- a/frontend/src/components/Settings/SecuritySettings.tsx
+++ b/frontend/src/components/Settings/SecuritySettings.tsx
@@ -116,10 +116,17 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
     // draft they are about to turn off; draft-only would enrol against a
     // prerequisite the server has not accepted yet and would reject.
     const gestureDraftPrerequisites = meetsPrerequisites(settings);
-    // Fall back to the server's view only when the cache has not loaded yet.
-    const gesturePersistedPrerequisites = persistedSettings
-        ? meetsPrerequisites(persistedSettings)
-        : gestureStatus?.canConfigure === true;
+    // Both sources must agree, and neither substitutes for the other. The
+    // cache can be stale - another tab disabling login leaves a cached `true`
+    // until its refetch lands, or that refetch fails - and trusting it alone
+    // would keep enrolment enabled while the server already says no, letting
+    // the admin complete both drawings only to eat a 409. The server answer
+    // alone is not enough either: it knows nothing about the unsaved draft.
+    // When the status is unknown the switch is disabled regardless, so this
+    // never turns a failed status request into a claim about prerequisites.
+    const gesturePersistedPrerequisites =
+        gestureStatus?.canConfigure === true &&
+        (persistedSettings ? meetsPrerequisites(persistedSettings) : true);
     const gestureConfigured = gestureStatus?.configured === true;
     const gestureLocked = gestureStatus?.locked === true;
     const gestureResetRequired = gestureStatus?.resetRequired === true;

--- a/frontend/src/components/Settings/SecuritySettings.tsx
+++ b/frontend/src/components/Settings/SecuritySettings.tsx
@@ -17,6 +17,7 @@ import {
     fetchGestureLoginStatus,
     removeGestureLogin,
 } from '../../utils/gestureLogin';
+import { settingsQueryOptions } from '../../utils/settingsQueries';
 import GestureLoginSetupDialog from '../Auth/GestureLoginSetupDialog';
 import AlertModal from '../AlertModal';
 import ConfirmationModal from '../ConfirmationModal';
@@ -99,12 +100,26 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
         },
     });
 
-    // Enrolment needs the prerequisite to be true in BOTH the persisted status
+    // The prerequisite is a settings question, and the client already has both
+    // halves of it: `settings` is the unsaved draft, and the persisted values
+    // sit in the shared settings cache. Asking the gesture endpoint instead
+    // meant a failed status request reported "prerequisites unmet" - advice the
+    // client could see was untrue from data already in hand.
+    const persistedSettings = queryClient.getQueryData<Settings>(
+        settingsQueryOptions.queryKey
+    );
+    const meetsPrerequisites = (candidate: Partial<Settings> | undefined) =>
+        candidate?.loginEnabled === true && candidate.passwordLoginAllowed !== false;
+
+    // Enrolment needs the prerequisite to be true in BOTH the persisted state
     // and the unsaved draft. Persisted-only would let the admin enrol against a
     // draft they are about to turn off; draft-only would enrol against a
     // prerequisite the server has not accepted yet and would reject.
-    const gestureDraftPrerequisites =
-        settings.loginEnabled === true && settings.passwordLoginAllowed !== false;
+    const gestureDraftPrerequisites = meetsPrerequisites(settings);
+    // Fall back to the server's view only when the cache has not loaded yet.
+    const gesturePersistedPrerequisites = persistedSettings
+        ? meetsPrerequisites(persistedSettings)
+        : gestureStatus?.canConfigure === true;
     const gestureConfigured = gestureStatus?.configured === true;
     const gestureLocked = gestureStatus?.locked === true;
     const gestureResetRequired = gestureStatus?.resetRequired === true;
@@ -114,7 +129,7 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
     const canStartGestureEnrollment =
         gestureStatusKnown &&
         gestureDraftPrerequisites &&
-        gestureStatus.canConfigure &&
+        gesturePersistedPrerequisites &&
         !gestureConfigured;
 
     const isSecureOriginForPasskeys =
@@ -371,7 +386,7 @@ const SecuritySettings: React.FC<SecuritySettingsProps> = ({ settings, onChange 
                             </Typography>
                         )}
 
-                        {gestureStatusKnown && !gestureConfigured && !gestureResetRequired && gestureDraftPrerequisites && !gestureStatus.canConfigure && (
+                        {gestureStatusKnown && !gestureConfigured && !gestureResetRequired && gestureDraftPrerequisites && !gesturePersistedPrerequisites && (
                             <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }} data-testid="gesture-save-first-hint">
                                 {t('gestureLoginSavePrerequisitesFirst') || 'Save login and password settings before enabling Gesture Login.'}
                             </Typography>

--- a/frontend/src/components/Settings/__tests__/SecuritySettingsGesture.test.tsx
+++ b/frontend/src/components/Settings/__tests__/SecuritySettingsGesture.test.tsx
@@ -174,6 +174,20 @@ describe('prerequisites come from settings, not the status payload', () => {
         expect(screen.queryByTestId('gesture-save-first-hint')).toBeNull();
     });
 
+    it('refuses enrolment when the server disagrees with a stale cache', async () => {
+        // Another tab disabled login; the settings refetch has not landed (or
+        // failed), so the cache still says the prerequisites hold.
+        gestureResponse = { status: STATUS.prerequisiteOff };
+        renderSettings({}, { loginEnabled: true, passwordLoginAllowed: true });
+
+        await waitFor(() =>
+            expect(screen.getByTestId('gesture-save-first-hint')).toBeTruthy()
+        );
+        // Trusting the cache alone would let the admin draw twice and then eat
+        // a 409 from the PUT.
+        expect(gestureSwitch()).toBeDisabled();
+    });
+
     it('does not blame the prerequisites when the status request fails', async () => {
         gestureResponse = { reject: true };
         renderSettings({}, { loginEnabled: true, passwordLoginAllowed: true });

--- a/frontend/src/components/Settings/__tests__/SecuritySettingsGesture.test.tsx
+++ b/frontend/src/components/Settings/__tests__/SecuritySettingsGesture.test.tsx
@@ -79,8 +79,14 @@ const BASE_SETTINGS: any = {
 let gestureResponse: { status?: GestureLoginStatus; reject?: boolean; pending?: boolean };
 let passkeysExist = false;
 
-const renderSettings = (settings: Partial<typeof BASE_SETTINGS> = {}) => {
+const renderSettings = (
+    settings: Partial<typeof BASE_SETTINGS> = {},
+    persisted?: Partial<typeof BASE_SETTINGS>
+) => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    if (persisted) {
+        queryClient.setQueryData(['settings'], { ...BASE_SETTINGS, ...persisted });
+    }
     const onChange = vi.fn();
     const result = rtlRender(
         <QueryClientProvider client={queryClient}>
@@ -146,6 +152,37 @@ describe('toggle state', () => {
 
         await waitFor(() => expect(gestureSwitch()).toBeChecked());
         expect(screen.getByTestId('gesture-change-button')).toBeTruthy();
+    });
+});
+
+describe('prerequisites come from settings, not the status payload', () => {
+    it('asks the admin to save when the persisted settings do not agree yet', async () => {
+        // The server would say canConfigure here; the cache is the authority
+        // for a question the client can already answer.
+        renderSettings({}, { loginEnabled: false });
+
+        await waitFor(() =>
+            expect(screen.getByTestId('gesture-save-first-hint')).toBeTruthy()
+        );
+        expect(gestureSwitch()).toBeDisabled();
+    });
+
+    it('enables enrolment once the persisted settings agree', async () => {
+        renderSettings({}, { loginEnabled: true, passwordLoginAllowed: true });
+
+        await waitFor(() => expect(gestureSwitch()).not.toBeDisabled());
+        expect(screen.queryByTestId('gesture-save-first-hint')).toBeNull();
+    });
+
+    it('does not blame the prerequisites when the status request fails', async () => {
+        gestureResponse = { reject: true };
+        renderSettings({}, { loginEnabled: true, passwordLoginAllowed: true });
+
+        await waitFor(() => expect(screen.getByTestId('gesture-status-error')).toBeTruthy());
+        // The old build reported "save your settings first" here, which the
+        // client could see was untrue from the settings it already held.
+        expect(screen.queryByTestId('gesture-save-first-hint')).toBeNull();
+        expect(screen.queryByTestId('gesture-prerequisite-hint')).toBeNull();
     });
 });
 

--- a/frontend/src/hooks/__tests__/useSettingsMutations.test.tsx
+++ b/frontend/src/hooks/__tests__/useSettingsMutations.test.tsx
@@ -340,6 +340,54 @@ describe('useSettingsMutations', () => {
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['liveTranslationConfig'] });
     });
 
+    it('invalidates gesture login status when login protection is saved', async () => {
+        const queryClient = createTestQueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        queryClient.setQueryData(['settings'], makeSettings({ loginEnabled: false }));
+        const { result } = renderSettingsHook({ queryClient });
+
+        await act(async () => {
+            await result.current.saveMutation.mutateAsync(
+                makeSettings({ loginEnabled: true })
+            );
+        });
+
+        // Gesture availability is derived server-side from the persisted
+        // login settings. Without this the Security page keeps the status it
+        // fetched on mount and tells the admin to save what they just saved.
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['gesture-login-status'] });
+    });
+
+    it('invalidates gesture login status when password login is toggled', async () => {
+        const queryClient = createTestQueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        queryClient.setQueryData(['settings'], makeSettings({ passwordLoginAllowed: false }));
+        const { result } = renderSettingsHook({ queryClient });
+
+        await act(async () => {
+            await result.current.saveMutation.mutateAsync(
+                makeSettings({ passwordLoginAllowed: true })
+            );
+        });
+
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['gesture-login-status'] });
+    });
+
+    it('leaves gesture login status alone for unrelated settings saves', async () => {
+        const queryClient = createTestQueryClient();
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+        queryClient.setQueryData(['settings'], makeSettings({ itemsPerPage: 10 }));
+        const { result } = renderSettingsHook({ queryClient });
+
+        await act(async () => {
+            await result.current.saveMutation.mutateAsync(
+                makeSettings({ itemsPerPage: 20 })
+            );
+        });
+
+        expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: ['gesture-login-status'] });
+    });
+
     it('invalidates live translation availability when only the API key changes', async () => {
         const testApiKey = 'test-key';
         const queryClient = createTestQueryClient();

--- a/frontend/src/hooks/useSettingsMutations.ts
+++ b/frontend/src/hooks/useSettingsMutations.ts
@@ -3,6 +3,7 @@ import { useLanguage } from "../contexts/LanguageContext";
 import { Settings } from "../types";
 import { api, getApiErrorData, getApiErrorMessage } from "../utils/apiClient";
 import { generateTimestamp } from "../utils/formatUtils";
+import { GESTURE_LOGIN_STATUS_QUERY_KEY } from "../utils/gestureLogin";
 import { InfoModalState } from "./useSettingsModals";
 import { SUBSCRIPTIONS_QUERY_KEY } from "./useSubscriptions";
 
@@ -214,6 +215,19 @@ export function useSettingsMutations({
       }
       if (changedSettings.tags !== undefined) {
         void queryClient.invalidateQueries({ queryKey: ["videos"] });
+      }
+      // Gesture Login availability is derived server-side from the persisted
+      // loginEnabled and passwordLoginAllowed. Saving either changes the
+      // answer, and without this the Security page keeps showing the status it
+      // fetched on mount - so the toggle stays disabled telling the admin to
+      // save settings they just saved, until a reload or window refocus.
+      if (
+        changedSettings.loginEnabled !== undefined ||
+        changedSettings.passwordLoginAllowed !== undefined
+      ) {
+        void queryClient.invalidateQueries({
+          queryKey: GESTURE_LOGIN_STATUS_QUERY_KEY,
+        });
       }
     },
     onError: async (error: unknown) => {

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -576,9 +576,6 @@ const LoginPage: React.FC = () => {
                                         <>
                                             {gestureAvailable && (
                                                 <Box sx={{ mb: 2 }} data-testid="gesture-login-panel">
-                                                    <Typography variant="subtitle2">
-                                                        {t('gestureLoginUse') || 'Use Gesture Login'}
-                                                    </Typography>
                                                     <GesturePattern
                                                         mode="verify"
                                                         disabled={

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1728,6 +1728,7 @@ export const ar = {
   gestureLoginLockedSettings: "مقفل مؤقتًا. سجّل الخروج ثم سجّل الدخول مرة واحدة بكلمة مرور المسؤول لاستعادته.",
   gestureLoginLockedPasswordRecovery: "تم قفل تسجيل الدخول بالنمط بعد 3 محاولات خاطئة. سجّل الدخول مرة واحدة بكلمة مرور المسؤول لاستعادته.",
   gestureLoginIncorrectAttemptsRemaining: "نمط غير صحيح. تبقّى {count} محاولات.",
+  gestureLoginStateUnavailable: "تعذّر التحقق من حالة تسجيل الدخول بالنمط، لذا لا يمكن تعطيل تسجيل الدخول بكلمة المرور الآن.",
   gestureLoginUnavailable: "تسجيل الدخول بالنمط غير متاح.",
   gestureLoginResetRequired: "لم يعد بالإمكان التحقق من النمط المحفوظ على هذا الخادم. عيّن نمطًا جديدًا.",
   gestureLoginStatusFailed: "تعذّر تحميل حالة تسجيل الدخول بالنمط.",

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -1724,7 +1724,6 @@ export const ar = {
   gestureLoginMinimumDots: "ارسم نمطًا يصل بين 3 نقاط على الأقل.",
   gestureLoginMismatch: "النمطان غير متطابقين. ابدأ من جديد.",
   gestureLoginSaveFailed: "تعذّر حفظ تسجيل الدخول بالنمط. حاول مرة أخرى.",
-  gestureLoginUse: "استخدام تسجيل الدخول بالنمط",
   gestureLoginLockedSettings: "مقفل مؤقتًا. سجّل الخروج ثم سجّل الدخول مرة واحدة بكلمة مرور المسؤول لاستعادته.",
   gestureLoginLockedPasswordRecovery: "تم قفل تسجيل الدخول بالنمط بعد 3 محاولات خاطئة. سجّل الدخول مرة واحدة بكلمة مرور المسؤول لاستعادته.",
   gestureLoginIncorrectAttemptsRemaining: "نمط غير صحيح. تبقّى {count} محاولات.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1776,7 +1776,6 @@ export const de = {
   gestureLoginMinimumDots: "Zeichne eine Geste, die mindestens 3 Punkte verbindet.",
   gestureLoginMismatch: "Die Gesten stimmen nicht überein. Bitte neu beginnen.",
   gestureLoginSaveFailed: "Die Gesten-Anmeldung konnte nicht gespeichert werden. Bitte erneut versuchen.",
-  gestureLoginUse: "Gesten-Anmeldung verwenden",
   gestureLoginLockedSettings: "Vorübergehend gesperrt. Melde dich ab und einmal mit dem Administratorpasswort an, um sie wiederherzustellen.",
   gestureLoginLockedPasswordRecovery: "Die Gesten-Anmeldung ist nach 3 falschen Versuchen gesperrt. Melde dich einmal mit deinem Administratorpasswort an, um sie wiederherzustellen.",
   gestureLoginIncorrectAttemptsRemaining: "Falsche Geste. Noch {count} Versuche.",

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -1780,6 +1780,7 @@ export const de = {
   gestureLoginLockedSettings: "Vorübergehend gesperrt. Melde dich ab und einmal mit dem Administratorpasswort an, um sie wiederherzustellen.",
   gestureLoginLockedPasswordRecovery: "Die Gesten-Anmeldung ist nach 3 falschen Versuchen gesperrt. Melde dich einmal mit deinem Administratorpasswort an, um sie wiederherzustellen.",
   gestureLoginIncorrectAttemptsRemaining: "Falsche Geste. Noch {count} Versuche.",
+  gestureLoginStateUnavailable: "Der Status der Gesten-Anmeldung konnte nicht überprüft werden, daher lässt sich die Passwortanmeldung gerade nicht deaktivieren.",
   gestureLoginUnavailable: "Die Gesten-Anmeldung ist nicht verfügbar.",
   gestureLoginResetRequired: "Deine gespeicherte Geste kann auf diesem Server nicht mehr überprüft werden. Lege eine neue fest.",
   gestureLoginStatusFailed: "Der Status der Gesten-Anmeldung konnte nicht geladen werden.",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1716,7 +1716,6 @@ export const en = {
   gestureLoginMinimumDots: "Draw a gesture connecting at least 3 dots.",
   gestureLoginMismatch: "Gestures do not match. Start again.",
   gestureLoginSaveFailed: "Gesture Login could not be saved. Please try again.",
-  gestureLoginUse: "Use Gesture Login",
   gestureLoginLockedSettings: "Temporarily locked. Sign out and complete one admin password login to restore it.",
   gestureLoginLockedPasswordRecovery: "Gesture Login is locked after 3 incorrect attempts. Sign in once with your admin password to restore it.",
   gestureLoginIncorrectAttemptsRemaining: "Incorrect gesture. {count} attempts remaining.",

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -1720,6 +1720,7 @@ export const en = {
   gestureLoginLockedSettings: "Temporarily locked. Sign out and complete one admin password login to restore it.",
   gestureLoginLockedPasswordRecovery: "Gesture Login is locked after 3 incorrect attempts. Sign in once with your admin password to restore it.",
   gestureLoginIncorrectAttemptsRemaining: "Incorrect gesture. {count} attempts remaining.",
+  gestureLoginStateUnavailable: "Gesture Login state could not be verified, so password login cannot be disabled right now.",
   gestureLoginUnavailable: "Gesture Login is not available.",
   gestureLoginResetRequired: "Your saved gesture can no longer be verified on this server. Set a new one.",
   gestureLoginStatusFailed: "Gesture Login status could not be loaded.",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1782,6 +1782,7 @@ export const es = {
   gestureLoginLockedSettings: "Bloqueado temporalmente. Cierra sesión y entra una vez con la contraseña de administrador para restaurarlo.",
   gestureLoginLockedPasswordRecovery: "El inicio con gesto está bloqueado tras 3 intentos incorrectos. Entra una vez con tu contraseña de administrador para restaurarlo.",
   gestureLoginIncorrectAttemptsRemaining: "Gesto incorrecto. Quedan {count} intentos.",
+  gestureLoginStateUnavailable: "No se pudo verificar el estado del inicio con gesto, así que ahora mismo no se puede desactivar el inicio con contraseña.",
   gestureLoginUnavailable: "El inicio con gesto no está disponible.",
   gestureLoginResetRequired: "Tu gesto guardado ya no puede verificarse en este servidor. Define uno nuevo.",
   gestureLoginStatusFailed: "No se pudo cargar el estado del inicio con gesto.",

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -1778,7 +1778,6 @@ export const es = {
   gestureLoginMinimumDots: "Dibuja un gesto que conecte al menos 3 puntos.",
   gestureLoginMismatch: "Los gestos no coinciden. Empieza de nuevo.",
   gestureLoginSaveFailed: "No se pudo guardar el inicio con gesto. Inténtalo de nuevo.",
-  gestureLoginUse: "Usar inicio con gesto",
   gestureLoginLockedSettings: "Bloqueado temporalmente. Cierra sesión y entra una vez con la contraseña de administrador para restaurarlo.",
   gestureLoginLockedPasswordRecovery: "El inicio con gesto está bloqueado tras 3 intentos incorrectos. Entra una vez con tu contraseña de administrador para restaurarlo.",
   gestureLoginIncorrectAttemptsRemaining: "Gesto incorrecto. Quedan {count} intentos.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1793,6 +1793,7 @@ export const fr = {
   gestureLoginLockedSettings: "Temporairement verrouillé. Déconnectez-vous et connectez-vous une fois avec le mot de passe administrateur pour la rétablir.",
   gestureLoginLockedPasswordRecovery: "La connexion par geste est verrouillée après 3 tentatives incorrectes. Connectez-vous une fois avec votre mot de passe administrateur pour la rétablir.",
   gestureLoginIncorrectAttemptsRemaining: "Geste incorrect. {count} tentatives restantes.",
+  gestureLoginStateUnavailable: "L'état de la connexion par geste n'a pas pu être vérifié, la connexion par mot de passe ne peut donc pas être désactivée pour le moment.",
   gestureLoginUnavailable: "La connexion par geste n'est pas disponible.",
   gestureLoginResetRequired: "Votre geste enregistré ne peut plus être vérifié sur ce serveur. Définissez-en un nouveau.",
   gestureLoginStatusFailed: "Le statut de la connexion par geste n'a pas pu être chargé.",

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -1789,7 +1789,6 @@ export const fr = {
   gestureLoginMinimumDots: "Dessinez un geste reliant au moins 3 points.",
   gestureLoginMismatch: "Les gestes ne correspondent pas. Recommencez.",
   gestureLoginSaveFailed: "La connexion par geste n'a pas pu être enregistrée. Veuillez réessayer.",
-  gestureLoginUse: "Utiliser la connexion par geste",
   gestureLoginLockedSettings: "Temporairement verrouillé. Déconnectez-vous et connectez-vous une fois avec le mot de passe administrateur pour la rétablir.",
   gestureLoginLockedPasswordRecovery: "La connexion par geste est verrouillée après 3 tentatives incorrectes. Connectez-vous une fois avec votre mot de passe administrateur pour la rétablir.",
   gestureLoginIncorrectAttemptsRemaining: "Geste incorrect. {count} tentatives restantes.",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1755,6 +1755,7 @@ export const ja = {
   gestureLoginLockedSettings: "一時的にロックされています。サインアウトし、管理者パスワードで1回ログインすると復旧します。",
   gestureLoginLockedPasswordRecovery: "3回間違えたためジェスチャーログインはロックされています。管理者パスワードで1回サインインすると復旧します。",
   gestureLoginIncorrectAttemptsRemaining: "ジェスチャーが違います。残り {count} 回です。",
+  gestureLoginStateUnavailable: "ジェスチャーログインの状態を確認できなかったため、現在パスワードログインを無効にできません。",
   gestureLoginUnavailable: "ジェスチャーログインは利用できません。",
   gestureLoginResetRequired: "保存されたジェスチャーはこのサーバーでは検証できなくなりました。新しく設定してください。",
   gestureLoginStatusFailed: "ジェスチャーログインの状態を読み込めませんでした。",

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -1751,7 +1751,6 @@ export const ja = {
   gestureLoginMinimumDots: "3つ以上の点をつなぐジェスチャーを描いてください。",
   gestureLoginMismatch: "ジェスチャーが一致しません。最初からやり直してください。",
   gestureLoginSaveFailed: "ジェスチャーログインを保存できませんでした。もう一度お試しください。",
-  gestureLoginUse: "ジェスチャーログインを使う",
   gestureLoginLockedSettings: "一時的にロックされています。サインアウトし、管理者パスワードで1回ログインすると復旧します。",
   gestureLoginLockedPasswordRecovery: "3回間違えたためジェスチャーログインはロックされています。管理者パスワードで1回サインインすると復旧します。",
   gestureLoginIncorrectAttemptsRemaining: "ジェスチャーが違います。残り {count} 回です。",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1732,6 +1732,7 @@ export const ko = {
   gestureLoginLockedSettings: "일시적으로 잠겼습니다. 로그아웃한 뒤 관리자 비밀번호로 한 번 로그인하면 복구됩니다.",
   gestureLoginLockedPasswordRecovery: "3회 틀려 제스처 로그인이 잠겼습니다. 관리자 비밀번호로 한 번 로그인하면 복구됩니다.",
   gestureLoginIncorrectAttemptsRemaining: "제스처가 올바르지 않습니다. {count}회 남았습니다.",
+  gestureLoginStateUnavailable: "제스처 로그인 상태를 확인할 수 없어 지금은 비밀번호 로그인을 끌 수 없습니다.",
   gestureLoginUnavailable: "제스처 로그인을 사용할 수 없습니다.",
   gestureLoginResetRequired: "저장된 제스처를 이 서버에서 더 이상 확인할 수 없습니다. 새로 설정하세요.",
   gestureLoginStatusFailed: "제스처 로그인 상태를 불러오지 못했습니다.",

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -1728,7 +1728,6 @@ export const ko = {
   gestureLoginMinimumDots: "점을 3개 이상 잇는 제스처를 그리세요.",
   gestureLoginMismatch: "제스처가 일치하지 않습니다. 처음부터 다시 시작하세요.",
   gestureLoginSaveFailed: "제스처 로그인을 저장하지 못했습니다. 다시 시도해 주세요.",
-  gestureLoginUse: "제스처 로그인 사용",
   gestureLoginLockedSettings: "일시적으로 잠겼습니다. 로그아웃한 뒤 관리자 비밀번호로 한 번 로그인하면 복구됩니다.",
   gestureLoginLockedPasswordRecovery: "3회 틀려 제스처 로그인이 잠겼습니다. 관리자 비밀번호로 한 번 로그인하면 복구됩니다.",
   gestureLoginIncorrectAttemptsRemaining: "제스처가 올바르지 않습니다. {count}회 남았습니다.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1769,6 +1769,7 @@ export const pt = {
   gestureLoginLockedSettings: "Bloqueado temporariamente. Saia e faça um login com a senha de administrador para restaurá-lo.",
   gestureLoginLockedPasswordRecovery: "O login por gesto está bloqueado após 3 tentativas incorretas. Entre uma vez com sua senha de administrador para restaurá-lo.",
   gestureLoginIncorrectAttemptsRemaining: "Gesto incorreto. Restam {count} tentativas.",
+  gestureLoginStateUnavailable: "Não foi possível verificar o estado do login por gesto, portanto o login por senha não pode ser desativado agora.",
   gestureLoginUnavailable: "O login por gesto não está disponível.",
   gestureLoginResetRequired: "Seu gesto salvo não pode mais ser verificado neste servidor. Defina um novo.",
   gestureLoginStatusFailed: "Não foi possível carregar o status do login por gesto.",

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -1765,7 +1765,6 @@ export const pt = {
   gestureLoginMinimumDots: "Desenhe um gesto conectando pelo menos 3 pontos.",
   gestureLoginMismatch: "Os gestos não coincidem. Comece de novo.",
   gestureLoginSaveFailed: "Não foi possível salvar o login por gesto. Tente novamente.",
-  gestureLoginUse: "Usar login por gesto",
   gestureLoginLockedSettings: "Bloqueado temporariamente. Saia e faça um login com a senha de administrador para restaurá-lo.",
   gestureLoginLockedPasswordRecovery: "O login por gesto está bloqueado após 3 tentativas incorretas. Entre uma vez com sua senha de administrador para restaurá-lo.",
   gestureLoginIncorrectAttemptsRemaining: "Gesto incorreto. Restam {count} tentativas.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1763,6 +1763,7 @@ export const ru = {
   gestureLoginLockedSettings: "Временно заблокировано. Выйдите и один раз войдите с паролем администратора, чтобы восстановить.",
   gestureLoginLockedPasswordRecovery: "Вход жестом заблокирован после 3 неверных попыток. Войдите один раз с паролем администратора, чтобы восстановить.",
   gestureLoginIncorrectAttemptsRemaining: "Неверный жест. Осталось попыток: {count}.",
+  gestureLoginStateUnavailable: "Не удалось проверить состояние входа жестом, поэтому вход по паролю сейчас отключить нельзя.",
   gestureLoginUnavailable: "Вход жестом недоступен.",
   gestureLoginResetRequired: "Сохранённый жест больше нельзя проверить на этом сервере. Задайте новый.",
   gestureLoginStatusFailed: "Не удалось загрузить состояние входа жестом.",

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -1759,7 +1759,6 @@ export const ru = {
   gestureLoginMinimumDots: "Нарисуйте жест, соединяющий не менее 3 точек.",
   gestureLoginMismatch: "Жесты не совпадают. Начните заново.",
   gestureLoginSaveFailed: "Не удалось сохранить вход жестом. Попробуйте ещё раз.",
-  gestureLoginUse: "Использовать вход жестом",
   gestureLoginLockedSettings: "Временно заблокировано. Выйдите и один раз войдите с паролем администратора, чтобы восстановить.",
   gestureLoginLockedPasswordRecovery: "Вход жестом заблокирован после 3 неверных попыток. Войдите один раз с паролем администратора, чтобы восстановить.",
   gestureLoginIncorrectAttemptsRemaining: "Неверный жест. Осталось попыток: {count}.",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1658,6 +1658,7 @@ export const zh = {
   gestureLoginLockedSettings: "已暂时锁定。请退出登录并用管理员密码登录一次以恢复。",
   gestureLoginLockedPasswordRecovery: "手势错误 3 次，手势登录已锁定。请用管理员密码登录一次以恢复。",
   gestureLoginIncorrectAttemptsRemaining: "手势错误，还可尝试 {count} 次。",
+  gestureLoginStateUnavailable: "无法确认手势登录的状态，因此暂时无法关闭密码登录。",
   gestureLoginUnavailable: "手势登录不可用。",
   gestureLoginResetRequired: "此服务器已无法验证已保存的手势，请重新设置。",
   gestureLoginStatusFailed: "无法加载手势登录状态。",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -1654,7 +1654,6 @@ export const zh = {
   gestureLoginMinimumDots: "绘制一个至少连接 3 个点的手势。",
   gestureLoginMismatch: "两次手势不一致，请重新开始。",
   gestureLoginSaveFailed: "无法保存手势登录，请重试。",
-  gestureLoginUse: "使用手势登录",
   gestureLoginLockedSettings: "已暂时锁定。请退出登录并用管理员密码登录一次以恢复。",
   gestureLoginLockedPasswordRecovery: "手势错误 3 次，手势登录已锁定。请用管理员密码登录一次以恢复。",
   gestureLoginIncorrectAttemptsRemaining: "手势错误，还可尝试 {count} 次。",


### PR DESCRIPTION
Two Gesture Login fixes that are not on `master`.

## Why they are missing

#435 was branched from `feat/gesture-login` and merged **into that branch** at 16:04, but #434 had already merged to `master` at 15:40. So #435's fix landed on a branch that was already merged and never travelled any further. `finishStroke` on `master` still goes straight from `releasePointerCapture` to `const drawn = patternRef.current`.

The second commit is new and was never in a PR.

## 1. Extend the stroke to the pointer release position (was #435)

`finishStroke` read the pattern accumulated by `pointermove` and never processed the `pointerup` coordinates, so the closing segment was dropped. `pointerup` carries its own position and is not guaranteed to be preceded by a `pointermove` at the same place — on touch and pen a fast swipe can lift a dot's width past the final sample.

At enrolment that stores a gesture the user did not draw. At login it rejects a correct draw and spends one of only **three** attempts before the credential locks permanently, so a device that consistently drops the endpoint lets a user lock themselves out by drawing correctly three times.

Six tests, five of which fail without the change.

Originally raised as a review comment on #434 by the Codex reviewer.

## 2. Refresh gesture status after saving login settings

Found while testing on a real NAS instance: the Gesture Login toggle stayed disabled, telling the admin to *"save login and password settings"* they had just saved.

Availability is derived server-side from the persisted `loginEnabled` and `passwordLoginAllowed`. The Security page reads it once on mount, and the settings save invalidated `settings`, `liveTranslationConfig` and `videos` but never `gesture-login-status` — so after enabling login protection the cached answer still said the prerequisites were unmet. It only came right on a page reload or window refocus, which makes the feature look broken on a fresh setup.

Saving either field now invalidates the status; unrelated saves do not, so a normal save costs no extra request. Three tests cover both directions.

## Verification

Frontend: 2034 tests passing under coverage, `tsc` clean, `vite build` clean.

## Cleanup note

`feat/gesture-login` currently carries these same two commits on top of its merge. Once this lands, that branch is fully superseded and can be deleted.
