### PR TITLE
fix(scan): keep the scan button busy after the page remounts

### DIFF
--- a/backend/src/__tests__/controllers/scanController.test.ts
+++ b/backend/src/__tests__/controllers/scanController.test.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import fs from 'fs-extra';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { scanFiles, scanMountDirectories } from '../../controllers/scanController';
+import { getScanStatus, scanFiles, scanMountDirectories } from '../../controllers/scanController';
 import * as storageService from '../../services/storageService';
 
 vi.mock('../../services/storageService');
@@ -180,6 +180,66 @@ describe('ScanController', () => {
           fileSize: '1024',
         }),
         { statisticsReason: 'scan' },
+      );
+    });
+  });
+
+  describe('scan status', () => {
+    it('reports an idle scanner', async () => {
+      await getScanStatus(req as Request, res as Response);
+
+      expect(status).toHaveBeenCalledWith(200);
+      expect(json).toHaveBeenCalledWith({
+        scanning: false,
+        scanType: null,
+        startedAt: null,
+      });
+    });
+
+    it('reports the running scan and rejects a concurrent one', async () => {
+      (storageService.getVideos as any).mockReturnValue([]);
+
+      // Hold the first scan open at its first await so a second request
+      // arrives while it is still running.
+      let releaseFirstScan: () => void = () => undefined;
+      (fs.pathExists as any).mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            releaseFirstScan = () => resolve(false);
+          }),
+      );
+
+      const firstScan = scanFiles(req as Request, res as Response);
+
+      await getScanStatus(req as Request, res as Response);
+      expect(json).toHaveBeenCalledWith(
+        expect.objectContaining({ scanning: true, scanType: 'files' }),
+      );
+
+      const secondJson = vi.fn();
+      const secondStatus = vi.fn().mockReturnValue({ json: secondJson });
+      await scanFiles(req as Request, {
+        json: secondJson,
+        status: secondStatus,
+      } as unknown as Response);
+
+      expect(secondStatus).toHaveBeenCalledWith(409);
+      expect(secondJson).toHaveBeenCalledWith(
+        expect.objectContaining({ errorKey: 'scanAlreadyRunning' }),
+      );
+
+      releaseFirstScan();
+      await firstScan;
+
+      // The lock is released once the scan finishes.
+      const thirdJson = vi.fn();
+      const thirdStatus = vi.fn().mockReturnValue({ json: thirdJson });
+      await getScanStatus(req as Request, {
+        json: thirdJson,
+        status: thirdStatus,
+      } as unknown as Response);
+      expect(thirdJson).toHaveBeenCalledWith(
+        expect.objectContaining({ scanning: false }),
       );
     });
   });

--- a/backend/src/controllers/scanController.ts
+++ b/backend/src/controllers/scanController.ts
@@ -12,7 +12,12 @@ import { scrapeMetadataFromTMDB } from "../services/tmdbService";
 import { formatVideoFilename } from "../utils/helpers";
 import { logger } from "../utils/logger";
 import { AUDIO_CONTAINER_EXTENSIONS, MEDIA_FILE_EXTENSIONS } from "../utils/videoExtensions";
