### PR TITLE
fix: prevent core media and backup data loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Fix
+
+- Protect shared media and companion files during deletion, redownload, and thumbnail replacement. Ownership reads now fail safely with the affected record ID and metadata field; unrelated malformed tags no longer block deleting another video.
+- Handle interrupted database exports without writing a second response, and distinguish SQLite integrity failures from invalid file formats.
+- Read file ownership once per temporary-file cleanup. New Bilibili temporary directories carry an ownership marker so abandoned jobs can be removed without treating user folders as disposable. Active jobs and referenced files remain protected.
+- Reuse sidecar path plans across deletions while reconciling current owners, including when export is disabled and historical sidecars remain.
+
+### Data safety notes
+
+- A stale stored path is never repaired by guessing a matching filename during deletion. A file left at another location may be rediscovered on a later scan. Case and Unicode aliases are conservatively treated as shared, which can retain files on case-sensitive disks.
+- Legacy temporary directories without an ownership marker retain completed/unfinished media; only unreferenced `.part` and `.ytdl` files are eligible for automatic cleanup. Confirm their contents before removing them manually.
+- Database import performs a full, synchronous integrity check, which can take longer on large backups. Export requires temporary space for a SQLite snapshot per concurrent download. Normal completion and disconnects remove snapshots; a process crash can leave `export-*.db.tmp` files, which can be removed while MyTube is stopped after confirming no export is active.
+
 ## v1.11.6 (2026-09-04)
 
 ### Fix

--- a/backend/src/__tests__/controllers/cleanupController.test.ts
+++ b/backend/src/__tests__/controllers/cleanupController.test.ts
@@ -5,9 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanupTempFiles } from '../../controllers/cleanupController';
 
 // Mock config/paths to use a temp directory
