### PR TITLE
fix(downloads): resolve the re-download target by source identity, not URL

### DIFF
--- a/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
+++ b/backend/src/__tests__/services/downloaders/MissAVDownloader.test.ts
@@ -20,6 +20,7 @@ vi.mock('../../../services/storageService', () => ({
   getSettings: vi.fn().mockReturnValue({}),
   getVideos: vi.fn().mockReturnValue([]),
   getVideoBySourceUrl: vi.fn().mockReturnValue(null),
+  checkVideoDownloadBySourceId: vi.fn().mockReturnValue({ found: false }),
   organizeVideoByAuthor: vi.fn().mockReturnValue(null),
   getVideoById: vi.fn().mockReturnValue(null),
   persistDownloadedMediaIdentity: vi.fn(({ video }) => video),
@@ -503,6 +504,62 @@ describe('MissAVDownloader', () => {
       expect(mockPage.goto).toHaveBeenCalledWith(
         'https://missav.ai/dm30/en/juq-819-uncensored-leak',
         expect.any(Object),
+      );
+    });
+
+    it('resolves the row to replace by source identity, not by URL string', async () => {
+      // The duplicate gate keys on (sourceVideoId, platform, mediaType), so a
+      // forced re-download it let through must resolve the same row here even
+      // when the URL is spelled differently - another mirror, a fragment, a
+      // locale segment. Resolving by exact URL missed it and inserted a
+      // duplicate beside the row the download meant to replace.
+      const mockPage = buildPageMock('timeout');
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+        found: true,
+        status: 'exists',
+        videoId: 'local-1',
+      } as any);
+      vi.mocked(storageService.getVideoById).mockReturnValue({
+        id: 'local-1',
+        mediaType: 'video',
+        // Stored on a different mirror, with a fragment.
+        sourceUrl: 'https://missav.ws/dm30/juq-819-uncensored-leak#frag',
+        videoPath: '/videos/Episode.mp4',
+      } as any);
+
+      await expect(
+        MissAVDownloader.downloadVideo('https://missav.ai/dm30/en/juq-819-uncensored-leak'),
+      ).rejects.toThrow('returned no video stream URL');
+
+      expect(storageService.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
+        'juq-819-uncensored-leak',
+        'missav',
+        'video',
+      );
+      // Identity answered, so the URL lookup is never consulted.
+      expect(storageService.getVideoBySourceUrl).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the URL lookup when nothing tracks the source id', async () => {
+      const mockPage = buildPageMock('timeout');
+      const mockBrowser = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn().mockResolvedValue(undefined) };
+      (puppeteer.launch as ReturnType<typeof vi.fn>).mockResolvedValue(mockBrowser);
+
+      vi.mocked(storageService.checkVideoDownloadBySourceId).mockReturnValue({
+        found: false,
+      } as any);
+
+      await expect(
+        MissAVDownloader.downloadVideo('https://missav.ai/dm30/en/juq-819-uncensored-leak'),
+      ).rejects.toThrow('returned no video stream URL');
+
+      // Rows predating the tracking table are still reachable.
+      expect(storageService.getVideoBySourceUrl).toHaveBeenCalledWith(
+        'https://missav.ai/dm30/en/juq-819-uncensored-leak',
+        'video',
       );
     });
 

--- a/backend/src/__tests__/services/downloaders/YtDlpDownloader.safari.test.ts
+++ b/backend/src/__tests__/services/downloaders/YtDlpDownloader.safari.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../../services/storageService', () => ({
     getVideos: vi.fn().mockReturnValue([]),
     getVideoById: vi.fn(),
     getVideoBySourceUrl: vi.fn(),
+    checkVideoDownloadBySourceId: vi.fn().mockReturnValue({ found: false }),
     updateVideo: vi.fn(),
     organizeVideoByAuthor: vi.fn(),
     isThumbnailReferencedByOtherVideo: vi.fn().mockReturnValue(false),