-import { errorResponse, sendBadRequest, successResponse } from "../utils/response";
+import {
+  errorResponse,
+  sendBadRequest,
+  sendData,
+  successResponse,
+} from "../utils/response";
 import {
   execFileSafe,
   isPathWithinDirectory,
@@ -623,10 +628,51 @@ const processDirectoryFiles = async (
  * only operates on the app-managed local /videos tree, not arbitrary host paths.
  * Errors are automatically handled by asyncHandler middleware
  */
-export const scanFiles = async (
+type ScanType = "files" | "mount";
+
+type ActiveScan = {
+  scanType: ScanType;
+  startedAt: string;
+};
+
+// A scan rewrites library records, so only one may run at a time. The state is
+// held here rather than in the client so a scan still reports as running after
+// the page that started it navigated away and remounted.
+let activeScan: ActiveScan | null = null;
+
+const beginScan = (scanType: ScanType, res: Response): boolean => {
+  if (activeScan) {
+    res.status(409).json(
+      errorResponse("A scan is already running.", {
+        errorKey: "scanAlreadyRunning",
+      })
+    );
+    return false;
+  }
+
+  activeScan = { scanType, startedAt: new Date().toISOString() };
+  return true;
+};
+
+const endScan = (): void => {
+  activeScan = null;
+};
+
+/**
+ * Report whether a scan is currently running
+ */
+export const getScanStatus = async (
   _req: Request,
   res: Response
 ): Promise<void> => {
+  sendData(res, {
+    scanning: activeScan !== null,
+    scanType: activeScan?.scanType ?? null,
+    startedAt: activeScan?.startedAt ?? null,
+  });
+};
+
+const runFileScan = async (res: Response): Promise<void> => {
   logger.info("Starting file scan...");
 
   const existingVideos = storageService.getVideos();
@@ -706,19 +752,26 @@ export const scanFiles = async (
   res.status(200).json({ addedCount, deletedCount });
 };
 
+export const scanFiles = async (
+  _req: Request,
+  res: Response
+): Promise<void> => {
+  if (!beginScan("files", res)) {
+    return;
+  }
+
+  try {
+    await runFileScan(res);
+  } finally {
+    endScan();
+  }
+};
+
 /**
  * Scan mount directories for video files
  * Accepts array of directory paths in request body: { directories: string[] }
  */
-export const scanMountDirectories = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  if (!isAdminTrustLevelAtLeast("host")) {
-    res.status(403).json(createAdminTrustLevelError("host"));
-    return;
-  }
-
+const runMountScan = async (req: Request, res: Response): Promise<void> => {
   logger.info("Starting mount directories scan...");
 
   const { directories } = req.body;
@@ -854,4 +907,24 @@ export const scanMountDirectories = async (
     deletedCount,
     scannedDirectories: validDirectories.length,
   });
+};
+
+export const scanMountDirectories = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  if (!isAdminTrustLevelAtLeast("host")) {
+    res.status(403).json(createAdminTrustLevelError("host"));
+    return;
+  }
+
+  if (!beginScan("mount", res)) {
+    return;
+  }
+
+  try {
+    await runMountScan(req, res);
+  } finally {
+    endScan();
+  }
 };

--- a/backend/src/routes/api.ts
+++ b/backend/src/routes/api.ts
@@ -154,6 +154,11 @@ const apiRouteDefinitions: ApiRouteDefinition[] = [
     handlers: [asyncHandler(videoMetadataController.updateProgress)],
   },
   {
+    method: "get",
+    path: "/scan-status",
+    handlers: [asyncHandler(scanController.getScanStatus)],
+  },
+  {
     method: "post",
     path: "/scan-files",
     handlers: [asyncHandler(scanController.scanFiles)],

--- a/frontend/src/components/Settings/MountDirectoriesSettings.tsx
+++ b/frontend/src/components/Settings/MountDirectoriesSettings.tsx
@@ -9,6 +9,7 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import React from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { useScanStatus } from '../../hooks/useScanStatus';
 import { Settings } from '../../types';
 import { api, getApiErrorMessage } from '../../utils/apiClient';
 import { createTranslateOrFallback } from '../../utils/translateOrFallback';
@@ -49,6 +50,12 @@ const MountDirectoriesSettings: React.FC<MountDirectoriesSettingsProps> = ({
 }) => {
     const { t } = useLanguage();
     const translateOrFallback = createTranslateOrFallback(t);
+
+    // Server-side scan state: the scan outlives this component, so a remount
+    // (navigating away and back) must not reset the button to idle.
+    const { data: scanStatus } = useScanStatus(canUseHostAdminFeatures);
+    const isMountScanRunning = scanStatus?.scanType === 'mount';
+    const isOtherScanRunning = !!scanStatus?.scanning && !isMountScanRunning;
 
     // Scan mount directories mutation. Lives here (not in useSettingsMutations)
     // because it composes with the page-local `settings` + `saveMutation`.
@@ -148,7 +155,8 @@ const MountDirectoriesSettings: React.FC<MountDirectoriesSettingsProps> = ({
                             variant="outlined"
                             startIcon={<FindInPage />}
                             onClick={handleScanMountDirectories}
-                            loading={scanMountDirectoriesMutation.isPending}
+                            loading={scanMountDirectoriesMutation.isPending || isMountScanRunning}
+                            disabled={isOtherScanRunning}
                             loadingPosition="start"
                         >
                             {t('scanFiles') || 'Scan Files'}

--- a/frontend/src/components/Settings/__tests__/MountDirectoriesSettings.test.tsx
+++ b/frontend/src/components/Settings/__tests__/MountDirectoriesSettings.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
 import MountDirectoriesSettings from '../MountDirectoriesSettings';
+import { api } from '../../../utils/apiClient';
 
 // Mock language context: t echoes the key. createTranslateOrFallback then
 // returns the *fallback* when the key matches, so assertions check fallbacks.
@@ -10,9 +11,15 @@ vi.mock('../../../contexts/LanguageContext', () => ({
     useLanguage: () => ({ t: (key: string) => key }),
 }));
 
-// Mock the scan API so the mutation doesn't hit the network
+// Mock the scan API so the mutation doesn't hit the network. `get` backs the
+// scan-status poll that keeps the button in sync with the server.
 vi.mock('../../../utils/apiClient', () => ({
-    api: { post: vi.fn().mockResolvedValue({ data: { addedCount: 0, deletedCount: 0 } }) },
+    api: {
+        post: vi.fn().mockResolvedValue({ data: { addedCount: 0, deletedCount: 0 } }),
+        get: vi.fn().mockResolvedValue({
+            data: { scanning: false, scanType: null, startedAt: null },
+        }),
+    },
     getApiErrorMessage: vi.fn().mockResolvedValue('err'),
 }));
 
@@ -70,5 +77,20 @@ describe('MountDirectoriesSettings', () => {
         await user.click(screen.getByRole('button', { name: /scanFiles/ }));
 
         expect(baseProps.setMessage).toHaveBeenCalledWith({ text: 'mountDirectoriesEmptyError', type: 'error' });
+    });
+
+    it('keeps the scan button busy when the server reports a mount scan in progress', async () => {
+        // Simulates a remount after navigating away mid-scan: the mutation
+        // state is gone, so only the server-side status can keep the button
+        // from inviting a second scan.
+        (api.get as any).mockResolvedValue({
+            data: { scanning: true, scanType: 'mount', startedAt: new Date().toISOString() },
+        });
+
+        renderWithClient(<MountDirectoriesSettings {...baseProps} mountDirectories="/mnt/media" />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /scanFiles/ })).toBeDisabled();
+        });
     });
 });

