### PR TITLE
fix(scan): tighten extras markers, read leading episode designators

### DIFF
--- a/backend/src/__tests__/controllers/scanController.test.ts
+++ b/backend/src/__tests__/controllers/scanController.test.ts
@@ -659,6 +659,118 @@ describe('ScanController', () => {
       );
     });
 
+    it('does not read an ordinary title word as an extras marker', async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = 'host';
+      (storageService.getVideos as any).mockReturnValue([]);
+      (storageService.getCollections as any).mockReturnValue([]);
+      (fs.pathExists as any).mockResolvedValue(true);
+      const { scrapeMetadataFromTMDB } = await import('../../services/tmdbService');
+      (scrapeMetadataFromTMDB as any).mockResolvedValue(null);
+      (fs.readdir as any).mockImplementation((dir: string) =>
+        dir === '/mnt/movies'
+          ? Promise.resolve([
+              { name: 'The Interview', isDirectory: () => true, isSymbolicLink: () => false },
+            ])
+          : Promise.resolve([
+              // Films, not bonus material - only the hyphen form marks an extra.
+              { name: 'The.Interview.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+              { name: 'One.Short.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+              { name: 'The.Interview-trailer.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+            ]),
+      );
+      (fs.stat as any).mockResolvedValue({
+        isDirectory: () => false,
+        birthtime: new Date(),
+        size: 1024,
+      });
+
+      req = { body: { directories: ['/mnt/movies'] } };
+
+      await scanMountDirectories(req as Request, res as Response);
+
+      const imported = (storageService.saveVideo as any).mock.calls
+        .map((call: any[]) => path.basename(call[0].videoPath))
+        .sort();
+      expect(imported).toEqual(['One.Short.mkv', 'The.Interview.mkv']);
+    });
+
+    it('links a refreshed video when its folder first earns a collection', async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = 'host';
+      // The original file changed size, so it is refreshed rather than
+      // inserted - and the collection guard only fires on insert.
+      (storageService.getVideos as any).mockReturnValue([
+        {
+          id: 'ep1',
+          title: 'S01E01',
+          videoPath: 'mount:/mnt/tv/Show/S01E01.mkv',
+          fileSize: '512',
+        },
+      ]);
+      (storageService.getCollections as any).mockReturnValue([]);
+      (fs.pathExists as any).mockResolvedValue(true);
+      const { scrapeMetadataFromTMDB } = await import('../../services/tmdbService');
+      (scrapeMetadataFromTMDB as any).mockResolvedValue(null);
+      (fs.readdir as any).mockImplementation((dir: string) =>
+        dir === '/mnt/tv'
+          ? Promise.resolve([
+              { name: 'Show', isDirectory: () => true, isSymbolicLink: () => false },
+            ])
+          : Promise.resolve([
+              { name: 'S01E01.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+              { name: 'S01E02.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+            ]),
+      );
+      (fs.stat as any).mockResolvedValue({
+        isDirectory: () => false,
+        birthtime: new Date(),
+        size: 1024,
+      });
+
+      req = { body: { directories: ['/mnt/tv'] } };
+
+      await scanMountDirectories(req as Request, res as Response);
+
+      expect(storageService.addVideoToCollection).toHaveBeenCalledWith(
+        expect.any(String),
+        'ep1',
+        { moveFiles: false },
+      );
+    });
+
+    it('keeps the episode number when the designator opens the filename', async () => {
+      process.env.MYTUBE_ADMIN_TRUST_LEVEL = 'host';
+      (storageService.getVideos as any).mockReturnValue([]);
+      (storageService.getCollections as any).mockReturnValue([]);
+      (fs.pathExists as any).mockResolvedValue(true);
+      const { scrapeMetadataFromTMDB } = await import('../../services/tmdbService');
+      (scrapeMetadataFromTMDB as any).mockResolvedValue({ title: '医院五日' });
+      (fs.readdir as any).mockImplementation((dir: string) =>
+        dir === '/mnt/tv'
+          ? Promise.resolve([
+              { name: 'Show', isDirectory: () => true, isSymbolicLink: () => false },
+            ])
+          : Promise.resolve([
+              { name: 'S01E01.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+              { name: 'S01E02.mkv', isDirectory: () => false, isSymbolicLink: () => false },
+            ]),
+      );
+      (fs.stat as any).mockResolvedValue({
+        isDirectory: () => false,
+        birthtime: new Date(),
+        size: 1024,
+      });
+
+      req = { body: { directories: ['/mnt/tv'] } };
+
+      await scanMountDirectories(req as Request, res as Response);
+
+      // Without a designator both files would be saved as plain "医院五日".
+      const titles = (storageService.saveVideo as any).mock.calls
+        .map((call: any[]) => call[0].title)
+        .sort();
+      expect(titles).toEqual(['医院五日 - S01E01', '医院五日 - S01E02']);
+    });
+
     it('drops mount records that are no longer under a configured directory', async () => {
       process.env.MYTUBE_ADMIN_TRUST_LEVEL = 'host';
       (storageService.getVideos as any).mockReturnValue([

--- a/backend/src/controllers/scanController.ts
+++ b/backend/src/controllers/scanController.ts
@@ -262,7 +262,20 @@ const resolveIdentityFolderName = (
 // TMDB matches a series, never a single episode, so every file in a season
 // folder comes back carrying the same show title. Keep the episode designator
 // from the filename so the episodes stay tellable apart in the library.
+// Read straight off the filename rather than through the title parser, whose
+// patterns require title text before the token - episodes named plainly
+// "S01E01.mkv" would otherwise carry no designator at all, leaving every file
+// in the folder sharing the show's title.
+const EPISODE_DESIGNATOR_PATTERN = /(?:^|[^A-Za-z0-9])[Ss](\d{1,3})[Ee](\d{1,3})(?![0-9])/;
+
 const buildEpisodeLabel = (filename: string): string | null => {
+  const designator = EPISODE_DESIGNATOR_PATTERN.exec(path.parse(filename).name);
+  if (designator) {
+    const season = designator[1].padStart(2, "0");
+    const episode = designator[2].padStart(2, "0");
+    return `S${season}E${episode}`;
+  }
+
   const parsed = parseFilename(filename);
   if (!parsed.isTVShow || typeof parsed.episode !== "number") {
     return null;
@@ -293,10 +306,12 @@ const EXTRAS_FOLDER_NAMES = new Set([
   "trailers",
 ]);
 
-// Matched as a suffix or as the whole name only. A bare "trailer" or "sample"
-// anywhere in the name would swallow real titles - "Trailer.Park.Boys.S01E01".
+// Media servers mark an extra with a hyphen suffix: "Film-trailer.mkv". The
+// hyphen is required, not any separator: several of these words end ordinary
+// titles - "The.Interview", "The.Other", "One.Short" - and treating those as
+// bonus material would skip the film and delete the record it already had.
 const EXTRA_FILENAME_SUFFIX_PATTERN =
-  /[.\s_-](?:sample|trailer|teaser|featurette|behindthescenes|bloopers?|deleted|interview|scene|short|other)$/i;
+  /-(?:sample|trailer|teaser|featurette|behindthescenes|bloopers?|deleted|interview|scene|short|other)$/i;
 const EXTRA_FILENAME_WHOLE_PATTERN = /^(?:sample|trailer)$/i;
 const RELEASE_SAMPLE_PATTERN = /\.sample\./i;
 
@@ -501,7 +516,7 @@ const processSingleVideoFile = async (
     collectionName: string,
     displayTitle?: string
   ) => Promise<string | undefined>,
-  noteUnchangedVideo: (videoId: string, collectionName: string) => void
+  noteExistingVideo: (videoId: string, collectionName: string) => void
 ): Promise<ProcessFileResult> => {
   const filename = path.basename(filePath);
   const relativePath = path.relative(normalizedDirectory, filePath);
@@ -523,7 +538,7 @@ const processSingleVideoFile = async (
     // new collection would permanently omit the file that did not change.
     const unchangedDirName = path.dirname(relativePath);
     if (unchangedDirName !== ".") {
-      noteUnchangedVideo(existingVideo.id, unchangedDirName.split(path.sep)[0]);
+      noteExistingVideo(existingVideo.id, unchangedDirName.split(path.sep)[0]);
     }
 
     return "skipped";
@@ -531,6 +546,15 @@ const processSingleVideoFile = async (
 
   const replacingVideoId = existingVideo?.id;
   if (replacingVideoId) {
+    // Refreshed, not inserted - so the collection guard below skips it. Hand it
+    // to the same reconciliation the unchanged files use, or a folder that
+    // crosses the grouping threshold while its original file also changed ends
+    // up with a collection missing that original.
+    const replacingDirName = path.dirname(relativePath);
+    if (replacingDirName !== ".") {
+      noteExistingVideo(replacingVideoId, replacingDirName.split(path.sep)[0]);
+    }
+
     logger.info(`Detected file change at ${webPath}, refreshing metadata`);
   }
 
@@ -817,7 +841,7 @@ const processDirectoryFiles = async (
 
   let addedCount = 0;
   let updatedCount = 0;
-  const unchangedVideosByCollectionName = new Map<string, string[]>();
+  const existingVideosByCollectionName = new Map<string, string[]>();
 
   await runWithConcurrencyLimit(
     videoFiles,
@@ -831,9 +855,9 @@ const processDirectoryFiles = async (
           isMountDirectory,
           resolveCollectionId,
           (videoId, collectionName) => {
-            unchangedVideosByCollectionName.set(
+            existingVideosByCollectionName.set(
               collectionName,
-              [...(unchangedVideosByCollectionName.get(collectionName) ?? []), videoId]
+              [...(existingVideosByCollectionName.get(collectionName) ?? []), videoId]
             );
           }
         );
@@ -850,8 +874,8 @@ const processDirectoryFiles = async (
   );
 
   // Reconcile after the pass, so a collection created from a newly added file
-  // already carries the title TMDB recognised before the unchanged files join.
-  for (const [collectionName, videoIds] of unchangedVideosByCollectionName) {
+  // already carries the title TMDB recognised before the existing files join.
+  for (const [collectionName, videoIds] of existingVideosByCollectionName) {
     if (!shouldGroupIntoCollection(collectionName)) {
       continue;
     }


### PR DESCRIPTION
Three review findings on [#437](https://github.com/franklioxygen/MyTube/pull/437), raised after it merged. All three are real; each is fixed here with a test.

## 1. An ordinary title word marked a film as an extra

The extras suffix pattern accepted any separator:

```
/[.\s_-](?:sample|trailer|…|deleted|interview|scene|short|other)$/i
```

So `The.Interview.mkv`, `The.Other.mkv` and `One.Short.mkv` read as bonus material. That is worse than skipping an import: such a file is dropped from the scan's file list, which also keeps it out of `actualMountPathsOnDisk`, so the cleanup pass **deletes the library record it already had**.

Media servers mark an extra with a hyphen — `Film-trailer.mkv` — so require the hyphen. The whole-name form (`sample.mkv`) and the release-group `.sample.` infix are unchanged, and those are what a real library actually uses.

## 2. Episodes named `S01E01.mkv` lost their episode number

`buildEpisodeLabel` went through `parseFilename`, whose patterns are anchored as `^(.+?)\s*[Ss](\d+)[Ee](\d+)` — they need title text before the token. A file named plainly `S01E01.mkv` therefore parsed as not-a-TV-show and produced no designator.

Combined with the folder-name TMDB retry that #437 added, every file in the folder then matched the series and was saved under the identical show title, indistinguishable from its siblings — the exact problem the designator was added to solve.

Read the designator off the filename directly; `parseFilename` stays as the fallback for `Season 1 Episode 2` forms.

## 3. Refreshed files were left out of a new collection

#437 reconciles collection membership for files that did not change, because collections are assigned on insert only. It missed the other half: a file whose size changed is saved with `replacingVideoId` set and fails the same `!replacingVideoId` guard.

So a folder crossing the grouping threshold while its original file also changed produced a collection containing only the newly added file. Refreshed files now go through the same reconciliation pass.

## Tests

- `The.Interview.mkv` and `One.Short.mkv` import; `The.Interview-trailer.mkv` does not
- Two files named `S01E01.mkv` / `S01E02.mkv` under a folder TMDB matches are saved as `医院五日 - S01E01` / `- S01E02` rather than both as `医院五日`
- A refreshed `ep1` is linked when its folder first earns a collection

Backend `tsc --noEmit` clean; 3161 tests pass. The six failures in `favoriteMigration`, `sourceVideoIdMigration` and `ytdlpHelpers` reproduce on clean `master` — they fail on a missing `drizzle/0021_audio_media_type.sql` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