--- a/backend/src/__tests__/services/downloaders/redownloadTarget.test.ts
+++ b/backend/src/__tests__/services/downloaders/redownloadTarget.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  checkVideoDownloadBySourceId: vi.fn(),
+  getVideoById: vi.fn(),
+}));
+
+vi.mock("../../../services/storageService", () => ({
+  checkVideoDownloadBySourceId: mocks.checkVideoDownloadBySourceId,
+  getVideoById: mocks.getVideoById,
+}));
+
+import { findRedownloadTargetBySourceIdentity } from "../../../services/downloaders/redownloadTarget";
+
+const STORED_URL = "https://missav.ws/dm3/sone-192#frag_mobile-watch-next";
+const OTHER_MIRROR_URL = "https://missav.ai/dm3/cn/sone-192";
+
+function libraryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "local-1",
+    sourceUrl: STORED_URL,
+    mediaType: "video",
+    videoPath: "/videos/Episode.mp4",
+    ...overrides,
+  } as any;
+}
+
+describe("findRedownloadTargetBySourceIdentity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("finds the row a different URL spelling points at", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "local-1",
+    });
+    mocks.getVideoById.mockReturnValue(libraryRow());
+
+    // The stored row carries a missav.ws URL with a fragment; the request comes
+    // in on the .ai mirror. Exact URL equality misses; the identity key does not.
+    const found = findRedownloadTargetBySourceIdentity(OTHER_MIRROR_URL, "video");
+
+    expect(found?.id).toBe("local-1");
+    expect(mocks.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
+      "sone-192",
+      "missav",
+      "video"
+    );
+  });
+
+  it("keys on the same identity the duplicate gate uses for youtube", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({ found: false });
+
+    findRedownloadTargetBySourceIdentity(
+      "https://youtu.be/dQw4w9WgXcQ?t=30",
+      "video"
+    );
+
+    expect(mocks.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
+      "dQw4w9WgXcQ",
+      "youtube",
+      "video"
+    );
+  });
+
+  it("scopes the lookup to the requested media type", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({ found: false });
+
+    findRedownloadTargetBySourceIdentity("https://youtu.be/dQw4w9WgXcQ", "audio");
+
+    expect(mocks.checkVideoDownloadBySourceId).toHaveBeenCalledWith(
+      "dQw4w9WgXcQ",
+      "youtube",
+      "audio"
+    );
+  });
+
+  it("declines a tracking row whose download was deleted", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({
+      found: true,
+      status: "deleted",
+      videoId: "local-1",
+    });
+
+    expect(
+      findRedownloadTargetBySourceIdentity(OTHER_MIRROR_URL, "video")
+    ).toBeUndefined();
+    expect(mocks.getVideoById).not.toHaveBeenCalled();
+  });
+
+  it("declines a tracking row pointing at a video that is gone", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "local-gone",
+    });
+    mocks.getVideoById.mockReturnValue(undefined);
+
+    expect(
+      findRedownloadTargetBySourceIdentity(OTHER_MIRROR_URL, "video")
+    ).toBeUndefined();
+  });
+
+  it("declines a row of the other media type", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "local-1",
+    });
+    mocks.getVideoById.mockReturnValue(libraryRow({ mediaType: "audio" }));
+
+    expect(
+      findRedownloadTargetBySourceIdentity(OTHER_MIRROR_URL, "video")
+    ).toBeUndefined();
+  });
+
+  it("treats a legacy null media type as video", () => {
+    mocks.checkVideoDownloadBySourceId.mockReturnValue({
+      found: true,
+      status: "exists",
+      videoId: "local-1",
+    });
+    mocks.getVideoById.mockReturnValue(libraryRow({ mediaType: null }));
+
+    expect(
+      findRedownloadTargetBySourceIdentity(OTHER_MIRROR_URL, "video")?.id
+    ).toBe("local-1");
+  });
+
+  it("returns undefined without consulting tracking when no id can be read", () => {
+    expect(
+      findRedownloadTargetBySourceIdentity(
+        "https://www.youtube.com/results?search_query=nothing",
+        "video"
+      )
+    ).toBeUndefined();
+    expect(mocks.checkVideoDownloadBySourceId).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/downloaders/MissAVDownloader.ts
+++ b/backend/src/services/downloaders/MissAVDownloader.ts
@@ -29,6 +29,7 @@ import {
 } from "../filenameTemplate/outputPathAllocator";
 import { resolveSupersededManagedPath } from "./supersededOutput";
 import { FilenameTemplateSourceOptions } from "../filenameTemplate/types";
+import { findRedownloadTargetBySourceIdentity } from "./redownloadTarget";
 import {
   flagsToArgs,
   getAxiosProxyConfig,
@@ -128,7 +129,13 @@ function resolveExistingVideoForRedownload(
   existingLocalVideoId?: string
 ): Video | undefined {
   if (!existingLocalVideoId) {
-    return storageService.getVideoBySourceUrl(url, "video");
+    // Identity first, so this agrees with the duplicate gate that let a forced
+    // re-download through; the URL lookup stays as the fallback for rows that
+    // predate the tracking table.
+    return (
+      findRedownloadTargetBySourceIdentity(url, "video") ??
+      storageService.getVideoBySourceUrl(url, "video")
+    );
   }
 
   const selectedVideo = storageService.getVideoById(existingLocalVideoId);

--- a/backend/src/services/downloaders/redownloadTarget.ts
+++ b/backend/src/services/downloaders/redownloadTarget.ts
@@ -1,0 +1,53 @@
+import { extractSourceVideoId } from "../../utils/helpers";
+import * as storageService from "../storageService";
+import type { MediaType, Video } from "../storageService/types";
+
+/**
+ * Finds the library row a forced re-download is meant to replace, using the
+ * same key the duplicate gate used to let that download through.
+ *
+ * The gate in videoDownloadController keys on (sourceVideoId, platform,
+ * mediaType) via checkVideoDownloadBySourceId. Downloaders used to resolve the
+ * row to replace by exact source_url equality instead, so any difference in URL
+ * spelling - a mirror host, a fragment, a locale path segment, tracking
+ * parameters - left them unable to recognise the row the gate had just
+ * matched. The download then inserted a second row and left the previous file
+ * on disk with nothing referencing it, because the superseded-file cleanup only
+ * runs on the branch that found an existing row.
+ *
+ * Returns undefined rather than guessing whenever the tracking row is missing,
+ * marked deleted, or points at a row that is gone; callers fall back to the URL
+ * lookup, which still covers rows predating the tracking table.
+ *
+ * Not suitable for Bilibili: every part of a multipart video collapses onto one
+ * tracking row, so this would resolve any part to whichever one that row names.
+ * bilibiliSinglePart resolves through URL aliases for that reason.
+ */
+export function findRedownloadTargetBySourceIdentity(
+  url: string,
+  mediaType: MediaType
+): Video | undefined {
+  const { id: sourceVideoId, platform } = extractSourceVideoId(url);
+  if (!sourceVideoId) {
+    return undefined;
+  }
+
+  const tracked = storageService.checkVideoDownloadBySourceId(
+    sourceVideoId,
+    platform,
+    mediaType
+  );
+  if (!tracked.found || tracked.status !== "exists" || !tracked.videoId) {
+    return undefined;
+  }
+
+  const video = storageService.getVideoById(tracked.videoId);
+  if (!video) {
+    return undefined;
+  }
+
+  // The tracking row is keyed by media type, but a stale row could still name a
+  // video of the other kind; keep the caller's contract exact.
+  const videoMediaType: MediaType = video.mediaType === "audio" ? "audio" : "video";
+  return videoMediaType === mediaType ? video : undefined;
+}

--- a/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
+++ b/backend/src/services/downloaders/ytdlp/ytdlpVideo.ts
@@ -68,6 +68,7 @@ import {
   createYtDlpOutputTemplate,
   isExpectedTwitchMetadataError,
 } from "./ytdlpVideoHelpers";
+import { findRedownloadTargetBySourceIdentity } from "../redownloadTarget";
 
 function resolveExistingVideoForRedownload(
   videoUrl: string,
@@ -75,7 +76,13 @@ function resolveExistingVideoForRedownload(
   existingLocalVideoId?: string
 ): Video | undefined {
   if (!existingLocalVideoId) {
-    return storageService.getVideoBySourceUrl(videoUrl, mediaType);
+    // Identity first, so this agrees with the duplicate gate that let a forced
+    // re-download through; the URL lookup stays as the fallback for rows that
+    // predate the tracking table.
+    return (
+      findRedownloadTargetBySourceIdentity(videoUrl, mediaType) ??
+      storageService.getVideoBySourceUrl(videoUrl, mediaType)
+    );
   }
 
   const selectedVideo = storageService.getVideoById(existingLocalVideoId);


### PR DESCRIPTION
Fixes #457.

## The defect

Two places decide something about the same download, and they keyed on different things.

- **The duplicate gate** — `videoDownloadController.ts:109` — keys on `(sourceVideoId, platform, mediaType)` via `checkVideoDownloadBySourceId`.
- **The resolver that decides which row a download replaces** — `MissAVDownloader.ts:126`, `ytdlpVideo.ts:72` — keyed on exact `source_url` equality via `getVideoBySourceUrl`, which is a plain `eq(videos.sourceUrl, sourceUrl)` with no normalization.

So a forced re-download that the gate had *positively matched to a row* could reach the downloader and fail to recognise that same row, whenever the URL was spelled differently: another mirror host, a fragment, a locale path segment, tracking parameters. `missav.ai` against `missav.ws`; `youtu.be/X` against `youtube.com/watch?v=X&t=30`.

When the resolver misses, `existingLocalVideo` is `undefined`, and three things follow:

- `planOwnedReplacementStagingPathSync` gets no id and returns `null`, so the download writes to a fresh final path rather than replacing;
- a new row is inserted instead of the matched one being updated;
- the superseded-file cleanup never runs — it only exists on the branch that found an existing row (`MissAVDownloader.ts:947`, via `resolveSupersededManagedPath`), and it is what would otherwise have removed the previous file.

The previous file stays on disk, referenced by nothing. #457 has a 4.6 GB instance.

This was already known for one platform. `bilibiliSinglePart.ts:71` carries a workaround with a comment naming the failure exactly: *"matching only the exact URL would add a duplicate beside the item a forced download meant to replace."* It fixes bilibili's `?p=1` spelling and nothing else.

## The change

`findRedownloadTargetBySourceIdentity` resolves through the same key the gate used, and MissAV and yt-dlp consult it before falling back to the URL lookup:

```ts
return (
  findRedownloadTargetBySourceIdentity(url, "video") ??
  storageService.getVideoBySourceUrl(url, "video")
);
```

No new table, no URL normalization, no naming change. The helper reuses `checkVideoDownloadBySourceId` and `getVideoById` as they are, and declines — rather than guessing — when the tracking row is missing, marked deleted, points at a row that is gone, or names a video of the other media type. The URL fallback stays for rows predating the tracking table.

**Bilibili is deliberately left alone.** Every part of a multipart video collapses onto one tracking row there — `VideoDownloadCheckResult.sourceUrl` exists for exactly that reason — so identity resolution would resolve any part to whichever one that row happens to name. Its URL-alias handling is the correct answer for that shape. The helper's doc comment says so, to keep someone from "unifying" it later.

## Correction to the issue

#457 as originally filed claimed that any second download from a different mirror duplicates. That was wrong, and the issue has been corrected. The gate already blocks the un-forced case on `source_video_id`, so this only bites forced re-downloads — which is still the path a user takes when they deliberately re-download something they have. The original framing also presented it as MissAV-specific when `ytdlpVideo.ts` has the identical shape.

## Tests

`redownloadTarget.test.ts` — 8 unit tests: resolves across a differing URL spelling; keys on the same `(id, platform, mediaType)` the gate uses, checked for both missav and youtube URLs; scopes to media type; declines a deleted tracking row, a dangling `videoId`, and a row of the other media type; treats a legacy null `mediaType` as video; and does not consult tracking at all when no source id can be read.

`MissAVDownloader.test.ts` — two wiring tests: identity resolves the row and the URL lookup is never consulted; and with nothing tracked, the URL lookup still runs. The first fails without this change. The second passes either way by design — it guards the fallback against being dropped rather than covering the bug, and is labelled as such.

Two existing suites mocked `storageService` partially and had to declare `checkVideoDownloadBySourceId`, since the module under test now reaches for it.

Backend suite: 3270 passed. The 6 failures (provider script/plugin paths ×4, favorites self-heal, sourceVideoId migration) are identical on master and unrelated.

## Not covered

No end-to-end run. The reproduction in #457 was observed on a live install before this change; the reverse — a forced re-download on a mirror URL now replacing in place — has not been exercised against a real download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
