### PR TITLE
fix(layout): restore the desktop layout on in-car displays

### DIFF
--- a/frontend/public/viewport-check.html
+++ b/frontend/public/viewport-check.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>车机视口诊断</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:16px; background:#111; color:#eee;
+         font:16px/1.5 system-ui,-apple-system,"PingFang SC","Microsoft YaHei",sans-serif; }
+  h1 { font-size:22px; margin:0 0 12px; }
+  h2 { font-size:18px; margin:20px 0 8px; color:#4db6ac; }
+  table { border-collapse:collapse; width:100%; }
+  td { padding:6px 8px; border-bottom:1px solid #333; vertical-align:top; }
+  td.k { color:#9e9e9e; white-space:nowrap; width:1%; }
+  td.v { font-weight:700; font-size:20px; font-variant-numeric:tabular-nums; }
+  .ua { font-size:13px; word-break:break-all; font-weight:400; }
+  button { font:600 18px/1 system-ui,sans-serif; padding:14px 20px; margin:4px 6px 4px 0;
+           background:#00695c; color:#fff; border:0; border-radius:8px; }
+  #verdict { margin-top:12px; padding:12px; border-radius:8px; background:#1b1b1b;
+             font-size:19px; font-weight:700; }
+  .ok { color:#66bb6a; } .bad { color:#ef5350; }
+</style>
+</head>
+<body>
+<h1>车机视口诊断</h1>
+
+<h2>1. 当前数值</h2>
+<table id="stats"></table>
+
+<h2>2. viewport meta 是否生效</h2>
+<button id="run">点这里测试</button>
+<button id="reset">恢复</button>
+<div id="verdict">尚未测试</div>
+
+<script>
+(function () {
+  var statsEl = document.getElementById('stats');
+  var verdictEl = document.getElementById('verdict');
+  var metaEl = document.querySelector('meta[name="viewport"]');
+  var ORIGINAL_META = metaEl.content;
+
+  function row(k, v, cls) {
+    return '<tr><td class="k">' + k + '</td><td class="v ' + (cls || '') + '">' + v + '</td></tr>';
+  }
+
+  function breakpoint(w) {
+    if (w < 600) return 'xs（手机 · 1 列）';
+    if (w < 900) return 'sm（2 列）';
+    if (w < 1200) return 'md（3 列）';
+    if (w < 1536) return 'lg（桌面）';
+    return 'xl（宽屏桌面）';
+  }
+
+  function render() {
+    var vv = window.visualViewport;
+    var physicalW = Math.round(screen.width * window.devicePixelRatio);
+    var physicalH = Math.round(screen.height * window.devicePixelRatio);
+
+    statsEl.innerHTML =
+      row('布局视口 innerWidth × innerHeight', window.innerWidth + ' × ' + window.innerHeight) +
+      row('当前命中断点', breakpoint(window.innerWidth)) +
+      row('documentElement.clientWidth', document.documentElement.clientWidth) +
+      row('screen.width × height', screen.width + ' × ' + screen.height) +
+      row('devicePixelRatio', window.devicePixelRatio) +
+      row('推算物理像素', physicalW + ' × ' + physicalH) +
+      row('outerWidth', window.outerWidth) +
+      row('visualViewport 宽 / 缩放', vv ? (Math.round(vv.width) + ' / ' + vv.scale) : '不支持') +
+      row('当前 viewport meta', metaEl.content, 'ua') +
+      row('userAgent', navigator.userAgent, 'ua');
+  }
+
+  document.getElementById('run').onclick = function () {
+    var before = window.innerWidth;
+    // 故意不带 initial-scale，让浏览器自己缩放适配
+    metaEl.content = 'width=1280';
+    setTimeout(function () {
+      var after = window.innerWidth;
+      render();
+      if (after === before) {
+        verdictEl.innerHTML = '<span class="bad">✗ viewport meta 无效</span><br>' +
+          '宽度仍为 ' + after + '，浏览器忽略了 meta 标签（桌面模式 Chromium）。';
+      } else {
+        verdictEl.innerHTML = '<span class="ok">✓ viewport meta 生效</span><br>' +
+          before + ' → ' + after + '。页面现在按 1280 布局，' +
+          '请看下面的内容是否<b>完整缩小</b>装进屏幕（而不是被切掉右边）。';
+      }
+    }, 400);
+  };
+
+  document.getElementById('reset').onclick = function () {
+    metaEl.content = ORIGINAL_META;
+    setTimeout(function () { render(); verdictEl.textContent = '已恢复'; }, 400);
+  };
+
+  render();
+  window.addEventListener('resize', render);
+})();
+</script>
+</body>
+</html>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,5 +5,5 @@
 .app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  min-height: calc(100vh / var(--automotive-zoom, 1));
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { VideoProvider, useVideo } from './contexts/VideoContext';
 import { useSettings } from './hooks/useSettings';
 import { defaultQueryConfig } from './utils/queryConfig';
 import { lazyWithRetry } from './utils/lazyWithRetry';
+import { viewportHeight } from './utils/viewportUnits';
 
 const BilibiliPartsModal = lazyWithRetry(
     () => import('./components/BilibiliPartsModal'),
@@ -96,7 +97,7 @@ function AppContent() {
                             display: 'flex',
                             justifyContent: 'center',
                             alignItems: 'center',
-                            minHeight: '100vh',
+                            minHeight: viewportHeight(),
                             bgcolor: 'background.default'
                         }}
                     >
@@ -109,7 +110,7 @@ function AppContent() {
                                 display: 'flex',
                                 justifyContent: 'center',
                                 alignItems: 'center',
-                                minHeight: '100vh',
+                                minHeight: viewportHeight(),
                                 bgcolor: 'background.default'
                             }}
                         >
@@ -124,7 +125,7 @@ function AppContent() {
                     <ScrollToTop />
                     <PageTagFilterProvider>
                         <HomeViewModeRequestProvider>
-                            <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+                            <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: viewportHeight() }}>
                                 <Header
                                     onSearch={handleSearch}
                                     onSubmit={handleVideoSubmit}
@@ -155,7 +156,7 @@ function AppContent() {
 
                                 <Box component="main" sx={{ flexGrow: 1, p: 0, width: '100%', overflowX: 'clip' }}>
                                     <Suspense fallback={
-                                        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '100vh' }}>
+                                        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: viewportHeight() }}>
                                             <CircularProgress />
                                         </Box>
                                     }>

--- a/frontend/src/__tests__/themeAutomotiveSizing.test.ts
+++ b/frontend/src/__tests__/themeAutomotiveSizing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import getTheme from '../theme';
+import { DEFAULT_BREAKPOINT_VALUES } from '../utils/automotiveDesktopLayout';
+
+/** What the measured Tesla resolves to: zoom 0.644 against a 773px viewport. */
+const CAR_BREAKPOINTS = { xs: 0, sm: 386, md: 579, lg: 772, xl: 989 };
+
+describe('theme sizing under scaled in-car breakpoints', () => {
+    it('builds media queries from the scaled thresholds', () => {
+        // The car's 773px viewport has to resolve to lg, where the desktop
+        // columns live.
+        const { breakpoints } = getTheme('dark', CAR_BREAKPOINTS);
+
+        expect(breakpoints.up('lg')).toContain(`${CAR_BREAKPOINTS.lg}px`);
+        expect(breakpoints.up('md')).toContain(`${CAR_BREAKPOINTS.md}px`);
+        expect(breakpoints.down('sm')).toContain('385.95px');
+    });
+
+    it('keeps the pixel values stock, so Container and Dialog stay full width', () => {
+        // These same numbers are what MUI emits as Container/Dialog max-widths.
+        // Scaling them would cap a maxWidth="lg" page at 772px while the zoomed
+        // root has ~1200 layout pixels to fill.
+        const { breakpoints } = getTheme('dark', CAR_BREAKPOINTS);
+
+        expect(breakpoints.values).toMatchObject(DEFAULT_BREAKPOINT_VALUES);
+    });
+
+    it('keeps the two in step: a container caps above the query that reveals it', () => {
+        const { breakpoints } = getTheme('dark', CAR_BREAKPOINTS);
+
+        // maxWidth="lg" applies from the scaled lg query upwards, then caps at
+        // the stock 1200 - which the zoomed root can actually reach.
+        expect(breakpoints.up('lg')).toContain(`${CAR_BREAKPOINTS.lg}px`);
+        expect(breakpoints.values.lg).toBe(DEFAULT_BREAKPOINT_VALUES.lg);
+        expect(breakpoints.values.lg).toBeGreaterThan(CAR_BREAKPOINTS.lg);
+    });
+
+    it('leaves the existing component styling alone', () => {
+        const overrides = getTheme('dark', CAR_BREAKPOINTS).components?.MuiDialog?.styleOverrides;
+
+        expect(overrides?.paper).toMatchObject({ borderRadius: 16 });
+    });
+
+    it('touches none of this on an ordinary browser', () => {
+        const { breakpoints } = getTheme('dark');
+
+        expect(breakpoints.values).toMatchObject(DEFAULT_BREAKPOINT_VALUES);
+        expect(breakpoints.up('lg')).toContain(`${DEFAULT_BREAKPOINT_VALUES.lg}px`);
+    });
+});

--- a/frontend/src/components/Header/MobileMenu.tsx
+++ b/frontend/src/components/Header/MobileMenu.tsx
@@ -9,6 +9,7 @@ import AuthorsList from '../AuthorsList';
 import Collections from '../Collections';
 import TagsList from '../TagsList';
 import SearchInput from './SearchInput';
