### PR TITLE
fix(player): stop taps on the controls from selecting the time text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fix
 
+- Stop taps on the player's controls from selecting the time text next to them. MUI's buttons and sliders already suppress selection, but the elapsed and duration labels beside the progress bar did not, so on a touch screen a tap that landed just off a control - or the second tap of a quick double-tap - started a text selection on the nearest selectable thing, which is that text. Selection is now suppressed across the whole control cluster, which also covers the speed label and the compatibility player's transport strip, and on audio mode's artwork, where the surface is itself the play/pause target and holds a note glyph as real text. Prose that users may want to copy - the description, comments, titles - is untouched.
+
 - Protect shared media and companion files during deletion, redownload, and thumbnail replacement. Ownership reads now fail safely with the affected record ID and metadata field; unrelated malformed tags no longer block deleting another video.
 - Handle interrupted database exports without writing a second response, and distinguish SQLite integrity failures from invalid file formats.
 - Read file ownership once per temporary-file cleanup. New Bilibili temporary directories carry an ownership marker so abandoned jobs can be removed without treating user folders as disposable. Active jobs and referenced files remain protected.

--- a/frontend/src/components/VideoPlayer/VideoControls/ControlsOverlay.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/ControlsOverlay.tsx
@@ -119,6 +119,9 @@ const ControlsOverlay: React.FC<ControlsOverlayProps> = ({
         <Box
             sx={{
                 p: 1,
+                // Nothing in the control cluster is meant to be selected; a
+                // stray tap on touch screens should never start a selection.
+                userSelect: 'none',
                 bgcolor: isFullscreen
                     ? overlay.black55
                     : modePalette.backgroundElevated,

--- a/frontend/src/components/VideoPlayer/VideoControls/ProgressBar.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/ProgressBar.tsx
@@ -44,7 +44,15 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
     };
 
     return (
-        <Stack direction="row" spacing={{ xs: 0.5, sm: 1 }} alignItems="center" sx={{ flex: 1, minWidth: 0 }}>
+        <Stack
+            direction="row"
+            spacing={{ xs: 0.5, sm: 1 }}
+            alignItems="center"
+            // The buttons on either side are tapped repeatedly on touch
+            // screens, and a tap that lands just off one of them would
+            // otherwise select the elapsed/duration text next to it.
+            sx={{ flex: 1, minWidth: 0, userSelect: 'none' }}
+        >
             <Typography variant="caption" sx={{ minWidth: { xs: '35px', sm: '45px' }, textAlign: 'right', fontSize: '0.75rem', color: textColor }}>
                 {formatTime(currentTime)}
             </Typography>

--- a/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
+++ b/frontend/src/components/VideoPlayer/VideoControls/VideoElement.tsx
@@ -195,6 +195,9 @@ const VideoElement: React.FC<VideoElementProps> = ({
                         overflow: 'hidden',
                         background: `linear-gradient(135deg, #161b2d 0%, #3b1d5a 55%, #0f766e 100%)`,
                         cursor: 'pointer',
+                        // The whole surface toggles playback, so repeated taps
+                        // must not select the placeholder glyph inside it.
+                        userSelect: 'none',
                     }}
                 >
                     {poster ? (


### PR DESCRIPTION
## Problem

Reported on mobile: tapping the player's transport buttons sometimes selects the elapsed/duration text beside the progress bar.

MUI's `IconButton` and `Slider` already carry `user-select: none`, but the two `Typography` labels flanking the slider do not. On a touch screen, a tap that lands just off a control — or the second tap of a quick double-tap — starts a text selection on the nearest selectable node, which is that time text.

## Changes

- `ProgressBar` — suppress selection on the row holding both time labels and the slider. This is the reported case, and it carries to the compatibility ("D mode") player's transport strip, which reuses this component.
- `ControlsOverlay` — same on the overlay root, so every label the cluster holds now or later is covered (e.g. the speed button's `1.5x`), windowed and fullscreen alike.
- `VideoElement` — audio mode's artwork surface is itself the play/pause target and holds the `♪` glyph as real text, so repeated taps could select it.

## Deliberately left alone

- The description, comments and titles — prose users may legitimately want to copy.
- Swipe surfaces (`FavoriteHeroCarousel`, `usePaginationSwipeNavigation`, `GesturePattern`) — they set `touch-action`, and a touch drag does not start a selection.
- The compatibility player's centre overlay — only `IconButton`s over a `<canvas>`, nothing selectable.
- `VideoInfo` action buttons and the various menus — MUI already suppresses selection on `Button`/`MenuItem`.

## Verification

- `tsc --noEmit` clean; eslint clean on the changed files.
- Player control + compatibility player suites pass: 16 files, 134 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