-vi.mock('../../config/paths', async () => {
+vi.mock('../../config/paths', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../config/paths')>();
   const path = await import('path');
   return {
+    ...original,
     VIDEOS_DIR: path.default.join(process.cwd(), 'src', '__tests__', 'temp_cleanup_test_videos_dir')
   };
 });
@@ -16,7 +18,8 @@ import { VIDEOS_DIR } from '../../config/paths';
 
 // Mock storageService to simulate no active downloads
 vi.mock('../../services/storageService', () => ({
-  getDownloadStatus: vi.fn(() => ({ activeDownloads: [] }))
+  getDownloadStatus: vi.fn(() => ({ activeDownloads: [] })),
+  getVideosStrict: vi.fn(() => [])
 }));
 
 describe('cleanupController', () => {
@@ -39,13 +42,13 @@ describe('cleanupController', () => {
     }
   });
 
-  it('should delete directories starting with temp_ recursively', async () => {
+  it('preserves temp_ folders and completed files while removing partial files inside them', async () => {
     // Create structure:
     // videos/
-    //   temp_folder1/ (should be deleted)
+    //   temp_folder1/ (should stay)
     //     file.txt
     //   normal_folder/ (should stay)
-    //     temp_nested/ (should be deleted per current recursive logic)
+    //     temp_nested/ (should stay)
     //     normal_nested/ (should stay)
     //   video.mp4 (should stay)
     //   video.mp4.part (should be deleted)
@@ -62,6 +65,8 @@ describe('cleanupController', () => {
     
     await fs.ensureDir(normalFolder);
     await fs.ensureDir(nestedTemp);
+    await fs.writeFile(path.join(nestedTemp, 'keep.mp4'), 'completed video');
+    await fs.writeFile(path.join(nestedTemp, 'abandoned.mp4.part'), 'partial');
     await fs.ensureDir(nestedNormal);
     
     await fs.ensureFile(partFile);
@@ -69,9 +74,10 @@ describe('cleanupController', () => {
 
     await cleanupTempFiles(req, res);
 
-    expect(await fs.pathExists(tempFolder1)).toBe(false);
+    expect(await fs.readFile(path.join(tempFolder1, 'file.txt'), 'utf8')).toBe('content');
     expect(await fs.pathExists(normalFolder)).toBe(true);
-    expect(await fs.pathExists(nestedTemp)).toBe(false);
+    expect(await fs.readFile(path.join(nestedTemp, 'keep.mp4'), 'utf8')).toBe('completed video');
+    expect(await fs.pathExists(path.join(nestedTemp, 'abandoned.mp4.part'))).toBe(false);
     expect(await fs.pathExists(nestedNormal)).toBe(true);
     expect(await fs.pathExists(partFile)).toBe(false);
     expect(await fs.pathExists(normalFile)).toBe(true);

--- a/backend/src/__tests__/controllers/cleanupController.test.ts
+++ b/backend/src/__tests__/controllers/cleanupController.test.ts
@@ -14,12 +14,13 @@ vi.mock('../../config/paths', async (importOriginal) => {
   };
 });
 
+import * as storageService from '../../services/storageService';
 import { VIDEOS_DIR } from '../../config/paths';
 
 // Mock storageService to simulate no active downloads
 vi.mock('../../services/storageService', () => ({
   getDownloadStatus: vi.fn(() => ({ activeDownloads: [] })),
-  getVideosStrict: vi.fn(() => [])
+  getArtifactOwners: vi.fn(() => [])
 }));
 
 describe('cleanupController', () => {
@@ -82,4 +83,27 @@ describe('cleanupController', () => {
     expect(await fs.pathExists(partFile)).toBe(false);
     expect(await fs.pathExists(normalFile)).toBe(true);
   });
+  it('reads owners once for many candidates and fails before unlinking on a read error', async () => {
+    for (let i = 0; i < 20; i++) await fs.outputFile(path.join(VIDEOS_DIR, `${i}.part`), 'data');
+    vi.mocked(storageService.getArtifactOwners).mockImplementationOnce(() => { throw new Error('library unreadable'); });
+    await expect(cleanupTempFiles(req, res)).rejects.toThrow('library unreadable');
+    expect(await fs.readdir(VIDEOS_DIR)).toHaveLength(20);
+    expect(storageService.getArtifactOwners).toHaveBeenCalledTimes(1);
+    vi.mocked(storageService.getArtifactOwners).mockClear();
+    await cleanupTempFiles(req, res);
+    expect(storageService.getArtifactOwners).toHaveBeenCalledTimes(1);
+    expect(await fs.readdir(VIDEOS_DIR)).toHaveLength(0);
+  });
+
+  it('aborts if a download starts during directory collection', async () => {
+    const partial = path.join(VIDEOS_DIR, 'active.part');
+    await fs.outputFile(partial, 'data');
+    vi.mocked(storageService.getDownloadStatus)
+      .mockReturnValueOnce({ activeDownloads: [] } as any)
+      .mockReturnValueOnce({ activeDownloads: [{ id: 'started' }] } as any);
+    await expect(cleanupTempFiles(req, res)).rejects.toThrow('downloads are active');
+    expect(await fs.pathExists(partial)).toBe(true);
+    expect(storageService.getArtifactOwners).not.toHaveBeenCalled();
+  });
+
 });

--- a/backend/src/__tests__/controllers/databaseBackupController.test.ts
+++ b/backend/src/__tests__/controllers/databaseBackupController.test.ts
@@ -53,6 +53,16 @@ describe('databaseBackupController', () => {
             await rejected;
             expect(databaseBackupService.cleanupDatabaseExport).toHaveBeenCalledWith('/path/to/snapshot.db');
         });
+        it.each(['ECONNABORTED', 'ECONNRESET', 'EPIPE'])('cleans up a peer disconnect (%s) without invoking error handling', async (code) => {
+            vi.mocked(databaseBackupService.exportDatabase).mockResolvedValue('/path/to/snapshot.db');
+            mockRes.headersSent = true;
+            mockRes.destroy = vi.fn();
+            sendFileMock.mockImplementation((_path: string, finish: (error: Error) => void) =>
+                finish(Object.assign(new Error('peer disconnected'), { code })));
+            await databaseBackupController.exportDatabase(mockReq as Request, mockRes as Response);
+            expect(databaseBackupService.cleanupDatabaseExport).toHaveBeenCalledWith('/path/to/snapshot.db');
+            expect(mockRes.destroy).toHaveBeenCalled();
+        });
         it('cleans up if the client disconnects while the snapshot is being prepared', async () => {
             vi.mocked(databaseBackupService.exportDatabase).mockResolvedValue('/path/to/snapshot.db');
             mockRes.destroyed = true;

--- a/backend/src/__tests__/controllers/databaseBackupController.test.ts
+++ b/backend/src/__tests__/controllers/databaseBackupController.test.ts
@@ -19,7 +19,7 @@ describe('databaseBackupController', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         jsonMock = vi.fn();
-        sendFileMock = vi.fn();
+        sendFileMock = vi.fn((_path, callback) => callback());
         mockReq = {};
         mockRes = {
             json: jsonMock,
@@ -37,7 +37,28 @@ describe('databaseBackupController', () => {
             expect(databaseBackupService.exportDatabase).toHaveBeenCalled();
             expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'application/octet-stream');
             expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Disposition', expect.stringContaining('mytube-backup-'));
-            expect(sendFileMock).toHaveBeenCalledWith('/path/to/backup.db');
+            expect(sendFileMock).toHaveBeenCalledWith('/path/to/backup.db', expect.any(Function));
+            expect(databaseBackupService.cleanupDatabaseExport).toHaveBeenCalledWith('/path/to/backup.db');
+        });
+        it('keeps the snapshot until transfer finishes and cleans up a failed transfer', async () => {
+            vi.mocked(databaseBackupService.exportDatabase).mockResolvedValue('/path/to/snapshot.db');
+            let finish: (error?: Error) => void = () => {};
+            sendFileMock.mockImplementation((_path: string, callback: typeof finish) => { finish = callback; });
+            const response = databaseBackupController.exportDatabase(mockReq as Request, mockRes as Response);
+            await vi.waitFor(() => expect(sendFileMock).toHaveBeenCalled());
+            expect(databaseBackupService.cleanupDatabaseExport).not.toHaveBeenCalled();
+            const error = new Error('client disconnected');
+            const rejected = expect(response).rejects.toThrow(error);
+            finish(error);
+            await rejected;
+            expect(databaseBackupService.cleanupDatabaseExport).toHaveBeenCalledWith('/path/to/snapshot.db');
+        });
+        it('cleans up if the client disconnects while the snapshot is being prepared', async () => {
+            vi.mocked(databaseBackupService.exportDatabase).mockResolvedValue('/path/to/snapshot.db');
+            mockRes.destroyed = true;
+            await databaseBackupController.exportDatabase(mockReq as Request, mockRes as Response);
+            expect(sendFileMock).not.toHaveBeenCalled();
+            expect(databaseBackupService.cleanupDatabaseExport).toHaveBeenCalledWith('/path/to/snapshot.db');
         });
     });
 

--- a/backend/src/__tests__/controllers/videoMetadataController.test.ts
+++ b/backend/src/__tests__/controllers/videoMetadataController.test.ts
@@ -70,6 +70,7 @@ vi.mock("../../utils/security", () => ({
   pathExistsSafe: vi.fn((targetPath: string) => fs.pathExists(targetPath)),
   pathExistsSafeSync: vi.fn((targetPath: string) => fs.existsSync(targetPath)),
   pathExistsTrustedSync: vi.fn((targetPath: string) => fs.existsSync(targetPath)),
+  unlinkSafeSync: vi.fn((targetPath: string) => fs.unlinkSync(targetPath)),
   removeSafe: vi.fn((targetPath: string) => fs.remove(targetPath)),
   resolveSafeChildPath: vi.fn((baseDir: string, childPath: string) => {
     if (childPath.includes("..")) {
@@ -96,6 +97,7 @@ vi.mock("fs-extra", () => ({
     ensureFileSync: vi.fn(),
     pathExists: vi.fn(),
     remove: vi.fn(),
+    unlinkSync: vi.fn(),
     stat: vi.fn(),
     writeFile: vi.fn(),
   },
@@ -855,14 +857,17 @@ describe("videoMetadataController", () => {
       ).rejects.toThrow(ValidationError);
     });
 
-    it("skips deleting the old thumbnail when another video still references it", async () => {
+    it.each(["shared", "unreadable"])("keeps the old thumbnail when owners are %s", async (condition) => {
       const { res, status } = createResponse();
       vi.mocked(storageService.getVideoById as any).mockReturnValue({
         id: "v1",
         thumbnailPath: "/images/shared.jpg",
         thumbnailFilename: "shared.jpg",
       });
-      vi.mocked(storageService.isThumbnailReferencedByOtherVideo as any).mockReturnValue(true);
+      vi.mocked(storageService.isThumbnailReferencedByOtherVideo as any).mockImplementation(() => {
+        if (condition === "unreadable") throw new Error("owner metadata unreadable");
+        return true;
+      });
 
       await videoMetadataController.uploadThumbnail(
         { params: { id: "v1" }, file: fakeFile } as unknown as Request,
@@ -876,7 +881,9 @@ describe("videoMetadataController", () => {
           thumbnailFilename: "shared.jpg",
         }),
         "v1",
+        expect.stringMatching(/shared\.jpg$/),
       );
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
       expect(fs.remove).not.toHaveBeenCalled();
       expect(status).toHaveBeenCalledWith(200);
     });
@@ -894,7 +901,7 @@ describe("videoMetadataController", () => {
         res
       );
 
-      expect(fs.remove).toHaveBeenCalledWith(
+      expect(fs.unlinkSync).toHaveBeenCalledWith(
         expect.stringMatching(/old-thumb\.jpg$/),
       );
     });

--- a/backend/src/__tests__/middleware/errorHandler.test.ts
+++ b/backend/src/__tests__/middleware/errorHandler.test.ts
@@ -42,6 +42,15 @@ describe('ErrorHandler Middleware', () => {
   });
 
   describe('errorHandler', () => {
+    it('delegates streaming failures without writing or logging a second response', () => {
+      const error = new Error('disk read failed');
+      res.headersSent = true;
+      errorHandler(error, req as Request, res as Response, next);
+      expect(next).toHaveBeenCalledWith(error);
+      expect(status).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it('should handle DownloadError with 400 status', () => {
       const error = new DownloadError('network', 'Network error', true);
 

--- a/backend/src/__tests__/services/coreDataSafety.integration.test.ts
+++ b/backend/src/__tests__/services/coreDataSafety.integration.test.ts
@@ -3,6 +3,7 @@ import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import express from "express";
 import fs from "fs-extra";
 import nodeFs from "node:fs";
+import http from "node:http";
 import path from "path";
 import request from "supertest";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,6 +28,9 @@ vi.mock("../../utils/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
+import { createTempDir } from "../../services/downloaders/bilibili/bilibiliFileManager";
+import { releaseDownloadTempDir } from "../../services/downloadTempDirectories";
+import { errorHandler } from "../../middleware/errorHandler";
 import * as paths from "../../config/paths";
 import { cleanupTempFiles } from "../../controllers/cleanupController";
 import { exportDatabase as exportController } from "../../controllers/databaseBackupController";
@@ -35,6 +39,7 @@ import { db, sqlite } from "../../db";
 import { runAutoDeleteSweep } from "../../services/autoDeleteService";
 import * as backupService from "../../services/databaseBackupService";
 import { validateDatabase } from "../../services/databaseBackup/backupFiles";
+import { removeMediaServerArtifactsForVideo } from "../../services/mediaServerExport";
 import { planMediaServerExportPaths } from "../../services/mediaServerExport/pathPlanner";
 import * as storage from "../../services/storageService";
 import type { Video } from "../../services/storageService";
@@ -90,6 +95,58 @@ describe("media deletion safety with real files and SQLite", () => {
     for (const file of [rootFile, nestedFile, referenced]) expect(fs.readFileSync(file, "utf8")).toBe("completed media");
     for (const file of [partial, journal]) expect(fs.existsSync(file)).toBe(false);
     expect(res.json).toHaveBeenCalledWith({ deletedCount: 2 });
+  });
+
+  it("cleans marked abandoned jobs but preserves active, referenced and unmarked directories", async () => {
+    const abandoned = createTempDir();
+    fs.outputFileSync(path.join(abandoned, "nested/unfinished.mp4"), "data");
+    releaseDownloadTempDir(abandoned);
+    const active = createTempDir();
+    fs.outputFileSync(path.join(active, "active.part"), "data");
+    const referenced = createTempDir();
+    fs.outputFileSync(path.join(referenced, "keep.mp4"), "data");
+    saveVideo("registered-temp", `/videos/${path.basename(referenced)}/keep.mp4`);
+    releaseDownloadTempDir(referenced);
+    const unmarked = "temp_1700000000000_12345678-1234-1234-1234-123456789012";
+    const userMedia = writeMedia(`videos/${unmarked}/keep.mp4`);
+    try {
+      await cleanupTempFiles({} as never, responseStub() as never);
+      expect(fs.existsSync(abandoned)).toBe(false);
+      expect(fs.existsSync(path.join(active, "active.part"))).toBe(true);
+      expect(fs.existsSync(path.join(referenced, "keep.mp4"))).toBe(true);
+      expect(fs.existsSync(userMedia)).toBe(true);
+    } finally { releaseDownloadTempDir(active); }
+  });
+
+  it("does not let malformed tags or an invalid avatar path block unrelated deletion", () => {
+    const media = writeMedia("videos/remove.mp4");
+    const avatar = writeMedia("avatars/shared.jpg");
+    saveVideo("remove", "/videos/remove.mp4", {
+      author: "A", authorAvatarPath: "/avatars/shared.jpg", authorAvatarFilename: "shared.jpg",
+    });
+    saveVideo("other", "/videos/other.mp4", {
+      author: "B", authorAvatarPath: "/avatars/../../outside.jpg", authorAvatarFilename: "shared.jpg",
+    });
+    sqlite.prepare("UPDATE videos SET tags = ? WHERE id = ?").run("invalid json", "other");
+    expect(storage.deleteVideo("remove")).toBe(true);
+    expect(fs.existsSync(media)).toBe(false);
+    expect(fs.existsSync(avatar)).toBe(true);
+  });
+
+  it("blocks redownload cleanup on unreadable owners and checks the actual candidate across aliases", () => {
+    const media = writeMedia("videos/group/shared.mp4");
+    const thumbnail = writeMedia("images/shared.jpg");
+    const old = saveVideo("old", "/videos/group/shared.mp4", { thumbnailPath: "/images/shared.jpg", thumbnailFilename: "shared.jpg" });
+    saveVideo("owner", "", { videoFilename: "shared.mp4", thumbnailPath: "/images/folder/../shared.jpg", thumbnailFilename: "shared.jpg" });
+    expect(storage.isVideoFileReferencedByOtherVideo(old, old.id, media)).toBe(true);
+    expect(storage.isVideoFileReferencedByOtherVideo({ ...old, videoPath: undefined, videoFilename: undefined }, old.id, media)).toBe(true);
+    expect(storage.isThumbnailReferencedByOtherVideo(old, old.id, thumbnail)).toBe(true);
+    saveVideo("broken-owner", "/videos/broken.mp4");
+    sqlite.prepare("UPDATE videos SET subtitles = ? WHERE id = ?").run('{"unexpected":"object"}', "broken-owner");
+    expect(() => storage.isVideoFileReferencedByOtherVideo(old, old.id, media)).toThrow(/broken-owner.*subtitles/);
+    expect(() => storage.isThumbnailReferencedByOtherVideo(old, old.id, thumbnail)).toThrow(/broken-owner.*subtitles/);
+    expect(fs.existsSync(media)).toBe(true);
+    expect(fs.existsSync(thumbnail)).toBe(true);
   });
 
   it("deletes a missing record without selecting another owner's matching basenames", () => {
@@ -149,6 +206,23 @@ describe("media deletion safety with real files and SQLite", () => {
     for (const file of files) expect(fs.existsSync(file), file).toBe(false);
   });
 
+  it("preserves shared sidecars during redownload with export disabled and skips removal on read failure", () => {
+    const old = saveVideo("redownload", "/videos/shared/episode.mp4");
+    saveVideo("other-container", "/videos/shared/episode.mkv");
+    const sidecar = planMediaServerExportPaths(old)!.episodeNfoAbsolutePath;
+    fs.outputFileSync(sidecar, "historical sidecar");
+    storage.updateVideo(old.id, { videoPath: "/videos/new/episode.mp4" });
+    storage.saveSettings({ mediaServerExportMode: "off" });
+    removeMediaServerArtifactsForVideo(old, { preserveSharedArtifacts: true });
+    expect(fs.existsSync(sidecar)).toBe(true);
+    sqlite.prepare("UPDATE videos SET subtitles = ? WHERE id = ?").run("broken", "other-container");
+    removeMediaServerArtifactsForVideo(old, { preserveSharedArtifacts: true });
+    expect(fs.existsSync(sidecar)).toBe(true);
+    sqlite.prepare("UPDATE videos SET subtitles = NULL, video_path = ? WHERE id = ?").run("/videos/elsewhere/episode.mkv", "other-container");
+    removeMediaServerArtifactsForVideo(old, { preserveSharedArtifacts: true });
+    expect(fs.existsSync(sidecar)).toBe(false);
+  });
+
   it("protects a legacy basename-only owner and permits deletion of an unshared legacy file", () => {
     const shared = writeMedia("videos/group/shared.mp4");
     saveVideo("explicit", "/videos/group/shared.mp4");
@@ -177,13 +251,43 @@ describe("media deletion safety with real files and SQLite", () => {
     saveVideo("keep", "/videos/keep.mp4");
     saveVideo("malformed", "/videos/other.mp4");
     sqlite.prepare("UPDATE videos SET subtitles = ? WHERE id = ?").run("invalid json", "malformed");
-    expect(() => storage.deleteVideo("keep")).toThrow();
+    expect(() => storage.deleteVideo("keep")).toThrow(/video malformed has invalid subtitles/);
     expect(fs.existsSync(media)).toBe(true);
     expect(storage.getVideoById("keep")).toBeDefined();
   });
 });
 
 describe("SQLite snapshot export and import integrity", () => {
+  it("handles a real client disconnect without a second response and releases its snapshot", async () => {
+    sqlite.exec("CREATE TABLE disconnect_probe (payload BLOB); INSERT INTO disconnect_probe VALUES (zeroblob(4000000))");
+    const cleanup = vi.spyOn(backupService, "cleanupDatabaseExport");
+    const errors: Error[] = [];
+    const app = express();
+    app.get("/export", exportController);
+    app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      errors.push(err);
+      errorHandler(err, req, res, next);
+    });
+    const server = app.listen(0, "127.0.0.1");
+    try {
+      await new Promise<void>((resolve) => server.once("listening", resolve));
+      const address = server.address() as { port: number };
+      await new Promise<void>((resolve, reject) => {
+        http.get(`http://127.0.0.1:${address.port}/export`, (res) => {
+          res.once("data", () => { res.destroy(); resolve(); });
+          res.on("error", () => {});
+        }).on("error", reject);
+      });
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledTimes(1));
+      expect(fs.existsSync(cleanup.mock.calls[0][0])).toBe(false);
+      expect(errors).toEqual([]);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      cleanup.mockRestore();
+      sqlite.exec("DROP TABLE disconnect_probe");
+    }
+  });
+
   it("streams a consistent snapshot while the live database changes, then removes the snapshot", async () => {
     sqlite.exec("CREATE TABLE export_probe (id INTEGER PRIMARY KEY, payload BLOB)");
     const add = sqlite.prepare("INSERT INTO export_probe VALUES (?, ?)");

--- a/backend/src/__tests__/services/coreDataSafety.integration.test.ts
+++ b/backend/src/__tests__/services/coreDataSafety.integration.test.ts
@@ -1,0 +1,272 @@
+import Database from "better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import express from "express";
+import fs from "fs-extra";
+import nodeFs from "node:fs";
+import path from "path";
+import request from "supertest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// setupDataDir gives each file a scratch DB. Redirect every media path as well:
+// these regressions exercise actual destructive operations, not mocked unlink.
+vi.mock("../../config/paths", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../config/paths")>();
+  const uploads = path.join(original.DATA_DIR, "uploads");
+  return {
+    ...original,
+    UPLOADS_DIR: uploads,
+    VIDEOS_DIR: path.join(uploads, "videos"),
+    IMAGES_DIR: path.join(uploads, "images"),
+    IMAGES_SMALL_DIR: path.join(uploads, "images-small"),
+    SUBTITLES_DIR: path.join(uploads, "subtitles"),
+    AVATARS_DIR: path.join(uploads, "avatars"),
+    CLOUD_THUMBNAIL_CACHE_DIR: path.join(uploads, "cloud-thumbnail-cache"),
+  };
+});
+vi.mock("../../utils/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import * as paths from "../../config/paths";
+import { cleanupTempFiles } from "../../controllers/cleanupController";
+import { exportDatabase as exportController } from "../../controllers/databaseBackupController";
+import { scanFiles } from "../../controllers/scanController";
+import { db, sqlite } from "../../db";
+import { runAutoDeleteSweep } from "../../services/autoDeleteService";
+import * as backupService from "../../services/databaseBackupService";
+import { validateDatabase } from "../../services/databaseBackup/backupFiles";
+import { planMediaServerExportPaths } from "../../services/mediaServerExport/pathPlanner";
+import * as storage from "../../services/storageService";
+import type { Video } from "../../services/storageService";
+
+function writeMedia(relative: string, content = "completed media"): string {
+  const file = path.join(paths.UPLOADS_DIR, relative);
+  fs.outputFileSync(file, content);
+  return file;
+}
+
+function saveVideo(id: string, videoPath: string, extra: Partial<Video> = {}): Video {
+  return storage.saveVideo({
+    id, title: id, sourceUrl: `https://example.com/${id}`,
+    videoPath, videoFilename: path.basename(videoPath),
+    createdAt: new Date(Date.now() - 90 * 86_400_000).toISOString(),
+    ...extra,
+  }, { suppressStatistics: true });
+}
+
+function responseStub() {
+  return { status: vi.fn().mockReturnThis(), json: vi.fn() };
+}
+
+beforeAll(() => {
+  migrate(db, { migrationsFolder: path.resolve("drizzle") });
+  storage.initializeStorage();
+});
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM videos; DELETE FROM downloads; DELETE FROM settings; DELETE FROM download_history; DELETE FROM video_downloads; DELETE FROM collections;");
+  storage.invalidateSettingsCache();
+  fs.emptyDirSync(paths.UPLOADS_DIR);
+  for (const dir of [paths.VIDEOS_DIR, paths.IMAGES_DIR, paths.SUBTITLES_DIR, paths.AVATARS_DIR]) fs.ensureDirSync(dir);
+});
+
+afterAll(() => { sqlite.close(); });
+
+describe("media deletion safety with real files and SQLite", () => {
+  it("preserves root/nested temp_ libraries and referenced partial-looking artifacts", async () => {
+    const rootFile = writeMedia("videos/temp_holidays/keep.mp4");
+    const nestedFile = writeMedia("videos/author/temp_archive/keep.mp4");
+    const referenced = writeMedia("videos/temp_holidays/protected.part");
+    const partial = writeMedia("videos/temp_holidays/abandoned.mp4.part");
+    const journal = writeMedia("videos/author/temp_archive/abandoned.ytdl");
+    saveVideo("root", "/videos/temp_holidays/keep.mp4", { autoDeleteLocked: 1 });
+    saveVideo("nested", "/videos/author/temp_archive/keep.mp4", {
+      subtitles: [{ filename: "protected.part", path: "/videos/temp_holidays/protected.part", language: "en" }],
+    });
+
+    const res = responseStub();
+    await cleanupTempFiles({} as never, res as never);
+
+    for (const file of [rootFile, nestedFile, referenced]) expect(fs.readFileSync(file, "utf8")).toBe("completed media");
+    for (const file of [partial, journal]) expect(fs.existsSync(file)).toBe(false);
+    expect(res.json).toHaveBeenCalledWith({ deletedCount: 2 });
+  });
+
+  it("deletes a missing record without selecting another owner's matching basenames", () => {
+    const media = writeMedia("videos/ChannelB/same.mp4");
+    const thumbnail = writeMedia("images/same.jpg");
+    const subtitle = writeMedia("subtitles/same.en.vtt");
+    saveVideo("missing", "/videos/ChannelA/same.mp4", {
+      thumbnailFilename: "same.jpg", thumbnailPath: "/images/old/same.jpg",
+      subtitles: [{ filename: "same.en.vtt", path: "/subtitles/old/same.en.vtt", language: "en" }],
+    });
+    saveVideo("keep", "/videos/ChannelB/same.mp4", { autoDeleteLocked: 1 });
+
+    expect(storage.deleteVideo("missing")).toBe(true);
+    expect(storage.getVideoById("missing")).toBeUndefined();
+    expect(storage.getVideoById("keep")).toBeDefined();
+    for (const file of [media, thumbnail, subtitle]) expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("rescans a missing entry without destroying the surviving video", async () => {
+    const media = writeMedia("videos/ChannelB/same.mp4");
+    saveVideo("missing", "/videos/ChannelA/same.mp4");
+    saveVideo("keep", "/videos/ChannelB/same.mp4", { fileSize: String(fs.statSync(media).size) });
+    const res = responseStub();
+
+    await scanFiles({} as never, res as never);
+
+    expect(fs.existsSync(media)).toBe(true);
+    expect(storage.getVideoById("keep")).toBeDefined();
+    expect(storage.getVideoById("missing")).toBeUndefined();
+    expect(res.json).toHaveBeenCalledWith({ addedCount: 0, deletedCount: 1 });
+  });
+
+  it("keeps shared media, thumbnails, subtitles, avatars and sidecars through auto-delete until the last owner goes", async () => {
+    const files = [writeMedia("videos/shared/file.mp4"), writeMedia("images/shared.jpg"),
+      writeMedia("subtitles/shared.en.vtt"), writeMedia("avatars/shared.jpg")];
+    const shared = {
+      thumbnailPath: "/images/shared.jpg", thumbnailFilename: "shared.jpg",
+      authorAvatarPath: "/avatars/shared.jpg", authorAvatarFilename: "shared.jpg",
+      subtitles: [{ path: "/subtitles/shared.en.vtt", filename: "shared.en.vtt", language: "en" }],
+    };
+    const old = saveVideo("old", "/videos/shared/file.mp4", { ...shared, author: "Old Author" });
+    saveVideo("locked", "/videos/shared/file.mp4", { ...shared, author: "Other Author", autoDeleteLocked: 1 });
+    const plan = planMediaServerExportPaths(old)!;
+    for (const file of [plan.episodeNfoAbsolutePath, plan.episodeSourceJsonAbsolutePath, plan.episodeThumbAliasAbsolutePath]) {
+      fs.outputFileSync(file, "sidecar");
+      files.push(file);
+    }
+    storage.saveSettings({ autoDeleteEnabled: true, autoDeleteIntervalDays: 30 });
+
+    const result = await runAutoDeleteSweep();
+
+    expect(result.deletedVideos).toBe(1);
+    expect(storage.getVideoById("old")).toBeUndefined();
+    expect(storage.getVideoById("locked")?.autoDeleteLocked).toBe(1);
+    for (const file of files) expect(fs.existsSync(file), file).toBe(true);
+    expect(storage.deleteVideo("locked")).toBe(true);
+    for (const file of files) expect(fs.existsSync(file), file).toBe(false);
+  });
+
+  it("protects a legacy basename-only owner and permits deletion of an unshared legacy file", () => {
+    const shared = writeMedia("videos/group/shared.mp4");
+    saveVideo("explicit", "/videos/group/shared.mp4");
+    saveVideo("legacy-owner", "", { videoFilename: "shared.mp4" });
+    storage.deleteVideo("explicit");
+    expect(fs.existsSync(shared)).toBe(true);
+
+    const own = writeMedia("videos/legacy.mp4");
+    saveVideo("legacy", "", { videoFilename: "legacy.mp4" });
+    expect(storage.deleteVideo("legacy")).toBe(true);
+    expect(fs.existsSync(own)).toBe(false);
+  });
+
+  it("does not confuse identical relative paths under different media roots", () => {
+    const own = writeMedia("videos/same.jpg");
+    const other = writeMedia("images/same.jpg");
+    saveVideo("own", "/videos/a.mp4", { thumbnailFilename: "same.jpg", thumbnailPath: "/videos/same.jpg" });
+    saveVideo("other", "/videos/b.mp4", { thumbnailFilename: "same.jpg", thumbnailPath: "/images/same.jpg" });
+    storage.deleteVideo("own");
+    expect(fs.existsSync(own)).toBe(false);
+    expect(fs.existsSync(other)).toBe(true);
+  });
+
+  it("fails closed before deleting files when another owner's metadata cannot be read", () => {
+    const media = writeMedia("videos/keep.mp4");
+    saveVideo("keep", "/videos/keep.mp4");
+    saveVideo("malformed", "/videos/other.mp4");
+    sqlite.prepare("UPDATE videos SET subtitles = ? WHERE id = ?").run("invalid json", "malformed");
+    expect(() => storage.deleteVideo("keep")).toThrow();
+    expect(fs.existsSync(media)).toBe(true);
+    expect(storage.getVideoById("keep")).toBeDefined();
+  });
+});
+
+describe("SQLite snapshot export and import integrity", () => {
+  it("streams a consistent snapshot while the live database changes, then removes the snapshot", async () => {
+    sqlite.exec("CREATE TABLE export_probe (id INTEGER PRIMARY KEY, payload BLOB)");
+    const add = sqlite.prepare("INSERT INTO export_probe VALUES (?, ?)");
+    sqlite.transaction(() => {
+      for (let i = 0; i < 1000; i++) add.run(i, Buffer.alloc(6000, 65));
+    })();
+    let servedPath = "";
+    let mutated = false;
+    const originalReadStream = nodeFs.createReadStream;
+    const streamSpy = vi.spyOn(nodeFs, "createReadStream").mockImplementation((file, options) => {
+      const isExport = typeof file === "string" &&
+        (path.basename(file).startsWith("export-") || file === path.join(paths.DATA_DIR, "mytube.db"));
+      const stream = originalReadStream(file, isExport ? { ...(typeof options === "object" ? options : {}), highWaterMark: 4096 } : options);
+      if (isExport) {
+        servedPath = String(file);
+        stream.once("data", () => { sqlite.exec("DELETE FROM export_probe"); mutated = true; });
+      }
+      return stream;
+    });
+    try {
+      const app = express();
+      app.get("/export", exportController);
+      const response = await request(app).get("/export").buffer(true).parse((res, done) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () => done(null, Buffer.concat(chunks)));
+        res.on("error", done);
+      });
+      expect(response.status).toBe(200);
+      expect(mutated).toBe(true);
+      expect(response.body.length).toBe(Number(response.headers["content-length"]));
+      const received = path.join(paths.DATA_DIR, "received.db");
+      fs.writeFileSync(received, response.body);
+      const exported = new Database(received, { readonly: true });
+      try {
+        expect(exported.pragma("integrity_check")).toEqual([{ integrity_check: "ok" }]);
+        expect(exported.prepare("SELECT count(*) AS n FROM export_probe").get()).toEqual({ n: 1000 });
+      } finally { exported.close(); }
+      expect(sqlite.prepare("SELECT count(*) AS n FROM export_probe").get()).toEqual({ n: 0 });
+      expect(sqlite.pragma("integrity_check")).toEqual([{ integrity_check: "ok" }]);
+      expect(fs.existsSync(servedPath)).toBe(false);
+    } finally {
+      streamSpy.mockRestore();
+      sqlite.exec("DROP TABLE export_probe");
+    }
+  });
+
+  it("gives simultaneous exports separate immutable files", async () => {
+    saveVideo("saved", "/videos/saved.mp4");
+    const snapshots = await Promise.all([backupService.exportDatabase(), backupService.exportDatabase()]);
+    try {
+      expect(new Set(snapshots).size).toBe(2);
+      storage.updateVideo("saved", { title: "changed" });
+      for (const file of snapshots) {
+        const snapshot = new Database(file, { readonly: true });
+        try {
+          expect(snapshot.prepare("SELECT title FROM videos WHERE id = 'saved'").get()).toEqual({ title: "saved" });
+          expect(snapshot.pragma("integrity_check")).toEqual([{ integrity_check: "ok" }]);
+        } finally { snapshot.close(); }
+      }
+    } finally { snapshots.forEach(backupService.cleanupDatabaseExport); }
+  });
+
+  it("rejects a corrupt file with a readable schema before replacing the current database", async () => {
+    saveVideo("keep", "/videos/keep.mp4");
+    const fixture = path.join(paths.DATA_DIR, "corrupt.db");
+    const source = new Database(fixture);
+    source.exec("CREATE TABLE probe (payload BLOB); INSERT INTO probe VALUES (zeroblob(200000)); DELETE FROM probe;");
+    source.close();
+    const corrupt = fs.readFileSync(fixture);
+    // Lose the freelist pointers while leaving sqlite_master and its schema
+    // readable, reproducing the mixed-revision export's allocation corruption.
+    corrupt.writeUInt32BE(0, 32);
+    corrupt.writeUInt32BE(0, 36);
+    fs.writeFileSync(fixture, corrupt);
+    const readable = new Database(fixture, { readonly: true });
+    try { expect(readable.prepare("SELECT name FROM sqlite_master LIMIT 1").get()).toEqual({ name: "probe" }); }
+    finally { readable.close(); }
+
+    expect(() => validateDatabase(fixture)).toThrow("Invalid database file");
+    await expect(backupService.importDatabase(corrupt)).rejects.toThrow("Invalid database file");
+    expect(storage.getVideoById("keep")).toBeDefined();
+    expect(sqlite.pragma("integrity_check")).toEqual([{ integrity_check: "ok" }]);
+    expect(fs.readdirSync(paths.DATA_DIR).filter((name) => name.startsWith("import-"))).toEqual([]);
+  });
+});

--- a/backend/src/__tests__/services/databaseBackupService.test.ts
+++ b/backend/src/__tests__/services/databaseBackupService.test.ts
@@ -34,6 +34,7 @@ vi.mock("../../db", () => ({
   reinitializeDatabase: vi.fn(),
   sqlite: {
     close: vi.fn(),
+    backup: vi.fn().mockResolvedValue({}),
     prepare: vi.fn(),
     transaction: vi.fn((callback: () => void) => callback),
   },
@@ -143,7 +144,7 @@ const createSourceDbHandle = (
   });
 
   const close = vi.fn();
-  return { prepare, close };
+  return { prepare, close, pragma: vi.fn(() => [{ integrity_check: "ok" }]) };
 };
 
 const createSqlitePrepareMock = (
@@ -260,20 +261,27 @@ describe("databaseBackupService", () => {
   });
 
   describe("exportDatabase", () => {
-    it("returns db path when database exists", () => {
+    it("creates a SQLite snapshot rather than returning the live database path", async () => {
       vi.mocked(fs.existsSync as any).mockReturnValue(true);
 
-      const exported = databaseBackupService.exportDatabase();
+      const exported = await databaseBackupService.exportDatabase();
 
-      expect(exported).toContain("mytube.db");
+      expect(exported).toMatch(/export-.*\.db\.tmp$/);
+      expect(sqlite.backup).toHaveBeenCalledWith(exported);
     });
 
-    it("throws when database is missing", () => {
+    it("throws when database is missing", async () => {
       vi.mocked(fs.existsSync as any).mockReturnValue(false);
 
-      expect(() => databaseBackupService.exportDatabase()).toThrow(
+      await expect(databaseBackupService.exportDatabase()).rejects.toThrow(
         "Database file not found"
       );
+    });
+    it("removes an incomplete export when the backup operation fails", async () => {
+      vi.mocked(fs.existsSync as any).mockReturnValue(true);
+      vi.mocked(sqlite.backup).mockRejectedValueOnce(new Error("disk full"));
+      await expect(databaseBackupService.exportDatabase()).rejects.toThrow("disk full");
+      expect(fs.unlinkSync).toHaveBeenCalledWith(expect.stringMatching(/export-.*\.db\.tmp$/));
     });
   });
 

--- a/backend/src/__tests__/services/downloaders/YtDlpDownloader.safari.test.ts
+++ b/backend/src/__tests__/services/downloaders/YtDlpDownloader.safari.test.ts
@@ -352,7 +352,7 @@ describe('YtDlpDownloader format defaults', () => {
         expect(result.id).toBe(selectedVideo.id);
     });
 
-    it('does not delete an old video file still referenced by another row', async () => {
+    it.each(['shared', 'unreadable'])('keeps the old video when owners are %s', async (condition) => {
         const sourceUrl = 'https://www.youtube.com/watch?v=123456';
         const selectedVideo = {
             id: 'selected-row',
@@ -369,7 +369,10 @@ describe('YtDlpDownloader format defaults', () => {
         vi.mocked(storageService.getVideoById).mockReturnValue(selectedVideo);
         vi.mocked(
             storageService.isVideoFileReferencedByOtherVideo,
-        ).mockReturnValue(true);
+        ).mockImplementation(() => {
+            if (condition === 'unreadable') throw new Error('owner metadata unreadable');
+            return true;
+        });
         vi.mocked(storageService.updateVideo).mockImplementation((id, updates) => ({
             ...selectedVideo,
             ...updates,
@@ -382,7 +385,7 @@ describe('YtDlpDownloader format defaults', () => {
 
         expect(
             storageService.isVideoFileReferencedByOtherVideo,
-        ).toHaveBeenCalledWith(selectedVideo, selectedVideo.id);
+        ).toHaveBeenCalledWith(selectedVideo, selectedVideo.id, `${process.cwd()}/uploads/videos/shared.mp4`);
         expect(mockUnlinkSync).not.toHaveBeenCalled();
     });
 

--- a/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
+++ b/backend/src/__tests__/services/downloaders/bilibiliVideo.test.ts
@@ -491,9 +491,12 @@ describe("bilibiliVideo.downloadSinglePart", () => {
     expect(mocks.saveVideo).not.toHaveBeenCalled();
   });
 
-  it("skips deleting the old thumbnail when another video still references it", async () => {
+  it.each(["shared", "unreadable"])("keeps the old thumbnail when owners are %s", async (condition) => {
     mocks.getVideoBySourceUrl.mockReturnValue(buildExistingVideo());
-    mocks.isThumbnailReferencedByOtherVideo.mockReturnValue(true);
+    mocks.isThumbnailReferencedByOtherVideo.mockImplementation(() => {
+      if (condition === "unreadable") throw new Error("owner metadata unreadable");
+      return true;
+    });
     mocks.resolveManagedThumbnailWebPathFromAbsolutePath.mockReturnValue(
       "/images/Collection/final-thumb.jpg",
     );
@@ -516,6 +519,7 @@ describe("bilibiliVideo.downloadSinglePart", () => {
         thumbnailPath: "/images/Collection/old-thumb.jpg",
       }),
       "existing-video",
+      "/mock/images/Collection/old-thumb.jpg",
     );
     expect(mocks.unlinkSync).not.toHaveBeenCalled();
     expect(mocks.deleteSmallThumbnailMirrorSync).not.toHaveBeenCalled();

--- a/backend/src/__tests__/services/mediaServerExport/artifactReferenceIndex.test.ts
+++ b/backend/src/__tests__/services/mediaServerExport/artifactReferenceIndex.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { ArtifactReferenceIndex } from "../../../services/mediaServerExport/artifactReferenceIndex";
+import * as planner from "../../../services/mediaServerExport/pathPlanner";
+import type { Video } from "../../../services/storageService/types";
+
+const videoRecord = (id: string, videoPath: string): Video => ({
+  id, videoPath, title: id, sourceUrl: `https://example.com/${id}`, createdAt: "2026-01-01T00:00:00Z",
+});
+
+describe("sidecar ownership during batch deletion", () => {
+  it("plans unchanged paths once and reflects deletions, moves and new owners", () => {
+    let library = Array.from({ length: 30 }, (_, i) => videoRecord(String(i), `/videos/group/file-${i}.mp4`));
+    const shared = videoRecord("shared", library[29].videoPath);
+    library.push(shared);
+    const targetPath = planner.planMediaServerExportPaths(shared)!.episodeNfoAbsolutePath;
+    const plan = vi.spyOn(planner, "planMediaServerExportPaths");
+    const index = new ArtifactReferenceIndex();
+    try {
+      for (let i = 0; i < 29; i++) {
+        index.update(library, String(i));
+        library = library.filter((row) => row.id !== String(i));
+        expect(index.has(targetPath)).toBe(true);
+      }
+      expect(plan).toHaveBeenCalledTimes(30);
+      shared.videoPath = "/videos/moved/file.mp4";
+      index.update(library, "29");
+      expect(index.has(targetPath)).toBe(false);
+      expect(plan).toHaveBeenCalledTimes(31);
+      library = [shared];
+      index.update(library, "shared");
+      expect(index.has(targetPath)).toBe(false);
+      library.push(videoRecord("new", "/videos/group/file-29.mp4"));
+      index.update(library, "shared");
+      expect(index.has(targetPath)).toBe(true);
+    } finally { plan.mockRestore(); }
+  });
+});

--- a/backend/src/__tests__/services/mediaServerExport/syncService.test.ts
+++ b/backend/src/__tests__/services/mediaServerExport/syncService.test.ts
@@ -34,6 +34,10 @@ vi.mock("../../../services/storageService/settings", () => ({
   getSettings: getSettingsMock,
 }));
 
+vi.mock("../../../services/storageService/videoQueries", () => ({
+  getArtifactOwners: vi.fn(() => { throw new Error("Ownership read unavailable"); }),
+}));
+
 vi.mock("../../../utils/logger", () => ({
   logger: {
     error: vi.fn(),

--- a/backend/src/controllers/cleanupController.ts
+++ b/backend/src/controllers/cleanupController.ts
@@ -3,85 +3,78 @@ import { VIDEOS_DIR } from "../config/paths";
 import { ValidationError } from "../errors/DownloadErrors";
 import * as storageService from "../services/storageService";
 import { createArtifactReferenceGuard } from "../services/storageService/artifactReferences";
+import { DOWNLOAD_TEMP_MARKER, isActiveDownloadTempDir, isOwnedInactiveDownloadTempDir } from "../services/downloadTempDirectories";
 import { logger } from "../utils/logger";
-import {
-  readdirDirentsSafe,
-  resolveSafeChildPath,
-  unlinkSafeSync,
-} from "../utils/security";
+import { readdirDirentsSafe, removeEmptyDirSafeSync, resolveSafeChildPath, unlinkSafeSync } from "../utils/security";
 
-/**
- * Clean up temporary download files (.ytdl, .part)
- * Errors are automatically handled by asyncHandler middleware
- */
-export const cleanupTempFiles = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
-  // Check if there are active downloads
-  const downloadStatus = storageService.getDownloadStatus();
-  if (downloadStatus.activeDownloads.length > 0) {
-    throw new ValidationError(
-      `Cannot clean up while downloads are active (${downloadStatus.activeDownloads.length} active)`,
-      "activeDownloads"
-    );
+interface DirectorySnapshot {
+  path: string;
+  files: string[];
+  directories: DirectorySnapshot[];
+  hasSpecialEntries: boolean;
+}
+
+function requireIdleDownloads(): void {
+  if (storageService.getDownloadStatus().activeDownloads.length > 0) {
+    throw new ValidationError("Cannot clean up while downloads are active", "activeDownloads");
   }
+}
 
+async function collectDirectory(directory: string): Promise<DirectorySnapshot> {
+  const snapshot: DirectorySnapshot = { path: directory, files: [], directories: [], hasSpecialEntries: false };
+  for (const entry of await readdirDirentsSafe(directory, VIDEOS_DIR)) {
+    const child = resolveSafeChildPath(directory, entry.name);
+    if (entry.isDirectory()) snapshot.directories.push(await collectDirectory(child));
+    else if (entry.isFile()) snapshot.files.push(child);
+    else snapshot.hasSpecialEntries = true;
+  }
+  return snapshot;
+}
+
+/** Collect asynchronously, then validate ownership and delete without yielding. */
+export const cleanupTempFiles = async (_req: Request, res: Response): Promise<void> => {
+  requireIdleDownloads();
+  const snapshot = await collectDirectory(VIDEOS_DIR);
+  requireIdleDownloads();
+  // A read failure aborts once, before any unlink. No reference snapshot is
+  // held across the asynchronous directory walk.
+  const isReferenced = createArtifactReferenceGuard(storageService.getArtifactOwners());
   let deletedCount = 0;
   const errors: string[] = [];
-
-  // Recursively find and delete .ytdl and .part files
-  const cleanupDirectory = async (dir: string) => {
-    try {
-      const entries = await readdirDirentsSafe(dir, VIDEOS_DIR);
-
-      for (const entry of entries) {
-        const fullPath = resolveSafeChildPath(dir, entry.name);
-
-        if (entry.isDirectory()) {
-          // A temp_ prefix is also a valid author/template directory. Without
-          // a job-owned manifest it does not establish that a folder is trash.
-          await cleanupDirectory(fullPath);
-        } else if (entry.isFile()) {
-          // Check if file has .ytdl or .part extension
-          if (entry.name.endsWith(".ytdl") || entry.name.endsWith(".part")) {
-            try {
-              // Recheck after asynchronous traversal, then inspect owners and
-              // unlink synchronously so another request cannot start a download
-              // or register this artifact between the check and deletion.
-              if (storageService.getDownloadStatus().activeDownloads.length > 0) {
-                throw new Error("Downloads became active during cleanup");
-              }
-              const isReferenced = createArtifactReferenceGuard(storageService.getVideosStrict());
-              if (isReferenced(fullPath)) continue;
-              unlinkSafeSync(fullPath, VIDEOS_DIR);
-              deletedCount++;
-              logger.debug(`Deleted temp file: ${fullPath}`);
-            } catch (error) {
-              const errorMsg = `Failed to delete ${fullPath}: ${
-                error instanceof Error ? error.message : String(error)
-              }`;
-              logger.warn(errorMsg);
-              errors.push(errorMsg);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      const errorMsg = `Failed to read directory ${dir}: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
-      logger.error(errorMsg);
-      errors.push(errorMsg);
+  const safely = (operation: () => void) => {
+    try { operation(); } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      errors.push(message);
+      logger.warn("Temporary-file cleanup failed", { message });
     }
   };
-
-  // Start cleanup from VIDEOS_DIR
-  await cleanupDirectory(VIDEOS_DIR);
-
-  // Return format expected by frontend: { deletedCount, errors? }
-  res.status(200).json({
-    deletedCount,
-    ...(errors.length > 0 && { errors }),
-  });
+  const protectedTree = (node: DirectorySnapshot): boolean => node.hasSpecialEntries ||
+    node.files.some(isReferenced) || node.directories.some(protectedTree);
+  const removeOwnedTree = (node: DirectorySnapshot) => {
+    for (const child of node.directories) removeOwnedTree(child);
+    // Keep the marker until the other files have been removed so an interrupted
+    // cleanup remains identifiable. Never recursively remove unknown entries.
+    const marker = resolveSafeChildPath(node.path, DOWNLOAD_TEMP_MARKER);
+    for (const file of node.files.filter((file) => file !== marker)) {
+      unlinkSafeSync(file, VIDEOS_DIR);
+      deletedCount++;
+    }
+    if (node.files.includes(marker)) unlinkSafeSync(marker, VIDEOS_DIR);
+    removeEmptyDirSafeSync(node.path, VIDEOS_DIR);
+  };
+  const clean = (node: DirectorySnapshot) => {
+    if (isActiveDownloadTempDir(node.path)) return;
+    if (isOwnedInactiveDownloadTempDir(node.path)) {
+      if (!protectedTree(node)) safely(() => removeOwnedTree(node));
+      return;
+    }
+    for (const file of node.files) {
+      if ((file.endsWith(".part") || file.endsWith(".ytdl")) && !isReferenced(file)) {
+        safely(() => { unlinkSafeSync(file, VIDEOS_DIR); deletedCount++; });
+      }
+    }
+    for (const child of node.directories) clean(child);
+  };
+  clean(snapshot);
+  res.status(200).json({ deletedCount, ...(errors.length ? { errors } : {}) });
 };

--- a/backend/src/controllers/cleanupController.ts
+++ b/backend/src/controllers/cleanupController.ts
@@ -2,11 +2,12 @@ import { Request, Response } from "express";
 import { VIDEOS_DIR } from "../config/paths";
 import { ValidationError } from "../errors/DownloadErrors";
 import * as storageService from "../services/storageService";
+import { createArtifactReferenceGuard } from "../services/storageService/artifactReferences";
 import { logger } from "../utils/logger";
 import {
   readdirDirentsSafe,
-  removeSafe,
   resolveSafeChildPath,
+  unlinkSafeSync,
 } from "../utils/security";
 
 /**
@@ -38,28 +39,22 @@ export const cleanupTempFiles = async (
         const fullPath = resolveSafeChildPath(dir, entry.name);
 
         if (entry.isDirectory()) {
-          // Check for temp_ folder
-          if (entry.name.startsWith("temp_")) {
-            try {
-              await removeSafe(fullPath, VIDEOS_DIR);
-              deletedCount++;
-              logger.debug(`Deleted temp directory: ${fullPath}`);
-            } catch (error) {
-              const errorMsg = `Failed to delete directory ${fullPath}: ${
-                error instanceof Error ? error.message : String(error)
-              }`;
-              logger.warn(errorMsg);
-              errors.push(errorMsg);
-            }
-          } else {
-            // Recursively clean subdirectories
-            await cleanupDirectory(fullPath);
-          }
+          // A temp_ prefix is also a valid author/template directory. Without
+          // a job-owned manifest it does not establish that a folder is trash.
+          await cleanupDirectory(fullPath);
         } else if (entry.isFile()) {
           // Check if file has .ytdl or .part extension
           if (entry.name.endsWith(".ytdl") || entry.name.endsWith(".part")) {
             try {
-              await removeSafe(fullPath, VIDEOS_DIR);
+              // Recheck after asynchronous traversal, then inspect owners and
+              // unlink synchronously so another request cannot start a download
+              // or register this artifact between the check and deletion.
+              if (storageService.getDownloadStatus().activeDownloads.length > 0) {
+                throw new Error("Downloads became active during cleanup");
+              }
+              const isReferenced = createArtifactReferenceGuard(storageService.getVideosStrict());
+              if (isReferenced(fullPath)) continue;
+              unlinkSafeSync(fullPath, VIDEOS_DIR);
               deletedCount++;
               logger.debug(`Deleted temp file: ${fullPath}`);
             } catch (error) {

--- a/backend/src/controllers/databaseBackupController.ts
+++ b/backend/src/controllers/databaseBackupController.ts
@@ -39,7 +39,19 @@ export const exportDatabase = async (
     // Wait for sendFile's callback on completion/error (including disconnect)
     // before unlinking the snapshot. Reject so asyncHandler handles failures.
     await new Promise<void>((resolve, reject) => {
-      res.sendFile(dbPath, (error) => error ? reject(error) : resolve());
+      res.sendFile(dbPath, (error) => {
+        const code = (error as NodeJS.ErrnoException | undefined)?.code;
+        if (error && ["ECONNABORTED", "ECONNRESET", "EPIPE"].includes(code ?? "")) {
+          // sendFile reports these when the peer closes the transfer. There
+          // is no response left to send; still release the snapshot in finally.
+          if (!res.destroyed) res.destroy();
+          resolve();
+        } else if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
     });
   } finally {
     databaseBackupService.cleanupDatabaseExport(dbPath);

--- a/backend/src/controllers/databaseBackupController.ts
+++ b/backend/src/controllers/databaseBackupController.ts
@@ -28,17 +28,22 @@ export const exportDatabase = async (
   _req: Request,
   res: Response
 ): Promise<void> => {
-  const dbPath = databaseBackupService.exportDatabase();
+  const dbPath = await databaseBackupService.exportDatabase();
 
-  // Generate filename with date and time
-  const filename = `mytube-backup-${generateTimestamp()}.db`;
-
-  // Set headers for file download
-  res.setHeader("Content-Type", "application/octet-stream");
-  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-
-  // Send the database file
-  res.sendFile(dbPath);
+  try {
+    // A client can disconnect while the snapshot is being created.
+    if (res.destroyed) return;
+    const filename = `mytube-backup-${generateTimestamp()}.db`;
+    res.setHeader("Content-Type", "application/octet-stream");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    // Wait for sendFile's callback on completion/error (including disconnect)
+    // before unlinking the snapshot. Reject so asyncHandler handles failures.
+    await new Promise<void>((resolve, reject) => {
+      res.sendFile(dbPath, (error) => error ? reject(error) : resolve());
+    });
+  } finally {
+    databaseBackupService.cleanupDatabaseExport(dbPath);
+  }
 };
 
 /**

--- a/backend/src/controllers/videoMetadataController.ts
+++ b/backend/src/controllers/videoMetadataController.ts
@@ -27,6 +27,7 @@ import {
   removeSafe,
   resolveSafeChildPath,
   statSafe,
+  unlinkSafeSync,
   validateImagePath,
   validateUrl,
   validateVideoPath,
@@ -89,7 +90,10 @@ const resolveLocalThumbnailAbsolutePath = async (
   return resolveSafeChildPath(VIDEOS_DIR, relativePath);
 };
 
-const removeImageFileSafely = async (imagePath: string): Promise<void> => {
+const removeImageFileSafely = async (
+  imagePath: string,
+  canDelete?: (absolutePath: string) => boolean,
+): Promise<void> => {
   const safeResolvedPath = await resolveLocalThumbnailAbsolutePath(imagePath);
   if (!safeResolvedPath) {
     return;
@@ -108,7 +112,14 @@ const removeImageFileSafely = async (imagePath: string): Promise<void> => {
     return;
   }
 
-  await removeSafe(safeResolvedPath, [VIDEOS_DIR, IMAGES_DIR]);
+  if (canDelete) {
+    // Recheck owners after the async filesystem probes and unlink without
+    // yielding, so another request cannot acquire this file between them.
+    if (!canDelete(safeResolvedPath)) return;
+    unlinkSafeSync(safeResolvedPath, [VIDEOS_DIR, IMAGES_DIR]);
+  } else {
+    await removeSafe(safeResolvedPath, [VIDEOS_DIR, IMAGES_DIR]);
+  }
   deleteSmallThumbnailMirrorSync(imagePath);
 };
 
@@ -756,14 +767,13 @@ export const uploadThumbnail = async (
     oldThumbnailRelativePath !== resolveStoredThumbnailPath(newThumbnailPath)
   ) {
     try {
-      if (!storageService.isThumbnailReferencedByOtherVideo(video, id)) {
-        const oldThumbnailWebPath =
-          video.thumbnailPath?.startsWith("/images/") ||
-          video.thumbnailPath?.startsWith("/videos/")
-            ? video.thumbnailPath
-            : oldThumbnailRelativePath;
-        await removeImageFileSafely(oldThumbnailWebPath);
-      }
+      const oldThumbnailWebPath =
+        video.thumbnailPath?.startsWith("/images/") ||
+        video.thumbnailPath?.startsWith("/videos/")
+          ? video.thumbnailPath
+          : oldThumbnailRelativePath;
+      await removeImageFileSafely(oldThumbnailWebPath, (absolutePath) =>
+        !storageService.isThumbnailReferencedByOtherVideo(video, id, absolutePath));
     } catch (err) {
       logger.warn("Failed to delete old thumbnail file", err);
     }

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -61,6 +61,14 @@ export function errorHandler(
   res: Response,
   next: NextFunction
 ): void {
+  // Once streaming starts, Express must close the response on failure rather
+  // than attempting to send a second set of headers.
+  if (res.headersSent) {
+    next(err);
+    return;
+  }
+  if (res.destroyed) return;
+
   // Handle Multer errors (file size exceeded, unexpected field, etc.)
   if (err instanceof multer.MulterError) {
     const status = err.code === "LIMIT_FILE_SIZE" ? 413 : 400;

--- a/backend/src/services/databaseBackup/backupFiles.ts
+++ b/backend/src/services/databaseBackup/backupFiles.ts
@@ -36,11 +36,15 @@ export function validateDatabase(filePath: string): void {
     // freelist are sound (e.g. a copy taken across two commits).
     const checks = sourceDb.pragma("integrity_check") as Array<{ integrity_check: string }>;
     if (checks.length !== 1 || checks[0].integrity_check !== "ok") {
-      throw new Error("SQLite integrity check failed");
+      logger.warn("Database import integrity check failed", { checks: checks.slice(0, 3) });
+      throw new ValidationError("Invalid database file: SQLite integrity check failed. Restore an intact backup; the active database has not been replaced.", "file");
     }
   } catch (validationError) {
+    if (validationError instanceof ValidationError) throw validationError;
     throw new ValidationError(
-      "Invalid database file. The file is not a valid SQLite database.",
+      sourceDb
+        ? "Invalid database file: SQLite integrity check could not complete. The active database has not been replaced."
+        : "Invalid database file. The file is not a valid SQLite database.",
       "file"
     );
   } finally {

--- a/backend/src/services/databaseBackup/backupFiles.ts
+++ b/backend/src/services/databaseBackup/backupFiles.ts
@@ -32,19 +32,19 @@ export function validateDatabase(filePath: string): void {
   let sourceDb: Database.Database | null = null;
   try {
     sourceDb = new Database(filePath, { readonly: true });
-    // Try to query the database to verify it's valid
-    sourceDb
-      .prepare("SELECT name FROM sqlite_master WHERE type='table' LIMIT 1")
-      .get();
-    sourceDb.close();
-  } catch (validationError) {
-    if (sourceDb) {
-      sourceDb.close();
+    // A readable sqlite_master does not prove that data pages, indexes, or the
+    // freelist are sound (e.g. a copy taken across two commits).
+    const checks = sourceDb.pragma("integrity_check") as Array<{ integrity_check: string }>;
+    if (checks.length !== 1 || checks[0].integrity_check !== "ok") {
+      throw new Error("SQLite integrity check failed");
     }
+  } catch (validationError) {
     throw new ValidationError(
       "Invalid database file. The file is not a valid SQLite database.",
       "file"
     );
+  } finally {
+    sourceDb?.close();
   }
 }
 
@@ -65,9 +65,14 @@ export function prepareTempImportFile(fileBuffer: Buffer): string {
     throw new ValidationError("Invalid database path", "file");
   }
 
-  writeFileSafeSync(tempImportPath, DATA_DIR, fileBuffer);
-  validateDatabase(tempImportPath);
-  return tempImportPath;
+  try {
+    writeFileSafeSync(tempImportPath, DATA_DIR, fileBuffer);
+    validateDatabase(tempImportPath);
+    return tempImportPath;
+  } catch (error) {
+    cleanupTempImportFile(tempImportPath);
+    throw error;
+  }
 }
 
 export function cleanupTempImportFile(tempImportPath: string): void {

--- a/backend/src/services/databaseBackupService.ts
+++ b/backend/src/services/databaseBackupService.ts
@@ -1,4 +1,5 @@
 import Database from "better-sqlite3";
+import crypto from "crypto";
 import path from "path";
 import { DATA_DIR } from "../config/paths";
 import { sqlite } from "../db";
@@ -36,13 +37,31 @@ import type { DatabaseMergeSummary } from "./databaseBackup/types";
 
 /**
  * Export database as backup file
- * Returns the path to the database file
+ * Returns an immutable SQLite snapshot. The caller owns cleanup after transfer.
  */
-export function exportDatabase(): string {
+export async function exportDatabase(): Promise<string> {
   if (!pathExistsSafeSync(dbPath, DATA_DIR)) {
     throw new NotFoundError("Database file", "mytube.db");
   }
-  return dbPath;
+  const snapshotPath = resolveSafePath(
+    path.join(DATA_DIR, `export-${crypto.randomUUID()}.db.tmp`),
+    DATA_DIR
+  );
+  try {
+    await sqlite.backup(snapshotPath);
+    return snapshotPath;
+  } catch (error) {
+    cleanupTempImportFile(snapshotPath);
+    throw error;
+  }
+}
+
+export function cleanupDatabaseExport(snapshotPath: string): void {
+  // Never let a cleanup mistake target mytube.db or a saved restore backup.
+  if (!/^export-[0-9a-f-]+\.db\.tmp$/i.test(path.basename(snapshotPath))) {
+    throw new ValidationError("Invalid database export path", "file");
+  }
+  cleanupTempImportFile(snapshotPath);
 }
 
 /**

--- a/backend/src/services/downloadTempDirectories.ts
+++ b/backend/src/services/downloadTempDirectories.ts
@@ -1,0 +1,38 @@
+import path from "path";
+import { VIDEOS_DIR } from "../config/paths";
+import { lstatSafeSync, readFileSafeSync, resolveSafeChildPath, writeFileSafeSync } from "../utils/security";
+
+export const DOWNLOAD_TEMP_MARKER = ".mytube-download.json";
+const tempNamePattern = /^temp_\d{13}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const activeDirectories = new Set<string>();
+
+/** Persist ownership so a subsequent process can recognize abandoned jobs. */
+export function registerDownloadTempDir(directory: string): void {
+  const marker = resolveSafeChildPath(directory, DOWNLOAD_TEMP_MARKER);
+  writeFileSafeSync(marker, VIDEOS_DIR, JSON.stringify({
+    owner: "mytube-bilibili", version: 1, directory: path.basename(directory),
+  }), { flag: "wx" });
+  activeDirectories.add(directory);
+}
+
+export function releaseDownloadTempDir(directory: string): void {
+  activeDirectories.delete(directory);
+}
+
+export function isActiveDownloadTempDir(directory: string): boolean {
+  return activeDirectories.has(directory);
+}
+
+export function isOwnedInactiveDownloadTempDir(directory: string): boolean {
+  if (path.dirname(directory) !== VIDEOS_DIR || !tempNamePattern.test(path.basename(directory)) ||
+      activeDirectories.has(directory)) return false;
+  try {
+    const marker = resolveSafeChildPath(directory, DOWNLOAD_TEMP_MARKER);
+    const stat = lstatSafeSync(marker, VIDEOS_DIR);
+    if (!stat.isFile() || stat.size > 1024) return false;
+    const data = JSON.parse(readFileSafeSync(marker, VIDEOS_DIR, "utf8"));
+    return data.owner === "mytube-bilibili" && data.version === 1 && data.directory === path.basename(directory);
+  } catch {
+    return false;
+  }
+}

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -956,6 +956,7 @@ export class MissAVDownloader extends BaseDownloader {
               !storageService.isVideoFileReferencedByOtherVideo(
                 existingLocalVideo,
                 existingLocalVideo.id,
+                previousVideoPath,
               )
             ) {
               unlinkSafeSync(previousVideoPath, VIDEOS_DIR);
@@ -968,7 +969,7 @@ export class MissAVDownloader extends BaseDownloader {
           }
         }
 
-        removeMediaServerArtifactsForVideo(existingLocalVideo);
+        removeMediaServerArtifactsForVideo(existingLocalVideo, { preserveSharedArtifacts: true });
         persistedVideoData = updatedVideo;
         if (sourceVideoId) {
           persistedVideoData = storageService.persistDownloadedMediaIdentity({

--- a/backend/src/services/downloaders/bilibili/bilibiliFileManager.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliFileManager.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { registerDownloadTempDir, releaseDownloadTempDir } from "../../downloadTempDirectories";
 import path from "path";
 import { IMAGES_DIR, SUBTITLES_DIR, VIDEOS_DIR } from "../../../config/paths";
 import {
@@ -109,6 +110,7 @@ export function createTempDir(): string {
     `temp_${Date.now()}_${crypto.randomUUID()}`
   );
   ensureDirSafeSync(tempDir, VIDEOS_DIR);
+  registerDownloadTempDir(tempDir);
   logger.info("Created temp directory:", tempDir);
   return tempDir;
 }
@@ -117,9 +119,13 @@ export function createTempDir(): string {
  * Clean up temporary directory
  */
 export async function cleanupTempDir(tempDir: string): Promise<void> {
-  if (pathExistsSafeSync(tempDir, VIDEOS_DIR)) {
-    await safeRemove(tempDir);
-    logger.info("Deleted temp directory:", tempDir);
+  try {
+    if (pathExistsSafeSync(tempDir, VIDEOS_DIR)) {
+      await safeRemove(tempDir);
+      logger.info("Deleted temp directory:", tempDir);
+    }
+  } finally {
+    releaseDownloadTempDir(tempDir);
   }
 }
 

--- a/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
+++ b/backend/src/services/downloaders/bilibili/bilibiliSinglePart.ts
@@ -499,6 +499,7 @@ export async function downloadSinglePart(
               !storageService.isThumbnailReferencedByOtherVideo(
                 existingVideo,
                 existingVideo.id,
+                oldThumbnailPath,
               )
             ) {
               unlinkSafeSync(oldThumbnailPath, [IMAGES_DIR, VIDEOS_DIR]);
@@ -563,7 +564,7 @@ export async function downloadSinglePart(
             }
           }
 
-          removeMediaServerArtifactsForVideo(existingVideo);
+          removeMediaServerArtifactsForVideo(existingVideo, { preserveSharedArtifacts: true });
           if (sourceVideoId) {
             finalVideoData = storageService.persistDownloadedMediaIdentity({
               video: finalVideoData,

--- a/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
+++ b/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
@@ -779,6 +779,7 @@ export async function downloadVideo(
           !storageService.isVideoFileReferencedByOtherVideo(
             existingVideo,
             existingVideo.id,
+            oldVideoPath,
           )
         ) {
           unlinkSafeSync(oldVideoPath, VIDEOS_DIR);
@@ -807,6 +808,7 @@ export async function downloadVideo(
           !storageService.isThumbnailReferencedByOtherVideo(
             existingVideo,
             existingVideo.id,
+            oldThumbnailPath,
           )
         ) {
           unlinkSafeSync(oldThumbnailPath, [VIDEOS_DIR, IMAGES_DIR]);
@@ -867,7 +869,7 @@ export async function downloadVideo(
         }
       }
 
-      removeMediaServerArtifactsForVideo(existingVideo);
+      removeMediaServerArtifactsForVideo(existingVideo, { preserveSharedArtifacts: true });
       const trackedSource = extractSourceVideoId(videoUrl);
       if (trackedSource.id) {
         finalVideoData = storageService.persistDownloadedMediaIdentity({

--- a/backend/src/services/mediaServerExport/artifactReferenceIndex.ts
+++ b/backend/src/services/mediaServerExport/artifactReferenceIndex.ts
@@ -1,0 +1,40 @@
+import path from "path";
+import type { Video } from "../storageService/types";
+import { planMediaServerExportPaths } from "./pathPlanner";
+
+const key = (value: string) => path.normalize(value).normalize("NFKC").toLowerCase();
+
+/** Reconcile fresh owners, but only plan paths for new or moved records.
+ * A retention sweep consequently plans the library once, not once per delete.
+ * Entries removed from the library are evicted, keeping memory bounded by it.
+ */
+export class ArtifactReferenceIndex {
+  private rows = new Map<string, { videoPath: unknown; artifacts: string[] }>();
+  private counts = new Map<string, number>();
+
+  update(videos: Video[], excludedId: string): void {
+    const remaining = new Map(videos.filter((video) => video.id !== excludedId).map((video) => [video.id, video]));
+    for (const [id, previous] of this.rows) {
+      if (remaining.has(id) && remaining.get(id)!.videoPath === previous.videoPath) continue;
+      for (const artifact of previous.artifacts) {
+        const count = this.counts.get(artifact)! - 1;
+        if (count) this.counts.set(artifact, count);
+        else this.counts.delete(artifact);
+      }
+      this.rows.delete(id);
+    }
+    for (const [id, video] of remaining) {
+      if (this.rows.has(id)) continue;
+      const plan = planMediaServerExportPaths(video);
+      const artifacts = plan ? [...new Set([
+        plan.episodeNfoAbsolutePath, plan.episodeSourceJsonAbsolutePath,
+        plan.episodeThumbAliasAbsolutePath, ...plan.showPosterAbsolutePaths,
+        ...(plan.showNfoAbsolutePath ? [plan.showNfoAbsolutePath] : []),
+      ].map(key))] : [];
+      for (const artifact of artifacts) this.counts.set(artifact, (this.counts.get(artifact) ?? 0) + 1);
+      this.rows.set(id, { videoPath: video.videoPath, artifacts });
+    }
+  }
+
+  has(absolutePath: string): boolean { return this.counts.has(key(absolutePath)); }
+}

--- a/backend/src/services/mediaServerExport/syncService.ts
+++ b/backend/src/services/mediaServerExport/syncService.ts
@@ -11,6 +11,7 @@ import {
   writeFileSafeSync,
 } from "../../utils/security";
 import { getSettings } from "../storageService/settings";
+import { getArtifactOwners } from "../storageService/videoQueries";
 import { removeEmptyDirectoryChain } from "../storageService/fileHelpers";
 import type { Video } from "../storageService";
 import {
@@ -19,6 +20,7 @@ import {
   normalizeVideoDateToDay,
 } from "./nfoBuilders";
 import { planMediaServerExportPaths } from "./pathPlanner";
+import { ArtifactReferenceIndex } from "./artifactReferenceIndex";
 import type {
   MediaServerExportMode,
   RemoveMediaServerArtifactsOptions,
@@ -473,6 +475,8 @@ export function syncMediaServerArtifactsForRecord(
   }
 }
 
+const deletionArtifactReferences = new ArtifactReferenceIndex();
+
 export function removeMediaServerArtifactsForVideo(
   video: Video,
   options: RemoveMediaServerArtifactsOptions = {}
@@ -483,32 +487,27 @@ export function removeMediaServerArtifactsForVideo(
       return;
     }
 
-    // Duplicate media paths (and different containers with the same stem) can
-    // share sidecars. Keep them until their last owning video is removed.
-    // Only read the library when a caller actually asks for that check: an
-    // eager read would abort the whole removal for layouts that never need it.
-    const artifactKey = (value: string) =>
-      path.normalize(value).normalize("NFKC").toLowerCase();
-    const sharedArtifacts = new Set<string>();
-    for (const candidate of options.preserveSharedArtifacts ? getLibraryVideos(options) : []) {
-      if (candidate.id === video.id) continue;
-      const candidatePlan = planMediaServerExportPaths(candidate);
-      if (!candidatePlan) continue;
-      for (const artifact of [candidatePlan.episodeNfoAbsolutePath,
-        candidatePlan.episodeSourceJsonAbsolutePath, candidatePlan.episodeThumbAliasAbsolutePath]) {
-        sharedArtifacts.add(artifactKey(artifact));
-      }
+    // Export may now be off while sidecars from previous exports still exist.
+    // Always remove unshared historical artifacts; reuse path plans across a
+    // batch while reconciling against fresh owners on every invocation.
+    if (options.preserveSharedArtifacts) {
+      const owners = options.libraryVideos ?? getArtifactOwners();
+      deletionArtifactReferences.update(owners, video.id);
     }
+    const isShared = (artifact: string) => options.preserveSharedArtifacts === true &&
+      deletionArtifactReferences.has(artifact);
     for (const artifact of [plan.episodeNfoAbsolutePath,
       plan.episodeSourceJsonAbsolutePath, plan.episodeThumbAliasAbsolutePath]) {
-      if (!sharedArtifacts.has(artifactKey(artifact))) removeOwnedArtifact(artifact);
+      if (!isShared(artifact)) removeOwnedArtifact(artifact);
     }
 
     if (!plan.tvLayout.isTvCompatible || !plan.tvLayout.showRootRelativeDir) {
       return;
     }
 
-    const showStillHasEpisodes = getLibraryVideos(options).some(
+    const showStillHasEpisodes = options.preserveSharedArtifacts
+      ? Boolean(plan.showNfoAbsolutePath && isShared(plan.showNfoAbsolutePath))
+      : getLibraryVideos(options).some(
       (candidate) =>
         candidate.id !== video.id &&
         matchesShowRoot(candidate, plan.tvLayout.showRootRelativeDir as string)

--- a/backend/src/services/mediaServerExport/syncService.ts
+++ b/backend/src/services/mediaServerExport/syncService.ts
@@ -483,13 +483,14 @@ export function removeMediaServerArtifactsForVideo(
       return;
     }
 
-    const libraryVideos = getLibraryVideos(options);
     // Duplicate media paths (and different containers with the same stem) can
     // share sidecars. Keep them until their last owning video is removed.
+    // Only read the library when a caller actually asks for that check: an
+    // eager read would abort the whole removal for layouts that never need it.
     const artifactKey = (value: string) =>
       path.normalize(value).normalize("NFKC").toLowerCase();
     const sharedArtifacts = new Set<string>();
-    for (const candidate of options.preserveSharedArtifacts ? libraryVideos : []) {
+    for (const candidate of options.preserveSharedArtifacts ? getLibraryVideos(options) : []) {
       if (candidate.id === video.id) continue;
       const candidatePlan = planMediaServerExportPaths(candidate);
       if (!candidatePlan) continue;
@@ -507,7 +508,7 @@ export function removeMediaServerArtifactsForVideo(
       return;
     }
 
-    const showStillHasEpisodes = libraryVideos.some(
+    const showStillHasEpisodes = getLibraryVideos(options).some(
       (candidate) =>
         candidate.id !== video.id &&
         matchesShowRoot(candidate, plan.tvLayout.showRootRelativeDir as string)

--- a/backend/src/services/mediaServerExport/syncService.ts
+++ b/backend/src/services/mediaServerExport/syncService.ts
@@ -483,15 +483,30 @@ export function removeMediaServerArtifactsForVideo(
       return;
     }
 
-    removeOwnedArtifact(plan.episodeNfoAbsolutePath);
-    removeOwnedArtifact(plan.episodeSourceJsonAbsolutePath);
-    removeOwnedArtifact(plan.episodeThumbAliasAbsolutePath);
+    const libraryVideos = getLibraryVideos(options);
+    // Duplicate media paths (and different containers with the same stem) can
+    // share sidecars. Keep them until their last owning video is removed.
+    const artifactKey = (value: string) =>
+      path.normalize(value).normalize("NFKC").toLowerCase();
+    const sharedArtifacts = new Set<string>();
+    for (const candidate of options.preserveSharedArtifacts ? libraryVideos : []) {
+      if (candidate.id === video.id) continue;
+      const candidatePlan = planMediaServerExportPaths(candidate);
+      if (!candidatePlan) continue;
+      for (const artifact of [candidatePlan.episodeNfoAbsolutePath,
+        candidatePlan.episodeSourceJsonAbsolutePath, candidatePlan.episodeThumbAliasAbsolutePath]) {
+        sharedArtifacts.add(artifactKey(artifact));
+      }
+    }
+    for (const artifact of [plan.episodeNfoAbsolutePath,
+      plan.episodeSourceJsonAbsolutePath, plan.episodeThumbAliasAbsolutePath]) {
+      if (!sharedArtifacts.has(artifactKey(artifact))) removeOwnedArtifact(artifact);
+    }
 
     if (!plan.tvLayout.isTvCompatible || !plan.tvLayout.showRootRelativeDir) {
       return;
     }
 
-    const libraryVideos = getLibraryVideos(options);
     const showStillHasEpisodes = libraryVideos.some(
       (candidate) =>
         candidate.id !== video.id &&

--- a/backend/src/services/mediaServerExport/types.ts
+++ b/backend/src/services/mediaServerExport/types.ts
@@ -32,6 +32,9 @@ export interface SyncMediaServerArtifactsOptions {
 
 export interface RemoveMediaServerArtifactsOptions {
   libraryVideos?: Video[];
+  // A library-row deletion must preserve sidecars used by remaining rows.
+  // An explicit export cleanup/rebuild still needs to remove those artifacts.
+  preserveSharedArtifacts?: boolean;
 }
 
 export interface MediaServerExportJobItem {

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -73,6 +73,7 @@ const mockSelect = ({
   const getMock = vi.fn().mockReturnValue(whereRow);
   vi.mocked(db.select).mockReturnValue({
     from: vi.fn().mockReturnValue({
+      all: allMock,
       orderBy: vi.fn().mockReturnValue({ all: allMock }),
       where: vi.fn().mockReturnValue({
         get: getMock,
@@ -514,6 +515,7 @@ describe("storageService videos", () => {
           where: vi.fn().mockReturnValue({
             get: vi.fn().mockReturnValue(video),
           }),
+          all: vi.fn().mockReturnValue(allVideos),
           orderBy: vi.fn().mockReturnValue({
             all: vi.fn().mockReturnValue(allVideos),
           }),

--- a/backend/src/services/storageService/__tests__/videos.test.ts
+++ b/backend/src/services/storageService/__tests__/videos.test.ts
@@ -580,7 +580,7 @@ describe("storageService videos", () => {
       );
     });
 
-    it("falls back to filename lookup when stored video path is stale", () => {
+    it("never guesses a replacement file when the stored video path is stale", () => {
       const video = {
         id: "1",
         videoFilename: "video.mp4",
@@ -601,15 +601,10 @@ describe("storageService videos", () => {
       const ok = deleteVideo("1");
 
       expect(ok).toBe(true);
-      expect(fileHelpers.findVideoFilesByFilename).toHaveBeenCalledWith("video.mp4");
+      expect(fileHelpers.findVideoFilesByFilename).not.toHaveBeenCalled();
       expect(fileHelpers.findVideoFile).not.toHaveBeenCalled();
-      expect(fs.unlinkSync).toHaveBeenCalledWith(
-        path.join(VIDEOS_DIR, "video.mp4")
-      );
-      expect(fileHelpers.removeEmptyDirectoryChain).toHaveBeenCalledWith(
-        VIDEOS_DIR,
-        VIDEOS_DIR
-      );
+      expect(fs.unlinkSync).not.toHaveBeenCalled();
+      expect(fileHelpers.removeEmptyDirectoryChain).not.toHaveBeenCalled();
     });
 
     it("skips stale-path fallback deletion when filename lookup is ambiguous", () => {
@@ -632,7 +627,7 @@ describe("storageService videos", () => {
       const ok = deleteVideo("1");
 
       expect(ok).toBe(true);
-      expect(fileHelpers.findVideoFilesByFilename).toHaveBeenCalledWith("video.mp4");
+      expect(fileHelpers.findVideoFilesByFilename).not.toHaveBeenCalled();
       expect(fileHelpers.findVideoFile).not.toHaveBeenCalled();
       expect(fs.unlinkSync).not.toHaveBeenCalled();
       expect(fileHelpers.removeEmptyDirectoryChain).not.toHaveBeenCalled();

--- a/backend/src/services/storageService/artifactReferences.ts
+++ b/backend/src/services/storageService/artifactReferences.ts
@@ -3,6 +3,7 @@ import { AVATARS_DIR } from "../../config/paths";
 import { resolveSafeChildPath } from "../../utils/security";
 import { resolveManagedWebPath } from "../filenameTemplate/pathHelpers";
 import type { Video } from "./types";
+import { logger } from "../../utils/logger";
 
 // Keep the absolute root in the key: /videos/a.jpg and /images/a.jpg are
 // different files. Case/Unicode folding conservatively protects aliases on
@@ -22,12 +23,20 @@ export function createArtifactReferenceGuard(libraryVideos: Video[]): (absoluteP
       if (webPath.startsWith("mount:")) {
         absolutePath = webPath.slice("mount:".length);
       } else if (webPath.startsWith("/avatars/")) {
-        absolutePath = resolveSafeChildPath(AVATARS_DIR, webPath.slice("/avatars/".length));
+        try {
+          absolutePath = resolveSafeChildPath(AVATARS_DIR, webPath.slice("/avatars/".length));
+        } catch {
+          logger.warn("Ignoring invalid avatar path during ownership checks", { webPath });
+        }
       } else {
         absolutePath = resolveManagedWebPath(webPath)?.absolutePath;
       }
-      if (absolutePath) paths.add(pathKey(absolutePath));
-    } else if (typeof filename === "string" && filename) {
+      if (absolutePath) {
+        paths.add(pathKey(absolutePath));
+        return;
+      }
+    }
+    if (typeof filename === "string" && filename) {
       // Legacy rows do not identify a folder. Preserve all possible owners
       // instead of assuming a basename-only row lives at the storage root.
       legacyFilenames.add(pathKey(path.basename(filename.replace(/\\/g, "/"))));

--- a/backend/src/services/storageService/artifactReferences.ts
+++ b/backend/src/services/storageService/artifactReferences.ts
@@ -1,0 +1,46 @@
+import path from "path";
+import { AVATARS_DIR } from "../../config/paths";
+import { resolveSafeChildPath } from "../../utils/security";
+import { resolveManagedWebPath } from "../filenameTemplate/pathHelpers";
+import type { Video } from "./types";
+
+// Keep the absolute root in the key: /videos/a.jpg and /images/a.jpg are
+// different files. Case/Unicode folding conservatively protects aliases on
+// filesystems that do not distinguish them.
+function pathKey(value: string): string {
+  return path.normalize(value).replace(/\\/g, "/").normalize("NFKC").toLowerCase();
+}
+
+/** Build once from a successful library read, excluding any row being deleted. */
+export function createArtifactReferenceGuard(libraryVideos: Video[]): (absolutePath: string) => boolean {
+  const paths = new Set<string>();
+  const legacyFilenames = new Set<string>();
+
+  const add = (webPath: unknown, filename: unknown): void => {
+    if (typeof webPath === "string" && webPath) {
+      let absolutePath: string | undefined;
+      if (webPath.startsWith("mount:")) {
+        absolutePath = webPath.slice("mount:".length);
+      } else if (webPath.startsWith("/avatars/")) {
+        absolutePath = resolveSafeChildPath(AVATARS_DIR, webPath.slice("/avatars/".length));
+      } else {
+        absolutePath = resolveManagedWebPath(webPath)?.absolutePath;
+      }
+      if (absolutePath) paths.add(pathKey(absolutePath));
+    } else if (typeof filename === "string" && filename) {
+      // Legacy rows do not identify a folder. Preserve all possible owners
+      // instead of assuming a basename-only row lives at the storage root.
+      legacyFilenames.add(pathKey(path.basename(filename.replace(/\\/g, "/"))));
+    }
+  };
+
+  for (const video of libraryVideos) {
+    add(video.videoPath, video.videoFilename);
+    add(video.thumbnailPath, video.thumbnailFilename);
+    add(video.authorAvatarPath, video.authorAvatarFilename);
+    for (const subtitle of video.subtitles ?? []) add(subtitle.path, subtitle.filename);
+  }
+
+  return (absolutePath) => paths.has(pathKey(absolutePath)) ||
+    legacyFilenames.has(pathKey(path.basename(absolutePath)));
+}

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -62,6 +62,7 @@ export {
     getVideoById,
     getVideoBySourceUrl,
     getVideos,
+    getVideosStrict,
     getVideoSummaries,
     getVideosListETag,
     isCloudFileVisibleToVisitor,

--- a/backend/src/services/storageService/index.ts
+++ b/backend/src/services/storageService/index.ts
@@ -63,6 +63,7 @@ export {
     getVideoBySourceUrl,
     getVideos,
     getVideosStrict,
+    getArtifactOwners,
     getVideoSummaries,
     getVideosListETag,
     isCloudFileVisibleToVisitor,

--- a/backend/src/services/storageService/videoDeletion.ts
+++ b/backend/src/services/storageService/videoDeletion.ts
@@ -21,7 +21,6 @@ import {
   buildStoragePath,
   findImageFile,
   findVideoFile,
-  findVideoFilesByFilename,
   pathExists,
   removeEmptyDirectoryChain,
   removeFileIfExists,
@@ -33,7 +32,10 @@ import {
   resolveManagedThumbnailWebPathFromAbsolutePath,
 } from "../thumbnailMirrorService";
 import { bumpVideosListRevision } from "./videoListRevision";
-import { getVideoById, getVideos } from "./videoQueries";
+import { getVideoById, getVideos, getVideosStrict } from "./videoQueries";
+import { createArtifactReferenceGuard } from "./artifactReferences";
+
+type ReferenceGuard = (absolutePath: string) => boolean;
 
 export function deleteVideo(
   id: string,
@@ -44,18 +46,22 @@ export function deleteVideo(
     if (!videoToDelete) return false;
 
     const allCollections = getCollections();
+    // Read all owners before touching disk. Never treat a database/JSON read
+    // failure as an empty library and delete potentially shared artifacts.
+    const remainingVideos = getVideosStrict().filter((video) => video.id !== id);
+    const isReferenced = createArtifactReferenceGuard(remainingVideos);
 
     // Remove video file
-    deleteVideoFile(videoToDelete, allCollections);
+    deleteVideoFile(videoToDelete, allCollections, isReferenced);
 
     // Remove thumbnail file
-    deleteThumbnailFile(videoToDelete, allCollections);
+    deleteThumbnailFile(videoToDelete, allCollections, isReferenced);
 
     // Remove author avatar file only if this is the last video from this author
-    deleteAuthorAvatarIfNeeded(videoToDelete, id);
+    deleteAuthorAvatarIfNeeded(videoToDelete, remainingVideos, isReferenced);
 
     // Remove subtitle files
-    deleteSubtitleFiles(videoToDelete, allCollections);
+    deleteSubtitleFiles(videoToDelete, allCollections, isReferenced);
 
     const deletedAt = Date.now();
 
@@ -75,7 +81,8 @@ export function deleteVideo(
       // recommendation signals are best-effort
     }
     removeMediaServerArtifactsForVideo(videoToDelete, {
-      libraryVideos: getVideos(),
+      libraryVideos: remainingVideos,
+      preserveSharedArtifacts: true,
     });
 
     // Statistics: emit library_video_deleted with the reason bucket and a size
@@ -189,7 +196,8 @@ export function isVideoFileReferencedByOtherVideo(
 
 function deleteVideoFile(
   video: import("./types").Video,
-  allCollections: import("./types").Collection[]
+  allCollections: import("./types").Collection[],
+  isReferenced: ReferenceGuard
 ): void {
   if (!isLocalManagedVideo(video)) {
     return;
@@ -200,18 +208,13 @@ function deleteVideoFile(
   // location. Once template subdirectories are enabled identical basenames
   // can exist in different folders, and findVideoFile() (basename-only
   // lookup) could match the wrong file or miss the intended one entirely.
-  const resolved = video.videoPath ? resolveManagedWebPath(video.videoPath) : null;
-  if (resolved) {
-    if (deleteLocalVideoPath(resolved.absolutePath, resolved.rootDir)) {
-      return;
+  if (video.videoPath) {
+    const resolved = resolveManagedWebPath(video.videoPath);
+    if (resolved?.prefix === "/videos") {
+      deleteLocalVideoPath(resolved.absolutePath, resolved.rootDir, isReferenced);
     }
-
-    if (video.videoFilename) {
-      const fallbackPath = findUnambiguousVideoFileFallback(video.videoFilename);
-      if (fallbackPath) {
-        deleteLocalVideoPath(fallbackPath, VIDEOS_DIR);
-      }
-    }
+    // A missing or invalid explicit path must never select someone else's
+    // file by basename. Scanning uses this path to reconcile missing records.
     return;
   }
 
@@ -219,13 +222,13 @@ function deleteVideoFile(
   if (video.videoFilename) {
     const actualPath = findVideoFile(video.videoFilename, allCollections);
     if (actualPath) {
-      deleteLocalVideoPath(actualPath, VIDEOS_DIR);
+      deleteLocalVideoPath(actualPath, VIDEOS_DIR, isReferenced);
     }
   }
 }
 
-function deleteLocalVideoPath(absolutePath: string, rootDir: string): boolean {
-  if (!pathExists(absolutePath)) {
+function deleteLocalVideoPath(absolutePath: string, rootDir: string, isReferenced: ReferenceGuard): boolean {
+  if (!pathExists(absolutePath) || isReferenced(absolutePath)) {
     return false;
   }
 
@@ -234,28 +237,13 @@ function deleteLocalVideoPath(absolutePath: string, rootDir: string): boolean {
   return true;
 }
 
-function findUnambiguousVideoFileFallback(filename: string): string | null {
-  const matches = findVideoFilesByFilename(filename);
-  if (matches.length === 1) {
-    return matches[0];
-  }
-
-  if (matches.length > 1) {
-    logger.warn(
-      `Skipping stale-path video deletion because filename is ambiguous: ${filename}`,
-      { matches }
-    );
-  }
-
-  return null;
-}
-
 function deleteThumbnailFile(
   video: import("./types").Video,
-  allCollections: import("./types").Collection[]
+  allCollections: import("./types").Collection[],
+  isReferenced: ReferenceGuard
 ): void {
   if (video.thumbnailFilename) {
-    const canUseLocalFallbacks = isLocalManagedVideo(video);
+    const canUseLocalFallbacks = !video.thumbnailPath && isLocalManagedVideo(video);
     let thumbnailPath: string | null = null;
 
     // Determine the actual file path based on thumbnailPath
@@ -283,7 +271,9 @@ function deleteThumbnailFile(
     ) {
       // Try alongside video file (when moveThumbnailsToVideoFolder is enabled)
       if (video.videoFilename) {
-        const videoPath = findVideoFile(video.videoFilename, allCollections);
+        const videoPath = video.videoPath
+          ? resolveManagedWebPath(video.videoPath)?.absolutePath
+          : findVideoFile(video.videoFilename, allCollections);
         if (videoPath) {
           const videoDir = path.dirname(videoPath);
           thumbnailPath = buildStoragePath(videoDir, video.thumbnailFilename);
@@ -304,7 +294,7 @@ function deleteThumbnailFile(
 
     // Delete the thumbnail file if it exists
     if (thumbnailPath && pathExists(thumbnailPath)) {
-      if (isThumbnailReferencedByOtherVideo(video, video.id)) {
+      if (isReferenced(thumbnailPath)) {
         logger.info(
           `Skipping thumbnail deletion - another video still references it: ${thumbnailPath}`
         );
@@ -332,13 +322,13 @@ function deleteThumbnailFile(
 
 function deleteAuthorAvatarIfNeeded(
   video: import("./types").Video,
-  exceptionId: string
+  remainingVideos: import("./types").Video[],
+  isReferenced: ReferenceGuard
 ): void {
   if (video.authorAvatarFilename && video.author) {
     // Check if there are other videos from the same author
-    const allVideos = getVideos();
-    const otherVideosFromAuthor = allVideos.filter(
-      (v) => v.id !== exceptionId && v.author === video.author
+    const otherVideosFromAuthor = remainingVideos.filter(
+      (v) => v.author === video.author
     );
 
     // Only delete avatar if this is the last video from this author
@@ -364,7 +354,7 @@ function deleteAuthorAvatarIfNeeded(
 
       // Fallback: try to find by filename in avatars directory
       // nosemgrep: javascript.pathtraversal.rule-non-literal-fs-filename
-      if (!avatarPath || !pathExists(avatarPath)) {
+      if (!video.authorAvatarPath) {
         const fallbackPath = buildStoragePath(
           AVATARS_DIR,
           video.authorAvatarFilename
@@ -375,7 +365,7 @@ function deleteAuthorAvatarIfNeeded(
       }
 
       // Delete the avatar file if it exists
-      if (avatarPath && pathExists(avatarPath)) {
+      if (avatarPath && pathExists(avatarPath) && !isReferenced(avatarPath)) {
         try {
           removeFileIfExists(avatarPath);
           removeEmptyDirectoryChain(path.dirname(avatarPath), AVATARS_DIR);
@@ -397,7 +387,8 @@ function deleteAuthorAvatarIfNeeded(
 
 function deleteSubtitleFiles(
   video: import("./types").Video,
-  allCollections: import("./types").Collection[]
+  allCollections: import("./types").Collection[],
+  isReferenced: ReferenceGuard
 ): void {
   if (video.subtitles && video.subtitles.length > 0) {
     const canUseLocalFallbacks = isLocalManagedVideo(video);
@@ -410,18 +401,16 @@ function deleteSubtitleFiles(
       // Fallback: try to find by filename if path-based lookup fails
       // nosemgrep: javascript.pathtraversal.rule-non-literal-fs-filename
       if (
-        canUseLocalFallbacks &&
-        (!subtitlePath || !pathExists(subtitlePath))
+        canUseLocalFallbacks && !subtitle.path
       ) {
         // Try root subtitles directory
         subtitlePath = buildStoragePath(SUBTITLES_DIR, subtitle.filename);
         if (!pathExists(subtitlePath)) {
           // Try alongside video file
           if (video.videoFilename) {
-            const videoPath = findVideoFile(
-              video.videoFilename,
-              allCollections
-            );
+            const videoPath = video.videoPath
+              ? resolveManagedWebPath(video.videoPath)?.absolutePath
+              : findVideoFile(video.videoFilename, allCollections);
             if (videoPath) {
               const videoDir = path.dirname(videoPath);
               subtitlePath = buildStoragePath(videoDir, subtitle.filename);
@@ -431,7 +420,7 @@ function deleteSubtitleFiles(
       }
 
       // Delete the subtitle file if it exists
-      if (subtitlePath && pathExists(subtitlePath)) {
+      if (subtitlePath && pathExists(subtitlePath) && !isReferenced(subtitlePath)) {
         try {
           removeFileIfExists(subtitlePath);
           pruneManagedArtifactParentDirectories(subtitlePath);

--- a/backend/src/services/storageService/videoDeletion.ts
+++ b/backend/src/services/storageService/videoDeletion.ts
@@ -10,10 +10,7 @@ import {
 import { db } from "../../db";
 import { videos } from "../../db/schema";
 import { DatabaseError } from "../../errors/DownloadErrors";
-import {
-  canonicalizeManagedPath,
-  resolveManagedWebPath,
-} from "../filenameTemplate/pathHelpers";
+import { resolveManagedWebPath } from "../filenameTemplate/pathHelpers";
 import { removeMediaServerArtifactsForVideo } from "../mediaServerExport";
 import { logger } from "../../utils/logger";
 import { getCollections } from "./collections";
@@ -32,7 +29,7 @@ import {
   resolveManagedThumbnailWebPathFromAbsolutePath,
 } from "../thumbnailMirrorService";
 import { bumpVideosListRevision } from "./videoListRevision";
-import { getVideoById, getVideos, getVideosStrict } from "./videoQueries";
+import { getVideoById, getArtifactOwners } from "./videoQueries";
 import { createArtifactReferenceGuard } from "./artifactReferences";
 
 type ReferenceGuard = (absolutePath: string) => boolean;
@@ -48,7 +45,7 @@ export function deleteVideo(
     const allCollections = getCollections();
     // Read all owners before touching disk. Never treat a database/JSON read
     // failure as an empty library and delete potentially shared artifacts.
-    const remainingVideos = getVideosStrict().filter((video) => video.id !== id);
+    const remainingVideos = getArtifactOwners().filter((video) => video.id !== id);
     const isReferenced = createArtifactReferenceGuard(remainingVideos);
 
     // Remove video file
@@ -120,6 +117,7 @@ export function deleteVideo(
       "Error deleting video",
       error instanceof Error ? error : new Error(String(error))
     );
+    if (error instanceof DatabaseError) throw error;
     throw new DatabaseError(
       `Failed to delete video: ${id}`,
       error instanceof Error ? error : new Error(String(error)),
@@ -136,62 +134,29 @@ function isLocalManagedVideo(
 
 export function isThumbnailReferencedByOtherVideo(
   video: import("./types").Video,
-  exceptionId: string
+  exceptionId: string,
+  candidatePath?: string
 ): boolean {
-  if (!video.thumbnailFilename && !video.thumbnailPath) {
-    return false;
-  }
-
-  const allVideos = getVideos();
-
-  return allVideos.some((candidate) => {
-    if (candidate.id === exceptionId) {
-      return false;
-    }
-
-    if (video.thumbnailPath && candidate.thumbnailPath === video.thumbnailPath) {
-      return true;
-    }
-
-    return Boolean(
-      video.thumbnailFilename &&
-        candidate.thumbnailFilename === video.thumbnailFilename &&
-        (!video.thumbnailPath ||
-          !candidate.thumbnailPath ||
-          candidate.thumbnailPath === video.thumbnailPath)
-    );
-  });
-}
-
-function canonicalManagedVideoReference(
-  video: import("./types").Video
-): string | null {
-  if (video.videoPath) {
-    const resolved = resolveManagedWebPath(video.videoPath);
-    return resolved?.prefix === "/videos"
-      ? canonicalizeManagedPath(resolved.absolutePath)
-      : null;
-  }
-
-  return video.videoFilename
-    ? canonicalizeManagedPath(`/videos/${video.videoFilename}`)
-    : null;
+  if (!candidatePath && !video.thumbnailFilename && !video.thumbnailPath) return false;
+  const owners = getArtifactOwners().filter((candidate) => candidate.id !== exceptionId);
+  const absolutePath = candidatePath ?? (video.thumbnailPath
+    ? resolveManagedWebPath(video.thumbnailPath)?.absolutePath
+    : video.thumbnailFilename ? buildStoragePath(IMAGES_DIR, video.thumbnailFilename) : undefined);
+  // An unresolved explicit path cannot establish which file is safe to delete.
+  return !absolutePath || createArtifactReferenceGuard(owners)(absolutePath);
 }
 
 export function isVideoFileReferencedByOtherVideo(
   video: import("./types").Video,
-  exceptionId: string
+  exceptionId: string,
+  candidatePath?: string
 ): boolean {
-  const managedReference = canonicalManagedVideoReference(video);
-  if (!managedReference) {
-    return false;
-  }
-
-  return getVideos().some(
-    (candidate) =>
-      candidate.id !== exceptionId &&
-      canonicalManagedVideoReference(candidate) === managedReference
-  );
+  if (!candidatePath && !video.videoFilename && !video.videoPath) return false;
+  const owners = getArtifactOwners().filter((candidate) => candidate.id !== exceptionId);
+  const absolutePath = candidatePath ?? (video.videoPath
+    ? resolveManagedWebPath(video.videoPath)?.absolutePath
+    : video.videoFilename ? buildStoragePath(VIDEOS_DIR, video.videoFilename) : undefined);
+  return !absolutePath || createArtifactReferenceGuard(owners)(absolutePath);
 }
 
 function deleteVideoFile(

--- a/backend/src/services/storageService/videoQueries.ts
+++ b/backend/src/services/storageService/videoQueries.ts
@@ -6,6 +6,45 @@ import { logger } from "../../utils/logger";
 
 export type VideoCallerRole = "admin" | "visitor";
 
+function parseVideoMetadata(id: string, field: "tags" | "subtitles", value: string | null) {
+  try {
+    const parsed: unknown = value ? JSON.parse(value) : [];
+    if (!Array.isArray(parsed) || (field === "subtitles" && parsed.some((item) =>
+      !item || typeof item !== "object" ||
+      (item.path != null && typeof item.path !== "string") ||
+      (item.filename != null && typeof item.filename !== "string") ||
+      (typeof item.path !== "string" && typeof item.filename !== "string")
+    ))) throw new Error("Expected an array of valid metadata entries");
+    return parsed;
+  } catch (error) {
+    throw new DatabaseError(
+      `Cannot read video library: video ${id} has invalid ${field} metadata. Repair this record before deleting files.`,
+      error instanceof Error ? error : new Error(String(error)),
+      "readVideoMetadata"
+    );
+  }
+}
+
+/** Ownership checks do not need tags, descriptions, or playback metadata. */
+export function getArtifactOwners(): import("./types").Video[] {
+  try {
+    return db.select({
+      id: videos.id, title: videos.title, sourceUrl: videos.sourceUrl,
+      createdAt: videos.createdAt, author: videos.author,
+      videoPath: videos.videoPath, videoFilename: videos.videoFilename,
+      thumbnailPath: videos.thumbnailPath, thumbnailFilename: videos.thumbnailFilename,
+      authorAvatarPath: videos.authorAvatarPath, authorAvatarFilename: videos.authorAvatarFilename,
+      subtitles: videos.subtitles,
+    }).from(videos).all().map((v) => ({
+      ...v, subtitles: parseVideoMetadata(v.id, "subtitles", v.subtitles),
+    })) as import("./types").Video[];
+  } catch (error) {
+    if (error instanceof DatabaseError) throw error;
+    throw new DatabaseError("Cannot verify file ownership: failed to read video library. File removal was stopped.",
+      error instanceof Error ? error : new Error(String(error)), "getArtifactOwners");
+  }
+}
+
 // Visibility: 0 = hidden, 1 = public (see db/schema.ts). Visitors are only
 // allowed to see public videos; admins see everything. Mirrors the existing
 // RSS feed filter (rssService.ts). Used to fix GHSA-hcm6-w6x8-6jhr.
@@ -43,14 +82,15 @@ export function getVideosStrict(
         : baseQuery.all();
     return allVideos.map((v) => ({
       ...v,
-      tags: v.tags ? JSON.parse(v.tags) : [],
-      subtitles: v.subtitles ? JSON.parse(v.subtitles) : undefined,
+      tags: parseVideoMetadata(v.id, "tags", v.tags),
+      subtitles: v.subtitles ? parseVideoMetadata(v.id, "subtitles", v.subtitles) : undefined,
     })) as import("./types").Video[];
   } catch (error) {
     logger.error(
       "Error getting videos",
       error instanceof Error ? error : new Error(String(error))
     );
+    if (error instanceof DatabaseError) throw error;
     throw new DatabaseError(
       "Failed to read video library",
       error instanceof Error ? error : new Error(String(error)),

--- a/backend/src/services/storageService/videoQueries.ts
+++ b/backend/src/services/storageService/videoQueries.ts
@@ -21,6 +21,18 @@ export function getVideos(
   role?: VideoCallerRole
 ): import("./types").Video[] {
   try {
+    return getVideosStrict(role);
+  } catch {
+    // Preserve the existing list API fallback. Destructive callers must use
+    // getVideosStrict: a failed read is not evidence that a file has no owners.
+    return [];
+  }
+}
+
+export function getVideosStrict(
+  role?: VideoCallerRole
+): import("./types").Video[] {
+  try {
     const baseQuery = db
       .select()
       .from(videos)
@@ -39,8 +51,11 @@ export function getVideos(
       "Error getting videos",
       error instanceof Error ? error : new Error(String(error))
     );
-    // Return empty array for backward compatibility with frontend
-    return [];
+    throw new DatabaseError(
+      "Failed to read video library",
+      error instanceof Error ? error : new Error(String(error)),
+      "getVideosStrict"
+    );
   }
 }
 

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -4,6 +4,7 @@
 export type { VideoCallerRole } from "./videoQueries";
 export {
   getVideos,
+  getVideosStrict,
   getVideoSummaries,
   getVideoBySourceUrl,
   getVideoById,

--- a/backend/src/services/storageService/videos.ts
+++ b/backend/src/services/storageService/videos.ts
@@ -5,6 +5,7 @@ export type { VideoCallerRole } from "./videoQueries";
 export {
   getVideos,
   getVideosStrict,
+  getArtifactOwners,
   getVideoSummaries,
   getVideoBySourceUrl,
   getVideoById,


### PR DESCRIPTION
## Summary

Maintenance cleanup, deleting stale/shared records, and exporting a live database could lose media or produce corrupt backups. This change verifies file ownership before removal and exports an immutable SQLite snapshot.

- Preserve user directories and shared media, thumbnails, avatars, subtitles, and sidecars. Apply strict ownership checks to redownload and thumbnail replacement too; unreadable ownership metadata stops removal with a record ID and field in the error.
- Collect cleanup candidates before a single current ownership read. Mark new Bilibili job directories so inactive abandoned jobs can be removed safely; retain active jobs, referenced files, and unmarked directories.
- Reuse sidecar path plans while reconciling current owners, including historical sidecars when export is disabled.
- Clean up snapshots after completion or client disconnect without writing a second response. Preserve other streaming errors for Express and reject corrupt imports with an integrity-specific message.

## Validation

- Backend: `npm test` — full suite passed.
- Backend: `./node_modules/.bin/tsc --noEmit` — passed.
- Regression coverage includes real SQLite/filesystem deletion, HTTP client disconnects, concurrent backup writes, corrupt imports, marked temporary directories, failed ownership reads during redownload, and sidecar ownership changes during batch deletion.

## Behavior notes

Stale paths are never repaired by guessing a matching basename during deletion. Case/Unicode aliases and legacy unmarked temporary directories are handled conservatively. Full integrity checks and per-export snapshot disk usage, including crash leftovers, are documented in `CHANGELOG.md`.