--- a/frontend/src/hooks/useScanStatus.ts
+++ b/frontend/src/hooks/useScanStatus.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../utils/apiClient";
+
+export type ScanType = "files" | "mount";
+
+export interface ScanStatus {
+  scanning: boolean;
+  scanType: ScanType | null;
+  startedAt: string | null;
+}
+
+const ACTIVE_POLL_INTERVAL_MS = 2000;
+const IDLE_POLL_INTERVAL_MS = 15000;
+
+const IDLE_STATUS: ScanStatus = {
+  scanning: false,
+  scanType: null,
+  startedAt: null,
+};
+
+/**
+ * Tracks the server-side scan state so a scan started elsewhere - or before the
+ * current page was remounted - still shows as running.
+ */
+export const useScanStatus = (enabled: boolean = true) => {
+  return useQuery<ScanStatus>({
+    queryKey: ["scanStatus"],
+    queryFn: async () => {
+      const res = await api.get("/scan-status");
+      return res.data;
+    },
+    enabled: !!enabled,
+    // Poll with a dynamic interval: fast while a scan runs, low-frequency when
+    // idle so a scan started from another tab still surfaces here.
+    refetchInterval: (query) =>
+      (query.state.data as ScanStatus | undefined)?.scanning
+        ? ACTIVE_POLL_INTERVAL_MS
+        : IDLE_POLL_INTERVAL_MS,
+    // Always refetch on mount so returning to the page picks up a running scan.
+    refetchOnMount: "always",
+    initialData: IDLE_STATUS,
+    staleTime: 1000,
+    gcTime: 5 * 60 * 1000,
+  });
+};

