### PR TITLE
fix(player): keep fullscreen menus anchored on in-car displays

### DIFF
--- a/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
+++ b/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
@@ -20,7 +20,7 @@ import {
 import FullscreenControl from '../VideoControls/FullscreenControl';
 import ProgressBar from '../VideoControls/ProgressBar';
 import SeekButton from '../VideoControls/SeekButton';
-import { viewportHeight, viewportWidth } from '../../../utils/viewportUnits';
+import { cancelAutomotiveZoom, viewportHeight } from '../../../utils/viewportUnits';
 import {
     getMissingCompatibilityModeApis,
     isCompatibilityModeSupported,
@@ -528,8 +528,13 @@ const CompatibilityPlayer: React.FC<CompatibilityPlayerProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    width: viewportWidth(),
-                    height: viewportHeight(),
+                    // Cancelling the zoom here restores the viewport's coordinate
+                    // system, which the menus portalled into this element by
+                    // SpeedControl and SubtitleControl are positioned in. Plain
+                    // viewport units are therefore correct inside it.
+                    zoom: cancelAutomotiveZoom,
+                    width: '100vw',
+                    height: '100vh',
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 0,

--- a/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
+++ b/frontend/src/components/VideoPlayer/CompatibilityPlayer/index.tsx
@@ -20,7 +20,7 @@ import {
 import FullscreenControl from '../VideoControls/FullscreenControl';
 import ProgressBar from '../VideoControls/ProgressBar';
 import SeekButton from '../VideoControls/SeekButton';
-import { cancelAutomotiveZoom, viewportHeight } from '../../../utils/viewportUnits';
+import { viewportHeight, viewportWidth } from '../../../utils/viewportUnits';
 import {
     getMissingCompatibilityModeApis,
     isCompatibilityModeSupported,
@@ -528,13 +528,17 @@ const CompatibilityPlayer: React.FC<CompatibilityPlayerProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    // Cancelling the zoom here restores the viewport's coordinate
-                    // system, which the menus portalled into this element by
-                    // SpeedControl and SubtitleControl are positioned in. Plain
-                    // viewport units are therefore correct inside it.
-                    zoom: cancelAutomotiveZoom,
-                    width: '100vw',
-                    height: '100vh',
+                    // Deliberately keeps the in-car zoom, unlike the standard
+                    // player's fullscreen container. This one renders only
+                    // FullscreenControl, ProgressBar and SeekButton - nothing
+                    // that portals a menu into the fullscreen element - so
+                    // there are no coordinates to realign, and cancelling the
+                    // zoom would only inflate its px-sized controls by 1/zoom
+                    // and drop its layout width from the compensated desktop
+                    // one to the raw viewport. Revisit if it ever gains a
+                    // control that portals here.
+                    width: viewportWidth(),
+                    height: viewportHeight(),
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 0,

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -17,7 +17,7 @@ import { useVideoLoading } from './hooks/useVideoLoading';
 import { useVideoPlayer } from './hooks/useVideoPlayer';
 import { useVolume } from './hooks/useVolume';
 import VideoElement from './VideoElement';
-import { viewportHeight, viewportWidth } from '../../../utils/viewportUnits';
+import { cancelAutomotiveZoom } from '../../../utils/viewportUnits';
 
 interface VideoControlsProps {
     src: string;
@@ -328,8 +328,13 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    width: viewportWidth(),
-                    height: viewportHeight(),
+                    // Cancelling the zoom here restores the viewport's coordinate
+                    // system, which the menus portalled into this element by
+                    // SpeedControl and SubtitleControl are positioned in. Plain
+                    // viewport units are therefore correct inside it.
+                    zoom: cancelAutomotiveZoom,
+                    width: '100vw',
+                    height: '100vh',
                     display: 'flex',
                     flexDirection: 'column',
                     borderRadius: 0

--- a/frontend/src/components/VideoPlayer/VideoControls/index.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/index.tsx
@@ -328,10 +328,20 @@ const VideoControls: React.FC<VideoControlsProps> = ({
                 boxShadow: 4,
                 position: 'relative',
                 ...(isFullscreen && {
-                    // Cancelling the zoom here restores the viewport's coordinate
-                    // system, which the menus portalled into this element by
-                    // SpeedControl and SubtitleControl are positioned in. Plain
-                    // viewport units are therefore correct inside it.
+                    // SpeedControl and SubtitleControl portal their menus into
+                    // this element so they clear the video, and MUI positions
+                    // them from viewport coordinates, which the inherited
+                    // in-car zoom would scale a second time - 157px off the
+                    // button, measured. Cancelling the zoom puts anchor and
+                    // menu back in one coordinate system, which also makes
+                    // plain viewport units the correct ones inside here.
+                    //
+                    // The cost is that px-sized controls render at 1/zoom, i.e.
+                    // their unshrunk size. That is the right trade in
+                    // fullscreen - bigger touch targets, and no desktop layout
+                    // to preserve - but it is why CompatibilityPlayer, which
+                    // portals nothing here, keeps the compensated dimensions
+                    // instead.
                     zoom: cancelAutomotiveZoom,
                     width: '100vw',
                     height: '100vh',

--- a/frontend/src/utils/__tests__/viewportUnits.test.ts
+++ b/frontend/src/utils/__tests__/viewportUnits.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { cancelAutomotiveZoom, viewportHeight, viewportWidth } from '../viewportUnits';
+
+/** Resolve a calc() the way the browser would, for a given variable value. */
+const evaluate = (expression: string, zoom: number | null, viewport: number) => {
+    const substituted = expression.replace(
+        /var\(--automotive-zoom,\s*1\)/g,
+        String(zoom ?? 1)
+    );
+    const match = /^calc\((\d+)(vh|vw) \/ ([\d.]+)\)$/.exec(substituted)
+        ?? /^calc\(([\d.]+) \/ ([\d.]+)\)$/.exec(substituted);
+    if (!match) throw new Error(`unparsed: ${substituted}`);
+    return match.length === 4 && match[2]
+        ? (Number(match[1]) / 100) * viewport / Number(match[3])
+        : Number(match[1]) / Number(match[2]);
+};
+
+describe('viewportUnits', () => {
+    it('divides the viewport term by the published zoom', () => {
+        // 601px viewport at zoom 0.644 must lay out at 933 so it renders at 601.
+        expect(evaluate(viewportHeight(), 0.644, 601)).toBeCloseTo(933, 0);
+        expect(evaluate(viewportWidth(), 0.644, 773)).toBeCloseTo(1200, 0);
+    });
+
+    it('takes a percentage', () => {
+        expect(evaluate(viewportHeight(50), 0.644, 601)).toBeCloseTo(466.6, 0);
+        expect(evaluate(viewportHeight(80), 0.644, 601)).toBeCloseTo(746.6, 0);
+    });
+
+    it('is a no-op wherever the variable is unset', () => {
+        // Ordinary browsers must land on exactly the plain viewport unit.
+        expect(evaluate(viewportHeight(), null, 900)).toBe(900);
+        expect(evaluate(viewportWidth(), null, 1440)).toBe(1440);
+        expect(evaluate(viewportHeight(50), null, 900)).toBe(450);
+    });
+
+    it('cancels the zoom to exactly its reciprocal', () => {
+        // A fullscreen element inherits the root zoom; this puts it back at 1:1
+        // so portalled menus and viewport coordinates agree again.
+        expect(evaluate(cancelAutomotiveZoom, 0.644, 0)).toBeCloseTo(1 / 0.644, 5);
+    });
+
+    it('cancels to 1 in an ordinary browser, which is the CSS default', () => {
+        expect(evaluate(cancelAutomotiveZoom, null, 0)).toBe(1);
+    });
+});

--- a/frontend/src/utils/viewportUnits.ts
+++ b/frontend/src/utils/viewportUnits.ts
@@ -25,3 +25,21 @@ export const viewportHeight = (percent = 100) => compensated('vh', percent);
 
 /** Viewport width that survives the in-car zoom. Defaults to the full width. */
 export const viewportWidth = (percent = 100) => compensated('vw', percent);
+
+/**
+ * Cancels the in-car zoom for a subtree, restoring the viewport's own
+ * coordinate system inside it.
+ *
+ * Fullscreen elements need this. They sit under #root and so inherit the zoom,
+ * and SpeedControl and SubtitleControl deliberately portal their menus into
+ * `document.fullscreenElement` so the menus are visible above the video. MUI
+ * positions those from getBoundingClientRect - viewport coordinates - which a
+ * zoomed ancestor then scales a second time, landing them far from their
+ * buttons. Cancelling the zoom puts the two back in the same space.
+ *
+ * Inside this subtree, plain viewport units are correct again: use `100vh`,
+ * not viewportHeight(). Resolves to `1` in every ordinary browser, where the
+ * variable is unset, which is the CSS default and therefore a no-op.
+ */
+export const cancelAutomotiveZoom = 'calc(1 / var(--automotive-zoom, 1))';
+


### PR DESCRIPTION
Follow-up to #453, from a review comment that arrived after it merged.

## The problem

#453 restored the desktop layout on head units by zooming the app root back
down, and deliberately kept that zoom off `<body>` so MUI's portalled overlays
stay in the viewport's own coordinate system — a `fixed` element inside a
zoomed ancestor has its `left`/`top` scaled a second time.

`SpeedControl` and `SubtitleControl` opt out of that arrangement on purpose:
they portal their menus into `document.fullscreenElement` so the menus are
visible above the video. That element sits under `#root` and inherits the zoom,
which puts exactly those two menus back into the case #453 avoids everywhere
else.

Measured against the car's viewport (773×601, zoom 0.644), with a menu
positioned the way MUI positions one:

| | anchor | menu | off by |
|---|---|---|---|
| fullscreen element inherits the zoom | 441 | 284 | **157px** |
| zoom cancelled inside it | 685 | 685 | **0** |

The container also only filled two thirds of the screen in the first case.

## The fix

Cancel the zoom inside the fullscreen element, restoring the viewport's
coordinate system for that subtree:

```ts
zoom: cancelAutomotiveZoom,   // calc(1 / var(--automotive-zoom, 1))
width: '100vw',
height: '100vh',
```

Anchor and menu are back in the same space, and plain viewport units are
correct inside that subtree — so the fullscreen size rules go back to
`100vw`/`100vh` from the compensated helpers, and the container fills the
screen exactly. In an ordinary browser the variable is unset and this resolves
to `zoom: 1`, the CSS default, so it is a no-op.

The two `calc(viewportHeight() - 180px)` player caps are **untouched**: both sit
in the non-fullscreen branch, where the compensation is still what they need. I
checked that rather than assuming it.

## Verification

Measured in Chrome 148 — the same major the car runs — at the car's exact
viewport, with a real anchor/menu pair positioned from `getBoundingClientRect`.
Both numbers in the table above come from that.

`tsc --noEmit` clean, eslint clean, **2177 tests passing**, 5 of them new,
covering the helper's compensation, its no-op behaviour where the variable is
unset, and the cancellation resolving to exactly `1/zoom`.

## Review note

`cancelAutomotiveZoom` is the counterpart to `viewportHeight()`/`viewportWidth()`
and the rule for choosing between them now lives in `viewportUnits.ts`: inside a
zoom-cancelled subtree, plain viewport units are the correct ones. Mixing the
two would double-compensate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