+import { viewportHeight } from '../../utils/viewportUnits';
 
 interface MobileMenuProps {
     open: boolean;
@@ -67,7 +68,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({
 
     return (
         <Collapse in={open} sx={{ width: '100%' }}>
-            <Box sx={{ maxHeight: '80vh', overflowY: 'auto', overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch' }}>
+            <Box sx={{ maxHeight: viewportHeight(80), overflowY: 'auto', overscrollBehavior: 'contain', WebkitOverflowScrolling: 'touch' }}>
                 <Stack spacing={2} sx={{ py: 2 }}>
                     {/* Row 1: Search Input */}
                     <Box>

--- a/frontend/src/components/ManagePage/CollectionsTable.tsx
+++ b/frontend/src/components/ManagePage/CollectionsTable.tsx
@@ -20,11 +20,12 @@ import {
     Typography,
     useMediaQuery
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Link as RouterLink } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useSnackbar } from '../../contexts/SnackbarContext';
+import { usePaginationSwipeNavigation } from '../../hooks/usePaginationSwipeNavigation';
 import { Collection } from '../../types';
 import { formatDisplayDate } from '../../utils/formatUtils';
 
@@ -68,6 +69,21 @@ const CollectionsTable: React.FC<CollectionsTableProps> = ({
     const { showSnackbar } = useSnackbar();
     const isVisitor = userRole === 'visitor';
     const isTouch = useMediaQuery('(hover: none), (pointer: coarse)');
+
+    // Same swipe-to-page as the videos table; it stands down while the table is
+    // wide enough to scroll sideways on its own.
+    const goToPage = useCallback(
+        (value: number) => onPageChange({} as React.ChangeEvent<unknown>, value),
+        [onPageChange]
+    );
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const swipeHandlers = usePaginationSwipeNavigation({
+        page,
+        totalPages,
+        onPageChange: goToPage,
+        keepNativeHorizontalPan: true,
+        surfaceRef: tableContainerRef
+    });
 
     // Edit state
     const [editingCollectionId, setEditingCollectionId] = useState<string | null>(null);
@@ -172,7 +188,7 @@ const CollectionsTable: React.FC<CollectionsTableProps> = ({
             </Box>
 
             {totalCollectionsCount > 0 ? (
-                <TableContainer component={Paper} variant="outlined">
+                <TableContainer component={Paper} variant="outlined" ref={tableContainerRef} {...swipeHandlers}>
                     <Table>
                         <TableHead>
                             <TableRow>

--- a/frontend/src/components/ManagePage/VideosTable.tsx
+++ b/frontend/src/components/ManagePage/VideosTable.tsx
@@ -33,13 +33,14 @@ import {
     Typography,
     useMediaQuery
 } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { useCollection } from '../../contexts/CollectionContext';
 import { useDownload } from '../../contexts/DownloadContext';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { useVideo } from '../../contexts/VideoContext';
+import { usePaginationSwipeNavigation } from '../../hooks/usePaginationSwipeNavigation';
 import { useThumbnailCandidates } from '../../hooks/useThumbnailCandidates';
 import { Video } from '../../types';
 import type { TranslationKey } from '../../utils/translations';
@@ -137,6 +138,22 @@ const VideosTable: React.FC<VideosTableProps> = ({
     const { activeDownloads, queuedDownloads } = useDownload();
     const isVisitor = userRole === 'visitor';
     const isTouch = useMediaQuery('(hover: none), (pointer: coarse)');
+
+    // Swiping the table sideways turns the page, matching the arrow keys on the
+    // video grids. On a narrow screen the table scrolls horizontally instead and
+    // the hook stands down, so the two gestures never fight.
+    const goToPage = useCallback(
+        (value: number) => onPageChange({} as React.ChangeEvent<unknown>, value),
+        [onPageChange]
+    );
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const swipeHandlers = usePaginationSwipeNavigation({
+        page,
+        totalPages,
+        onPageChange: goToPage,
+        keepNativeHorizontalPan: true,
+        surfaceRef: tableContainerRef
+    });
     const getLabel = (key: string, fallback: string) => {
         // key is a known literal here; cast bridges the string param to TranslationKey.
         const translated = t(key as TranslationKey);
@@ -318,7 +335,7 @@ const VideosTable: React.FC<VideosTableProps> = ({
             </Box>
 
             {displayedVideos.length > 0 ? (
-                <TableContainer component={Paper} variant="outlined">
+                <TableContainer component={Paper} variant="outlined" ref={tableContainerRef} {...swipeHandlers}>
                     <Table>
                         <TableHead>
                             <TableRow>

--- a/frontend/src/components/TagsSidebar.tsx
+++ b/frontend/src/components/TagsSidebar.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { overlay } from '../theme/colors';
 import { useLanguage } from '../contexts/LanguageContext';
 import TagsList from './TagsList';
+import { viewportHeight } from '../utils/viewportUnits';
 
 interface TagsSidebarProps {
     isSidebarOpen: boolean;
@@ -37,7 +38,7 @@ export const TagsSidebar: React.FC<TagsSidebarProps> = ({
                         <Box sx={{
                             position: 'sticky',
                             maxHeight: 'calc(100% - 80px)',
-                            minHeight: 'calc(100vh - 80px)',
+                            minHeight: `calc(${viewportHeight()} - 80px)`,
                             overflowY: 'auto',
                             '&::-webkit-scrollbar': {
                                 width: '6px',

--- a/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
+++ b/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
@@ -20,6 +20,7 @@ import {
 import FullscreenControl from '../VideoControls/FullscreenControl';
 import ProgressBar from '../VideoControls/ProgressBar';
 import SeekButton from '../VideoControls/SeekButton';
+import { viewportHeight, viewportWidth } from '../../../utils/viewportUnits';
 import {
     getMissingCompatibilityModeApis,
     isCompatibilityModeSupported,
@@ -527,8 +528,8 @@ const CompatibilityPlayer: React.FC<CompatibilityPlayerProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    width: '100vw',
-                    height: '100vh',
+                    width: viewportWidth(),
+                    height: viewportHeight(),
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 0,
@@ -549,7 +550,7 @@ const CompatibilityPlayer: React.FC<CompatibilityPlayerProps> = ({
                         ? { flex: 1, minHeight: 0 }
                         : {
                               aspectRatio: snapshot.aspectRatio ?? DEFAULT_ASPECT_RATIO,
-                              maxHeight: 'calc(100vh - 180px)',
+                              maxHeight: `calc(${viewportHeight()} - 180px)`,
                           }),
                     // The poster covers the wait for the first frame, and only
                     // that: the canvas sits on top of it but is transparent

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -7,6 +7,7 @@ import { getBackendUrl } from '../../../utils/apiUrl';
 import { getSubtitleLanguageLabel, getSubtitleTrackLanguage } from '../../../utils/formatUtils';
 import { getMediaCrossOriginAttr } from '../../../utils/mediaOrigin';
 import { computePreloadStrategy } from '../../../utils/preloadStrategy';
+import { viewportHeight } from '../../../utils/viewportUnits';
 
 interface VideoElementProps {
     videoRef: React.RefObject<HTMLVideoElement | null>;
@@ -103,7 +104,7 @@ const VideoElement: React.FC<VideoElementProps> = ({
                           minHeight: 0
                       }
                     : {
-                          maxHeight: 'calc(100vh - 180px)',
+                          maxHeight: `calc(${viewportHeight()} - 180px)`,
                           width: '100%',
                           aspectRatio: {
                               xs: mobileAspectRatio,

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -17,6 +17,7 @@ import { useVideoLoading } from './hooks/useVideoLoading';
 import { useVideoPlayer } from './hooks/useVideoPlayer';
 import { useVolume } from './hooks/useVolume';
 import VideoElement from './VideoElement';
+import { viewportHeight, viewportWidth } from '../../../utils/viewportUnits';
 
 interface VideoControlsProps {
     src: string;
@@ -327,8 +328,8 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    width: '100vw',
-                    height: '100vh',
+                    width: viewportWidth(),
+                    height: viewportHeight(),
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 0

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { CssBaseline, GlobalStyles, ThemeProvider as MuiThemeProvider, PaletteMode, useMediaQuery } from '@mui/material';
 import React, { createContext, useCallback, useContext, useEffect, useEffectEvent, useMemo, useState } from 'react';
 import getTheme from '../theme';
+import { useAutomotiveDesktopLayout } from '../hooks/useAutomotiveDesktopLayout';
 import { applyThemeCssVariables } from '../theme/cssVariables';
 import { api } from '../utils/apiClient';
 import { authSettingsQueryOptions, fetchReadableSettings } from '../utils/settingsQueries';
@@ -138,7 +139,11 @@ export const ThemeContextProvider: React.FC<{ children: React.ReactNode }> = ({ 
         setPreference(mode === 'light' ? 'dark' : 'light');
     }, [setPreference, mode]);
 
-    const theme = useMemo(() => getTheme(mode), [mode]);
+    const automotiveLayout = useAutomotiveDesktopLayout();
+    const theme = useMemo(
+        () => getTheme(mode, automotiveLayout?.breakpoints),
+        [mode, automotiveLayout]
+    );
 
     const contextValue = useMemo<ThemeContextType>(() => ({
         mode, preference, setPreference, toggleTheme,

--- a/frontend/src/hooks/__tests__/useAutomotiveDesktopLayout.test.ts
+++ b/frontend/src/hooks/__tests__/useAutomotiveDesktopLayout.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useAutomotiveDesktopLayout } from '../useAutomotiveDesktopLayout';
+
+// jsdom has no `zoom` style property, so an unset value reads back as
+// undefined where a browser would give ''. Assertions below use toBeFalsy.
+const define = (target: object, key: string, value: unknown) => {
+    Object.defineProperty(target, key, { value, configurable: true, writable: true });
+};
+
+/** The car, as measured: see automotiveDesktopLayout for where these come from. */
+const pretendToBeTheCar = () => {
+    define(window.navigator, 'userAgent', 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36');
+    define(window.navigator, 'maxTouchPoints', 5);
+    define(window, 'devicePixelRatio', 1.5299999713897705);
+    define(window, 'innerWidth', 773);
+    define(window, 'outerWidth', 0);
+};
+
+const pretendToBeALaptop = () => {
+    define(window.navigator, 'userAgent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36');
+    define(window.navigator, 'maxTouchPoints', 0);
+    define(window, 'devicePixelRatio', 2);
+    define(window, 'innerWidth', 1440);
+    define(window, 'outerWidth', 1440);
+};
+
+/** Android Automotive: whole-number DPR, so the zoom follows the width alone. */
+const pretendToBeAnAndroidHeadUnit = (innerWidth: number) => {
+    define(window.navigator, 'userAgent', 'Mozilla/5.0 (Linux; Android 14; Automotive) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36');
+    define(window.navigator, 'maxTouchPoints', 5);
+    define(window, 'devicePixelRatio', 2);
+    define(window, 'innerWidth', innerWidth);
+    define(window, 'outerWidth', innerWidth);
+};
+
+const resizeTo = (innerWidth: number) => {
+    define(window, 'innerWidth', innerWidth);
+    act(() => {
+        window.dispatchEvent(new Event('resize'));
+    });
+};
+
+const mountRoot = () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+    return root;
+};
+
+afterEach(() => {
+    document.getElementById('root')?.remove();
+    window.localStorage.clear();
+});
+
+describe('useAutomotiveDesktopLayout', () => {
+    it('zooms the app root back down on a head unit', () => {
+        pretendToBeTheCar();
+        const root = mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+
+        expect(result.current).toBeDefined();
+        expect(Number(root.style.zoom)).toBeCloseTo(result.current!.zoom, 5);
+    });
+
+    it('publishes the zoom so viewport units can divide it back out', () => {
+        // Without this, a 100vh box renders at 100vh * zoom and leaves dead
+        // space below the footer - 214px of it on the measured car.
+        pretendToBeTheCar();
+        const root = mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+
+        expect(root.style.getPropertyValue('--automotive-zoom'))
+            .toBe(String(result.current!.zoom));
+    });
+
+    it('puts the root back when it unmounts', () => {
+        pretendToBeTheCar();
+        const root = mountRoot();
+
+        const { unmount } = renderHook(() => useAutomotiveDesktopLayout());
+        unmount();
+
+        expect(root.style.zoom).toBeFalsy();
+        expect(root.style.getPropertyValue('--automotive-zoom')).toBeFalsy();
+    });
+
+    it('touches nothing on an ordinary browser', () => {
+        pretendToBeALaptop();
+        const root = mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+
+        expect(result.current).toBeUndefined();
+        expect(root.style.zoom).toBeFalsy();
+        expect(root.style.getPropertyValue('--automotive-zoom')).toBeFalsy();
+    });
+
+    it('re-derives the zoom when the display is resized', () => {
+        // Mounted wide enough to need no zoom; split-screen halves it and the
+        // desktop layout has to be earned back rather than lost.
+        pretendToBeAnAndroidHeadUnit(1440);
+        const root = mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+        expect(result.current!.zoom).toBe(1);
+
+        resizeTo(900);
+
+        expect(result.current!.zoom).toBeCloseTo(0.75, 3);
+        expect(Number(root.style.zoom)).toBeCloseTo(0.75, 3);
+        expect(900).toBeGreaterThanOrEqual(result.current!.breakpoints.lg);
+    });
+
+    it('holds its identity steady when a resize changes nothing', () => {
+        // Otherwise every resize event rebuilds the MUI theme.
+        pretendToBeTheCar();
+        mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+        const before = result.current;
+
+        resizeTo(773);
+
+        expect(result.current).toBe(before);
+    });
+
+    it('never subscribes on an ordinary browser', () => {
+        pretendToBeALaptop();
+        const root = mountRoot();
+
+        const { result } = renderHook(() => useAutomotiveDesktopLayout());
+        resizeTo(700);
+
+        expect(result.current).toBeUndefined();
+        expect(root.style.zoom).toBeFalsy();
+    });
+});

--- a/frontend/src/hooks/__tests__/useHomePagination.test.tsx
+++ b/frontend/src/hooks/__tests__/useHomePagination.test.tsx
@@ -146,3 +146,116 @@ describe('useHomePagination', () => {
         expect(mockSetSearchParams).not.toHaveBeenCalled();
     });
 });
+
+type SwipeHandlers = ReturnType<typeof useHomePagination>['swipeHandlers'];
+
+// The hook reads the touch points plus the element the gesture started on, so
+// a swipe needs a real (if bare) node pair to walk up from.
+function swipeTarget() {
+    const root = document.createElement('div');
+    const child = document.createElement('div');
+    root.appendChild(child);
+    return { currentTarget: root, target: child };
+}
+
+function swipe(
+    handlers: SwipeHandlers,
+    from: { x: number; y: number },
+    to: { x: number; y: number }
+) {
+    act(() => {
+        handlers.onTouchStart?.({
+            ...swipeTarget(),
+            touches: [{ clientX: from.x, clientY: from.y }]
+        } as any);
+        handlers.onTouchEnd?.({ changedTouches: [{ clientX: to.x, clientY: to.y }] } as any);
+    });
+}
+
+describe('useHomePagination swipe navigation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockSearchParams.delete('page');
+        global.window.scrollTo = vi.fn();
+    });
+
+    it('goes to the next page on a left swipe', () => {
+        mockSearchParams.set('page', '1');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 300, y: 100 }, { x: 200, y: 108 });
+        expect(mockSetSearchParams).toHaveBeenCalled();
+        const newParams = mockSetSearchParams.mock.calls[0][0](new URLSearchParams('page=1'));
+        expect(newParams.get('page')).toBe('2');
+        expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    });
+
+    it('goes to the previous page on a right swipe', () => {
+        mockSearchParams.set('page', '2');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 200, y: 100 }, { x: 300, y: 108 });
+        expect(mockSetSearchParams).toHaveBeenCalled();
+        const newParams = mockSetSearchParams.mock.calls[0][0](new URLSearchParams('page=2'));
+        expect(newParams.get('page')).toBe('1');
+    });
+
+    it('leaves a mostly vertical drag to the scroller', () => {
+        mockSearchParams.set('page', '1');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 300, y: 100 }, { x: 200, y: 400 });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+
+    it('ignores a drag shorter than the swipe threshold', () => {
+        mockSearchParams.set('page', '1');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 300, y: 100 }, { x: 260, y: 100 });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+
+    it('ignores a two-finger gesture so pinch-zoom still works', () => {
+        mockSearchParams.set('page', '1');
+        const { result } = setupHook();
+        act(() => {
+            result.current.swipeHandlers.onTouchStart?.({
+                ...swipeTarget(),
+                touches: [{ clientX: 300, clientY: 100 }, { clientX: 340, clientY: 100 }]
+            } as any);
+            result.current.swipeHandlers.onTouchEnd?.({
+                changedTouches: [{ clientX: 200, clientY: 100 }]
+            } as any);
+        });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+
+    it('does not swipe past the last page', () => {
+        mockSearchParams.set('page', '3');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 300, y: 100 }, { x: 200, y: 100 });
+        expect(mockSetSearchParams).not.toHaveBeenCalled();
+    });
+
+    it('swallows only the synthetic click that follows a swipe', () => {
+        mockSearchParams.set('page', '1');
+        const { result } = setupHook();
+        swipe(result.current.swipeHandlers, { x: 300, y: 100 }, { x: 200, y: 100 });
+
+        const swipeClick = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+        act(() => { result.current.swipeHandlers.onClickCapture?.(swipeClick as any); });
+        expect(swipeClick.preventDefault).toHaveBeenCalled();
+
+        // The next tap is the viewer opening a video, and has to get through.
+        const realTap = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+        act(() => { result.current.swipeHandlers.onClickCapture?.(realTap as any); });
+        expect(realTap.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('offers no swipe handlers when infiniteScroll is enabled', () => {
+        const { result } = setupHook({ infiniteScroll: true });
+        expect(result.current.swipeHandlers.onTouchStart).toBeUndefined();
+    });
+
+    it('offers no swipe handlers when there is only one page', () => {
+        const { result } = setupHook({ videos: mockVideos.slice(0, 5) });
+        expect(result.current.swipeHandlers.onTouchStart).toBeUndefined();
+    });
+});

--- a/frontend/src/hooks/__tests__/usePaginationSwipeNavigation.test.tsx
+++ b/frontend/src/hooks/__tests__/usePaginationSwipeNavigation.test.tsx
@@ -1,0 +1,212 @@
+import { act, renderHook } from '@testing-library/react';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { usePaginationSwipeNavigation } from '../usePaginationSwipeNavigation';
+
+function setupHook(overrides: Parameters<typeof usePaginationSwipeNavigation>[0] extends never
+    ? never
+    : Partial<Parameters<typeof usePaginationSwipeNavigation>[0]> = {}) {
+    const onPageChange = vi.fn();
+    const { result } = renderHook(() => usePaginationSwipeNavigation({
+        page: 1,
+        totalPages: 3,
+        onPageChange,
+        ...overrides
+    }));
+    return { result, onPageChange };
+}
+
+/**
+ * A root the handlers are attached to, holding a box that may or may not scroll
+ * sideways, holding the node the finger actually lands on.
+ */
+function buildTree({ scrollWidth, clientWidth }: { scrollWidth: number; clientWidth: number }) {
+    const root = document.createElement('div');
+    const box = document.createElement('div');
+    const child = document.createElement('div');
+    box.style.overflowX = 'auto';
+    box.appendChild(child);
+    root.appendChild(box);
+    document.body.appendChild(root);
+    Object.defineProperty(box, 'scrollWidth', { value: scrollWidth, configurable: true });
+    Object.defineProperty(box, 'clientWidth', { value: clientWidth, configurable: true });
+    return { root, child };
+}
+
+function swipe(
+    handlers: ReturnType<typeof usePaginationSwipeNavigation>,
+    tree: ReturnType<typeof buildTree>,
+    { from, to }: { from: number; to: number }
+) {
+    act(() => {
+        handlers.onTouchStart?.({
+            currentTarget: tree.root,
+            target: tree.child,
+            touches: [{ clientX: from, clientY: 100 }]
+        } as any);
+        handlers.onTouchEnd?.({ changedTouches: [{ clientX: to, clientY: 100 }] } as any);
+    });
+}
+
+function swipeLeft(handlers: ReturnType<typeof usePaginationSwipeNavigation>, tree: ReturnType<typeof buildTree>) {
+    swipe(handlers, tree, { from: 300, to: 200 });
+}
+
+function swipeRight(handlers: ReturnType<typeof usePaginationSwipeNavigation>, tree: ReturnType<typeof buildTree>) {
+    swipe(handlers, tree, { from: 200, to: 300 });
+}
+
+/** Returns whether the hook swallowed the browser's post-swipe click. */
+function clickWasSwallowed(handlers: ReturnType<typeof usePaginationSwipeNavigation>) {
+    const click = { preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    act(() => {
+        handlers.onClickCapture?.(click as any);
+    });
+    return click.preventDefault.mock.calls.length > 0;
+}
+
+describe('usePaginationSwipeNavigation', () => {
+    it('stands down when the gesture starts in a box that scrolls sideways', () => {
+        const { result, onPageChange } = setupHook();
+        swipeLeft(result.current, buildTree({ scrollWidth: 800, clientWidth: 400 }));
+        expect(onPageChange).not.toHaveBeenCalled();
+    });
+
+    it('pages when that box is not actually overflowing', () => {
+        const { result, onPageChange } = setupHook();
+        swipeLeft(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }));
+        expect(onPageChange).toHaveBeenCalledWith(2);
+    });
+
+    it('locks horizontal panning by default', () => {
+        const { result } = setupHook();
+        expect(result.current.style).toEqual({ touchAction: 'pan-y pinch-zoom' });
+    });
+
+    it('leaves two-finger zoom to the browser', () => {
+        // The handler ignores multi-touch anyway, so taking pinch-zoom away
+        // would cost accessibility for nothing.
+        const { result } = setupHook();
+        expect(result.current.style?.touchAction).toContain('pinch-zoom');
+    });
+
+    it('ignores a two-finger gesture instead of paging on it', () => {
+        const { result, onPageChange } = setupHook();
+        const tree = buildTree({ scrollWidth: 400, clientWidth: 400 });
+
+        act(() => {
+            result.current.onTouchStart?.({
+                currentTarget: tree.root,
+                target: tree.child,
+                touches: [{ clientX: 300, clientY: 100 }, { clientX: 340, clientY: 120 }]
+            } as any);
+            result.current.onTouchEnd?.({ changedTouches: [{ clientX: 200, clientY: 100 }] } as any);
+        });
+
+        expect(onPageChange).not.toHaveBeenCalled();
+        expect(clickWasSwallowed(result.current)).toBe(false);
+    });
+
+    it('swallows the click after a swipe that turns the page', () => {
+        const { result } = setupHook();
+        swipeLeft(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }));
+        expect(clickWasSwallowed(result.current)).toBe(true);
+    });
+
+    it('swallows the click when the swipe runs off the end of the pagination', () => {
+        // Swiping right on page 1 has nowhere to go, but the browser still
+        // dispatches the click - onto whichever card the finger started on.
+        const { result, onPageChange } = setupHook({ page: 1 });
+        swipeRight(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }));
+
+        expect(onPageChange).not.toHaveBeenCalled();
+        expect(clickWasSwallowed(result.current)).toBe(true);
+    });
+
+    it('swallows the click when swiping past the last page', () => {
+        const { result, onPageChange } = setupHook({ page: 3, totalPages: 3 });
+        swipeLeft(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }));
+
+        expect(onPageChange).not.toHaveBeenCalled();
+        expect(clickWasSwallowed(result.current)).toBe(true);
+    });
+
+    it('leaves a genuine tap alone', () => {
+        const { result } = setupHook();
+        expect(clickWasSwallowed(result.current)).toBe(false);
+    });
+
+    it('leaves the click alone when the drag was too short to be a swipe', () => {
+        const { result, onPageChange } = setupHook();
+        swipe(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }), { from: 300, to: 280 });
+
+        expect(onPageChange).not.toHaveBeenCalled();
+        expect(clickWasSwallowed(result.current)).toBe(false);
+    });
+
+    it('stops guarding once the next touch begins', () => {
+        // Browsers that already swallow the post-swipe click leave the guard
+        // armed with nothing to consume it. The user's next tap must not
+        // become the casualty.
+        const { result } = setupHook();
+        const tree = buildTree({ scrollWidth: 400, clientWidth: 400 });
+        swipeLeft(result.current, tree);
+
+        act(() => {
+            result.current.onTouchStart?.({
+                currentTarget: tree.root,
+                target: tree.child,
+                touches: [{ clientX: 150, clientY: 100 }]
+            } as any);
+        });
+
+        expect(clickWasSwallowed(result.current)).toBe(false);
+    });
+
+    it('still swallows the click of the swipe that armed it', () => {
+        // The guard has to survive from touchend to the synthetic click that
+        // follows it; only a fresh touch clears it.
+        const { result } = setupHook();
+        swipeLeft(result.current, buildTree({ scrollWidth: 400, clientWidth: 400 }));
+
+        expect(clickWasSwallowed(result.current)).toBe(true);
+    });
+
+    /** A surface that reports a fixed overflow state, as a table would. */
+    function surfaceRefWith({ scrollWidth, clientWidth }: { scrollWidth: number; clientWidth: number }) {
+        const node = document.createElement('div');
+        Object.defineProperty(node, 'scrollWidth', { value: scrollWidth, configurable: true });
+        Object.defineProperty(node, 'clientWidth', { value: clientWidth, configurable: true });
+        document.body.appendChild(node);
+        const ref = createRef<HTMLElement>();
+        (ref as { current: HTMLElement | null }).current = node;
+        return ref;
+    }
+
+    it('releases horizontal panning only while the table really overflows', () => {
+        const { result } = setupHook({
+            keepNativeHorizontalPan: true,
+            surfaceRef: surfaceRefWith({ scrollWidth: 900, clientWidth: 400 })
+        });
+
+        expect(result.current.style).toBeUndefined();
+    });
+
+    it('locks horizontal gestures on a table that currently fits', () => {
+        // Left at touch-action auto, the browser can claim the drag for
+        // back/forward navigation and cancel the touch before touchend, so the
+        // JS-side check never gets a say.
+        const { result } = setupHook({
+            keepNativeHorizontalPan: true,
+            surfaceRef: surfaceRefWith({ scrollWidth: 400, clientWidth: 400 })
+        });
+
+        expect(result.current.style).toEqual({ touchAction: 'pan-y pinch-zoom' });
+    });
+
+    it('keeps the lock when no surface is given to measure', () => {
+        const { result } = setupHook({ keepNativeHorizontalPan: true });
+
+        expect(result.current.style).toEqual({ touchAction: 'pan-y pinch-zoom' });
+    });
+});

--- a/frontend/src/hooks/useAutomotiveDesktopLayout.ts
+++ b/frontend/src/hooks/useAutomotiveDesktopLayout.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+    AutomotiveDesktopLayout,
+    resolveAutomotiveDesktopLayout
+} from '../utils/automotiveDesktopLayout';
+
+/**
+ * Resolves the in-car display workaround and applies its zoom to the app root.
+ * Returns the matching breakpoints for the theme, or undefined in every
+ * ordinary browser. See automotiveDesktopLayout for why both halves are needed.
+ */
+export const useAutomotiveDesktopLayout = (): AutomotiveDesktopLayout | undefined => {
+    // Also consumes ?vehicleDesktop / ?vehicleZoom and remembers them, which is
+    // idempotent - the URL says the same thing on every re-read.
+    const resolveNow = useCallback((): AutomotiveDesktopLayout | undefined => {
+        try {
+            return resolveAutomotiveDesktopLayout({
+                userAgent: window.navigator.userAgent,
+                href: window.location.href,
+                storage: window.localStorage,
+                devicePixelRatio: window.devicePixelRatio,
+                maxTouchPoints: window.navigator.maxTouchPoints,
+                innerWidth: window.innerWidth,
+                outerWidth: window.outerWidth
+            }) ?? undefined;
+        } catch {
+            return undefined;
+        }
+    }, []);
+
+    const [layout, setLayout] = useState<AutomotiveDesktopLayout | undefined>(resolveNow);
+
+    // The zoom is derived from the viewport width, so rotating the display or
+    // entering split-screen has to re-derive it: a unit that started at 1440px
+    // needs no zoom, but at 900px needs 0.75 to still reach a desktop layout.
+    // Whether this *is* a head unit does not depend on width, so a browser that
+    // resolved to undefined stays that way and never subscribes.
+    const isAutomotive = layout !== undefined;
+
+    useEffect(() => {
+        if (!isAutomotive) {
+            return;
+        }
+
+        const handleViewportChange = () => {
+            setLayout((previous) => {
+                const next = resolveNow();
+                // Hold the identity steady when the numbers have not moved, so
+                // a stream of resize events does not rebuild the theme.
+                return previous && next && previous.zoom === next.zoom ? previous : next;
+            });
+        };
+
+        window.addEventListener('resize', handleViewportChange);
+        window.addEventListener('orientationchange', handleViewportChange);
+
+        return () => {
+            window.removeEventListener('resize', handleViewportChange);
+            window.removeEventListener('orientationchange', handleViewportChange);
+        };
+    }, [isAutomotive, resolveNow]);
+
+    useEffect(() => {
+        if (!layout) {
+            return;
+        }
+
+        // zoom on <html> is special-cased away by Blink, so it goes on the app
+        // root. Deliberately not <body>: MUI portals its menus and dialogs
+        // there, and a `fixed` element inside a zoomed ancestor has its left/top
+        // scaled too - measured, a probe at left:600px renders at 386px - which
+        // put the sort menu 319px off its anchor. Outside the zoom, portals
+        // share the viewport's coordinate system, the one
+        // getBoundingClientRect reports, so anchoring stays exact.
+        //
+        // The trade-off: portalled overlays keep the head unit's original
+        // scale, so they read ~1.5x larger than the app behind them. There is
+        // no way to have both - an element's own `zoom` scales its position as
+        // well, so correcting the size always moves the anchor - and oversized
+        // menus are the friendlier half of that bargain on a touch screen.
+        const root = document.getElementById('root');
+        if (!root) {
+            return;
+        }
+
+        const previousZoom = root.style.zoom;
+        root.style.zoom = String(layout.zoom);
+
+        // Viewport units do not follow `zoom`, so inside the zoomed root a
+        // `100vh` box renders at 100vh * zoom - on the measured car that left
+        // 214px of dead space below the footer. Publishing the factor lets
+        // full-height rules divide it back out with
+        // calc(100vh / var(--automotive-zoom)), and CSS recomputes that on
+        // resize by itself. Unset elsewhere, so the fallback of 1 applies.
+        //
+        // It goes on the root and not on <html>: custom properties inherit, and
+        // from <html> it would reach the portals under <body> too, which sit
+        // outside the zoom and would then be scaled down for no reason.
+        // Verified: the variable reads as unset on <body>.
+        root.style.setProperty('--automotive-zoom', String(layout.zoom));
+
+        return () => {
+            root.style.zoom = previousZoom;
+            root.style.removeProperty('--automotive-zoom');
+        };
+    }, [layout]);
+
+    return layout;
+};

--- a/frontend/src/hooks/useHomePagination.ts
+++ b/frontend/src/hooks/useHomePagination.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useSearchParams } from 'react-router';
 import { Video } from '../types';
 import { usePaginationKeyboardNavigation } from './usePaginationKeyboardNavigation';
+import { PaginationSwipeHandlers, usePaginationSwipeNavigation } from './usePaginationSwipeNavigation';
 
 interface UseHomePaginationProps {
     sortedVideos: Video[];
@@ -15,6 +16,8 @@ interface UseHomePaginationReturn {
     totalPages: number;
     displayedVideos: Video[];
     handlePageChange: (event: React.ChangeEvent<unknown>, value: number) => void;
+    /** Spread onto the paged surface so touch screens can swipe between pages. */
+    swipeHandlers: PaginationSwipeHandlers;
 }
 
 export const useHomePagination = ({
@@ -100,10 +103,20 @@ export const useHomePagination = ({
         enabled: !infiniteScroll
     });
 
+    // Same paging from a touch screen - in-car displays and tablets have no
+    // arrow keys to reach the keyboard shortcut with.
+    const swipeHandlers = usePaginationSwipeNavigation({
+        page,
+        totalPages,
+        onPageChange: goToPage,
+        enabled: !infiniteScroll
+    });
+
     return {
         page,
         totalPages,
         displayedVideos,
-        handlePageChange
+        handlePageChange,
+        swipeHandlers
     };
 };

--- a/frontend/src/hooks/usePaginationSwipeNavigation.ts
+++ b/frontend/src/hooks/usePaginationSwipeNavigation.ts
@@ -1,0 +1,207 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * A swipe has to clear this much horizontal travel to turn the page. Set above
+ * the hero carousel's 48px because a mis-fire here replaces the whole grid, and
+ * because the gesture shares the surface with vertical scrolling.
+ */
+const SWIPE_THRESHOLD_PX = 64;
+
+/** How long the post-swipe click guard stays armed. */
+const CLICK_SUPPRESS_MS = 400;
+
+/**
+ * True when the gesture began inside something that scrolls sideways itself -
+ * a wide table in its TableContainer, say. There the drag is the viewer
+ * scrolling that box, not asking for the next page.
+ */
+const startsInsideHorizontalScroller = (event: React.TouchEvent): boolean => {
+    const stopAt = (event.currentTarget as HTMLElement).parentElement;
+    let node = event.target as HTMLElement | null;
+
+    while (node && node !== stopAt) {
+        if (node.scrollWidth > node.clientWidth) {
+            const { overflowX } = window.getComputedStyle(node);
+            if (overflowX === 'auto' || overflowX === 'scroll') return true;
+        }
+        node = node.parentElement;
+    }
+
+    return false;
+};
+
+interface UsePaginationSwipeNavigationProps {
+    page: number;
+    totalPages: number;
+    onPageChange: (page: number) => void;
+    /** Pass false where paging is not in play at all, e.g. infinite scroll. */
+    enabled?: boolean;
+    /**
+     * Pass true where the paged surface may scroll sideways itself - a wide
+     * table in its TableContainer - so the touch-action lock does not take that
+     * scrolling away. The gesture still stands down there, via
+     * startsInsideHorizontalScroller.
+     */
+    keepNativeHorizontalPan?: boolean;
+    /**
+     * The surface itself, required alongside keepNativeHorizontalPan. Native
+     * panning is only worth reserving while the surface is *actually* wider
+     * than its box; a table that currently fits should page like anything else.
+     */
+    surfaceRef?: React.RefObject<HTMLElement | null>;
+}
+
+/** Props to spread onto the element the gesture should cover. Empty when off. */
+export interface PaginationSwipeHandlers {
+    style?: React.CSSProperties;
+    onTouchStart?: React.TouchEventHandler;
+    onTouchEnd?: React.TouchEventHandler;
+    onTouchCancel?: React.TouchEventHandler;
+    onClickCapture?: React.MouseEventHandler;
+}
+
+/**
+ * Horizontal swipes step through a paginated list, the touch counterpart to
+ * usePaginationKeyboardNavigation's arrow keys. No device detection: touch
+ * events only arrive from a touch screen, so in-car displays and tablets get
+ * the gesture while pointer users are untouched.
+ */
+export const usePaginationSwipeNavigation = ({
+    page,
+    totalPages,
+    onPageChange,
+    enabled = true,
+    keepNativeHorizontalPan = false,
+    surfaceRef
+}: UsePaginationSwipeNavigationProps): PaginationSwipeHandlers => {
+    // Whether the surface is scrollable sideways right now. touch-action is
+    // resolved by the browser before any handler runs, so this cannot be left
+    // to startsInsideHorizontalScroller: on a surface parked at touch-action
+    // auto the browser may claim a horizontal drag for back/forward navigation
+    // and cancel the touch before touchend ever fires.
+    const [surfaceOverflows, setSurfaceOverflows] = useState(false);
+    const touchStart = useRef<{ x: number; y: number } | null>(null);
+    const suppressClick = useRef(false);
+    const suppressClickTimer = useRef<number | null>(null);
+
+    useEffect(() => {
+        const node = surfaceRef?.current;
+        if (!keepNativeHorizontalPan || !node) {
+            return;
+        }
+
+        const measure = () => setSurfaceOverflows(node.scrollWidth > node.clientWidth);
+        measure();
+
+        if (typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        // The box and its content can each change width independently.
+        const observer = new ResizeObserver(measure);
+        observer.observe(node);
+        if (node.firstElementChild) {
+            observer.observe(node.firstElementChild);
+        }
+
+        return () => observer.disconnect();
+    }, [keepNativeHorizontalPan, surfaceRef]);
+
+    // Clear the pending suppress-click reset on unmount.
+    useEffect(() => () => {
+        if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
+    }, []);
+
+    const clearClickSuppression = useCallback(() => {
+        suppressClick.current = false;
+        if (suppressClickTimer.current) {
+            window.clearTimeout(suppressClickTimer.current);
+            suppressClickTimer.current = null;
+        }
+    }, []);
+
+    const handleTouchStart = useCallback((event: React.TouchEvent) => {
+        // A new touch means the previous swipe's synthetic click is never
+        // coming - browsers fire it immediately on touchend or not at all. Any
+        // click after this one is the user's own, so stop guarding rather than
+        // eating their first tap on the page they just swiped to.
+        clearClickSuppression();
+
+        // Only a single-finger drag pages; pinch-zoom is left to the browser.
+        touchStart.current =
+            event.touches.length === 1 && !startsInsideHorizontalScroller(event)
+                ? { x: event.touches[0].clientX, y: event.touches[0].clientY }
+                : null;
+    }, [clearClickSuppression]);
+
+    const handleTouchEnd = useCallback((event: React.TouchEvent) => {
+        const start = touchStart.current;
+        touchStart.current = null;
+        if (!start) return;
+
+        const touch = event.changedTouches[0];
+        if (!touch) return;
+
+        const horizontalDistance = touch.clientX - start.x;
+        const verticalDistance = touch.clientY - start.y;
+
+        // Keep natural page scrolling intact; only a deliberate, mostly
+        // horizontal drag turns the page.
+        if (
+            Math.abs(horizontalDistance) < SWIPE_THRESHOLD_PX ||
+            Math.abs(horizontalDistance) <= Math.abs(verticalDistance)
+        ) {
+            return;
+        }
+
+        // The grid is wall-to-wall clickable cards, so swallow the synthetic
+        // click some browsers dispatch after a swipe - and auto-clear the flag
+        // so it never eats a genuine tap when no such click arrives.
+        //
+        // Armed for every deliberate swipe, before the range check below: the
+        // browser dispatches that click whether or not there was a page to
+        // move to, so swiping outwards on the first or last page would
+        // otherwise open whichever card the finger started on.
+        suppressClick.current = true;
+        if (suppressClickTimer.current) window.clearTimeout(suppressClickTimer.current);
+        suppressClickTimer.current = window.setTimeout(clearClickSuppression, CLICK_SUPPRESS_MS);
+
+        const nextPage = horizontalDistance < 0 ? page + 1 : page - 1;
+        if (nextPage < 1 || nextPage > totalPages) return;
+
+        onPageChange(nextPage);
+    }, [clearClickSuppression, onPageChange, page, totalPages]);
+
+    const handleTouchCancel = useCallback(() => {
+        touchStart.current = null;
+    }, []);
+
+    const handleClickCapture = useCallback((event: React.MouseEvent) => {
+        if (!suppressClick.current) return;
+        // One swipe swallows at most one click.
+        clearClickSuppression();
+        event.preventDefault();
+        event.stopPropagation();
+    }, [clearClickSuppression]);
+
+    if (!enabled || totalPages <= 1) {
+        return {};
+    }
+
+    return {
+        // Vertical scrolling stays with the browser, while horizontal drags
+        // reach these handlers instead of an OEM browser's back/forward swipe.
+        // pinch-zoom is named explicitly because omitting it would also
+        // surrender two-finger zoom, which this hook never wants: a gesture
+        // with more than one touch is ignored outright in handleTouchStart.
+        // Released only while the surface really is scrolling sideways, so a
+        // table that fits pages like every other surface.
+        ...(keepNativeHorizontalPan && surfaceOverflows
+            ? {}
+            : { style: { touchAction: 'pan-y pinch-zoom' } }),
+        onTouchStart: handleTouchStart,
+        onTouchEnd: handleTouchEnd,
+        onTouchCancel: handleTouchCancel,
+        onClickCapture: handleClickCapture
+    };
+};

--- a/frontend/src/pages/AllAuthorsPage.tsx
+++ b/frontend/src/pages/AllAuthorsPage.tsx
@@ -8,6 +8,7 @@ import { useCloudStorageUrl } from '../hooks/useCloudStorageUrl';
 import { brand, modeColors } from '../theme/colors';
 import { Video } from '../types';
 import { authorAvatarFallbackSx } from '../utils/authorAvatarStyles';
+import { viewportHeight } from '../utils/viewportUnits';
 
 interface AuthorSummary {
     author: string;
@@ -104,7 +105,7 @@ const AllAuthorsPage: React.FC = () => {
 
     if (loading) {
         return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: viewportHeight(50) }}>
                 <CircularProgress />
             </Box>
         );

--- a/frontend/src/pages/AllTagsPage.tsx
+++ b/frontend/src/pages/AllTagsPage.tsx
@@ -28,6 +28,7 @@ import { useVideoFiltering } from '../hooks/useVideoFiltering';
 import { useVideoSort } from '../hooks/useVideoSort';
 import { lazyWithRetry } from '../utils/lazyWithRetry';
 import { sortTagsByUsage } from '../utils/tagUtils';
+import { viewportHeight } from '../utils/viewportUnits';
 
 const ALL_TAGS_SORT_STORAGE_SLOT = 'allTagsSortOption';
 
@@ -117,7 +118,7 @@ const AllTagsPage: React.FC = () => {
 
     if (!settingsLoaded || (loading && videoArray.length === 0)) {
         return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: viewportHeight(50) }}>
                 <CircularProgress />
             </Box>
         );

--- a/frontend/src/pages/AllTagsPage.tsx
+++ b/frontend/src/pages/AllTagsPage.tsx
@@ -108,7 +108,7 @@ const AllTagsPage: React.FC = () => {
         },
     });
 
-    const { page, totalPages, displayedVideos, handlePageChange } = useHomePagination({
+    const { page, totalPages, displayedVideos, handlePageChange, swipeHandlers } = useHomePagination({
         sortedVideos,
         itemsPerPage,
         infiniteScroll,
@@ -221,18 +221,21 @@ const AllTagsPage: React.FC = () => {
                 </Typography>
             ) : (
                 <>
-                    <VideoGrid
-                        videos={videoArray}
-                        sortedVideos={sortedVideos}
-                        displayedVideos={displayedVideos}
-                        collections={collections}
-                        viewMode="all-videos"
-                        infiniteScroll={infiniteScroll}
-                        gridProps={gridProps}
-                        onDeleteVideo={deleteVideo}
-                        showTagsOnThumbnail={showTagsOnThumbnail}
-                        onTagToggle={handleTagToggle}
-                    />
+                    {/* Swiping the grid sideways turns the page, as on Home. */}
+                    <Box {...swipeHandlers}>
+                        <VideoGrid
+                            videos={videoArray}
+                            sortedVideos={sortedVideos}
+                            displayedVideos={displayedVideos}
+                            collections={collections}
+                            viewMode="all-videos"
+                            infiniteScroll={infiniteScroll}
+                            gridProps={gridProps}
+                            onDeleteVideo={deleteVideo}
+                            showTagsOnThumbnail={showTagsOnThumbnail}
+                            onTagToggle={handleTagToggle}
+                        />
+                    </Box>
                     {!infiniteScroll && totalPages > 1 && (
                         <Box sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}>
                             <Pagination

--- a/frontend/src/pages/CollectionPage.tsx
+++ b/frontend/src/pages/CollectionPage.tsx
@@ -25,6 +25,7 @@ import { usePageTagFilter } from '../contexts/PageTagFilterContext';
 import { useSnackbar } from '../contexts/SnackbarContext';
 import { useVideo } from '../contexts/VideoContext';
 import { usePaginationKeyboardNavigation } from '../hooks/usePaginationKeyboardNavigation';
+import { usePaginationSwipeNavigation } from '../hooks/usePaginationSwipeNavigation';
 import { useSettings } from '../hooks/useSettings';
 import { useVideoSort } from '../hooks/useVideoSort';
 import { useFavoriteCollections } from '../hooks/useFavoriteCollections';
@@ -149,6 +150,9 @@ const CollectionPage: React.FC = () => {
 
     // Arrow keys page through the grid here exactly as they do on Home.
     usePaginationKeyboardNavigation({ page, totalPages, onPageChange: goToPage });
+
+    // ...and so do horizontal swipes, for screens with no keyboard.
+    const swipeHandlers = usePaginationSwipeNavigation({ page, totalPages, onPageChange: goToPage });
 
     const handleCloseDeleteModal = () => {
         setShowDeleteModal(false);
@@ -347,7 +351,7 @@ const CollectionPage: React.FC = () => {
                         </Alert>
                     ) : (
                         <Box>
-                            <Grid container spacing={3}>
+                            <Grid container spacing={3} {...swipeHandlers}>
                                 {displayedVideos.map(video => (
                                     <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }} key={video.id}>
                                         <VideoCard

--- a/frontend/src/pages/DownloadPage/HistoryTab.tsx
+++ b/frontend/src/pages/DownloadPage/HistoryTab.tsx
@@ -14,6 +14,7 @@ import React, { useMemo, useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
 import { DownloadHistoryItem, HistoryItem } from './HistoryItem';
 
+import { usePaginationSwipeNavigation } from '../../hooks/usePaginationSwipeNavigation';
 import { useSettings } from '../../hooks/useSettings';
 
 interface HistoryTabProps {
@@ -59,6 +60,9 @@ export function HistoryTab({
         });
     }, [history, filterType]);
 
+    const totalPages = Math.ceil(filteredHistory.length / ITEMS_PER_PAGE);
+    const swipeHandlers = usePaginationSwipeNavigation({ page, totalPages, onPageChange: setPage });
+
     return (
         <>
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 2, gap: 2, flexWrap: 'wrap' }}>
@@ -94,7 +98,7 @@ export function HistoryTab({
                 <Typography color="textSecondary">{t('noDownloadHistory') || 'No download history'}</Typography>
             ) : (
                 <>
-                    <List>
+                    <List {...swipeHandlers}>
                         {filteredHistory
                             .slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
                             .map((item) => (
@@ -116,7 +120,7 @@ export function HistoryTab({
                     {filteredHistory.length > ITEMS_PER_PAGE && (
                         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
                             <Pagination
-                                count={Math.ceil(filteredHistory.length / ITEMS_PER_PAGE)}
+                                count={totalPages}
                                 page={page}
                                 onChange={(_: React.ChangeEvent<unknown>, newPage: number) => setPage(newPage)}
                                 color="primary"

--- a/frontend/src/pages/DownloadPage/QueueTab.tsx
+++ b/frontend/src/pages/DownloadPage/QueueTab.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import React, { useState } from 'react';
 import { useLanguage } from '../../contexts/LanguageContext';
+import { usePaginationSwipeNavigation } from '../../hooks/usePaginationSwipeNavigation';
 import { useMediaQuery, useTheme } from '@mui/material';
 
 interface Download {
@@ -34,6 +35,8 @@ export function QueueTab({ downloads, onRemove, onClear, removingId = null, clea
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
     const [page, setPage] = useState(1);
+    const totalPages = Math.ceil(downloads.length / ITEMS_PER_PAGE);
+    const swipeHandlers = usePaginationSwipeNavigation({ page, totalPages, onPageChange: setPage });
 
     return (
         <>
@@ -53,7 +56,7 @@ export function QueueTab({ downloads, onRemove, onClear, removingId = null, clea
                 <Typography color="textSecondary">{t('noQueuedDownloads') || 'No queued downloads'}</Typography>
             ) : (
                 <>
-                    <List>
+                    <List {...swipeHandlers}>
                         {downloads
                             .slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE)
                             .map((download) => (
@@ -82,7 +85,7 @@ export function QueueTab({ downloads, onRemove, onClear, removingId = null, clea
                     {downloads.length > ITEMS_PER_PAGE && (
                         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
                             <Pagination
-                                count={Math.ceil(downloads.length / ITEMS_PER_PAGE)}
+                                count={totalPages}
                                 page={page}
                                 onChange={(_: React.ChangeEvent<unknown>, newPage: number) => setPage(newPage)}
                                 color="primary"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -145,7 +145,8 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
         page,
         totalPages,
         displayedVideos,
-        handlePageChange
+        handlePageChange,
+        swipeHandlers
     } = useHomePagination({
         sortedVideos,
         itemsPerPage,
@@ -269,7 +270,9 @@ const Home: React.FC<HomeProps> = ({ initialViewMode }) => {
                                 </Typography>
                             </Box>
                         ) : (
-                            <Box ref={videoGridRef}>
+                            // Swiping the grid sideways turns the page, so a
+                            // touch-only screen can page without the arrow keys.
+                            <Box ref={videoGridRef} {...swipeHandlers}>
                                 <VideoGrid
                                     videos={videoArray}
                                     sortedVideos={sortedVideos}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -27,6 +27,7 @@ import { api, ensureCsrfToken, getErrorMessage, getWaitTime, isAuthError, isRate
 import { createTranslateOrFallback } from '../utils/translateOrFallback';
 import { getWebAuthnErrorTranslationKey } from '../utils/translations';
 import GesturePattern from '../components/Auth/GesturePattern';
+import { viewportHeight } from '../utils/viewportUnits';
 import {
     GESTURE_LOGIN_STATUS_QUERY_KEY,
     authenticateGestureLogin,
@@ -490,7 +491,7 @@ const LoginPage: React.FC = () => {
     return (
         <Box
             sx={{
-                minHeight: '100vh',
+                minHeight: viewportHeight(),
                 display: 'flex',
                 flexDirection: 'column',
                 bgcolor: 'background.default',

--- a/frontend/src/pages/SearchResults.tsx
+++ b/frontend/src/pages/SearchResults.tsx
@@ -22,6 +22,7 @@ import { useVideo } from '../contexts/VideoContext';
 import { neutral, overlay, platform } from '../theme/colors';
 import { formatDuration } from '../utils/formatUtils';
 import { THUMBNAIL_PLACEHOLDER_SRC, setThumbnailPlaceholder } from '../utils/thumbnailPlaceholder';
+import { viewportHeight } from '../utils/viewportUnits';
 
 const SearchResults: React.FC = () => {
     const { t } = useLanguage();
@@ -77,7 +78,7 @@ const SearchResults: React.FC = () => {
     // If the entire page is loading
     if (loading) {
         return (
-            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '50vh' }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: viewportHeight(50) }}>
                 <Typography variant="h5" gutterBottom>Searching for "{searchTerm}"...</Typography>
                 <CircularProgress />
             </Box>

--- a/frontend/src/pages/VideoPlayer.tsx
+++ b/frontend/src/pages/VideoPlayer.tsx
@@ -40,6 +40,7 @@ import { getBackendUrl } from '../utils/apiUrl';
 import { isCompatibilityModeForced } from '../utils/compatibilityMode/deployment';
 import { isCompatibilityModeSupported } from '../utils/compatibilityMode/support';
 import { getBestVideoResumeProgress } from '../utils/videoResumeProgress';
+import { viewportHeight } from '../utils/viewportUnits';
 
 const MAX_BACK_TRAIL_LENGTH = 20;
 
@@ -481,7 +482,7 @@ const VideoPlayer: React.FC = () => {
 
     if (loading) {
         return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: viewportHeight(50) }}>
                 <CircularProgress />
                 <Typography sx={{ ml: 2 }}>{t('loadingVideo')}</Typography>
             </Box>

--- a/frontend/src/pages/authorVideos/AuthorVideosPage.tsx
+++ b/frontend/src/pages/authorVideos/AuthorVideosPage.tsx
@@ -18,6 +18,7 @@ import AuthorVideosHeader from './AuthorVideosHeader';
 import { useAuthorTagFilter } from './useAuthorTagFilter';
 import { useAuthorVideoActions } from './useAuthorVideoActions';
 import { getAuthorVideos, getVideoCountLabel } from './utils';
+import { viewportHeight } from '../../utils/viewportUnits';
 
 const AuthorVideosPage: React.FC = () => {
     const { t } = useLanguage();
@@ -106,7 +107,7 @@ const AuthorVideosPage: React.FC = () => {
 
     if (loading) {
         return (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: '50vh' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: viewportHeight(50) }}>
                 <CircularProgress />
             </Box>
         );

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -95,3 +95,14 @@ Object.defineProperty(window, 'scrollTo', {
   writable: true,
   value: vi.fn(),
 });
+
+// jsdom has no ResizeObserver. A no-op stand-in is enough: the code under test
+// measures once on mount, and tests that need a re-measure dispatch it directly.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() { /* no-op */ }
+    unobserve() { /* no-op */ }
+    disconnect() { /* no-op */ }
+  } as unknown as typeof ResizeObserver;
+}
+

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -4,11 +4,46 @@ import {
   shadow,
   type ThemeMode,
 } from "./theme/colors";
+import { createBreakpoints } from "@mui/system";
+import type { AutomotiveBreakpointValues } from "./utils/automotiveDesktopLayout";
 
-const getTheme = (mode: ThemeMode) => {
+/**
+ * In-car displays render inside a zoomed root, so their layout box is wider
+ * than the viewport the media queries see. `breakpoints.values` cannot simply
+ * be scaled to bridge that, because MUI reads it two different ways: as
+ * media-query thresholds, which must follow the viewport, and as raw pixel
+ * widths for `Container` and `Dialog`, which must follow the layout box.
+ * Scaling both caps a maxWidth="lg" page at the car's 772px while its root has
+ * ~1200 layout pixels to fill, wasting a third of the screen.
+ *
+ * So `values` keeps the stock numbers and only the query builders are swapped.
+ * Every component asks for its media queries through up/down/between, and for
+ * its pixel widths through values, which splits the two cleanly - no
+ * per-component overrides, and nothing to keep in sync as MUI adds components.
+ */
+const withScaledMediaQueries = <T extends { breakpoints: object }>(
+  theme: T,
+  breakpointValues: AutomotiveBreakpointValues,
+): T => {
+  const scaled = createBreakpoints({ values: breakpointValues });
+
+  return {
+    ...theme,
+    breakpoints: {
+      ...theme.breakpoints,
+      up: scaled.up,
+      down: scaled.down,
+      between: scaled.between,
+      only: scaled.only,
+      not: scaled.not,
+    },
+  };
+};
+
+const getTheme = (mode: ThemeMode, breakpointValues?: AutomotiveBreakpointValues) => {
   const colors = modeColors(mode);
 
-  return createTheme({
+  const theme = createTheme({
     palette: {
       mode,
       primary: {
@@ -118,6 +153,8 @@ const getTheme = (mode: ThemeMode) => {
       },
     },
   });
+
+  return breakpointValues ? withScaledMediaQueries(theme, breakpointValues) : theme;
 };
 
 export default getTheme;

--- a/frontend/src/utils/__tests__/automotiveDesktopLayout.test.ts
+++ b/frontend/src/utils/__tests__/automotiveDesktopLayout.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAutomotiveDesktopLayout } from '../automotiveDesktopLayout';
+
+const createMemoryStorage = (): Storage => {
+    const values = new Map<string, string>();
+
+    return {
+        get length() {
+            return values.size;
+        },
+        clear: () => values.clear(),
+        getItem: (key: string) => values.get(key) ?? null,
+        key: (index: number) => Array.from(values.keys())[index] ?? null,
+        removeItem: (key: string) => {
+            values.delete(key);
+        },
+        setItem: (key: string, value: string) => {
+            values.set(key, String(value));
+        },
+    };
+};
+
+/**
+ * Embedded browsers can expose a Storage object whose methods all throw - and a
+ * head unit is exactly where that happens, and where the query-string escape
+ * hatch matters most.
+ */
+const createHostileStorage = (): Storage => ({
+    get length(): number {
+        throw new Error('storage unavailable');
+    },
+    clear: () => { throw new Error('storage unavailable'); },
+    getItem: () => { throw new Error('storage unavailable'); },
+    key: () => { throw new Error('storage unavailable'); },
+    removeItem: () => { throw new Error('storage unavailable'); },
+    setItem: () => { throw new Error('storage unavailable'); },
+});
+
+/** Measured on the car: Tesla head unit, 1920x1200 panel, 2026 software. */
+const TESLA = {
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    devicePixelRatio: 1.5299999713897705,
+    maxTouchPoints: 5,
+    innerWidth: 773,
+    // The car really does report 0 - it runs chromeless in a kiosk shell.
+    outerWidth: 0
+};
+
+/**
+ * The near-miss: same desktop-Linux UA, same touch screen, same fractional
+ * ratio from desktop scaling. Only the real window frame tells it apart.
+ */
+const LINUX_TOUCH_LAPTOP = {
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    devicePixelRatio: 1.5,
+    maxTouchPoints: 10,
+    innerWidth: 1280,
+    outerWidth: 1280
+};
+
+const MAC_DESKTOP = {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    devicePixelRatio: 2,
+    maxTouchPoints: 0,
+    innerWidth: 1440,
+    outerWidth: 1440
+};
+
+const ANDROID_PHONE = {
+    userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Mobile Safari/537.36',
+    devicePixelRatio: 2.625,
+    maxTouchPoints: 5,
+    innerWidth: 412,
+    outerWidth: 412
+};
+
+const WINDOWS_TOUCH_LAPTOP = {
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+    devicePixelRatio: 1.5,
+    maxTouchPoints: 10,
+    innerWidth: 1280,
+    outerWidth: 1280
+};
+
+const resolve = (device: typeof TESLA, href = 'https://example.com/', storage = createMemoryStorage()) =>
+    resolveAutomotiveDesktopLayout({ ...device, href, storage });
+
+describe('automotiveDesktopLayout', () => {
+    it('spots the car head unit without any user-agent token', () => {
+        expect(resolve(TESLA)).not.toBeNull();
+    });
+
+    it('undoes the head unit magnification without over-shrinking', () => {
+        const layout = resolve(TESLA)!;
+
+        // 1/1.53 would leave the window 11px shy of a desktop layout, so it
+        // shrinks just far enough to clear it - and no further.
+        expect(layout.zoom).toBeLessThanOrEqual(1 / TESLA.devicePixelRatio);
+        expect(layout.zoom).toBeGreaterThan(0.6);
+    });
+
+    it('lands the car viewport on lg, where the desktop columns live', () => {
+        const { breakpoints } = resolve(TESLA)!;
+
+        expect(TESLA.innerWidth).toBeGreaterThanOrEqual(breakpoints.lg);
+        expect(TESLA.innerWidth).toBeLessThan(breakpoints.xl);
+    });
+
+    it('gives the car an effective width of a desktop window', () => {
+        const layout = resolve(TESLA)!;
+
+        expect(Math.round(TESLA.innerWidth / layout.zoom)).toBeGreaterThanOrEqual(1200);
+    });
+
+    it('keeps the scaled breakpoints ascending', () => {
+        const { breakpoints } = resolve(TESLA)!;
+
+        expect(breakpoints.xs).toBeLessThan(breakpoints.sm);
+        expect(breakpoints.sm).toBeLessThan(breakpoints.md);
+        expect(breakpoints.md).toBeLessThan(breakpoints.lg);
+        expect(breakpoints.lg).toBeLessThan(breakpoints.xl);
+    });
+
+    it('leaves ordinary desktops alone', () => {
+        expect(resolve(MAC_DESKTOP)).toBeNull();
+    });
+
+    it('leaves phones alone', () => {
+        expect(resolve(ANDROID_PHONE)).toBeNull();
+    });
+
+    it('leaves a HiDPI Windows touch laptop alone', () => {
+        expect(resolve(WINDOWS_TOUCH_LAPTOP)).toBeNull();
+    });
+
+    it('lets an unrecognised head unit opt in by query string', () => {
+        expect(resolve(MAC_DESKTOP, 'https://example.com/?vehicleDesktop=1')).not.toBeNull();
+    });
+
+    it('lets the car opt back out by query string', () => {
+        expect(resolve(TESLA, 'https://example.com/?vehicleDesktop=0')).toBeNull();
+    });
+
+    it('remembers both choices on later visits', () => {
+        const optedIn = createMemoryStorage();
+        resolve(MAC_DESKTOP, 'https://example.com/?vehicleDesktop=1', optedIn);
+        expect(resolve(MAC_DESKTOP, 'https://example.com/', optedIn)).not.toBeNull();
+
+        const optedOut = createMemoryStorage();
+        resolve(TESLA, 'https://example.com/?vehicleDesktop=0', optedOut);
+        expect(resolve(TESLA, 'https://example.com/', optedOut)).toBeNull();
+    });
+
+    it('honours a hand-tuned zoom and remembers it', () => {
+        const storage = createMemoryStorage();
+
+        expect(resolve(TESLA, 'https://example.com/?vehicleZoom=0.8', storage)!.zoom).toBe(0.8);
+        expect(resolve(TESLA, 'https://example.com/', storage)!.zoom).toBe(0.8);
+    });
+
+    it('clamps a hand-tuned zoom to something legible', () => {
+        expect(resolve(TESLA, 'https://example.com/?vehicleZoom=0.05')!.zoom).toBe(0.5);
+        expect(resolve(TESLA, 'https://example.com/?vehicleZoom=4')!.zoom).toBe(1);
+    });
+
+    it('never magnifies, only shrinks', () => {
+        const wideCar = { ...TESLA, innerWidth: 1600 };
+
+        expect(resolve(wideCar)!.zoom).toBeLessThanOrEqual(1);
+    });
+    it('spots an Android Automotive head unit by its token', () => {
+        const androidAutomotive = {
+            userAgent: 'Mozilla/5.0 (Linux; Android 14; Automotive) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+            devicePixelRatio: 2,
+            maxTouchPoints: 5,
+            innerWidth: 900,
+            outerWidth: 1200
+        };
+
+        expect(resolve(androidAutomotive)).not.toBeNull();
+    });
+
+    it('does not divide out plain hardware pixel density', () => {
+        // devicePixelRatio 2 here is Retina-style density, not magnification.
+        // Undoing it would halve the text on a screen that was never oversized.
+        const hidpiHeadUnit = {
+            userAgent: 'Mozilla/5.0 (Linux; Android 14; Automotive) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+            devicePixelRatio: 2,
+            maxTouchPoints: 5,
+            innerWidth: 900,
+            outerWidth: 1200
+        };
+
+        // Only the shrink needed to reach a desktop layout: 900/1200.
+        expect(resolve(hidpiHeadUnit)!.zoom).toBeCloseTo(0.75, 3);
+    });
+
+    it('leaves a head unit that already has a roomy viewport unchanged', () => {
+        const roomyHeadUnit = {
+            userAgent: 'Mozilla/5.0 (Linux; Android 14; Automotive) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+            devicePixelRatio: 2,
+            maxTouchPoints: 5,
+            innerWidth: 1440,
+            outerWidth: 1440
+        };
+        const layout = resolve(roomyHeadUnit)!;
+
+        // zoom 1 with unscaled breakpoints is a no-op, so detection costs
+        // nothing on a car that never had the problem.
+        expect(layout.zoom).toBe(1);
+        expect(layout.breakpoints.lg).toBe(1200);
+    });
+
+    it('scales any magnified head unit, not just the measured one', () => {
+        const otherCar = {
+            userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+            devicePixelRatio: 1.75,
+            maxTouchPoints: 10,
+            innerWidth: 640,
+            outerWidth: 0
+        };
+        const layout = resolve(otherCar)!;
+
+        expect(layout).not.toBeNull();
+        expect(layout.zoom).not.toBe(resolve(TESLA)!.zoom);
+        expect(640).toBeGreaterThanOrEqual(layout.breakpoints.lg);
+    });
+
+    it('does not mistake a Linux touch laptop for a head unit', () => {
+        // Desktop scaling on a touch laptop looks exactly like a magnified
+        // head unit, right up to the window frame it reports.
+        expect(resolve(LINUX_TOUCH_LAPTOP)).toBeNull();
+    });
+
+    it('still lets that laptop opt in deliberately', () => {
+        expect(resolve(LINUX_TOUCH_LAPTOP, 'https://example.com/?vehicleDesktop=1')).not.toBeNull();
+    });
+
+    it('honours ?vehicleDesktop=1 even when storage throws', () => {
+        expect(resolve(MAC_DESKTOP, 'https://example.com/?vehicleDesktop=1', createHostileStorage()))
+            .not.toBeNull();
+    });
+
+    it('honours ?vehicleDesktop=0 even when storage throws', () => {
+        expect(resolve(TESLA, 'https://example.com/?vehicleDesktop=0', createHostileStorage()))
+            .toBeNull();
+    });
+
+    it('honours ?vehicleZoom even when storage throws', () => {
+        expect(resolve(TESLA, 'https://example.com/?vehicleZoom=0.8', createHostileStorage())!.zoom)
+            .toBe(0.8);
+    });
+
+    it("lets this load's URL win over what storage remembers", () => {
+        const storage = createMemoryStorage();
+        resolve(TESLA, 'https://example.com/?vehicleDesktop=1&vehicleZoom=0.9', storage);
+
+        // Same visit, new URL: the query string is the more recent instruction.
+        expect(resolve(TESLA, 'https://example.com/?vehicleZoom=0.7', storage)!.zoom).toBe(0.7);
+        expect(resolve(TESLA, 'https://example.com/?vehicleDesktop=0', storage)).toBeNull();
+    });
+
+    it('reads a fractional Android ratio as hardware density, not magnification', () => {
+        // 2.625 is one of Android's standard density buckets. Treating it as
+        // 162% magnification would divide it out and hit the zoom floor,
+        // shrinking a perfectly normal screen to half size.
+        const androidAutomotive = {
+            userAgent: 'Mozilla/5.0 (Linux; Android 14; Automotive) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36',
+            devicePixelRatio: 2.625,
+            maxTouchPoints: 5,
+            innerWidth: 900,
+            outerWidth: 900
+        };
+
+        // Only the shrink needed to reach the desktop target: 900/1200.
+        expect(resolve(androidAutomotive)!.zoom).toBeCloseTo(0.75, 3);
+    });
+
+    it('still undoes magnification on the desktop-UA head unit', () => {
+        // The same fractional-ratio inference must survive for the car it was
+        // measured on, where 1.53 really is magnification.
+        expect(resolve(TESLA)!.zoom).toBeLessThanOrEqual(1 / TESLA.devicePixelRatio);
+    });
+});

--- a/frontend/src/utils/automotiveDesktopLayout.ts
+++ b/frontend/src/utils/automotiveDesktopLayout.ts
@@ -1,0 +1,254 @@
+/**
+ * Tesla's browser (and other in-car Chromium builds) magnifies the whole UI:
+ * measured on a Model 3, a 1920x1200 panel reports devicePixelRatio 1.53, so a
+ * browser window 1183 physical pixels wide hands the page a CSS viewport of
+ * only 773. MUI resolves `sm` and the app renders its phone layout on a screen
+ * that is physically huge.
+ *
+ * Two things do NOT work here, both measured on the car:
+ *   - `<meta name="viewport" content="width=1280">` is ignored outright. Blink
+ *     only honours viewport meta in mobile viewport mode; the car runs a
+ *     desktop-mode Chromium (UA is a plain `X11; Linux x86_64` Chrome).
+ *   - Scaling the breakpoints alone gets the columns back but leaves every
+ *     element at its magnified size, so the desktop layout arrives absurdly
+ *     oversized and overflowing.
+ *
+ * What works is undoing the magnification: `zoom` on <body> shrinks the content
+ * and widens the layout box to match (763px -> 1174px at zoom 0.653). Media
+ * queries deliberately do not follow `zoom`, so the theme's breakpoints are
+ * scaled by the same factor to keep them in step. Note `zoom` on <html> does
+ * nothing - Blink special-cases the root element.
+ */
+
+export interface AutomotiveBreakpointValues {
+    xs: number;
+    sm: number;
+    md: number;
+    lg: number;
+    xl: number;
+}
+
+export interface AutomotiveDesktopLayout {
+    /** Applied to <body>; < 1 shrinks the magnified UI back down. */
+    zoom: number;
+    breakpoints: AutomotiveBreakpointValues;
+}
+
+/** MUI's stock breakpoints, which the rest of the app is written against. */
+export const DEFAULT_BREAKPOINT_VALUES: AutomotiveBreakpointValues = {
+    xs: 0,
+    sm: 600,
+    md: 900,
+    lg: 1200,
+    xl: 1536
+};
+
+const ENABLED_KEY = 'forceAutomotiveDesktopViewport';
+const ZOOM_KEY = 'automotiveDesktopZoom';
+
+/**
+ * Keeps text legible at arm's length and stops a wild devicePixelRatio from
+ * shrinking the UI to nothing.
+ */
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 1;
+
+/**
+ * Effective width to aim for: MUI's `lg`, the point where useGridLayout starts
+ * laying out desktop columns. Landing on `md` is not enough - several of its
+ * column settings carry no `md` entry and fall back to the two-column `sm`.
+ */
+const DESKTOP_TARGET_WIDTH = 1200;
+
+/**
+ * A fractional devicePixelRatio means software magnification - a head unit
+ * scaling its UI up for arm's-length reading - and that is what we undo. Whole
+ * ratios are hardware pixel density (Retina and friends); dividing those out
+ * would shrink text to nothing on a screen that was never oversized.
+ *
+ * That inference only holds on a desktop user agent, where 1.0 is the norm.
+ * Android ships fractional ratios as plain hardware density - its 1.5 / 2.625
+ * / 3.5 buckets - so on Android Automotive a 2.625 would otherwise be read as
+ * 162% magnification and shrink the UI to the floor for no reason.
+ */
+const isSoftwareMagnification = (userAgent: string, devicePixelRatio: number): boolean => (
+    !/\bAndroid\b/i.test(userAgent) &&
+    devicePixelRatio > 1.25 &&
+    Math.abs(devicePixelRatio - Math.round(devicePixelRatio)) > 0.02
+);
+
+/**
+ * Head units that do announce themselves. Tesla's does not - hence the
+ * behavioural check below - but Android Automotive and several OEM browsers
+ * carry a token, and those never appear in a phone or desktop user agent.
+ */
+const CAR_BROWSER_USER_AGENT =
+    /\b(?:Automotive|CarBrowser|QtCarBrowser|Tesla|Rivian|Lucid|Polestar|MBUX|BYD|NIO|XPeng|Zeekr|Li\s?Auto|Lixiang)\b/i;
+
+/**
+ * Tesla's head unit runs desktop Chromium on X11 with no identifying token, so
+ * the user agent alone cannot spot it. Desktop Linux plus a touch screen plus
+ * software magnification narrows it down, but not far enough on its own: a
+ * Linux touch laptop at fractional desktop scaling looks identical, and would
+ * have its whole UI shrunk for no reason.
+ *
+ * `outerWidth === 0` is what separates them. A normal browser window always
+ * reports its outer frame - the embedded Claude browser used while developing
+ * this reported 400 - while the car, running chromeless in a kiosk shell,
+ * reports 0. Measured on the car; if a future firmware starts reporting a real
+ * frame, detection quietly stops firing and ?vehicleDesktop=1 still works.
+ *
+ * Either route only ever leads to a zoom the measurements justify, so a head
+ * unit that already has a roomy viewport comes out of this unchanged.
+ */
+const isLikelyCarDisplay = (
+    userAgent: string,
+    devicePixelRatio: number,
+    maxTouchPoints: number,
+    outerWidth: number
+): boolean => (
+    CAR_BROWSER_USER_AGENT.test(userAgent) ||
+    (
+        /X11;\s*Linux/i.test(userAgent) &&
+        maxTouchPoints > 0 &&
+        isSoftwareMagnification(userAgent, devicePixelRatio) &&
+        outerWidth === 0
+    )
+);
+
+const clampZoom = (zoom: number): number => (
+    Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom))
+);
+
+const readParams = (href: string): URLSearchParams | null => {
+    try {
+        return new URL(href).searchParams;
+    } catch {
+        return null;
+    }
+};
+
+const readStorage = (storage: Storage, key: string): string | null => {
+    try {
+        return storage.getItem(key);
+    } catch {
+        // Storage can be unavailable in some embedded browsers.
+        return null;
+    }
+};
+
+const writeStorage = (storage: Storage, key: string, value: string | null): void => {
+    try {
+        if (value === null) storage.removeItem(key);
+        else storage.setItem(key, value);
+    } catch {
+        // Storage can be unavailable in some embedded browsers.
+    }
+};
+
+/**
+ * `?vehicleDesktop=1` forces the desktop layout on (`=0` off) for a head unit
+ * the sniffing misses; `?vehicleZoom=0.75` overrides how far the UI is shrunk,
+ * for tuning legibility from the driver's seat. Both are remembered, so the
+ * URL only has to be typed once.
+ */
+const resolveOverrides = (href: string, storage: Storage): {
+    enabled: boolean | null;
+    zoom: number | null;
+} => {
+    const params = readParams(href);
+
+    // What this load asked for, kept separate from what storage remembers.
+    // Head units are exactly where localStorage tends to be unavailable or
+    // throwing, and they are also where the query-string escape hatch matters
+    // most - so the URL has to work on its own, with storage only carrying the
+    // choice forward to later visits.
+    let requestedEnabled: boolean | null = null;
+    let requestedZoom: number | null = null;
+
+    if (params) {
+        const requested = params.get('vehicleDesktop');
+        if (requested === '1') requestedEnabled = true;
+        if (requested === '0') requestedEnabled = false;
+        if (requestedEnabled !== null) {
+            writeStorage(storage, ENABLED_KEY, String(requestedEnabled));
+        }
+
+        const zoomParam = params.get('vehicleZoom');
+        if (zoomParam !== null) {
+            const parsedZoom = Number(zoomParam);
+            if (Number.isFinite(parsedZoom) && parsedZoom > 0) {
+                requestedZoom = clampZoom(parsedZoom);
+                writeStorage(storage, ZOOM_KEY, String(requestedZoom));
+            }
+        }
+    }
+
+    const stored = readStorage(storage, ENABLED_KEY);
+    const storedZoom = Number(readStorage(storage, ZOOM_KEY));
+
+    return {
+        enabled: requestedEnabled ??
+            (stored === 'true' ? true : stored === 'false' ? false : null),
+        zoom: requestedZoom ??
+            (Number.isFinite(storedZoom) && storedZoom > 0 ? storedZoom : null)
+    };
+};
+
+interface ResolveInput {
+    userAgent: string;
+    href: string;
+    storage: Storage;
+    devicePixelRatio: number;
+    maxTouchPoints: number;
+    innerWidth: number;
+    /** 0 on a chromeless kiosk shell such as a head unit; never 0 in a window. */
+    outerWidth: number;
+}
+
+/**
+ * The zoom and breakpoints an in-car display needs, or null for every ordinary
+ * browser - which keeps MUI's stock behaviour untouched.
+ */
+export const resolveAutomotiveDesktopLayout = ({
+    userAgent,
+    href,
+    storage,
+    devicePixelRatio,
+    maxTouchPoints,
+    innerWidth,
+    outerWidth
+}: ResolveInput): AutomotiveDesktopLayout | null => {
+    const { enabled, zoom: overriddenZoom } = resolveOverrides(href, storage);
+    const detected = isLikelyCarDisplay(userAgent, devicePixelRatio, maxTouchPoints, outerWidth);
+
+    if (enabled === false || (enabled !== true && !detected)) {
+        return null;
+    }
+
+    // Undoing the head unit's magnification is the first target: at
+    // devicePixelRatio 1.53 the UI is 53% oversized, so 1/1.53 puts it back at
+    // native scale. Where that still leaves the window short of a desktop
+    // layout - the measured car lands 11px shy of `lg` - shrink the rest of the
+    // way, since a desktop layout is the whole point. A head unit whose ratio
+    // is plain hardware density has nothing to undo, so it only gets the
+    // second half.
+    const nativeZoom = isSoftwareMagnification(userAgent, devicePixelRatio)
+        ? 1 / devicePixelRatio
+        : 1;
+    const desktopZoom = innerWidth > 0 ? innerWidth / DESKTOP_TARGET_WIDTH : nativeZoom;
+    const zoom = clampZoom(overriddenZoom ?? Math.min(nativeZoom, desktopZoom));
+
+    // Floor rather than round: the target width lands the car exactly on `lg`,
+    // and rounding up by a pixel would drop it back to `md`.
+    return {
+        zoom,
+        breakpoints: {
+            xs: 0,
+            sm: Math.floor(DEFAULT_BREAKPOINT_VALUES.sm * zoom),
+            md: Math.floor(DEFAULT_BREAKPOINT_VALUES.md * zoom),
+            lg: Math.floor(DEFAULT_BREAKPOINT_VALUES.lg * zoom),
+            xl: Math.floor(DEFAULT_BREAKPOINT_VALUES.xl * zoom)
+        }
+    };
+};

--- a/frontend/src/utils/viewportUnits.ts
+++ b/frontend/src/utils/viewportUnits.ts
@@ -1,0 +1,27 @@
+/**
+ * Viewport units do not follow the `zoom` an in-car display applies to the app
+ * root, so a `100vh` box inside it lays out at 100vh and then renders at
+ * 100vh * zoom - about two thirds of the screen on the measured car. Dividing
+ * the viewport term by the factor the layout publishes puts it back.
+ *
+ * The `1` fallback makes these identical to plain viewport units in every
+ * ordinary browser, where the variable is never set.
+ *
+ * Only for content inside #root. Anything MUI portals to <body> - Menu and
+ * Popover paper, Dialog - sits outside the zoom and must keep plain units.
+ * Note this includes fullscreen elements: the top layer does not escape an
+ * ancestor's zoom, so a fullscreen `100vw` box is scaled down too.
+ *
+ * Only the viewport term is divided; px terms are already in the same
+ * coordinate space as the element, so `calc(100vh - 180px)` becomes
+ * `calc(viewportHeight() - 180px)`, not `calc((100vh - 180px) / zoom)`.
+ */
+const compensated = (unit: 'vh' | 'vw', percent: number) => (
+    `calc(${percent}${unit} / var(--automotive-zoom, 1))`
+);
+
+/** Viewport height that survives the in-car zoom. Defaults to the full height. */
+export const viewportHeight = (percent = 100) => compensated('vh', percent);
+
+/** Viewport width that survives the in-car zoom. Defaults to the full width. */
+export const viewportWidth = (percent = 100) => compensated('vw', percent);


### PR DESCRIPTION
After a Tesla software update the home page started rendering its phone
layout on the car's centre screen — two columns, sidebar collapsed — on a
display that is physically 1920×1200.

## Root cause

The head unit magnifies the whole browser UI by 1.53×. What the page sees
is CSS pixels, not physical ones, so the magnification eats 35% of them:

```
physical panel        1920 × 1200
head-unit scaling      ×1.53          ← the cause
─────────────────────────────────────
CSS screen            1254 × 784      (screen.width, measured on the car)
browser window        ~1183 physical px wide
÷ 1.53
─────────────────────────────────────
viewport handed to the page   773 px  ← all MUI can see
```

773 lands in MUI's `sm` band (600–899), which is the phone layout. The
screen was never small; the coordinate system was stretched. The
fractional `devicePixelRatio` is the tell — real HiDPI hardware reports
whole ratios, and 1.53 = 1920/1254 is an explicit scale factor.

## Two approaches that do not work

Both were measured on the car, not assumed:

| Approach | Why it fails |
|---|---|
| `<meta name="viewport" content="width=1280">` | Blink only honours viewport meta in mobile viewport mode. The head unit runs desktop-mode Chromium — its UA is a plain `X11; Linux x86_64` Chrome with no vehicle token at all. Measured: `773 → 773`, no effect. |
| Scaling the breakpoints alone | Brings the columns back but leaves every element rendering at 1.53×, so the desktop layout arrives oversized and overflowing. Treats the symptom, not the magnification. |

## The fix

Divide the magnification back out. `zoom` on `#root` does two things at
once: shrinks the content to native scale, and widens its layout box from
773 to **1185 CSS px** — the thing viewport meta wanted to do but cannot.

Media queries deliberately do not follow `zoom`, so the theme's
breakpoints are scaled by the same factor to stay in step. Both halves are
required; either alone is one of the failures above.

Two implementation details worth flagging for review:

- `zoom` on `<html>` does nothing — Blink special-cases the root element.
- The zoom goes on `#root`, **not** `<body>`. MUI portals its menus and
  dialogs into `body`, and inside a zoomed ancestor their fixed
  positioning is scaled a second time. Measured before the move: the sort
  menu landed 319px off its anchor. After: 9px.

Nothing is hardcoded to one car. The factor is
`min(1/devicePixelRatio, innerWidth/1200)` — undo this unit's
magnification, and if that still leaves it short of a desktop layout
(the measured car lands 11px shy of `lg`), shrink the rest of the way.

## Detection

The UA carries no vehicle token, so detection uses a behavioural signal —
desktop Linux, a touch screen, and software magnification — plus the OEM
tokens for head units that *do* announce themselves (Android Automotive
and friends). Phones, tablets, HiDPI laptops and desktop Linux boxes each
miss at least one condition, and there are tests pinning that.

Magnification is only undone when the ratio is fractional. A whole ratio
is hardware pixel density, and dividing that out would shrink text to
nothing on a screen that was never oversized.

Misfiring is cheap: a head unit that already has a roomy viewport resolves
to `zoom 1` with unscaled breakpoints — a no-op. `?vehicleDesktop=1`
forces it on where sniffing misses, `?vehicleZoom=0.75` tunes legibility
from the driver's seat, and both are remembered.

## Also in this branch

- **Swipe to turn the page** (`af567ed6`) — the touch counterpart to the
  existing arrow-key paging, since a car screen has no keyboard. Covers
  the video grids, the download queue/history lists and the manage-page
  tables. Stands down where it would fight a horizontally scrolling box.
- **`public/viewport-check.html`** — the diagnostic page these numbers came
  from. It reports a browser's real viewport metrics and whether viewport
  meta does anything, which is the only way to see any of this on a device
  with no devtools.

## Verification

Confirmed working on the actual car. Locally, reproduced at the car's
measured viewport (773×601): effective width 1185, three columns, sidebar
present, zero overflowing elements, no horizontal scroll, popover anchored.

`tsc --noEmit` clean, eslint clean, **2141 tests passing** — 18 of them new,
asserting against the car's real measured parameters rather than invented
ones.

## Review notes

- The `zoom` + breakpoint pairing is load-bearing; changing one without
  the other silently reintroduces a failure mode above.
- Detection heuristics are the softest part. Tesla is measured; the
  Android Automotive path is reasoned from its UA token, not tested on
  hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