--- a/frontend/src/pages/ManagePage.tsx
+++ b/frontend/src/pages/ManagePage.tsx
@@ -15,7 +15,7 @@ import ConfirmationModal from '../components/ConfirmationModal';
 import DeleteCollectionModal from '../components/DeleteCollectionModal';
 import CollectionsTable from '../components/ManagePage/CollectionsTable';
 import VideosTable from '../components/ManagePage/VideosTable';
-import { api } from '../utils/apiClient';
+import { api, getApiErrorMessage } from '../utils/apiClient';
 
 import { useAuth } from '../contexts/AuthContext';
 import { useCollection } from '../contexts/CollectionContext';
@@ -25,6 +25,7 @@ import { useVideo } from '../contexts/VideoContext';
 import { Collection, Video } from '../types';
 import { formatSize } from '../utils/formatUtils';
 import { runMutationAsync } from '../utils/mutationUtils';
+import { useScanStatus } from '../hooks/useScanStatus';
 
 const ManagePage: React.FC = () => {
     const [searchTerm, setSearchTerm] = useState<string>('');
@@ -71,6 +72,12 @@ const ManagePage: React.FC = () => {
         setCollectionOrderBy(property);
     };
 
+    // Server-side scan state: a scan keeps running when this page unmounts, so
+    // the button state has to come from the server rather than the mutation.
+    const { data: scanStatus } = useScanStatus(!isVisitor);
+    const isFileScanRunning = scanStatus?.scanType === 'files';
+    const isOtherScanRunning = !!scanStatus?.scanning && !isFileScanRunning;
+
     // Scan files mutation
     const scanMutation = useMutation({
         mutationFn: async () => {
@@ -82,8 +89,9 @@ const ManagePage: React.FC = () => {
             const deletedMsg = data.deletedCount > 0 ? (t('scanFilesDeleted').replace('{count}', data.deletedCount.toString()) || ` ${data.deletedCount} missing files removed.`) : '';
             showSnackbar(addedMsg + deletedMsg);
         },
-        onError: (error: any) => {
-            showSnackbar(`${t('scanFilesFailed') || 'Scan failed'}: ${error.response?.data?.details || error.message}`);
+        onError: async (error: any) => {
+            const detail = await getApiErrorMessage(error, t) || error.message;
+            showSnackbar(`${t('scanFilesFailed') || 'Scan failed'}: ${detail}`);
         }
     });
 
@@ -312,7 +320,8 @@ const ManagePage: React.FC = () => {
                             variant="outlined"
                             startIcon={<FindInPage />}
                             onClick={() => setShowScanConfirmModal(true)}
-                            loading={scanMutation.isPending}
+                            loading={scanMutation.isPending || isFileScanRunning}
+                            disabled={isOtherScanRunning}
                             loadingPosition="start"
                         >
                             {t('scanFiles') || 'Scan Files'}

--- a/frontend/src/pages/__tests__/ManagePage.test.tsx
+++ b/frontend/src/pages/__tests__/ManagePage.test.tsx
@@ -77,6 +77,8 @@ vi.mock('../../contexts/CollectionContext', () => ({
 // Track useMutation calls per render cycle using a counter that resets
 let mutationCallIndex = 0;
 vi.mock('@tanstack/react-query', () => ({
+    // Scan status poll: idle unless a test says otherwise.
+    useQuery: () => ({ data: { scanning: false, scanType: null, startedAt: null } }),
     useMutation: ({ mutationFn, onSuccess, onError }: { mutationFn?: () => Promise<any>; onSuccess?: (data: any) => unknown; onError?: (error: any) => unknown }) => {
         const index = mutationCallIndex++;
         if (index % 2 === 0) {
@@ -102,6 +104,8 @@ vi.mock('../../utils/apiClient', () => ({
     api: {
         post: (...args: any[]) => mockApiPost(...args),
     },
+    getApiErrorMessage: (error: any) =>
+        Promise.resolve(error?.response?.data?.details ?? error?.message),
 }));
 
 vi.mock('../../utils/formatUtils', () => ({
@@ -678,13 +682,14 @@ describe('ManagePage', () => {
             expect(capturedVideosTableProps!.isRefreshingFileSizes).toBe(true);
         });
 
-        it('shows snackbar messages for scan mutation success and error callbacks', () => {
+        it('shows snackbar messages for scan mutation success and error callbacks', async () => {
             renderManagePage();
 
             scanMutationCallbacks.onSuccess?.({ addedCount: 2, deletedCount: 1 });
             expect(mockShowSnackbar).toHaveBeenCalledWith('scanFilesSuccess 2scanFilesDeleted 1');
 
-            scanMutationCallbacks.onError?.({ response: { data: { details: 'scan exploded' } } });
+            // onError resolves the (possibly localized) detail before showing it.
+            await scanMutationCallbacks.onError?.({ response: { data: { details: 'scan exploded' } } });
             expect(mockShowSnackbar).toHaveBeenLastCalledWith('scanFilesFailed: scan exploded');
         });
 

--- a/frontend/src/pages/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/SettingsPage.test.tsx
@@ -56,6 +56,8 @@ vi.mock('@mui/material', async () => {
 });
 
 vi.mock('@tanstack/react-query', () => ({
+  // Scan status poll: idle unless a test says otherwise.
+  useQuery: () => ({ data: { scanning: false, scanType: null, startedAt: null } }),
   useMutation: (options: any) => ({
     isPending: scanIsPending,
     mutate: (variables: any) => {

--- a/frontend/src/utils/locales/ar.ts
+++ b/frontend/src/utils/locales/ar.ts
@@ -381,6 +381,7 @@ export const ar = {
   scanFilesSuccess: "اكتمل المسح. تمت إضافة {count} مقاطع فيديو جديدة.",
   scanFilesDeleted: " تمت إزالة {count} ملفات مفقودة.",
   scanFilesFailed: "فشل المسح",
+  scanAlreadyRunning: "هناك عملية مسح قيد التشغيل بالفعل. يرجى انتظار انتهائها.",
   scanMountDirectoriesSuccess:
     "اكتمل فحص الدلائل المثبتة. تمت إضافة {addedCount} مقاطع فيديو جديدة. تم حذف {deletedCount} مقاطع فيديو مفقودة.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/de.ts
+++ b/frontend/src/utils/locales/de.ts
@@ -393,6 +393,8 @@ export const de = {
   scanFilesSuccess: "Scan abgeschlossen. {count} neue Videos hinzugefügt.",
   scanFilesDeleted: " {count} fehlende Dateien entfernt.",
   scanFilesFailed: "Scan fehlgeschlagen",
+  scanAlreadyRunning:
+    "Ein Scan läuft bereits. Bitte warte, bis er abgeschlossen ist.",
   scanMountDirectoriesSuccess:
     "Mount-Verzeichnisse-Scan abgeschlossen. {addedCount} neue Videos hinzugefügt. {deletedCount} fehlende Videos gelöscht.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/en.ts
+++ b/frontend/src/utils/locales/en.ts
@@ -369,6 +369,7 @@ export const en = {
   scanFilesSuccess: "Scan complete. Added {count} new videos.",
   scanFilesDeleted: " {count} missing files removed.",
   scanFilesFailed: "Scan failed",
+  scanAlreadyRunning: "A scan is already running. Please wait for it to finish.",
   scanMountDirectoriesSuccess:
     "Mount directories scan complete. Added {addedCount} new videos. Deleted {deletedCount} missing videos.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/es.ts
+++ b/frontend/src/utils/locales/es.ts
@@ -390,6 +390,8 @@ export const es = {
   scanFilesSuccess: "Escaneo completo. Se añadieron {count} videos nuevos.",
   scanFilesDeleted: " Se eliminaron {count} archivos faltantes.",
   scanFilesFailed: "Escaneo fallido",
+  scanAlreadyRunning:
+    "Ya hay un escaneo en curso. Espera a que termine.",
   scanMountDirectoriesSuccess:
     "Escaneo de directorios montados completado. Se añadieron {addedCount} videos nuevos. Se eliminaron {deletedCount} videos faltantes.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/fr.ts
+++ b/frontend/src/utils/locales/fr.ts
@@ -391,6 +391,8 @@ export const fr = {
   scanFilesSuccess: "Analyse terminée. {count} nouvelles vidéos ajoutées.",
   scanFilesDeleted: " {count} fichiers manquants supprimés.",
   scanFilesFailed: "L'analyse a échoué",
+  scanAlreadyRunning:
+    "Une analyse est déjà en cours. Veuillez attendre qu'elle se termine.",
   scanMountDirectoriesSuccess:
     "Analyse des répertoires de montage terminée. {addedCount} nouvelles vidéos ajoutées. {deletedCount} vidéos manquantes supprimées.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/ja.ts
+++ b/frontend/src/utils/locales/ja.ts
@@ -388,6 +388,7 @@ export const ja = {
   scanFilesSuccess: "スキャン完了。{count} 個の新しい動画が追加されました。",
   scanFilesDeleted: " {count} 個の不足ファイルが削除されました。",
   scanFilesFailed: "スキャンに失敗しました",
+  scanAlreadyRunning: "スキャンが既に実行中です。完了までお待ちください。",
   scanMountDirectoriesSuccess:
     "マウントディレクトリのスキャンが完了しました。{addedCount} 個の新しい動画が追加されました。{deletedCount} 個の不足動画が削除されました。",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/ko.ts
+++ b/frontend/src/utils/locales/ko.ts
@@ -384,6 +384,7 @@ export const ko = {
   scanFilesSuccess: "스캔 완료. {count}개의 새 동영상이 추가되었습니다.",
   scanFilesDeleted: " {count}개의 누락된 파일이 제거되었습니다.",
   scanFilesFailed: "스캔 실패",
+  scanAlreadyRunning: "이미 스캔이 실행 중입니다. 완료될 때까지 기다려 주세요.",
   scanMountDirectoriesSuccess:
     "마운트 디렉토리 스캔 완료. {addedCount}개의 새 동영상이 추가되었습니다. {deletedCount}개의 누락된 동영상이 삭제되었습니다.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/pt.ts
+++ b/frontend/src/utils/locales/pt.ts
@@ -390,6 +390,8 @@ export const pt = {
   scanFilesSuccess: "Verificação concluída. {count} novos vídeos adicionados.",
   scanFilesDeleted: " {count} arquivos ausentes removidos.",
   scanFilesFailed: "Falha na verificação",
+  scanAlreadyRunning:
+    "Já há uma verificação em andamento. Aguarde a conclusão.",
   scanMountDirectoriesSuccess:
     "Verificação de diretórios montados concluída. {addedCount} novos vídeos adicionados. {deletedCount} vídeos ausentes removidos.",
   subscribePlaylistsSuccess:

--- a/frontend/src/utils/locales/ru.ts
+++ b/frontend/src/utils/locales/ru.ts
@@ -390,6 +390,8 @@ export const ru = {
   scanFilesSuccess: "Сканирование завершено. Добавлено {count} новых видео.",
   scanFilesDeleted: " Удалено {count} отсутствующих файлов.",
   scanFilesFailed: "Сканирование не удалось",
+  scanAlreadyRunning:
+    "Сканирование уже выполняется. Дождитесь его завершения.",
   scanMountDirectoriesSuccess:
     "Сканирование смонтированных директорий завершено. Добавлено {addedCount} новых видео. Удалено {deletedCount} отсутствующих видео.",
   subscribePlaylistsSuccess: "Успешно подписано на {count} плейлист{plural}.",

--- a/frontend/src/utils/locales/zh.ts
+++ b/frontend/src/utils/locales/zh.ts
@@ -367,6 +367,7 @@ export const zh = {
   scanFilesSuccess: "扫描完成。添加了 {count} 个新视频。",
   scanFilesDeleted: " 移除了 {count} 个缺失文件。",
   scanFilesFailed: "扫描失败",
+  scanAlreadyRunning: "已有扫描正在进行，请等待其完成。",
   scanMountDirectoriesSuccess:
     "挂载目录扫描完成。添加了 {addedCount} 个新视频。删除了 {deletedCount} 个缺失视频。",
   subscribePlaylistsSuccess: "成功订阅了 {count} 个播放列表{plural}。",


### PR DESCRIPTION
## Problem

Both **Scan Files** buttons take their busy state from the local React Query mutation:

```tsx
loading={scanMutation.isPending}
```

Navigating away unmounts the page, and on return the mutation state is rebuilt as idle while the scan is still running on the server. The button looks clickable, so the user starts a second scan of the same library. State that lives only in the component cannot survive a remount.

Affects `ManagePage` (`/scan-files`) and `Settings → Content Management → Mount Directories` (`/scan-mount-directories`).

## Fix

Move the "a scan is running" fact to the server and have the client ask for it.

**Backend** — `scanController.ts`
- Module-level `activeScan` lock; `beginScan` / `endScan` wrap both scan entry points, released in `finally` so the error path unlocks too
- New `GET /scan-status` → `{ scanning, scanType, startedAt }`
- Only one scan at a time. A concurrent request gets 409 with `errorKey: "scanAlreadyRunning"`, using the existing errorKey localization path; the key is added to all ten locales
- The mount scan's `host` trust check still runs before the lock, so a 403 never takes it

**Frontend**
- New `useScanStatus` hook following the existing `useCloudflareStatus` / `DownloadContext` shape: dynamic polling (2s while scanning, 15s idle) and `refetchOnMount: 'always'`
- Buttons become `loading={mutation.isPending || <this scan type is running>}`, and `disabled` while the *other* scan type runs
- `ManagePage`'s `onError` now goes through `getApiErrorMessage`, so a 409 shows the localized message instead of `Request failed with status code 409`

A side effect worth noting: a scan started from another tab or device now shows up too, not just the remount case.

## Tests

- Backend: `/scan-status` reports the running scan, a concurrent scan gets 409 with the errorKey, and the lock is released once the first scan finishes
- Frontend: the mount scan button stays disabled when the server reports a scan in progress — the remount scenario
- Three existing test files needed updating: `ManagePage.test.tsx` and `SettingsPage.test.tsx` mock `@tanstack/react-query` with only `useMutation`, so the new `useQuery` threw; `MountDirectoriesSettings.test.tsx` mocked only `api.post`. `ManagePage`'s scan-error assertion now awaits, since `onError` resolves the detail before showing the snackbar

Verification: backend and frontend `tsc --noEmit` clean, `eslint .` clean, full frontend suite green (2039 tests). The backend suite has 6 failures in `favoriteMigration`, `sourceVideoIdMigration` and `ytdlpHelpers` — reproduced identically on clean `master`, unrelated to this change.

End-to-end button clicking was not exercised: the dev instance has login protection enabled. Route registration was confirmed against a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
